### PR TITLE
fix(hooks): exclude RequestOrReplied: Requested from review count (#123)

### DIFF
--- a/.claude/hooks/validate_pr_review.py
+++ b/.claude/hooks/validate_pr_review.py
@@ -5,6 +5,36 @@ Blocks `gh pr merge` unless the PR has at least two reviews from distinct
 non-authors, using either formal GitHub reviews or charter-format
 comment-based reviews from different team members.
 
+Input Language:
+  Fires on:      PreToolUse Bash
+  Matches:       gh pr merge {N} [--repo {OWNER/REPO}] [--squash|--merge|--rebase] [--admin]
+  Does NOT match: gh pr list, gh pr view, gh pr checks, gh pr create, gh pr comment, git merge
+  Flag pass-through:
+    --repo   → overrides cwd-resolved repo when querying gh pr view / gh api comments
+    --admin  → short-circuits (emergency override, allows merge)
+
+Comment-review detection (inside gh pr merge flow):
+  Counts a PR comment as a review iff it contains BOTH:
+    - Requestee:          <name>
+    - RequestOrReplied:   {Approved | Changes Requested | Replied}
+  Does NOT count as a review:
+    - RequestOrReplied: Requested  (this is a review REQUEST, not a review)
+    - Comments with only Requestee: but no RequestOrReplied: line
+    - Comments with only RequestOrReplied: but no Requestee: line
+
+Negative-match verification (guards against the #123 false-positive):
+  Input comment body (the review-request assignment that tripped the buggy hook on PR #122):
+    Requestor: Aino.Virtanen
+    Requestee: Nadia.Khoury
+    RequestOrReplied: Requested
+  Expected: NOT counted as a review → merge proceeds with 2 actual reviews.
+
+  Input comment body (an actual review missing TechDebt:):
+    Requestor: Aino.Virtanen
+    Requestee: Nadia.Khoury
+    RequestOrReplied: Approved
+  Expected: counted as a review AND blocks merge for missing TechDebt: line.
+
 Exit codes:
   0 — allow (not a merge command, or two reviews exist)
   2 — block (fewer than two peer reviews found)
@@ -157,7 +187,13 @@ def check_comment_reviews(
             # Check for charter-format review: must contain Requestee: and RequestOrReplied:
             # Handles markdown bold (**Requestee:**) and plain text (Requestee:)
             has_requestee = re.search(r"\*{0,2}Requestee:\*{0,2}\s*(.+)", body)
-            has_request_or_replied = re.search(r"RequestOrReplied:", body)
+            # Only count comments that record a review OUTCOME, not review requests.
+            # RequestOrReplied: Requested means "review requested" — not itself a review.
+            has_request_or_replied = re.search(
+                r"\*{0,2}RequestOrReplied:\*{0,2}\s*"
+                r"\*{0,2}(?:Approved|Changes Requested|Replied)\*{0,2}",
+                body,
+            )
 
             if has_requestee and has_request_or_replied:
                 # Extract Requestee name (the reviewer)

--- a/.claude/team/charter/hooks.md
+++ b/.claude/team/charter/hooks.md
@@ -46,8 +46,9 @@ The following charter rules are enforced automatically via Claude Code hooks in 
 
 ## Hook 7: Validate PR Review (`validate_pr_review.py`)
 
-- **What it automates:** Blocks `gh pr merge` unless the PR has at least one review from a non-author. Enforces the charter's peer review requirement.
+- **What it automates:** Blocks `gh pr merge` unless the PR has at least TWO reviews from distinct non-authors (formal GitHub reviews or charter-format comment reviews). Also blocks when any counted review is missing the mandatory `TechDebt:` attestation line. Enforces the charter's peer review requirement.
 - **Augments:** [Pull Requests](pull-requests.md) review requirements. Session 4 saw all PR reviews skipped across 3 waves.
+- **Comment-review detection (tightened for #123):** Counts a PR comment as a review iff it contains BOTH a `Requestee:` line AND a `RequestOrReplied:` line whose value is one of `Approved`, `Changes Requested`, or `Replied`. Comments with `RequestOrReplied: Requested` are review REQUESTS (assignment comments) — they are explicitly excluded and do NOT count as reviews.
 - **Manual steps remaining:** None — the hook queries `gh pr view` for reviews automatically. Use `--admin` flag for emergency overrides.
 - **Emergency override:** Pass `--admin` to `gh pr merge`, or remove the hook entry.
 


### PR DESCRIPTION
Closes #123

## Summary
- Tighten `validate_pr_review.py` comment-review detection so review-request assignment comments (`RequestOrReplied: Requested`) no longer count as reviews. Previously the hook triggered on mere presence of the `RequestOrReplied:` marker, flagging review-request comments as reviews missing `TechDebt:` and blocking merge (hit in PR #122).
- Now counts a comment as a review iff `RequestOrReplied` is one of `Approved`, `Changes Requested`, or `Replied`.
- Adds the charter-mandated Input Language docstring with embedded negative-match verification (`Requested` must be excluded; `Approved` missing `TechDebt:` must still block).
- Updates Hook 7's charter entry (`.claude/team/charter/hooks.md`) to document the tightened detection.

## Fix (line 160 area)
```python
# Before (buggy — any RequestOrReplied: marker counted as a review)
has_request_or_replied = re.search(r"RequestOrReplied:", body)

# After — only review OUTCOMES count
has_request_or_replied = re.search(
    r"\*{0,2}RequestOrReplied:\*{0,2}\s*"
    r"\*{0,2}(?:Approved|Changes Requested|Replied)\*{0,2}",
    body,
)
```

## Acceptance criteria (from #123)
- [x] Hook ignores `RequestOrReplied: Requested` (not a review)
- [x] Hook still catches `Approved` / `Changes Requested` / `Replied` as reviews
- [x] Regression test: review-request comment with both reviewers but no TechDebt does NOT block `gh pr merge`
- [x] Regression test: actual review missing TechDebt still blocks

## Test plan
Inline regex regression (11 cases) + end-to-end `check_comment_reviews` integration test with mocked `gh api` output covering both positive and negative scenarios — both passed locally.

## Notes for reviewer
- This is the 4th substring-bug of the W8 cluster (refs #113, #114, #118). Root cause is hooks written liberal without input-language spec; this PR exemplifies the corrected authorship requirements (charter § Hook Authorship Requirements).
- Dispatcher registration verified still present (`dispatcher.py:38`).
- Test pair documented in the hook's Input Language docstring (charter allows docstring-embedded manual verification where no test suite exists).
- Meta-caution: the review-request comment on this PR will trip the still-buggy deployed hook (this PR fixes it). Orchestrator may need `--admin` for the self-fix merge.

Requestor: Aino.Virtanen
Requestee: Lucas.Ferreira
RequestOrReplied: Requested