### PR TITLE
hook: Block gh pr merge when CI is not green (#109)

### DIFF
--- a/.claude/hooks/dispatcher.py
+++ b/.claude/hooks/dispatcher.py
@@ -36,6 +36,7 @@ _BASH_HOOKS = [
     "validate_labels",
     "validate_review_comment_format",
     "validate_pr_review",
+    "validate_pr_ci_status",
     "validate_branch_freshness",
     "validate_vps_host",
     "warn_ghcr_image",

--- a/.claude/hooks/validate_pr_ci_status.py
+++ b/.claude/hooks/validate_pr_ci_status.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: Block `gh pr merge` if CI is not green.
+
+Queries `gh pr view --json statusCheckRollup` and blocks merge when any
+required check has failed, been cancelled, timed out, or requires action.
+Pending checks block unless the user passes `--auto` (warn-but-allow).
+
+Exit codes:
+  0 — allow (not a merge command, --admin override, or all checks green)
+  2 — block (failing or pending checks without --auto)
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from annunaki_log import log_pretooluse_block
+
+# Conclusion values that unambiguously indicate a failed check.
+_FAILURE_CONCLUSIONS = {
+    "FAILURE",
+    "CANCELLED",
+    "TIMED_OUT",
+    "ACTION_REQUIRED",
+    "STARTUP_FAILURE",
+}
+
+# Status values that indicate the check has not finished yet.
+_PENDING_STATUSES = {"QUEUED", "IN_PROGRESS", "WAITING", "PENDING", "REQUESTED"}
+
+# Bucket values (GitHub check rollup) that map to pass/fail.
+_FAIL_BUCKETS = {"fail"}
+_PASS_BUCKETS = {"pass", "skipping"}
+
+
+def is_merge_command(command: str) -> bool:
+    """Check if the command is a gh pr merge invocation, including chained commands."""
+    for segment in re.split(r"\s*(?:&&|\|\||\||;)\s*", command):
+        stripped = segment.lstrip()
+        while re.match(r"[A-Za-z_][A-Za-z0-9_]*=\S*\s+", stripped):
+            stripped = re.sub(r"^[A-Za-z_][A-Za-z0-9_]*=\S*\s+", "", stripped)
+        if re.match(r"gh\s+pr\s+merge\b", stripped):
+            return True
+    return False
+
+
+def extract_pr_number(command: str) -> str | None:
+    """Extract PR number from gh pr merge command."""
+    match = re.search(r"\bgh\s+pr\s+merge\s+(\d+)", command)
+    if match:
+        return match.group(1)
+    match = re.search(r"/pull/(\d+)", command)
+    if match:
+        return match.group(1)
+    return None
+
+
+def extract_repo_from_command(command: str) -> str | None:
+    """Extract --repo value from gh pr merge command."""
+    match = re.search(r"--repo\s+(\S+)", command)
+    if match:
+        return match.group(1)
+    return None
+
+
+def fetch_checks(pr_number: str | None, repo: str | None) -> list[dict] | None:
+    """Fetch statusCheckRollup entries for the PR. Returns None on failure."""
+    try:
+        cmd = ["gh", "pr", "view"]
+        if pr_number:
+            cmd.append(pr_number)
+        if repo:
+            cmd.extend(["--repo", repo])
+        cmd.extend(["--json", "statusCheckRollup"])
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        if result.returncode != 0:
+            return None
+        data = json.loads(result.stdout)
+        rollup = data.get("statusCheckRollup", [])
+        if not isinstance(rollup, list):
+            return None
+        return rollup
+    except (subprocess.TimeoutExpired, json.JSONDecodeError, FileNotFoundError):
+        return None
+
+
+def classify_check(check: dict) -> str:
+    """Return 'fail', 'pending', or 'pass' for a single check entry."""
+    bucket = (check.get("bucket") or "").lower()
+    conclusion = (check.get("conclusion") or "").upper()
+    status = (check.get("status") or check.get("state") or "").upper()
+
+    if bucket in _FAIL_BUCKETS or conclusion in _FAILURE_CONCLUSIONS:
+        return "fail"
+    if status in _PENDING_STATUSES or conclusion == "":
+        # Completed with no conclusion is treated as success; truly pending
+        # checks have status != COMPLETED.
+        if status == "COMPLETED":
+            return "pass"
+        return "pending"
+    if bucket in _PASS_BUCKETS or conclusion in {"SUCCESS", "NEUTRAL", "SKIPPED"}:
+        return "pass"
+    return "pass"
+
+
+def check_name(check: dict) -> str:
+    """Best-effort display name for a check."""
+    return check.get("name") or check.get("context") or check.get("workflowName") or "<unnamed>"
+
+
+def check_url(check: dict) -> str:
+    """Best-effort URL for a check."""
+    return check.get("detailsUrl") or check.get("targetUrl") or ""
+
+
+def format_check_list(checks: list[dict]) -> str:
+    lines = []
+    for c in checks:
+        name = check_name(c)
+        conclusion = (c.get("conclusion") or c.get("status") or "").lower() or "unknown"
+        url = check_url(c)
+        suffix = f" ({url})" if url else ""
+        lines.append(f"  - {name} [{conclusion}]{suffix}")
+    return "\n".join(lines)
+
+
+def check(input_data: dict) -> dict | None:
+    """Check PR CI status. Returns result dict if blocking, None if allowed."""
+    tool_name = input_data.get("tool_name", "")
+    if tool_name != "Bash":
+        return None
+
+    command = input_data.get("tool_input", {}).get("command", "")
+
+    if not is_merge_command(command):
+        return None
+
+    if "--admin" in command:
+        return None
+
+    pr_number = extract_pr_number(command)
+    repo = extract_repo_from_command(command)
+    rollup = fetch_checks(pr_number, repo)
+
+    pr_display = f"#{pr_number}" if pr_number else "(current branch)"
+
+    if rollup is None:
+        return {
+            "decision": "allow",
+            "systemMessage": (
+                f"WARNING: Could not verify CI status for PR {pr_display}. "
+                "Ensure all checks are green before merging."
+            ),
+        }
+
+    if not rollup:
+        # No checks at all — allow (nothing to gate on).
+        return None
+
+    failing: list[dict] = []
+    pending: list[dict] = []
+    for entry in rollup:
+        verdict = classify_check(entry)
+        if verdict == "fail":
+            failing.append(entry)
+        elif verdict == "pending":
+            pending.append(entry)
+
+    if failing:
+        result = {
+            "decision": "block",
+            "reason": (
+                f"BLOCKED: PR {pr_display} has {len(failing)} failing CI check(s). "
+                "Charter § Pull Requests requires green CI before merge.\n"
+                f"Failing checks:\n{format_check_list(failing)}\n\n"
+                "Fix the failures and re-run, or pass `--admin` for emergency overrides only."
+            ),
+        }
+        log_pretooluse_block("validate_pr_ci_status", command, result["reason"])
+        return result
+
+    if pending:
+        if "--auto" in command:
+            return {
+                "decision": "allow",
+                "systemMessage": (
+                    f"WARNING: PR {pr_display} has {len(pending)} pending CI check(s); "
+                    "`--auto` will let GitHub merge when they finish.\n"
+                    f"{format_check_list(pending)}"
+                ),
+            }
+        result = {
+            "decision": "block",
+            "reason": (
+                f"BLOCKED: PR {pr_display} has {len(pending)} pending CI check(s). "
+                "Wait for CI to finish, pass `--auto` to let GitHub merge on green, "
+                "or pass `--admin` for emergency overrides.\n"
+                f"Pending checks:\n{format_check_list(pending)}"
+            ),
+        }
+        log_pretooluse_block("validate_pr_ci_status", command, result["reason"])
+        return result
+
+    return None
+
+
+def main() -> None:
+    try:
+        input_data = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        sys.exit(0)
+
+    result = check(input_data)
+    if result is None:
+        sys.exit(0)
+    print(json.dumps(result))
+    if result.get("decision") == "block":
+        sys.exit(2)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/team/charter/hooks.md
+++ b/.claude/team/charter/hooks.md
@@ -133,3 +133,10 @@ When hooks sharing the same matcher type (Bash, Agent, SendMessage, etc.) accumu
 - **Augments:** Cross-Repo Wave Plan § Board Maintenance Rules — "New issues created during a wave must be added to the board immediately."
 - **Manual steps remaining:** None — fully automated.
 - **Emergency override:** Remove the hook entry from `.claude/settings.json`.
+
+## Hook 14: Validate PR CI Status (`validate_pr_ci_status.py`)
+
+- **What it automates:** Blocks `gh pr merge` when any CI check on the PR is failing, cancelled, timed out, or requires action. Pending checks also block unless the user passes `--auto` (let GitHub auto-merge on green). Queries `gh pr view --json statusCheckRollup`; supports the `--repo` flag.
+- **Augments:** [Pull Requests](pull-requests.md) "green CI before merge" requirement. Phase 2 Wave 7 merged multiple PRs with red `security-audit`, `e2e`, and `test_migrate_users.py` checks despite the charter rule. Per the enforcement-hierarchy principle (hook > skill > charter), a repeatedly violated charter rule becomes a hook.
+- **Manual steps remaining:** None — the hook queries `gh pr view` for the check rollup automatically.
+- **Emergency override:** Pass `--admin` to `gh pr merge`, or remove the `validate_pr_ci_status` entry from the dispatcher hook list.


### PR DESCRIPTION
## Summary

New PreToolUse Bash hook `validate_pr_ci_status.py`, registered in `dispatcher.py`, that blocks `gh pr merge` when a PR has non-green CI.

Closes #109. Unblocked by #111 (CI sweep — #115, #56, #60, #811 all merged to main earlier today).

## Design

- **Data source:** `gh pr view --json statusCheckRollup`. The issue originally specified `gh pr checks --json`, but that flag does not exist; `statusCheckRollup` is the working path and provides `status`, `conclusion`, `name`, and `detailsUrl` per check.
- **Block on:** `conclusion` in `{FAILURE, CANCELLED, TIMED_OUT, ACTION_REQUIRED, STARTUP_FAILURE}` or `bucket` == `fail`.
- **Pending (`QUEUED` / `IN_PROGRESS` / `WAITING` / `REQUESTED` / no conclusion on non-`COMPLETED` status):** blocks by default; warn-and-allow with `--auto` (lets GitHub merge when CI goes green).
- **`--admin`:** emergency override, consistent with Hook 7 (`validate_pr_review.py`).
- **`--repo` flag:** honoured. PR number extracted from `gh pr merge <N>` or `/pull/<N>` URLs.
- **Dispatcher integration:** added to `_BASH_HOOKS` in `dispatcher.py` after `validate_pr_review` — no new `.claude/settings.json` entry, per the dispatcher consolidation policy in `charter/hooks.md`.
- **Logging:** block events pushed to Annunaki via `log_pretooluse_block` (matches pattern in `validate_pr_review.py` / `validate_branch_freshness.py`).
- **Fail-open:** if `gh pr view` fails or times out, emit a WARNING systemMessage and allow — consistent with `validate_pr_review.py` behaviour.

## Rationale

Per memory note `feedback_enforcement_hierarchy.md`: "Prefer hook > skill > charter." P2W7 merged PRs with red `security-audit` (CVE-2026-39892), red `e2e` (design-system tgz path), and red `test_migrate_users.py` (`ModuleNotFoundError: neo4j`) despite the charter's green-CI rule. Repeat charter violation → promote to hook.

## Test plan

- [x] Green PR (#115, all four checks SUCCESS) → allowed (`check()` returned `None`).
- [x] Red PR (#73, two FAILURE checks for ruff lint and ruff format) → blocked with exit code 2 from the dispatcher, both checks listed with their GitHub Actions URLs.
- [x] Red PR with `--admin` → allowed.
- [x] Pending checks via mocked rollup → blocked without `--auto`, allowed with `--auto` as a warning.
- [x] Non-merge command (`gh pr list`) → allowed.
- [x] `classify_check` unit cases for SUCCESS / FAILURE / CANCELLED / TIMED_OUT / ACTION_REQUIRED / IN_PROGRESS / QUEUED / bucket=fail / bucket=pass / NEUTRAL / SKIPPED → all correct.
- [x] `ruff check` — clean.
- [x] `ruff format --check` — clean.
- [x] `mypy .claude/hooks/ --ignore-missing-imports --no-error-summary` (same flags as CI) — clean.

## Charter

Hook 14 entry added to `.claude/team/charter/hooks.md`, following the format of Hooks 7-13.

## Reviewers

Requesting two reviews per charter § Pull Requests — the wave-bootstrap single-reviewer exception does not apply here.
- Nadia Khoury (Program Director)
- Santiago Ferreira (Release Coordinator)