### PR TITLE
Add enforcement hooks (#8-#12, #18) and workflow plugin (#13-#19)

### DIFF
--- a/.claude/hooks/validate_branch_freshness.py
+++ b/.claude/hooks/validate_branch_freshness.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: Validate branch freshness before PR creation.
+
+Blocks `gh pr create` if the feature branch is behind the base branch.
+
+Exit codes:
+  0 — allow (not gh pr create, or branch is up to date)
+  2 — block (branch is behind base)
+"""
+
+import json
+import re
+import subprocess
+import sys
+
+
+def get_base_branch(command: str) -> str:
+    """Extract --base flag value, default to 'main'."""
+    match = re.search(r"--base\s+[\"']?(\S+)[\"']?", command)
+    if match:
+        return match.group(1)
+    return "main"
+
+
+def is_branch_fresh(base: str) -> bool:
+    """Check if HEAD contains the latest commit from origin/base."""
+    try:
+        # Fetch latest from origin
+        subprocess.run(
+            ["git", "fetch", "origin", base],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        # Check if origin/base is an ancestor of HEAD
+        result = subprocess.run(
+            ["git", "merge-base", "--is-ancestor", f"origin/{base}", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        return result.returncode == 0
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        # If we can't check, allow
+        return True
+
+
+def main() -> None:
+    try:
+        input_data = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        sys.exit(0)
+
+    tool_name = input_data.get("tool_name", "")
+    if tool_name != "Bash":
+        sys.exit(0)
+
+    command = input_data.get("tool_input", {}).get("command", "")
+
+    if not re.search(r"\bgh\s+pr\s+create\b", command):
+        sys.exit(0)
+
+    base = get_base_branch(command)
+
+    if is_branch_fresh(base):
+        sys.exit(0)
+
+    result = {
+        "decision": "block",
+        "reason": (
+            f"BLOCKED: Your branch is behind origin/{base}. "
+            f"Merge or rebase before creating a PR.\n"
+            f"Run: git fetch origin && git merge origin/{base}\n\n"
+            "This prevents merge conflicts and ensures CI runs against current code."
+        ),
+    }
+    print(json.dumps(result))
+    sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/validate_lockfile_paths.py
+++ b/.claude/hooks/validate_lockfile_paths.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: Block commits with local paths in package-lock.json.
+
+Scans staged package-lock.json files for /tmp/ or file:/ references that are
+local worktree artifacts and break CI.
+
+Exit codes:
+  0 — allow (not a git commit, or no local paths found)
+  2 — block (local paths detected in staged lockfiles)
+"""
+
+import json
+import re
+import subprocess
+import sys
+
+
+def get_staged_lockfiles() -> list[str]:
+    """Return paths of staged package-lock.json files."""
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--cached", "--name-only", "--diff-filter=ACM"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            return []
+        return [
+            f for f in result.stdout.strip().splitlines()
+            if f.endswith("package-lock.json")
+        ]
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return []
+
+
+def check_lockfile(path: str) -> list[str]:
+    """Check a staged lockfile for local path references. Returns offending lines."""
+    offending = []
+    try:
+        result = subprocess.run(
+            ["git", "show", f":{path}"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            return []
+        for i, line in enumerate(result.stdout.splitlines(), 1):
+            if re.search(r"/tmp/|file:/", line):
+                offending.append(f"  {path}:{i}: {line.strip()}")
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+    return offending
+
+
+def main() -> None:
+    try:
+        input_data = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        sys.exit(0)
+
+    tool_name = input_data.get("tool_name", "")
+    if tool_name != "Bash":
+        sys.exit(0)
+
+    command = input_data.get("tool_input", {}).get("command", "")
+
+    if not re.search(r"\bgit\b.*\bcommit\b", command):
+        sys.exit(0)
+
+    lockfiles = get_staged_lockfiles()
+    if not lockfiles:
+        sys.exit(0)
+
+    all_offending = []
+    for lf in lockfiles:
+        all_offending.extend(check_lockfile(lf))
+
+    if not all_offending:
+        sys.exit(0)
+
+    details = "\n".join(all_offending)
+    result = {
+        "decision": "block",
+        "reason": (
+            "BLOCKED: Staged package-lock.json contains local path references "
+            "(/tmp/ or file:/) that will break CI.\n"
+            f"Offending lines:\n{details}\n\n"
+            "Fix: Remove the local dependency references and regenerate the lockfile "
+            "with `npm install` using the published package version."
+        ),
+    }
+    print(json.dumps(result))
+    sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/validate_pr_review.py
+++ b/.claude/hooks/validate_pr_review.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: Require PR review comment before merge.
+
+Blocks `gh pr merge` unless the PR has at least one review from a non-author.
+
+Exit codes:
+  0 — allow (not gh pr merge, or review exists)
+  2 — block (no peer review found)
+"""
+
+import json
+import re
+import subprocess
+import sys
+
+
+def extract_pr_number(command: str) -> str | None:
+    """Extract PR number from gh pr merge command."""
+    # gh pr merge 123 or gh pr merge <url>
+    match = re.search(r"\bgh\s+pr\s+merge\s+(\d+)", command)
+    if match:
+        return match.group(1)
+    # gh pr merge <url containing /pull/123>
+    match = re.search(r"/pull/(\d+)", command)
+    if match:
+        return match.group(1)
+    # gh pr merge with no number (current branch PR)
+    return None
+
+
+def get_pr_reviews(pr_number: str | None) -> tuple[str | None, list[dict]]:
+    """Fetch PR author and reviews. Returns (author, reviews)."""
+    try:
+        # Get PR author
+        pr_cmd = ["gh", "pr", "view"]
+        if pr_number:
+            pr_cmd.append(pr_number)
+        pr_cmd.extend(["--json", "author,number"])
+        pr_result = subprocess.run(
+            pr_cmd, capture_output=True, text=True, timeout=15,
+        )
+        if pr_result.returncode != 0:
+            return None, []
+
+        pr_data = json.loads(pr_result.stdout)
+        author = pr_data.get("author", {}).get("login", "")
+        number = pr_data.get("number", pr_number)
+
+        # Get reviews
+        review_cmd = ["gh", "pr", "view", str(number), "--json", "reviews"]
+        review_result = subprocess.run(
+            review_cmd, capture_output=True, text=True, timeout=15,
+        )
+        if review_result.returncode != 0:
+            return author, []
+
+        review_data = json.loads(review_result.stdout)
+        return author, review_data.get("reviews", [])
+
+    except (subprocess.TimeoutExpired, json.JSONDecodeError, FileNotFoundError):
+        return None, []
+
+
+def main() -> None:
+    try:
+        input_data = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        sys.exit(0)
+
+    tool_name = input_data.get("tool_name", "")
+    if tool_name != "Bash":
+        sys.exit(0)
+
+    command = input_data.get("tool_input", {}).get("command", "")
+
+    if not re.search(r"\bgh\s+pr\s+merge\b", command):
+        sys.exit(0)
+
+    # Allow --admin override only if explicitly present
+    if "--admin" in command:
+        sys.exit(0)
+
+    pr_number = extract_pr_number(command)
+    author, reviews = get_pr_reviews(pr_number)
+
+    if author is None:
+        # Could not fetch PR info — allow with warning
+        result = {
+            "decision": "allow",
+            "systemMessage": (
+                "WARNING: Could not verify PR review status. "
+                "Ensure the PR has at least one peer review before merging."
+            ),
+        }
+        print(json.dumps(result))
+        sys.exit(0)
+
+    # Check for at least one review from a non-author
+    has_peer_review = any(
+        review.get("author", {}).get("login", "") != author
+        for review in reviews
+    )
+
+    if has_peer_review:
+        sys.exit(0)
+
+    pr_display = f"#{pr_number}" if pr_number else "(current branch)"
+    result = {
+        "decision": "block",
+        "reason": (
+            f"BLOCKED: PR {pr_display} has no peer review. "
+            "At least one review from a non-author is required before merge.\n"
+            "Charter § Pull Requests requires peer review for all merges.\n"
+            "Use `gh pr review` to add a review, or pass `--admin` for emergency overrides."
+        ),
+    }
+    print(json.dumps(result))
+    sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/validate_vps_host.py
+++ b/.claude/hooks/validate_vps_host.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: Validate VPS_HOST is not a Cloudflare IP.
+
+Blocks `gh variable set VPS_HOST` if the value resolves to a known Cloudflare
+IP range. Also warns if a hostname is used instead of a direct IP.
+
+Exit codes:
+  0 — allow (not VPS_HOST, or value is a valid direct IP)
+  2 — block (value resolves to Cloudflare IP)
+"""
+
+import ipaddress
+import json
+import re
+import socket
+import sys
+
+# Known Cloudflare IP ranges
+CLOUDFLARE_RANGES = [
+    ipaddress.ip_network("104.16.0.0/12"),
+    ipaddress.ip_network("172.64.0.0/13"),
+    ipaddress.ip_network("103.21.244.0/22"),
+    ipaddress.ip_network("103.22.200.0/22"),
+    ipaddress.ip_network("103.31.4.0/22"),
+    ipaddress.ip_network("141.101.64.0/18"),
+    ipaddress.ip_network("108.162.192.0/18"),
+    ipaddress.ip_network("190.93.240.0/20"),
+    ipaddress.ip_network("188.114.96.0/20"),
+    ipaddress.ip_network("197.234.240.0/22"),
+    ipaddress.ip_network("198.41.128.0/17"),
+    ipaddress.ip_network("162.158.0.0/15"),
+    ipaddress.ip_network("131.0.72.0/22"),
+]
+
+
+def is_cloudflare_ip(ip_str: str) -> bool:
+    """Check if an IP address falls within known Cloudflare ranges."""
+    try:
+        addr = ipaddress.ip_address(ip_str)
+        return any(addr in net for net in CLOUDFLARE_RANGES)
+    except ValueError:
+        return False
+
+
+def resolve_hostname(hostname: str) -> str | None:
+    """Resolve a hostname to an IP address."""
+    try:
+        return socket.gethostbyname(hostname)
+    except (socket.gaierror, socket.timeout):
+        return None
+
+
+def is_ip_address(value: str) -> bool:
+    """Check if a string is a valid IP address."""
+    try:
+        ipaddress.ip_address(value)
+        return True
+    except ValueError:
+        return False
+
+
+def main() -> None:
+    try:
+        input_data = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        sys.exit(0)
+
+    tool_name = input_data.get("tool_name", "")
+    if tool_name != "Bash":
+        sys.exit(0)
+
+    command = input_data.get("tool_input", {}).get("command", "")
+
+    # Match gh variable set VPS_HOST <value>
+    match = re.search(
+        r"\bgh\s+variable\s+set\s+VPS_HOST\s+[\"']?(\S+)[\"']?", command
+    )
+    if not match:
+        sys.exit(0)
+
+    value = match.group(1).strip("\"'")
+
+    # Determine IP to check
+    if is_ip_address(value):
+        ip_to_check = value
+        is_hostname = False
+    else:
+        is_hostname = True
+        ip_to_check = resolve_hostname(value)
+
+    warnings = []
+
+    if is_hostname:
+        warnings.append(
+            f"WARNING: VPS_HOST is a hostname ({value}), not a direct IP. "
+            "SSH should use the direct VPS IP to avoid proxy issues."
+        )
+
+    if ip_to_check and is_cloudflare_ip(ip_to_check):
+        result = {
+            "decision": "block",
+            "reason": (
+                f"BLOCKED: VPS_HOST value '{value}' resolves to {ip_to_check}, "
+                "which is a Cloudflare IP. Cloudflare does not proxy SSH (port 22), "
+                "so deploys will fail with connection timeout.\n"
+                "Use the direct VPS IP address instead of the proxied domain.\n"
+                "Check your hosting provider's dashboard for the origin server IP."
+            ),
+        }
+        print(json.dumps(result))
+        sys.exit(2)
+
+    if warnings:
+        result = {
+            "decision": "allow",
+            "systemMessage": "\n".join(warnings),
+        }
+        print(json.dumps(result))
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/validate_wave_context.py
+++ b/.claude/hooks/validate_wave_context.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: Warn when agents are spawned without wave context.
+
+Checks for an active wave marker in cross-repo-status.json. If no active wave
+is found, emits a warning (does not block).
+
+Exit codes:
+  0 — always allow (warning only)
+"""
+
+import json
+from pathlib import Path
+import sys
+
+_STATUS_PATH = Path(__file__).resolve().parent.parent.parent / "cross-repo-status.json"
+
+
+def has_active_wave() -> bool:
+    """Check if cross-repo-status.json indicates an active wave."""
+    try:
+        data = json.loads(_STATUS_PATH.read_text(encoding="utf-8"))
+        # Check for explicit wave_active marker
+        if data.get("wave_active"):
+            return True
+        if data.get("current_wave"):
+            return True
+        return False
+    except (FileNotFoundError, json.JSONDecodeError, KeyError):
+        return False
+
+
+def main() -> None:
+    try:
+        input_data = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        sys.exit(0)
+
+    tool_name = input_data.get("tool_name", "")
+    if tool_name != "Agent":
+        sys.exit(0)
+
+    if has_active_wave():
+        sys.exit(0)
+
+    result = {
+        "decision": "allow",
+        "systemMessage": (
+            "WARNING: No active wave context detected in cross-repo-status.json. "
+            "Run `/wave-kickoff` to set up wave context before spawning agents. "
+            "Proceeding without wave context means retros, trust updates, and "
+            "charter enforcement may be skipped."
+        ),
+    }
+    print(json.dumps(result))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/warn_ghcr_image.py
+++ b/.claude/hooks/warn_ghcr_image.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: Warn if GHCR image may not exist before deploy.
+
+Warns (does not block) when `gh workflow run` triggers a deploy-related workflow
+and the expected GHCR image might not exist.
+
+Exit codes:
+  0 — always allow (this is a warning-only hook)
+"""
+
+import json
+import re
+import subprocess
+import sys
+
+# Deploy-related workflow names/files
+DEPLOY_PATTERNS = re.compile(
+    r"deploy|release|cd[.-]|deliver", re.IGNORECASE
+)
+
+# Map of repo short names to GHCR image paths
+REPO_IMAGE_MAP = {
+    "noorinalabs-isnad-graph": "ghcr.io/noorinalabs/noorinalabs-isnad-graph",
+    "noorinalabs-landing-page": "ghcr.io/noorinalabs/noorinalabs-landing-page",
+    "noorinalabs-design-system": "ghcr.io/noorinalabs/noorinalabs-design-system",
+    "noorinalabs-isnad-graph-ingestion": "ghcr.io/noorinalabs/noorinalabs-isnad-graph-ingestion",
+}
+
+
+def check_ghcr_image(image: str, tag: str = "latest") -> bool:
+    """Check if a GHCR image exists via gh api."""
+    # Extract org and package name from image path
+    # ghcr.io/noorinalabs/noorinalabs-isnad-graph -> noorinalabs/noorinalabs-isnad-graph
+    parts = image.replace("ghcr.io/", "").split("/")
+    if len(parts) < 2:
+        return True  # Can't determine — assume exists
+
+    org = parts[0]
+    package = parts[1]
+
+    try:
+        result = subprocess.run(
+            [
+                "gh", "api",
+                f"orgs/{org}/packages/container/{package}/versions",
+                "--jq", ".[0].metadata.container.tags[]",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        if result.returncode != 0:
+            return True  # API error — don't warn on transient failures
+        tags = result.stdout.strip().splitlines()
+        return tag in tags or len(tags) > 0
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return True
+
+
+def extract_repo_from_command(command: str) -> str | None:
+    """Try to extract repo context from the workflow run command."""
+    # Check for -R flag
+    match = re.search(r"-R\s+[\"']?(\S+)[\"']?", command)
+    if match:
+        repo = match.group(1)
+        # noorinalabs/noorinalabs-isnad-graph -> noorinalabs-isnad-graph
+        if "/" in repo:
+            return repo.split("/")[-1]
+        return repo
+    return None
+
+
+def main() -> None:
+    try:
+        input_data = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        sys.exit(0)
+
+    tool_name = input_data.get("tool_name", "")
+    if tool_name != "Bash":
+        sys.exit(0)
+
+    command = input_data.get("tool_input", {}).get("command", "")
+
+    # Match gh workflow run
+    if not re.search(r"\bgh\s+workflow\s+run\b", command):
+        sys.exit(0)
+
+    # Check if it's a deploy-related workflow
+    if not DEPLOY_PATTERNS.search(command):
+        sys.exit(0)
+
+    repo = extract_repo_from_command(command)
+    if not repo:
+        # No repo context — generic warning
+        result = {
+            "decision": "allow",
+            "systemMessage": (
+                "WARNING: Triggering a deploy workflow. Verify the GHCR image "
+                "exists before deploying. Run the service's build workflow first "
+                "if the image hasn't been published."
+            ),
+        }
+        print(json.dumps(result))
+        sys.exit(0)
+
+    image = REPO_IMAGE_MAP.get(repo)
+    if not image:
+        sys.exit(0)
+
+    if not check_ghcr_image(image):
+        result = {
+            "decision": "allow",
+            "systemMessage": (
+                f"WARNING: GHCR image {image}:latest may not exist. "
+                "The deploy may fail. Run the service's build workflow first.\n"
+                f"Check: gh api orgs/noorinalabs/packages/container/{repo}/versions"
+            ),
+        }
+        print(json.dumps(result))
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 /home/parameterization/code/noorinalabs_main/.claude/hooks/validate_commit_identity.py",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_commit_identity.py",
             "timeout": 10
           }
         ]
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 /home/parameterization/code/noorinalabs_main/.claude/hooks/block_no_verify.py",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/block_no_verify.py",
             "timeout": 10
           }
         ]
@@ -26,7 +26,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 /home/parameterization/code/noorinalabs_main/.claude/hooks/block_git_config.py",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/block_git_config.py",
             "timeout": 10
           }
         ]
