### PR TITLE
fix(hooks): resolve ruff lint and format errors in session_start.py

### DIFF
--- a/.claude/hooks/session_start.py
+++ b/.claude/hooks/session_start.py
@@ -30,7 +30,8 @@ def _ontology_staleness() -> tuple[int, int]:
         # Nested format: {version, description, files: {...}}
         data = data.get("files", data)
         dirty = sum(
-            1 for v in data.values()
+            1
+            for v in data.values()
             if isinstance(v, dict) and v.get("last_tracked") != v.get("last_resolved")
         )
         return dirty, len(data)
@@ -123,7 +124,7 @@ def main() -> None:
         lines.append(f"  Current ({dirty}/{total} dirty). No action needed.")
     else:
         lines.append(f"  DIRTY: {dirty}/{total} files need rebuild.")
-        lines.append(f"  ACTION: Run /ontology-rebuild NOW.")
+        lines.append("  ACTION: Run /ontology-rebuild NOW.")
     lines.append("")
 
     # Step 4: Annunaki errors
@@ -146,7 +147,10 @@ def main() -> None:
         lines.append(f"  Status from cross-repo-status.json: {wave_info}")
     else:
         lines.append("  cross-repo-status.json not found or unreadable.")
-    lines.append("  Run: gh issue list --repo noorinalabs/noorinalabs-main --state open --limit 10 --json number,title,labels")
+    lines.append(
+        "  Run: gh issue list --repo noorinalabs/noorinalabs-main --state open"
+        " --limit 10 --json number,title,labels"
+    )
     lines.append("  Establish current phase and open work items.")
     lines.append("")
 


### PR DESCRIPTION
## Summary

`CI — Hooks & Scripts` has been red on `main` since the session_start hook landed. Three jobs were failing:

- **Ruff lint**: `F541` f-string without placeholders (line 126); `E501` line too long (line 149: 127 > 100).
- **Ruff format check**: ruff format wanted to reformat the file.
- **Mypy / Smoke**: passing — not touched.

This PR fixes the lint and format errors with no logic change. Diff is 7 lines.

## What changed

- Drop the bare `f` prefix on `f"  ACTION: Run /ontology-rebuild NOW."` (no placeholders, F541).
- Split the long `gh issue list` reminder line across two strings (E501).
- Allow ruff format to normalize a generator expression in `_ontology_staleness` (cosmetic, format-only).

## What this PR is NOT

Not a fix to the hook bugs filed under #113 (validate_labels) and #114 (auto_set_env_test). Those are tracked for **Wave 9**. This PR is strictly the lint/format hygiene the W8 CI sweep (#111) requires to get main green.

## Verification (local)

- ruff check .claude/hooks/         — All checks passed!
- ruff format --check .claude/hooks/ — 23 files already formatted

CI will be re-validated on this PR — must be green before review.

## TechDebt

None new from this PR. Hook design issues remain in #113 / #114, untouched here.

Refs noorinalabs/noorinalabs-main#111

## Test plan

- [x] Local ruff check passes
- [x] Local ruff format check passes
- [ ] CI: Ruff lint, Ruff format check, Mypy type check, Smoke test all green on this PR
- [ ] Hook still emits its directives at session start (cosmetic-only change, no functional regression expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)