### PR TITLE
retro(W8): ratification — apply 5 accepted proposals stranded off #124

### DIFF
--- a/.claude/skills/wave-kickoff/SKILL.md
+++ b/.claude/skills/wave-kickoff/SKILL.md
@@ -33,7 +33,30 @@ If missing, create it:
 gh label create "p{N}-wave-{M}" --description "Phase {N} Wave {M}" --color "8B5CF6"
 ```
 
-### 3. Pre-wave CI triage
+### 3. Pre-wave auth/scope audit
+
+Verify the gh token has the scopes needed for this wave's operations. GitHub periodically hardens scope enforcement (e.g., Projects v2 requires the explicit `project` write scope; classic-Projects API deprecation). A missing scope mid-wave consumes orchestrator + user time chasing OAuth flows.
+
+```bash
+gh api -i user 2>&1 | grep -i "x-oauth-scopes"
+```
+
+Required scopes (baseline for all waves):
+- `repo` — issues, PRs, comments, code
+- `read:org` — roster / label lookups
+- `project` — adding issues/PRs to the board (`gh project item-add`)
+- `workflow` — editing `.github/workflows/*` files
+- `gist`, `admin:public_key` — retained from prior grants
+
+If any required scope is missing, instruct the user:
+```
+gh auth refresh -h github.com -s {missing_scope}
+```
+Wait for confirmation that scopes are updated before proceeding. Do NOT begin wave assignment with known-missing scopes.
+
+**Why:** Phase 2 Wave 8 surfaced the Projects v2 scope gap mid-retro while trying to add PR #122 to the board. Fixing it interactively consumed ~30 minutes. Catching this at wave-kickoff prevents mid-wave interruptions.
+
+### 4. Pre-wave CI triage
 
 Before assigning issues, verify CI health across all repos in the wave scope:
 
@@ -56,7 +79,7 @@ For each repo:
 
 Flag repos with known-red CI so engineers are not confused by pre-existing failures.
 
-### 4. Cross-reference wave issues against recent merges
+### 5. Cross-reference wave issues against recent merges
 
 Before posting kickoff comments, check if any wave issues were already resolved:
 
@@ -75,7 +98,7 @@ For each merged PR:
 
 Wait for user confirmation before proceeding with assignment. Remove any confirmed-resolved issues from the wave list.
 
-### 5. Collect issue list and assignments
+### 6. Collect issue list and assignments
 
 Prompt the user for:
 - List of issue numbers for this wave
@@ -90,7 +113,7 @@ gh label list --search "FIRSTNAME"
 
 Create any missing labels before applying.
 
-### 6. Label all issues
+### 7. Label all issues
 
 For each issue, apply the wave label and assignee label:
 
@@ -98,7 +121,7 @@ For each issue, apply the wave label and assignee label:
 gh issue edit {NUMBER} --add-label "p{N}-wave-{M}" --add-label "{FIRSTNAME_LASTNAME}"
 ```
 
-### 7. Post kickoff comments
+### 8. Post kickoff comments
 
 Post a kickoff comment on each issue using charter format:
 
@@ -118,7 +141,7 @@ This issue is assigned to you for p{N}-wave-{M}.
 Please begin implementation.
 ```
 
-### 8. Ontology librarian lookup per agent (MANDATORY)
+### 9. Ontology librarian lookup per agent (MANDATORY)
 
 **Before spawning any agent**, the orchestrator MUST run `/ontology-librarian {topic}` for each agent's work area and **include the output in the agent's spawn prompt**. Do NOT tell agents to "run it themselves" — the orchestrator runs it and bakes the context in.
 
@@ -139,7 +162,7 @@ For each agent in the wave:
 
 **Enforcement:** The `validate_wave_context.py` PreToolUse hook fires on Agent spawns. Agents spawned without ontology context in their prompt will trigger a warning.
 
-### 9. Output execution plan
+### 10. Output execution plan
 
 Generate and display a structured execution plan with:
 - **Priority ordering:** hotfixes first, then security fixes, then bugs, then features (per charter § Wave Planning & Priority)
@@ -147,7 +170,7 @@ Generate and display a structured execution plan with:
 - **Dependencies:** any cross-PR dependencies identified
 - **Estimated parallelism:** which issues can run concurrently
 
-### 9. Report
+### 11. Report
 
 Present the full plan to the user. Do NOT begin implementation until the user approves.
 

--- a/.claude/skills/wave-retro/SKILL.md
+++ b/.claude/skills/wave-retro/SKILL.md
@@ -56,25 +56,18 @@ Structure as:
 
 ### 5. Update trust matrix
 
-Use a temporary worktree to update the trust matrix (avoids conflicts with the current working tree). Use `mktemp -d` to generate a unique path, preventing collisions when multiple agents run trust updates concurrently:
+**Trust matrix lives on `main`**, not a side branch. Edit `.claude/team/trust_matrix.md` directly on the retro branch so the update lands in the same retro PR as the feedback log. Do NOT use a separate worktree or push to `CEO/0000-Trust_Matrix` — that pattern (retired 2026-04-17) orphaned trust updates off-main for months.
 
-```bash
-git fetch origin CEO/0000-Trust_Matrix
-TRUST_WORKTREE="$(mktemp -d /tmp/trust-matrix-update-XXXXXXXX)"
-rmdir "$TRUST_WORKTREE"  # git worktree add needs a non-existent path
-git worktree add "$TRUST_WORKTREE" CEO/0000-Trust_Matrix
-```
-
-Update `$TRUST_WORKTREE/.claude/team/trust_matrix.md` with directional trust changes based on wave performance:
+Apply directional trust changes based on wave performance:
 - Reliable delivery, clean reviews → increase trust (+1, max 5)
 - CI failures, must-fix items, broken commitments → decrease trust (-1, min 1)
 - No significant signal → no change
 
-Add change log entries with date and reason. Commit as the Manager (see `.claude/team/roster.json` for identity), push, then clean up:
+Append a new `## Phase {N} Wave {M} Trust Updates ({DATE}) — {theme}` section with:
+- A `| Rated | Old | New | Reason |` table for each relevant team grouping (e.g., `### Org-Level Team`)
+- A `### Done Well / Needs Improvement (Phase {N} Wave {M})` matrix
 
-```bash
-git worktree remove "$TRUST_WORKTREE"
-```
+The edit will be committed as part of the retro PR (see Step 6). Do NOT create a separate commit or PR for the trust matrix update.
 
 ### 6. Append to feedback log
 

--- a/.claude/team/charter/hooks.md
+++ b/.claude/team/charter/hooks.md
@@ -140,3 +140,48 @@ When hooks sharing the same matcher type (Bash, Agent, SendMessage, etc.) accumu
 - **Augments:** [Pull Requests](pull-requests.md) "green CI before merge" requirement. Phase 2 Wave 7 merged multiple PRs with red `security-audit`, `e2e`, and `test_migrate_users.py` checks despite the charter rule. Per the enforcement-hierarchy principle (hook > skill > charter), a repeatedly violated charter rule becomes a hook.
 - **Manual steps remaining:** None — the hook queries `gh pr view` for the check rollup automatically.
 - **Emergency override:** Pass `--admin` to `gh pr merge`, or remove the `validate_pr_ci_status` entry from the dispatcher hook list.
+
+---
+
+## Hook Authorship Requirements
+
+Every new hook in `.claude/hooks/` must meet these requirements **at the time it is merged**. Partial compliance is a moderate feedback event.
+
+### 1. Input-language specification
+
+The hook's module docstring (top of file) must include an explicit **Input Language** section defining:
+
+- **Fires on:** which PreToolUse event (Bash, Agent, Edit, Write, etc.)
+- **Matches:** the exact command / input shape the hook acts on, expressed as a regex or grammar fragment
+- **Does NOT match:** inputs that superficially look similar but are intentionally out of scope (with examples)
+- **Flag pass-through:** which CLI flags (e.g., `--repo`, `--admin`) are extracted from the matched command and how
+
+Example (from `validate_pr_ci_status.py`):
+```python
+"""
+Input Language:
+  Fires on:      PreToolUse Bash
+  Matches:       gh pr merge {N} [--repo {OWNER/REPO}] [--squash|--merge|--rebase] [--admin] [--auto]
+  Does NOT match: gh pr list, gh pr view, gh pr checks, gh pr create, git merge, git pull
+  Flag pass-through:
+    --repo   → overrides cwd-resolved repo when querying gh pr view
+    --admin  → short-circuits (emergency override, allows merge)
+    --auto   → allows pending checks (GitHub auto-merge)
+"""
+```
+
+**Why:** Phase 2 Wave 8 surfaced six hook substring/regex bugs (#113 validate_labels cwd, #114 auto_set_env_test test-string false-positives, #118 validate_branch_freshness cwd, #123 validate_pr_review RequestOrReplied-Requested false-positive, ontology-tracker /tmp ghost entries, validate_labels default-limit). Root cause was hooks written liberally without an explicit spec of what they match vs. don't. An input-language docstring forces the author to enumerate the negative space before shipping.
+
+### 2. Charter entry in `charter/hooks.md`
+
+Every new hook must have a numbered entry in this file with: What it automates, Augments (which charter section), Manual steps remaining, Emergency override. No hook ships without a charter entry.
+
+### 3. Test coverage for negative matches
+
+The hook's test suite (or docstring-embedded manual verification) must include at least one input that **looks like a match but is intentionally excluded** — to guard against the substring-bug pattern. Example: a `validate_pr_merge` hook must verify it does NOT fire on `gh pr list`.
+
+### 4. Dispatcher registration (not settings.json)
+
+New Bash hooks must register in `dispatcher.py`'s `_BASH_HOOKS` list, not as a separate `settings.json` entry. See `charter/hooks.md` § Hook Dispatcher Consolidation (Hook 7 pattern).
+
+**Enforcement:** The Standards & Quality Lead (Aino) verifies these requirements during hook PR review. A hook missing any of the four requirements must not be approved.

--- a/.claude/team/charter/pull-requests.md
+++ b/.claude/team/charter/pull-requests.md
@@ -49,6 +49,36 @@ Every PR must have **two reviewers** assigned at wave kickoff — a primary and 
 
 The Program Director's execution plan MUST include a review matrix with two named reviewers per expected PR. The orchestrator verifies this before spawning agents.
 
+## Single-Reviewer Exception (Wave-Bootstrap Only)
+
+The two-reviewer requirement may be waived **exclusively** for wave-bootstrap PRs — i.e., PRs that establish the tooling/CI/hooks that subsequent wave PRs will be gated by (e.g., the pre-commit hook rollout that the CI sweep depends on).
+
+Strict conditions — **all must hold**:
+- The PR is part of wave bootstrap (establishes infra that blocks other wave work)
+- No more than **one** such exception per wave
+- The single reviewer is the Standards & Quality Lead (Aino) or a comparable charter enforcer
+- The exception is logged by name in the wave retro, with explicit justification
+
+All other PRs require two comment-based reviews. `--admin` merges without two reviews are subject to the moderate-feedback-event classification in § Feedback System.
+
+**Why:** In Phase 2 Wave 8, the single-reviewer shortcut was invoked 8× — it had stopped being an exception and become a pattern of convenience. This clause formalizes the boundary.
+
+## Load-Bearing Followups for Disabled CI Jobs
+
+When a PR disables a CI job to unblock merge, the followup tracking issue must be **load-bearing** — the re-enablement of the job is a first-class acceptance criterion of the issue, not a hidden subtask of "fix the underlying bug."
+
+Concrete requirements:
+1. **Followup issue exists before the disable PR is approved.** The reviewer verifies the issue number in the PR body under a `## Disabled CI jobs (load-bearing followup)` section.
+2. **Followup issue acceptance criteria** must include:
+   - A specific fix for the underlying problem
+   - Re-enable the CI job (remove `if: false` / `--skip` / equivalent)
+   - Verify green CI after re-enablement
+   - All three bullets are required in the issue body.
+3. **Breadcrumb in PR body.** The PR that disables a job must include a top-level section `## Disabled CI jobs (load-bearing followup)` naming the job disabled, the reason, and the followup issue number.
+4. **No silent disables.** A PR that disables a CI job without both the issue and the breadcrumb is a moderate feedback event.
+
+**Why:** Phase 2 Wave 8 ratified this rule mid-wave after two PRs (isnad-graph#811, design-system#56) disabled CI jobs with tracking issues that could be "closed" by just fixing the bug without ever re-enabling the job. Promoting the rule into the charter closes that loophole. Reference: `feedback_disable_followup_load_bearing.md` (historical memory, superseded by this clause).
+
 ## PR Review Workflow for Deployments Branch PRs
 
 1. **Create the PR** targeting `deployments/phase{N}/wave-{M}`.

--- a/.claude/team/feedback_log.md
+++ b/.claude/team/feedback_log.md
@@ -791,12 +791,15 @@ None.
 3. **Single-reviewer exception overused** — bootstrap exception applied to all 4 #110 PRs AND all 4 #111 PRs (Aino sole reviewer). Became pattern-of-convenience rather than exception.
 4. **OAuth scope migration chased in real-time** — GitHub Projects v2 scope enforcement surfaced mid-retro, consumed ~30 min of orchestrator + user time. Should have been on W7 radar.
 
-### Proposed Process Changes
-1. **Hook authorship spec requirement** — any new hook must include explicit input-language spec (what commands/formats it matches) in docstring + charter/hooks.md entry. Rationale: fixes substring-bug cluster root cause.
-2. **W9 opens with hook-architecture mini-sprint** — bundle #113, #114, #118, #123 into a single day of hook triage before W9 main scope. Rationale: 6 hook bugs in one wave is a meta-debt signal.
-3. **Single-reviewer exception — formalize or drop** — wave-bootstrap PRs ONLY, one-time per wave, logged in retro. Otherwise require 2 reviewers per charter. Rationale: W8 used it 8 times; that's not an exception anymore.
-4. **Disable-with-followup rule → charter** — move `feedback_disable_followup_load_bearing` memory into charter § Pull Requests as ratified rule. Rationale: memory is session-scoped; charter is authoritative.
-5. **Pre-wave auth/scope audit step in /wave-kickoff** — verify gh token scopes against wave's expected operations. Rationale: Projects v2 scope gap was catchable.
+### Proposed Process Changes — ALL ACCEPTED 2026-04-17
+1. **Hook authorship spec requirement** — ACCEPTED. Ratified in `charter/hooks.md` § Hook Authorship Requirements (input-language docstring, charter entry, negative-match test coverage, dispatcher registration).
+2. **W9 opens with hook-architecture mini-sprint** — ACCEPTED. Tracked as issue #125.
+3. **Single-reviewer exception — formalize or drop** — ACCEPTED (formalized). Ratified in `charter/pull-requests.md` § Single-Reviewer Exception (wave-bootstrap PRs ONLY, one-time per wave, Aino as sole reviewer, logged in retro).
+4. **Disable-with-followup rule → charter** — ACCEPTED. Ratified in `charter/pull-requests.md` § Load-Bearing Followups for Disabled CI Jobs. Memory `feedback_disable_followup_load_bearing.md` superseded by charter.
+5. **Pre-wave auth/scope audit step in /wave-kickoff** — ACCEPTED. Added as `/wave-kickoff` step 3, running before CI triage.
+
+### Skill enforcement change — ACCEPTED 2026-04-17
+**Trust matrix updates now land in the retro PR**, not on `CEO/0000-Trust_Matrix`. The `/wave-retro` skill now edits `.claude/team/trust_matrix.md` directly on the retro branch. Stale side-branch pattern retired — it had diverged by 7622 lines from main.
 
 ### Trust Updates
 No changes. All scores stable. See trust_matrix.md § Phase 2 Wave 8.

--- a/.claude/team/trust_matrix.md
+++ b/.claude/team/trust_matrix.md
@@ -276,3 +276,26 @@ The org was restructured in Session 3 with new repo-level teams. The matrix abov
 | **Santiago Ferreira** | CI workflow for hooks (new infrastructure), release tagging cadence (process formalization). Both well-documented. | Pre-existing lint issues not caught before merge — CI introduced by his PR fails on his own branch |
 | **Aino Virtanen** | Label naming convention hook, 7 reviews as second reviewer. Consistent quality gate. | None this wave |
 | **Nadia Khoury** | Redis health check fix (security), coordination of wave execution | None this wave |
+
+---
+
+## Phase 2 Wave 8 Trust Updates (2026-04-17) — CI Hygiene
+
+### Org-Level Team
+
+| Rated | Old | New | Reason |
+|-------|-----|-----|--------|
+| Wanjiku Mwangi (TPM) | 4 | 4 | 4 PRs across 4 repos for #111 (main #115, isnad-graph #811, user-service #60, design-system #56), all merged clean. Filed high-quality tech-debt issues with forensic detail (#810, #812, #54, etc.). Handled load-bearing breadcrumb retrofit cleanly across session boundary. No negatives. |
+| Santiago Ferreira (RC) | 5 | 5 | 3 PRs for #110 (ruff autoformat in pre-commit): isnad-graph #808, user-service #58, data-acquisition #27. Clean delivery after commit-identity roster-blocker unblocked by Steven. Already at max. |
+| Aino Virtanen (SQL) | 5 | 5 | Implemented #109 CI gate hook solo (PR #122), caught spec substitution proactively (`gh pr checks --json` → `statusCheckRollup`), reviewed 7 W8 PRs as charter enforcer, zero must-fix items received. Already at max. |
+| Nadia Khoury (PD) | 5 | 5 | Light involvement — reviewed PR #122 with thorough spec-fidelity audit. Already at max, no change. |
+
+### Done Well / Needs Improvement (Phase 2 Wave 8)
+
+| Member | Done Well | Needs Improvement |
+|--------|-----------|-------------------|
+| **Wanjiku Mwangi** (TPM) | Forensic tech-debt filing during #111 sweep (caught hook bugs #113, #118, plus classic-Projects deprecation workaround via REST PATCH). Clean multi-repo delivery. | Had to rework PR bodies post-review when disable-with-followup rule was ratified mid-wave — workflow, not her fault |
+| **Santiago Ferreira** (RC) | Batched ruff-format across 3 Python repos efficiently. Review quality matched charter format on all #110 PRs. | Hit commit-identity roster-blocker on 3 of 4 child repos — unblocked by Steven authorizing cross-repo roster merge (long-term fix: #112) |
+| **Aino Virtanen** (SQL) | #109 implementation matched existing hook patterns exactly. Handled spec-discrepancy (nonexistent `gh pr checks --json bucket,name,state` flag combo) transparently in PR body. Thorough reviewer across the wave. | None this wave |
+| **Nadia Khoury** (PD) | Spec-fidelity review of #122 was executive-quality — validated substitution, checked dispatcher position, flagged program-level concerns (Hook 7 stacking) | Limited involvement — other members carried the wave; appropriate for a wave with tight scope |
+

--- a/ontology/checksums.json
+++ b/ontology/checksums.json
@@ -9,10 +9,10 @@
       "resolved_at": "2026-04-11T16:26:02.575946+00:00"
     },
     ".claude/skills/wave-retro/SKILL.md": {
-      "last_tracked": "674d9dee3f7aa20511e7dfd5fff1db591ab979a64578ff2e91e8f962fb81346a",
-      "last_resolved": "674d9dee3f7aa20511e7dfd5fff1db591ab979a64578ff2e91e8f962fb81346a",
-      "tracked_at": "2026-04-11T16:17:33.817632+00:00",
-      "resolved_at": "2026-04-11T16:26:02.575946+00:00"
+      "last_tracked": "4cb181da87445574175c9aeb268376114faa3b821ad833a0d80df1aab1b431bd",
+      "last_resolved": "4cb181da87445574175c9aeb268376114faa3b821ad833a0d80df1aab1b431bd",
+      "tracked_at": "2026-04-17T02:53:10.158033+00:00",
+      "resolved_at": "2026-04-17T02:56:03.855330+00:00"
     },
     "CLAUDE.md": {
       "last_tracked": "18498d583f3ab8a9ca84766f2821e091a5ecbcd9a4734c05d8a17cfcc5873dce",
@@ -159,16 +159,16 @@
       "resolved_at": "2026-04-11T18:37:30.535410+00:00"
     },
     ".claude/team/feedback_log.md": {
-      "last_tracked": "f768457338aa71feadb1390db271a29428abc2d501d7ff24c02f8db3af3499c4",
-      "last_resolved": "f768457338aa71feadb1390db271a29428abc2d501d7ff24c02f8db3af3499c4",
-      "tracked_at": "2026-04-16T21:36:05.052302+00:00",
-      "resolved_at": "2026-04-16T21:36:05.052302+00:00"
+      "last_tracked": "53a38a78680373a6668c7d29e7057c9151bf1ba516d881e0447944be7cbf8cf8",
+      "last_resolved": "53a38a78680373a6668c7d29e7057c9151bf1ba516d881e0447944be7cbf8cf8",
+      "tracked_at": "2026-04-17T02:55:49.813670+00:00",
+      "resolved_at": "2026-04-17T02:56:03.855330+00:00"
     },
     ".claude/skills/wave-kickoff/SKILL.md": {
-      "last_tracked": "3272e3bb7dabc24374820e3b6ae23b5a71f9f0461ce5f7e6793206d72a283956",
-      "last_resolved": "3272e3bb7dabc24374820e3b6ae23b5a71f9f0461ce5f7e6793206d72a283956",
-      "tracked_at": "2026-04-11T23:17:54.541953+00:00",
-      "resolved_at": "2026-04-12T03:32:34.047264+00:00"
+      "last_tracked": "4a12511cafd3640536ce552fbc0f25b9585c98ec8c3a22411918885270472b70",
+      "last_resolved": "4a12511cafd3640536ce552fbc0f25b9585c98ec8c3a22411918885270472b70",
+      "tracked_at": "2026-04-17T02:54:35.749176+00:00",
+      "resolved_at": "2026-04-17T02:56:03.855330+00:00"
     },
     ".claude/hooks/validate_wave_context.py": {
       "last_tracked": "24938c642f56e8f076f4cc0dfd137219605b83dfe814a92b713b67eece833451",
@@ -273,10 +273,10 @@
       "resolved_at": "2026-04-16T21:36:05.052302+00:00"
     },
     ".claude/team/charter/pull-requests.md": {
-      "last_tracked": "0f2728222e2db74008a89fd93b061be9ed5d67f118b071cb27277a6d538f4fb9",
-      "last_resolved": "0f2728222e2db74008a89fd93b061be9ed5d67f118b071cb27277a6d538f4fb9",
-      "tracked_at": "2026-04-16T21:36:05.052302+00:00",
-      "resolved_at": "2026-04-16T21:36:05.052302+00:00"
+      "last_tracked": "7fb84ff8c57335b6ec532761111e541fa3a90c8c1da9686d742d03c16349b97e",
+      "last_resolved": "7fb84ff8c57335b6ec532761111e541fa3a90c8c1da9686d742d03c16349b97e",
+      "tracked_at": "2026-04-17T02:53:35.642630+00:00",
+      "resolved_at": "2026-04-17T02:56:03.855330+00:00"
     },
     "/home/parameterization/.claude/projects/-home-parameterization-code-noorinalabs-main/memory/project_data_pipeline_architecture.md": {
       "last_tracked": "1b7e149d7ec1b371c04484175e9cb26cb1be11a45e1e03b41de0cbb92b622071",
@@ -321,10 +321,10 @@
       "resolved_at": "2026-04-17T02:37:52.367305+00:00"
     },
     ".claude/team/charter/hooks.md": {
-      "last_tracked": "701d9b0500f6c4158ecd9dce79e02ca8677082c7e845d57a35ca232615799eda",
-      "last_resolved": "701d9b0500f6c4158ecd9dce79e02ca8677082c7e845d57a35ca232615799eda",
-      "tracked_at": "2026-04-17T01:05:32.878330+00:00",
-      "resolved_at": "2026-04-17T02:37:52.367305+00:00"
+      "last_tracked": "c428fe52cd1a9b8837d8e00c4d7e5e71491a53baacf7e35ba72b83c58a9892a4",
+      "last_resolved": "c428fe52cd1a9b8837d8e00c4d7e5e71491a53baacf7e35ba72b83c58a9892a4",
+      "tracked_at": "2026-04-17T02:54:04.676509+00:00",
+      "resolved_at": "2026-04-17T02:56:03.855330+00:00"
     }
   }
 }


### PR DESCRIPTION
## Summary

**Follow-up to #124.** PR #124 was merged via `--admin` before its second commit (the ratification) reached the branch head. As a result, only `feedback_log.md` and `ontology/checksums.json` made it to main — the 5 accepted charter/skill changes plus the P2W8 trust matrix entry were stranded on the branch.

This PR applies what should have been in #124.

Nadia's review on #124 (posted after the fact) documented the divergence in detail: https://github.com/noorinalabs/noorinalabs-main/pull/124#issuecomment-4264655543

## Files changed (ratification contents)

- `.claude/team/trust_matrix.md` — new `## Phase 2 Wave 8 Trust Updates` section (replaces the orphaned entry on `CEO/0000-Trust_Matrix` which has since diverged 7622 lines from main)
- `.claude/team/charter/pull-requests.md` — new `§ Single-Reviewer Exception` and `§ Load-Bearing Followups for Disabled CI Jobs`
- `.claude/team/charter/hooks.md` — new `## Hook Authorship Requirements` section
- `.claude/skills/wave-retro/SKILL.md` — step 5 rewritten; trust matrix updates now commit to the retro branch on main (no more CEO side-branch)
- `.claude/skills/wave-kickoff/SKILL.md` — new step 3 pre-wave auth/scope audit; subsequent steps renumbered
- `.claude/team/feedback_log.md` — mark all 5 W8 proposals ACCEPTED with ratification pointers

## Test plan

- [x] Each ratified change points to the actual charter/skill file (not just the proposal list)
- [x] No `--admin` on this merge
- [ ] Two peer reviews required (Nadia + Santiago)
- [ ] Validate_pr_ci_status hook will gate the merge (hook is live as of #122)

## Meta observation

A retro PR ratifying "Load-Bearing Followups" and "Hook Authorship Requirements" was itself merged without load-bearing verification. Exactly the enforcement-hierarchy failure mode the proposals were designed to prevent. Strong argument for extending #125 to include a hook that blocks `gh pr merge --admin` on charter/retro PRs.

Closes follow-up to PR #124.
