### PR TITLE
retro: Phase 2 Wave 8 retrospective (CI Hygiene)

### DIFF
--- a/.claude/team/feedback_log.md
+++ b/.claude/team/feedback_log.md
@@ -740,3 +740,66 @@ No changes. All scores remain at current levels.
 
 ### Fire/Hire Actions
 None.
+
+---
+
+## 2026-04-17 — Phase 2 Wave 8 Retrospective
+
+**Scope:** 9 PRs merged across 5 repos. 3 issues closed (#109, #110, #111). 1 new issue filed mid-retro (#123, validate_pr_review false-positive). Theme: CI Hygiene.
+
+### Wave Highlights
+- **Wave sequencing worked as designed:** #110 (ruff format) → #111 (CI sweep) → #109 (CI gate hook). Doing #111 first shrank #109's risk of self-blocking.
+- **Enforcement-hierarchy principle validated:** #109 landed and immediately caught a real hook false-positive during its own PR's merge (`validate_pr_review` flagging the review-request comment) — filed as #123.
+- **Cross-session continuity:** wave spanned 2 sessions cleanly via session_handoff.md. All 3 team members picked back up with zero context loss.
+- **Tech-debt triage: 16 issues filed** during W8 across all repos. Pattern: 6 hook bugs (#113, #114, #118, #123 + two others), 7 infra items, 3 ops items.
+
+### Per-Engineer Assessments
+
+#### Wanjiku Mwangi (TPM) — Severity: None
+- PRs: main #115, isnad-graph #811, user-service #60, design-system #56 (#111 CI sweep across 4 repos)
+- Filed tech-debt with forensic detail: #810, #812, #54, #113, #114, #118
+- Worked around classic-Projects GraphQL deprecation via REST PATCH when `gh pr edit` failed
+- Handled retroactive breadcrumb edits cleanly when disable-with-followup rule was ratified mid-wave
+
+#### Santiago Ferreira (RC) — Severity: None
+- PRs: isnad-graph #808, user-service #58, data-acquisition #27 (#110 ruff pre-commit across 3 Python repos)
+- Hit commit-identity roster-blocker on 3 of 4 child repos — not his fault (long-term fix: #112)
+- Unblocked 4 PR merges tonight (#115, #56, #60, #811) with `--admin` per authorized exception
+
+#### Aino Virtanen (SQL) — Severity: None
+- PRs: main #122 (#109 CI gate hook implementation)
+- Proactively caught spec-discrepancy (nonexistent `gh pr checks --json bucket,name,state` flag combo), used equivalent `gh pr view --json statusCheckRollup`, documented in PR body for reviewers
+- Reviewed 7 W8 PRs as charter enforcer, all with correct TechDebt attestation format
+- Zero must-fix items received on #122
+
+#### Nadia Khoury (PD) — Severity: None
+- Reviewed PR #122 with executive-quality spec audit (dispatcher integration, Hook 7 stacking, program-level interactions)
+- Light involvement appropriate for a tightly-scoped wave
+
+#### Orchestrator — Severity: Minor
+- Spent ~30 min chasing OAuth scope migration (`read:project` → `project`) mid-retro, eating user time. Projects v2 scope enforcement should have been caught in W7.
+- Hit `validate_pr_review` false-positive on #122 merge — resolved by editing the review-request comment. Proper fix filed as #123.
+
+### Top 3 Going Well
+1. **Wave sequencing prevented self-blocking** — doing #111 (CI sweep) before #109 (CI gate hook) meant the hook didn't immediately block its own merge PR on any pre-existing red CI.
+2. **Enforcement-hierarchy validated** — the W7 principle ("charter rules without enforcement decay, promote to hooks") produced a hook that caught a real bug within minutes of landing.
+3. **Team simulation scaled cleanly** — 3 parallel implementers during #110/#111 execution, 2 parallel reviewers on #122. No collisions, no context-loss across spawn cycles.
+
+### Top 3 Pain Points
+1. **Hook substring/regex bug cluster (6 in one wave):** #113 (cwd repo), #114 (test cmd false-positives), #118 (branch freshness cwd), #110 (ontology-tracker ghost /tmp entries), #123 (validate_pr_review RequestOrReplied detection), plus pre-existing validate_labels default-limit. Systemic: hooks written without explicit input-language spec.
+2. **Disable-with-followup rule ratified mid-wave** — Wanjiku had to do retroactive breadcrumb edits across two PRs after the rule was established during #111 review. New-rule enforcement should wait for next wave boundary.
+3. **Single-reviewer exception overused** — bootstrap exception applied to all 4 #110 PRs AND all 4 #111 PRs (Aino sole reviewer). Became pattern-of-convenience rather than exception.
+4. **OAuth scope migration chased in real-time** — GitHub Projects v2 scope enforcement surfaced mid-retro, consumed ~30 min of orchestrator + user time. Should have been on W7 radar.
+
+### Proposed Process Changes
+1. **Hook authorship spec requirement** — any new hook must include explicit input-language spec (what commands/formats it matches) in docstring + charter/hooks.md entry. Rationale: fixes substring-bug cluster root cause.
+2. **W9 opens with hook-architecture mini-sprint** — bundle #113, #114, #118, #123 into a single day of hook triage before W9 main scope. Rationale: 6 hook bugs in one wave is a meta-debt signal.
+3. **Single-reviewer exception — formalize or drop** — wave-bootstrap PRs ONLY, one-time per wave, logged in retro. Otherwise require 2 reviewers per charter. Rationale: W8 used it 8 times; that's not an exception anymore.
+4. **Disable-with-followup rule → charter** — move `feedback_disable_followup_load_bearing` memory into charter § Pull Requests as ratified rule. Rationale: memory is session-scoped; charter is authoritative.
+5. **Pre-wave auth/scope audit step in /wave-kickoff** — verify gh token scopes against wave's expected operations. Rationale: Projects v2 scope gap was catchable.
+
+### Trust Updates
+No changes. All scores stable. See trust_matrix.md § Phase 2 Wave 8.
+
+### Fire/Hire Actions
+None.

--- a/ontology/checksums.json
+++ b/ontology/checksums.json
@@ -307,6 +307,24 @@
       "last_resolved": "b8ca5cc2f951054d287dd600c4eab104311e56dd4987bece91bb7e697855e27c",
       "tracked_at": "2026-04-16T21:36:05.052302+00:00",
       "resolved_at": "2026-04-16T21:36:05.052302+00:00"
+    },
+    ".claude/hooks/validate_pr_ci_status.py": {
+      "last_tracked": "ff4c0c20785a0a014013388070b9c009632a3da2c15fd4e34c0e44e5b6e62ce9",
+      "last_resolved": "ff4c0c20785a0a014013388070b9c009632a3da2c15fd4e34c0e44e5b6e62ce9",
+      "tracked_at": "2026-04-17T01:04:35.934020+00:00",
+      "resolved_at": "2026-04-17T02:37:52.367305+00:00"
+    },
+    ".claude/hooks/dispatcher.py": {
+      "last_tracked": "f550dd83a45a65b26a26193c2215b13d6196c3118ccf6437141009cc29bcca54",
+      "last_resolved": "f550dd83a45a65b26a26193c2215b13d6196c3118ccf6437141009cc29bcca54",
+      "tracked_at": "2026-04-17T01:04:35.138954+00:00",
+      "resolved_at": "2026-04-17T02:37:52.367305+00:00"
+    },
+    ".claude/team/charter/hooks.md": {
+      "last_tracked": "701d9b0500f6c4158ecd9dce79e02ca8677082c7e845d57a35ca232615799eda",
+      "last_resolved": "701d9b0500f6c4158ecd9dce79e02ca8677082c7e845d57a35ca232615799eda",
+      "tracked_at": "2026-04-17T01:05:32.878330+00:00",
+      "resolved_at": "2026-04-17T02:37:52.367305+00:00"
     }
   }
 }


### PR DESCRIPTION
## Summary

Wave 8 (CI Hygiene) retrospective. This PR includes feedback log + trust matrix updates + all 5 ratified charter/skill changes.

**W8 delivery:** 9 PRs merged across 5 repos, 3 issues closed (#109, #110, #111), 16 tech-debt issues filed.

## Ratified proposals (all accepted by Steven 2026-04-17)

1. **§ Hook Authorship Requirements** (`charter/hooks.md`) — input-language docstring, negative-match coverage, charter entry, dispatcher registration
2. **W9 hook-architecture mini-sprint** — tracked as #125
3. **§ Single-Reviewer Exception** (`charter/pull-requests.md`) — wave-bootstrap PRs only, one-time per wave, Aino as sole reviewer
4. **§ Load-Bearing Followups for Disabled CI Jobs** (`charter/pull-requests.md`) — supersedes `feedback_disable_followup_load_bearing` memory
5. **Pre-wave auth/scope audit** — new step 3 in `/wave-kickoff`

## Skill enforcement change

- `/wave-retro` now edits `.claude/team/trust_matrix.md` directly on the retro branch (no more `CEO/0000-Trust_Matrix` side branch — that branch had diverged 7622 lines from main, effectively orphaning trust updates for months)

## Trust updates

All four org-level members stable: Aino 5->5, Wanjiku 4->4, Santiago 5->5, Nadia 5->5. Full write-up in `.claude/team/trust_matrix.md` § Phase 2 Wave 8.

## Files changed

- `.claude/team/feedback_log.md` — full W8 retro + proposal acceptance marks
- `.claude/team/trust_matrix.md` — P2W8 trust update section
- `.claude/team/charter/pull-requests.md` — 2 new sections
- `.claude/team/charter/hooks.md` — Hook Authorship Requirements section
- `.claude/skills/wave-retro/SKILL.md` — trust matrix on retro branch
- `.claude/skills/wave-kickoff/SKILL.md` — pre-wave auth/scope audit, step renumbering
- `ontology/checksums.json` — resolve session churn

## Test plan

- [x] Ontology resolved
- [x] Trust matrix updates now in this PR
- [x] Issue #125 filed for hook-architecture sprint
- [x] All 5 proposals ratified
- [ ] Peer review (Nadia, Santiago)

Generated with Claude Code.
