### PR TITLE
fix(#119): add version sentinel to parent pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,10 @@
+# Meta-repo only — not a Python package. This file exists to share ruff config
+# across org tooling (hooks, scripts). The `version` sentinel below is required
+# so `uv` does not error when walking up from child repos during workspace
+# discovery. Do not publish, install, or treat as a workspace root.
 [project]
 name = "noorinalabs-main"
+version = "0.0.0"
 requires-python = ">=3.12"
 
 [tool.ruff]


### PR DESCRIPTION
Closes #119

## Summary
Parent `pyproject.toml` was missing `[project].version`, causing `uv` to error when walking up from any child Python repo during workspace discovery. Added a `0.0.0` sentinel + a 4-line header comment documenting intent (meta-repo, not a package, not a workspace root — file exists purely to share ruff config across org tooling).

## Option chosen: A (1-line fix + documenting comment)

Considered B (convert parent to a real `[tool.uv.workspace]`) and C (delete the file entirely). Rejected both:

- **B (workspace root):** Child repos are gitignored independent repos (see `CLAUDE.md § Architecture`). A workspace declaration would pin parent tooling to specific child paths that may not exist on a given clone, and wouldn't match how children actually operate (each has its own `uv.lock`). Wrong semantic for a meta-repo.
- **C (delete):** Loses the org-wide ruff config this file exists to provide.

A is the right call: it unblocks `uv` with minimal surface area and the comment prevents a future contributor from mistaking this for a real package.

## Validation
Ran `uv lock --check` from each child Python repo with the patched parent in place:

```
noorinalabs-isnad-graph:        Resolved 104 packages in 17ms
noorinalabs-user-service:       Resolved 63 packages in 1ms
noorinalabs-data-acquisition:   Resolved 146 packages in 0.98ms
```

Also confirmed the original file reproduces the bug (error: ``project.version` field is neither set nor present in the `project.dynamic` list``) — so the fix addresses a real, currently-breaking issue, not a theoretical one. Wanjiku's W8 manual-patch-and-revert workaround (#111) is no longer needed.

## LoC delta
+5 / -0, single file.

## Peer review
Requestor: Weronika.Zielinska
Requestee: Aino.Virtanen
RequestOrReplied: Requested