@@ -36,7 +36,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 /home/parameterization/code/noorinalabs_main/.claude/hooks/auto_set_env_test.py",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/auto_set_env_test.py",
             "timeout": 10
           }
         ]
@@ -46,8 +46,68 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 /home/parameterization/code/noorinalabs_main/.claude/hooks/validate_labels.py",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_labels.py",
             "timeout": 30
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_lockfile_paths.py",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_pr_review.py",
+            "timeout": 30
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_branch_freshness.py",
+            "timeout": 30
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_vps_host.py",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/warn_ghcr_image.py",
+            "timeout": 15
+          }
+        ]
+      },
+      {
+        "matcher": "Agent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_wave_context.py",
+            "timeout": 10
           }
         ]
       }

--- a/.claude/team/charter/hooks.md
+++ b/.claude/team/charter/hooks.md
@@ -36,3 +36,46 @@ The following charter rules are enforced automatically via Claude Code hooks in 
 - **Augments:** The label hygiene section. The manual rule to run `gh label list` first is now enforced automatically.
 - **Manual steps remaining:** None — the hook fetches labels and validates automatically.
 - **Emergency override:** Remove the hook entry from `.claude/settings.json`. If `gh label list` is unavailable (network issue), the hook allows the command with a warning.
+
+## Hook 6: Validate Lockfile Paths (`validate_lockfile_paths.py`)
+
+- **What it automates:** Blocks `git commit` if any staged `package-lock.json` contains `/tmp/` or `file:/` paths — local worktree artifacts that break CI.
+- **Augments:** CI reliability. Session 4 had a Playwright PR with `/tmp/noorinalabs-design-system-0.0.1.tgz` baked into the lockfile.
+- **Manual steps remaining:** None — the hook scans staged lockfiles automatically.
+- **Emergency override:** Remove the hook entry from `.claude/settings.json`.
+
+## Hook 7: Validate PR Review (`validate_pr_review.py`)
+
+- **What it automates:** Blocks `gh pr merge` unless the PR has at least one review from a non-author. Enforces the charter's peer review requirement.
+- **Augments:** [Pull Requests](pull-requests.md) review requirements. Session 4 saw all PR reviews skipped across 3 waves.
+- **Manual steps remaining:** None — the hook queries `gh pr view` for reviews automatically. Use `--admin` flag for emergency overrides.
+- **Emergency override:** Pass `--admin` to `gh pr merge`, or remove the hook entry.
+
+## Hook 8: Validate Branch Freshness (`validate_branch_freshness.py`)
+
+- **What it automates:** Blocks `gh pr create` if the feature branch is behind the base branch. Prevents merge conflicts from stale branches.
+- **Augments:** [Branching](branching.md) workflow. Session 4 had RBAC and session hardening PRs conflict because neither was rebased.
+- **Manual steps remaining:** None — the hook runs `git fetch` and `git merge-base --is-ancestor` automatically.
+- **Emergency override:** Remove the hook entry from `.claude/settings.json`.
+
+## Hook 9: Validate VPS_HOST (`validate_vps_host.py`)
+
+- **What it automates:** Blocks `gh variable set VPS_HOST` if the value resolves to a Cloudflare IP range. Also warns if a hostname is used instead of a direct IP.
+- **Augments:** Deployment safety. Session 4 had VPS_HOST set to a Cloudflare-proxied domain, causing SSH timeout on deploy.
+- **Manual steps remaining:** None — the hook resolves the hostname and checks against known Cloudflare ranges.
+- **Emergency override:** Remove the hook entry from `.claude/settings.json`.
+
+## Hook 10: Warn GHCR Image (`warn_ghcr_image.py`)
+
+- **What it automates:** Warns (does not block) when `gh workflow run` triggers a deploy-related workflow and the expected GHCR image may not exist.
+- **Augments:** Deployment safety. Session 4 had deploy-all triggered before the landing page GHCR image was built.
+- **Manual steps remaining:** None — the hook checks `gh api` for the image. This is a warning only since deploy workflows sometimes build the image.
+- **Emergency override:** Not needed (warning only). Remove the hook entry to suppress.
+
+## Hook 11: Validate Wave Context (`validate_wave_context.py`)
+
+- **What it automates:** Warns when agents are spawned without an active wave context in `cross-repo-status.json`. Ensures `/wave-kickoff` is run before agent work begins.
+- **Augments:** [Agent Lifecycle](agents.md) wave management. Session 4 had the orchestrator bypass the team structure entirely.
+- **Matcher:** `Agent` (not `Bash`) — fires on Agent tool calls.
+- **Manual steps remaining:** Run `/wave-kickoff` to set the wave context. The hook is a warning, not a block.
+- **Emergency override:** Not needed (warning only). Remove the hook entry to suppress.


