### PR TITLE
fix: Resolve ruff I001 import sorting violations

### DIFF
--- a/.claude/hooks/validate_commit_identity.py
+++ b/.claude/hooks/validate_commit_identity.py
@@ -10,9 +10,9 @@ Exit codes:
 """
 
 import json
-from pathlib import Path
 import re
 import sys
+from pathlib import Path
 
 # Load roster from shared JSON file — single source of truth for all hooks
 _ROSTER_PATH = Path(__file__).resolve().parent.parent / "team" / "roster.json"

--- a/.claude/hooks/validate_wave_context.py
+++ b/.claude/hooks/validate_wave_context.py
@@ -9,8 +9,8 @@ Exit codes:
 """
 
 import json
-from pathlib import Path
 import sys
+from pathlib import Path
 
 _STATUS_PATH = Path(__file__).resolve().parent.parent.parent / "cross-repo-status.json"
 


### PR DESCRIPTION
## Summary
- Fix ruff I001 import sorting violations in `validate_commit_identity.py` and `validate_wave_context.py`
- These pre-existing violations were exposed by the hooks CI workflow (PR #72), causing CI to be red on main

## Related Issues
Closes #79

## Review Checklist
- [ ] Reviewed by another team member
- [ ] Must-fix items resolved
- [ ] Tech debt items filed as GitHub Issues (if any)

Co-Authored-By: Wanjiku Mwangi <parametrization+Wanjiku.Mwangi@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>