### PR TITLE
process: Formalize release tagging cadence

### DIFF
--- a/.claude/skills/wave-wrapup/SKILL.md
+++ b/.claude/skills/wave-wrapup/SKILL.md
@@ -185,7 +185,51 @@ gh pr create --base main --head "deployments/phase{P}/wave-{M}" \
 
 **Do NOT merge to main without user approval.** This is a significant action that affects all downstream repos.
 
-### 12. Memory-to-automation audit
+### 12. Release tagging (mandatory)
+
+**After all PRs are merged**, create release tags for every repo that had changes in this wave. This is a mandatory step — missing tags means missing GHCR images and deploy failures.
+
+**Tag format:**
+- Wave releases: `phase{P}-wave{M}` (e.g., `phase2-wave1`)
+- Milestone releases: `v{major}.{minor}.{patch}` (semver)
+
+**Process:**
+
+1. **Identify repos with changes** — check which repos had PRs merged in this wave:
+   ```bash
+   # For each repo, check if it had PRs merged with the wave label
+   gh pr list --state merged --label "p{P}-wave-{M}" --repo noorinalabs/{repo} --json number,title
+   ```
+
+2. **Create tags** for each repo with changes:
+   ```bash
+   # Tag from the deployment branch (intermediate waves) or main (final wave)
+   gh release create "phase{P}-wave{M}" --repo noorinalabs/{repo} \
+       --title "Phase {P} Wave {M}" \
+       --notes "Wave release. See merged PRs for details." \
+       --target {branch}
+   ```
+
+3. **Verify GHCR images** — for repos with publish-on-tag workflows, confirm the image was built:
+   ```bash
+   gh api orgs/noorinalabs/packages/container/{repo}/versions --jq '.[0].metadata.container.tags[]'
+   ```
+
+4. **Report tagging results:**
+   ```
+   **Release Tags: Phase {P} Wave {M}**
+
+   | Repo | Tag | GHCR Image | Status |
+   |------|-----|------------|--------|
+   | isnad-graph | phase2-wave1 | ghcr.io/noorinalabs/isnad-graph:phase2-wave1 | Published |
+   | deploy | phase2-wave1 | N/A | Tagged |
+   ```
+
+**Owner:** Santiago Ferreira (Release Coordinator) executes this step. If Santiago is not available, the orchestrator delegates to another team member.
+
+**Why:** In Phase 1, 8 days of work went untagged. No tags means no GHCR images, which blocked the user-service production deploy. This step prevents that failure mode.
+
+### 13. Memory-to-automation audit
 
 Examine all memory files in the project memory directory for entries that describe behaviors, rules, or patterns that could be codified as a **hook**, **skill**, or **charter update** instead of remaining as soft memory.
 

--- a/.claude/team/charter/branching.md
+++ b/.claude/team/charter/branching.md
@@ -27,6 +27,38 @@ deployments/phase{N}/wave-{M}
   ```
   Resolve any conflicts before pushing and creating the PR.
 
+## Release Tagging Cadence
+
+**Tags are created at the end of every wave** — after all PRs are merged but before the retro. Missing tags means missing GHCR images and deploy failures.
+
+### Tag Format
+
+| Context | Format | Example |
+|---------|--------|---------|
+| Wave release | `phase{N}-wave{M}` | `phase2-wave1` |
+| Milestone release | `v{major}.{minor}.{patch}` | `v1.2.0` |
+
+### Rules
+
+1. **Every repo that had changes in the wave gets a tag.** Check merged PRs by wave label.
+2. **Tags are created via `gh release create`** — this triggers GHCR publish workflows for repos that have them.
+3. **Santiago Ferreira (Release Coordinator) owns tagging.** If unavailable, the orchestrator delegates.
+4. **The `/wave-wrapup` skill includes tagging as step 12** — it is mandatory, not optional.
+5. **Verify GHCR images were published** after tagging repos with publish-on-tag workflows.
+
+### Repos Requiring Tags
+
+| Repo | Has GHCR Publish? | Notes |
+|------|-------------------|-------|
+| `noorinalabs-isnad-graph` | Yes | Publishes on tag push |
+| `noorinalabs-isnad-graph-ingestion` | No | No container image |
+| `noorinalabs-deploy` | No | Config only, tag for versioning |
+| `noorinalabs-design-system` | No | NPM package, not containerized |
+| `noorinalabs-landing-page` | Yes | Publishes on tag push |
+| `noorinalabs-main` | No | Org config, tag for versioning |
+
+Failing to tag at wave end is a **minor feedback event** for the Release Coordinator.
+
 ## Worktree Cleanup
 
 **After every wave completes** (all PRs merged into the deployments branch), clean up stale worktrees:


### PR DESCRIPTION
## Summary
- Adds mandatory release tagging step (step 12) to `/wave-wrapup` skill
- Tags created for every repo with changes in the wave using `phase{N}-wave{M}` format
- Adds Release Tagging Cadence section to branching charter with format table, rules, and repo requirements
- Santiago Ferreira designated as tag owner; missing tags is a minor feedback event

## Related Issues
Closes #59

## Review Checklist
- [ ] Reviewed by another team member
- [ ] Must-fix items resolved
- [ ] Tech debt items filed as GitHub Issues (if any)

Co-Authored-By: Santiago Ferreira <parametrization+Santiago.Ferreira@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>