### PR TITLE
fix(hooks): validate_labels forwards --repo and ignores body content (#113)

### DIFF
--- a/.claude/hooks/test_validate_labels.py
+++ b/.claude/hooks/test_validate_labels.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Tests for validate_labels.py.
+
+Run with:  uv run python -m pytest .claude/hooks/test_validate_labels.py -v
+or:        python -m pytest .claude/hooks/test_validate_labels.py -v
+
+Covers positive extraction, --repo forwarding, and (critically) negative-match
+cases where label-like strings appear inside --body argument values.
+"""
+
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import validate_labels as vl
+
+
+class TestExtractLabels(unittest.TestCase):
+    def test_single_label_space_form(self):
+        self.assertEqual(
+            vl.extract_labels('gh issue create --title "t" --label bug'),
+            ["bug"],
+        )
+
+    def test_single_label_equals_form(self):
+        self.assertEqual(
+            vl.extract_labels("gh issue create --title t --label=bug"),
+            ["bug"],
+        )
+
+    def test_short_flag(self):
+        self.assertEqual(
+            vl.extract_labels("gh issue create --title t -l bug"),
+            ["bug"],
+        )
+
+    def test_comma_separated(self):
+        self.assertEqual(
+            vl.extract_labels('gh issue create --title t --label "bug,p2-wave-9,tech-debt"'),
+            ["bug", "p2-wave-9", "tech-debt"],
+        )
+
+    def test_multiple_label_flags(self):
+        self.assertEqual(
+            vl.extract_labels("gh issue create --title t --label bug --label p2-wave-9"),
+            ["bug", "p2-wave-9"],
+        )
+
+    def test_no_issue_create_subcommand(self):
+        # list / view / edit should be ignored entirely.
+        self.assertEqual(
+            vl.extract_labels("gh issue list --label bug"),
+            [],
+        )
+        self.assertEqual(
+            vl.extract_labels("gh issue edit 42 --add-label bug"),
+            [],
+        )
+
+    # --- Negative-match: body content must NOT be scanned for --label flags ---
+
+    def test_negative_label_inside_body_single_quotes(self):
+        """A --label fake-label inside a quoted --body must NOT be extracted."""
+        cmd = (
+            "gh issue create --title 'bug' "
+            "--body 'This issue documents `gh issue create --label fake-label` usage' "
+            "--label bug"
+        )
+        self.assertEqual(vl.extract_labels(cmd), ["bug"])
+
+    def test_negative_label_inside_body_double_quotes(self):
+        cmd = (
+            'gh issue create --title "bug" '
+            '--body "Example: gh issue create --label wrong-wave --label another-fake" '
+            "--label p2-wave-9"
+        )
+        self.assertEqual(vl.extract_labels(cmd), ["p2-wave-9"])
+
+    def test_negative_body_equals_form(self):
+        cmd = (
+            'gh issue create --title t --body="mentions --label prose-label" --label real'
+        )
+        self.assertEqual(vl.extract_labels(cmd), ["real"])
+
+    def test_negative_body_file_flag(self):
+        cmd = "gh issue create --title t -F body.md --label real"
+        self.assertEqual(vl.extract_labels(cmd), ["real"])
+
+    def test_negative_title_is_not_scanned(self):
+        cmd = "gh issue create --title 'refactor --label handling' --label tech-debt"
+        self.assertEqual(vl.extract_labels(cmd), ["tech-debt"])
+
+    def test_malformed_command_returns_empty(self):
+        # Unclosed quote — shlex will raise; hook must degrade silently.
+        self.assertEqual(vl.extract_labels("gh issue create --label 'unclosed"), [])
+
+
+class TestExtractRepo(unittest.TestCase):
+    def test_repo_space_form(self):
+        self.assertEqual(
+            vl.extract_repo(
+                "gh issue create --repo noorinalabs/noorinalabs-main --label bug"
+            ),
+            "noorinalabs/noorinalabs-main",
+        )
+
+    def test_repo_short_flag(self):
+        self.assertEqual(
+            vl.extract_repo("gh issue create -R owner/repo --label bug"),
+            "owner/repo",
+        )
+
+    def test_repo_equals_form(self):
+        self.assertEqual(
+            vl.extract_repo("gh issue create --repo=owner/repo --label bug"),
+            "owner/repo",
+        )
+
+    def test_repo_absent(self):
+        self.assertIsNone(vl.extract_repo("gh issue create --title t --label bug"))
+
+    def test_repo_inside_body_not_extracted(self):
+        """--repo inside a body value must NOT be treated as the real repo flag."""
+        cmd = (
+            'gh issue create --title t '
+            '--body "example: gh issue create --repo wrong/repo" '
+            "--repo right/repo --label bug"
+        )
+        self.assertEqual(vl.extract_repo(cmd), "right/repo")
+
+
+class TestGetExistingLabelsForwardsRepo(unittest.TestCase):
+    def test_repo_flag_forwarded(self):
+        captured = {}
+
+        class Result:
+            returncode = 0
+            stdout = "[]"
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            return Result()
+
+        with patch.object(vl.subprocess, "run", side_effect=fake_run):
+            vl.get_existing_labels(repo="noorinalabs/noorinalabs-main")
+
+        self.assertIn("--repo", captured["cmd"])
+        idx = captured["cmd"].index("--repo")
+        self.assertEqual(captured["cmd"][idx + 1], "noorinalabs/noorinalabs-main")
+
+    def test_no_repo_flag_when_absent(self):
+        captured = {}
+
+        class Result:
+            returncode = 0
+            stdout = "[]"
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            return Result()
+
+        with patch.object(vl.subprocess, "run", side_effect=fake_run):
+            vl.get_existing_labels()
+
+        self.assertNotIn("--repo", captured["cmd"])
+
+
+class TestCheckIntegration(unittest.TestCase):
+    def _input(self, command: str) -> dict:
+        return {"tool_name": "Bash", "tool_input": {"command": command}}
+
+    def test_body_false_positive_does_not_block(self):
+        """Key regression: body-only label mention must not trigger validation."""
+        # Existing labels in target repo include "bug" but NOT "fake-label".
+        with patch.object(vl, "get_existing_labels", return_value={"bug"}):
+            result = vl.check(
+                self._input(
+                    "gh issue create --title t "
+                    "--body 'docs: mentions --label fake-label in prose' "
+                    "--label bug"
+                )
+            )
+        self.assertIsNone(result)
+
+    def test_missing_label_blocks(self):
+        with patch.object(vl, "get_existing_labels", return_value={"bug"}):
+            result = vl.check(
+                self._input("gh issue create --title t --label does-not-exist")
+            )
+        self.assertIsNotNone(result)
+        self.assertEqual(result["decision"], "block")
+        self.assertIn("does-not-exist", result["reason"])
+
+    def test_repo_forwarded_to_label_lookup(self):
+        captured = {}
+
+        def fake_get(repo=None):
+            captured["repo"] = repo
+            return {"bug"}
+
+        with patch.object(vl, "get_existing_labels", side_effect=fake_get):
+            vl.check(
+                self._input(
+                    "gh issue create --repo noorinalabs/noorinalabs-main "
+                    "--title t --label bug"
+                )
+            )
+        self.assertEqual(captured["repo"], "noorinalabs/noorinalabs-main")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/hooks/test_validate_labels.py
+++ b/.claude/hooks/test_validate_labels.py
@@ -80,9 +80,7 @@ class TestExtractLabels(unittest.TestCase):
         self.assertEqual(vl.extract_labels(cmd), ["p2-wave-9"])
 
     def test_negative_body_equals_form(self):
-        cmd = (
-            'gh issue create --title t --body="mentions --label prose-label" --label real'
-        )
+        cmd = 'gh issue create --title t --body="mentions --label prose-label" --label real'
         self.assertEqual(vl.extract_labels(cmd), ["real"])
 
     def test_negative_body_file_flag(self):
@@ -101,9 +99,7 @@ class TestExtractLabels(unittest.TestCase):
 class TestExtractRepo(unittest.TestCase):
     def test_repo_space_form(self):
         self.assertEqual(
-            vl.extract_repo(
-                "gh issue create --repo noorinalabs/noorinalabs-main --label bug"
-            ),
+            vl.extract_repo("gh issue create --repo noorinalabs/noorinalabs-main --label bug"),
             "noorinalabs/noorinalabs-main",
         )
 
@@ -125,7 +121,7 @@ class TestExtractRepo(unittest.TestCase):
     def test_repo_inside_body_not_extracted(self):
         """--repo inside a body value must NOT be treated as the real repo flag."""
         cmd = (
-            'gh issue create --title t '
+            "gh issue create --title t "
             '--body "example: gh issue create --repo wrong/repo" '
             "--repo right/repo --label bug"
         )
@@ -187,9 +183,7 @@ class TestCheckIntegration(unittest.TestCase):
 
     def test_missing_label_blocks(self):
         with patch.object(vl, "get_existing_labels", return_value={"bug"}):
-            result = vl.check(
-                self._input("gh issue create --title t --label does-not-exist")
-            )
+            result = vl.check(self._input("gh issue create --title t --label does-not-exist"))
         self.assertIsNotNone(result)
         self.assertEqual(result["decision"], "block")
         self.assertIn("does-not-exist", result["reason"])
@@ -204,8 +198,7 @@ class TestCheckIntegration(unittest.TestCase):
         with patch.object(vl, "get_existing_labels", side_effect=fake_get):
             vl.check(
                 self._input(
-                    "gh issue create --repo noorinalabs/noorinalabs-main "
-                    "--title t --label bug"
+                    "gh issue create --repo noorinalabs/noorinalabs-main --title t --label bug"
                 )
             )
         self.assertEqual(captured["repo"], "noorinalabs/noorinalabs-main")

--- a/.claude/hooks/validate_labels.py
+++ b/.claude/hooks/validate_labels.py
@@ -2,7 +2,22 @@
 """PreToolUse hook: Validate labels before gh issue create.
 
 Extracts --label values from `gh issue create` commands and verifies each
-label exists in the repository. Blocks execution if any label is missing.
+label exists in the target repository. Blocks execution if any label is missing.
+
+Input Language:
+  Fires on:      PreToolUse Bash
+  Matches:       gh issue create [--repo {OWNER/REPO}] [--label {L} | -l {L} | --label={L}]... [--body {TEXT}] [...]
+  Does NOT match:
+    - gh issue list / view / edit / close
+    - Commands where `--label foo` appears only inside a `--body "..."` argument value
+      (e.g., documentation bodies referencing gh commands as prose)
+    - Non-`gh issue create` subcommands
+  Flag pass-through:
+    --repo {OWNER/REPO}  → forwarded to `gh label list --repo ...` so labels are
+                           resolved against the TARGET repo, not the cwd repo
+    --label / -l         → extracted as label values (comma-split supported)
+    --body / -b / -F     → values are NOT scanned for nested flags (tokenized
+                           via shlex so body content is a single token)
 
 Exit codes:
   0 — allow (not gh issue create, or all labels exist)
@@ -12,6 +27,7 @@ Exit codes:
 import json
 import os
 import re
+import shlex
 import subprocess
 import sys
 
@@ -19,11 +35,132 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from annunaki_log import log_pretooluse_block
 
 
-def get_existing_labels() -> set[str]:
-    """Fetch all existing labels from the repository."""
+def _tokenize(command: str) -> list[str] | None:
+    """Shell-tokenize a command. Returns None if the command is malformed."""
     try:
+        return shlex.split(command, posix=True)
+    except ValueError:
+        return None
+
+
+def _find_issue_create_tokens(tokens: list[str]) -> list[str] | None:
+    """Return the argv slice for the `gh issue create` invocation, or None.
+
+    Handles pipelines/chains by scanning for the `gh issue create` triplet and
+    returning tokens from that point until the next shell separator. Separators
+    that shlex.split will emit as their own tokens: ``|``, ``||``, ``&&``, ``;``,
+    ``&``. (shlex in posix mode keeps these as single tokens when unquoted.)
+    """
+    separators = {"|", "||", "&&", ";", "&"}
+    n = len(tokens)
+    for i in range(n - 2):
+        if tokens[i] == "gh" and tokens[i + 1] == "issue" and tokens[i + 2] == "create":
+            end = i + 3
+            while end < n and tokens[end] not in separators:
+                end += 1
+            return tokens[i + 3 : end]
+    return None
+
+
+# Flags whose immediate next token is a value that must NOT be scanned for
+# nested label flags. Body text is the primary source of false-positives.
+_VALUE_FLAGS_TO_SKIP = {"--body", "-b", "--body-file", "-F", "--title", "-t"}
+
+# Label flag names (space-separated form).
+_LABEL_FLAGS = {"--label", "-l"}
+
+
+def extract_labels(command: str) -> list[str]:
+    """Extract --label / -l values from a gh issue create command.
+
+    Uses shell tokenization so values inside quoted arguments (notably `--body`)
+    are not scanned for flags. Supports ``--label foo``, ``-l foo``,
+    ``--label=foo``, and comma-separated lists (``--label a,b,c``).
+    """
+    tokens = _tokenize(command)
+    if tokens is None:
+        return []
+
+    create_tokens = _find_issue_create_tokens(tokens)
+    if create_tokens is None:
+        return []
+
+    labels: list[str] = []
+    i = 0
+    n = len(create_tokens)
+    while i < n:
+        tok = create_tokens[i]
+
+        # --label=value / -l=value (attached form)
+        if tok.startswith("--label=") or tok.startswith("-l="):
+            _, _, value = tok.partition("=")
+            labels.extend(_split_label_value(value))
+            i += 1
+            continue
+
+        # --label value / -l value (separate form)
+        if tok in _LABEL_FLAGS:
+            if i + 1 < n:
+                labels.extend(_split_label_value(create_tokens[i + 1]))
+            i += 2
+            continue
+
+        # Skip value of flags whose arguments must not be scanned.
+        if tok in _VALUE_FLAGS_TO_SKIP:
+            i += 2
+            continue
+        if any(tok.startswith(f + "=") for f in _VALUE_FLAGS_TO_SKIP):
+            i += 1
+            continue
+
+        i += 1
+
+    return labels
+
+
+def _split_label_value(raw: str) -> list[str]:
+    """Split a raw --label argument on commas, stripping whitespace and empties."""
+    return [part.strip() for part in raw.split(",") if part.strip()]
+
+
+def extract_repo(command: str) -> str | None:
+    """Extract --repo / -R value from a gh issue create command.
+
+    Returns ``OWNER/REPO`` (or a URL that gh accepts) or None if absent. Only
+    reads the flag from the `gh issue create` argv slice — never from body text.
+    """
+    tokens = _tokenize(command)
+    if tokens is None:
+        return None
+    create_tokens = _find_issue_create_tokens(tokens)
+    if create_tokens is None:
+        return None
+
+    n = len(create_tokens)
+    for i, tok in enumerate(create_tokens):
+        if tok == "--repo" or tok == "-R":
+            if i + 1 < n:
+                return create_tokens[i + 1]
+            return None
+        if tok.startswith("--repo="):
+            return tok.split("=", 1)[1]
+        if tok.startswith("-R="):
+            return tok.split("=", 1)[1]
+    return None
+
+
+def get_existing_labels(repo: str | None = None) -> set[str]:
+    """Fetch all existing labels from the repository.
+
+    When ``repo`` is provided, forwards ``--repo`` to ``gh label list`` so the
+    labels are resolved against the target repo instead of the cwd-resolved one.
+    """
+    try:
+        cmd = ["gh", "label", "list", "--limit", "500", "--json", "name"]
+        if repo:
+            cmd.extend(["--repo", repo])
         result = subprocess.run(
-            ["gh", "label", "list", "--limit", "500", "--json", "name"],
+            cmd,
             capture_output=True,
             text=True,
             timeout=30,
@@ -34,23 +171,6 @@ def get_existing_labels() -> set[str]:
         return {label["name"] for label in labels_data}
     except (subprocess.TimeoutExpired, json.JSONDecodeError, FileNotFoundError):
         return set()
-
-
-def extract_labels(command: str) -> list[str]:
-    """Extract all --label and -l values from a gh issue create command."""
-    labels = []
-
-    # Match --label "value" or --label value or -l "value" or -l value
-    # Also handles comma-separated labels in a single --label flag
-    for match in re.finditer(r'(?:--label|-l)\s+["\']?([^"\']+?)["\']?(?:\s|$)', command):
-        raw = match.group(1).strip()
-        # gh CLI accepts comma-separated labels
-        for label in raw.split(","):
-            label = label.strip()
-            if label:
-                labels.append(label)
-
-    return labels
 
 
 def check(input_data: dict) -> dict | None:
@@ -68,7 +188,8 @@ def check(input_data: dict) -> dict | None:
     if not labels:
         return None
 
-    existing = get_existing_labels()
+    repo = extract_repo(command)
+    existing = get_existing_labels(repo)
     if not existing:
         return {
             "decision": "allow",
@@ -82,7 +203,8 @@ def check(input_data: dict) -> dict | None:
     if not missing:
         return None
 
-    suggestions = "\n".join(f'  gh label create "{label}"' for label in missing)
+    repo_hint = f" --repo {repo}" if repo else ""
+    suggestions = "\n".join(f'  gh label create "{label}"{repo_hint}' for label in missing)
     result = {
         "decision": "block",
         "reason": (

--- a/.claude/hooks/validate_labels.py
+++ b/.claude/hooks/validate_labels.py
@@ -6,7 +6,10 @@ label exists in the target repository. Blocks execution if any label is missing.
 
 Input Language:
   Fires on:      PreToolUse Bash
-  Matches:       gh issue create [--repo {OWNER/REPO}] [--label {L} | -l {L} | --label={L}]... [--body {TEXT}] [...]
+  Matches:       gh issue create
+                   [--repo {OWNER/REPO}]
+                   [--label {L} | -l {L} | --label={L}]...
+                   [--body {TEXT}] [...]
   Does NOT match:
     - gh issue list / view / edit / close
     - Commands where `--label foo` appears only inside a `--body "..."` argument value

--- a/.claude/team/charter/hooks.md
+++ b/.claude/team/charter/hooks.md
@@ -32,7 +32,8 @@ The following charter rules are enforced automatically via Claude Code hooks in 
 
 ## Hook 5: Validate Labels Before `gh issue create` (`validate_labels.py`)
 
-- **What it automates:** GitHub Label Hygiene — validates that all `--label` values exist in the repository before `gh issue create` runs.
+- **What it automates:** GitHub Label Hygiene — validates that all `--label` values exist in the **target** repository before `gh issue create` runs. The hook parses `--repo` / `-R` from the command and forwards it to `gh label list --repo ...`, so labels are resolved against the repo the issue is being created in, not the cwd-resolved repo.
+- **Input language:** uses `shlex.split` to tokenize the command, then walks the `gh issue create` argv slice. Only `--label` / `-l` tokens that appear as flags (not inside a `--body` / `--title` / `-F` value) are treated as labels. Prevents false-positives when issue bodies document gh commands or mention label names as prose.
 - **Augments:** The label hygiene section. The manual rule to run `gh label list` first is now enforced automatically.
 - **Manual steps remaining:** None — the hook fetches labels and validates automatically.
 - **Emergency override:** Remove the hook entry from `.claude/settings.json`. If `gh label list` is unavailable (network issue), the hook allows the command with a warning.


### PR DESCRIPTION
## Summary

Fixes two W8-surfaced bugs in `.claude/hooks/validate_labels.py`:

- **Bug 1 — `--repo` not propagated.** `get_existing_labels()` ran `gh label list` without forwarding the repo argument, so the hook validated against the cwd-resolved repo instead of the target. Issue creation against the parent repo from a child repo worktree hit false blocks.
- **Bug 2 — body content scanned for flags.** The previous regex matched `--label` substrings anywhere in the command string, including inside quoted `--body` values. Issue bodies that documented gh commands as prose triggered validation against fake labels.

### Implementation

- Replaced the single-pass regex with `shlex.split` + argv walking. Only `--label` / `-l` tokens inside the `gh issue create` argv slice are treated as flags. Values of `--body` / `-b` / `--body-file` / `-F` / `--title` / `-t` are skipped so nested flag patterns inside them are not scanned.
- Added `extract_repo()` which parses `--repo` / `-R` / `--repo=` / `-R=` from the argv slice (never from body text) and forwards it to `gh label list --repo ...`.
- Added an **Input Language** docstring per charter § Hook Authorship Requirements.
- Updated charter Hook 5 entry to describe the new input language.

### Tests (`.claude/hooks/test_validate_labels.py`)

22 unit tests, including charter-mandated negative-match coverage:

- `test_negative_label_inside_body_single_quotes` — `--body 'mentions --label fake-label'` + real `--label bug` → only `["bug"]` extracted
- `test_negative_label_inside_body_double_quotes`
- `test_negative_body_equals_form` — `--body="..."` attached form
- `test_negative_body_file_flag` — `-F body.md`
- `test_negative_title_is_not_scanned`
- `test_repo_inside_body_not_extracted` — body content referencing `--repo` does not override the real flag
- `test_body_false_positive_does_not_block` — full `check()` integration

All 22 pass locally.

### Dispatcher / settings.json

`validate_labels` is already registered in `dispatcher.py`'s `_BASH_HOOKS` (line 36). No `settings.json` change needed.

### Line-of-code delta

`3 files changed, 362 insertions(+), 24 deletions(-)` — most of the additions are the test file.

## Charter § Hook Authorship Requirements checklist

- [x] Input-language docstring (Fires on / Matches / Does NOT match / Flag pass-through)
- [x] Charter entry updated in `.claude/team/charter/hooks.md` (Hook 5)
- [x] Negative-match test coverage (see list above)
- [x] Dispatcher registration verified (no new settings.json entry)

## Peer review request

Requestor: Wanjiku.Mwangi
Requestee: Aisha.Idrissi
RequestOrReplied: Requested

Closes #113