### PR DESCRIPTION
## Summary

- **6 new hooks** in `.claude/hooks/` registered in `settings.json`:
  - `validate_lockfile_paths.py` — blocks commits with local `/tmp/` or `file:/` paths in `package-lock.json` (#8)
  - `validate_pr_review.py` — requires peer review before `gh pr merge` (#9)
  - `validate_branch_freshness.py` — blocks `gh pr create` when branch is behind base (#10)
  - `validate_vps_host.py` — blocks `VPS_HOST` set to Cloudflare IP range (#11)
  - `warn_ghcr_image.py` — warns on deploy workflow if GHCR image may not exist (#12)
  - `validate_wave_context.py` — warns on Agent spawn without active wave context (#18)

- **Workflow plugin** at `~/.claude/plugins/.../noorinalabs-workflow/` with 5 slash commands:
  - `/retro` — automated wave retrospective (#13)
  - `/new-service-deploy` — deployment checklist walkthrough (#14)
  - `/wave-kickoff` — automated wave startup from project board (#15)
  - `/wave-wrapup` — end-of-wave automation with worktree lock cleanup (#16, #19)
  - `/trust-update` — trust matrix and roster card updates (#17)

- **Charter docs** updated in `charter/hooks.md` with all new hooks

## Notes

- Plugin is installed outside the repo at `~/.claude/plugins/`. Claude Code restart needed for `/commands` to appear.
- Worktree lock management (#19) is integrated into `/wave-wrapup` (stale lock detection, 20-min timeout, prune after agent shutdown). Charter already documents the mechanism in `charter/agents.md`.

## Test plan

- [ ] Verify each hook blocks/warns correctly with sample input
- [ ] Verify `/wave-kickoff`, `/retro`, `/wave-wrapup`, `/trust-update`, `/new-service-deploy` appear in `/help` after restart
- [ ] Run a test wave cycle to validate end-to-end flow

Closes #8, Closes #9, Closes #10, Closes #11, Closes #12, Closes #13, Closes #14, Closes #15, Closes #16, Closes #17, Closes #18, Closes #19