### PR TITLE
fix: Branch freshness hook respects worktree CWD

### DIFF
--- a/.claude/hooks/validate_branch_freshness.py
+++ b/.claude/hooks/validate_branch_freshness.py
@@ -22,19 +22,60 @@ def get_base_branch(command: str) -> str:
     return "main"
 
 
-def is_branch_fresh(base: str) -> bool:
-    """Check if HEAD contains the latest commit from origin/base."""
+def extract_cwd_from_command(command: str) -> str | None:
+    """Extract the working directory from a command with a leading 'cd <dir> &&'.
+
+    Worktree agents commonly prefix commands with 'cd /tmp/agent-name &&'.
+    This function detects that pattern and returns the target directory.
+    """
+    match = re.match(r"cd\s+([^\s;|&]+)\s*&&", command.strip())
+    if match:
+        return match.group(1).strip("\"'")
+    return None
+
+
+def resolve_git_dir(cwd: str | None = None) -> str | None:
+    """Resolve the git toplevel directory, respecting worktree context.
+
+    If cwd is provided, runs git from that directory. Otherwise uses
+    the process CWD. Returns the toplevel path or None on failure.
+    """
     try:
+        cmd = ["git"]
+        if cwd:
+            cmd.extend(["-C", cwd])
+        cmd.extend(["rev-parse", "--show-toplevel"])
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=10,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+        return None
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return None
+
+
+def is_branch_fresh(base: str, git_dir: str | None = None) -> bool:
+    """Check if HEAD contains the latest commit from origin/base.
+
+    When git_dir is provided, all git commands run with -C <git_dir>
+    to respect worktree context.
+    """
+    try:
+        git_prefix = ["git"]
+        if git_dir:
+            git_prefix.extend(["-C", git_dir])
+
         # Fetch latest from origin
         subprocess.run(
-            ["git", "fetch", "origin", base],
+            [*git_prefix, "fetch", "origin", base],
             capture_output=True,
             text=True,
             timeout=30,
         )
         # Check if origin/base is an ancestor of HEAD
         result = subprocess.run(
-            ["git", "merge-base", "--is-ancestor", f"origin/{base}", "HEAD"],
+            [*git_prefix, "merge-base", "--is-ancestor", f"origin/{base}", "HEAD"],
             capture_output=True,
             text=True,
             timeout=10,
@@ -62,7 +103,12 @@ def main() -> None:
 
     base = get_base_branch(command)
 
-    if is_branch_fresh(base):
+    # Detect worktree CWD: check for 'cd <dir> &&' prefix in the command,
+    # then resolve the git toplevel from that directory.
+    cmd_cwd = extract_cwd_from_command(command)
+    git_dir = resolve_git_dir(cmd_cwd)
+
+    if is_branch_fresh(base, git_dir=git_dir):
         sys.exit(0)
 
     result = {


### PR DESCRIPTION
## Summary
- Adds `extract_cwd_from_command()` to detect `cd <dir> &&` prefixes in worktree agent commands
- Adds `resolve_git_dir()` using `git rev-parse --show-toplevel` with `-C` for worktree context
- All git operations in `is_branch_fresh()` now run with `-C <git_dir>` when a worktree directory is detected
- Prevents false positives/skipped checks when hook runs from main repo root instead of worktree

## Related Issues
Closes #63

## Review Checklist
- [ ] Reviewed by another team member
- [ ] Must-fix items resolved
- [ ] Tech debt items filed as GitHub Issues (if any)

Co-Authored-By: Wanjiku Mwangi <parametrization+Wanjiku.Mwangi@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>