### PR TITLE
hook(#114): scope auto_set_env_test to effective argv[0], not substring

### DIFF
--- a/.claude/hooks/auto_set_env_test.py
+++ b/.claude/hooks/auto_set_env_test.py
@@ -2,16 +2,93 @@
 """PreToolUse hook: Auto-set ENVIRONMENT=test before pytest/make test.
 
 Ensures ENVIRONMENT=test is present in the environment for any pytest or
-`make test` command. If not already set, prepends ENVIRONMENT=test to the
-command.
+`make test` command. If not already set, blocks with instructions to prepend
+ENVIRONMENT=test to the command.
+
+Input Language:
+  Fires on:      PreToolUse Bash
+  Matches:       A command (possibly chained with &&/||/|/;) in which at least
+                 one segment's effective argv[0] is one of:
+                   - pytest
+                   - python -m pytest
+                   - uv run pytest
+                   - make test
+                 Leading `VAR=value` env assignments are stripped before
+                 inspecting argv[0], so `FOO=bar pytest` still matches.
+  Does NOT match:
+                 - gh pr comment --body "... pytest ..."   (gh is never a test runner)
+                 - gh issue create --body "... make test ..."
+                 - gh pr review --body "pytest failed"
+                 - git log --grep pytest
+                 - echo "run pytest"                       (literal inside quotes)
+                 - cat README.md | grep "make test"
+                 - any command whose first argv is not a test-runner token
+  Flag pass-through:
+                 - If ENVIRONMENT=test already appears as a leading env
+                   assignment on the matched segment, allow through.
 
 Exit codes:
-  0 — allow (always; modifies command if needed via JSON output)
+  0 — allow (not a test command, or already has ENVIRONMENT=test)
+  2 — block (test command missing ENVIRONMENT=test)
 """
 
 import json
 import re
+import shlex
 import sys
+
+# Segments of a matched test-runner invocation. Each tuple is matched left-to-right
+# against the post-env-strip tokens of a command segment.
+_TEST_RUNNER_PREFIXES: tuple[tuple[str, ...], ...] = (
+    ("pytest",),
+    ("python", "-m", "pytest"),
+    ("python3", "-m", "pytest"),
+    ("uv", "run", "pytest"),
+    ("make", "test"),
+)
+
+
+def _split_segments(command: str) -> list[str]:
+    """Split a command string on shell chain operators (&&, ||, |, ;)."""
+    return re.split(r"\s*(?:&&|\|\||\||;)\s*", command)
+
+
+def _strip_leading_env(tokens: list[str]) -> tuple[list[str], bool]:
+    """Strip leading VAR=value tokens. Return (remaining_tokens, had_env_test)."""
+    had_env_test = False
+    i = 0
+    env_re = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+    while i < len(tokens) and env_re.match(tokens[i]):
+        if tokens[i] == "ENVIRONMENT=test":
+            had_env_test = True
+        i += 1
+    return tokens[i:], had_env_test
+
+
+def _matches_test_runner(tokens: list[str]) -> bool:
+    """Check if tokens start with any known test-runner prefix."""
+    for prefix in _TEST_RUNNER_PREFIXES:
+        if len(tokens) >= len(prefix) and tuple(tokens[: len(prefix)]) == prefix:
+            return True
+    return False
+
+
+def _segment_is_unenvironmented_test(segment: str) -> bool:
+    """Return True if this segment is a test-runner invocation lacking ENVIRONMENT=test."""
+    segment = segment.strip()
+    if not segment:
+        return False
+    try:
+        tokens = shlex.split(segment, posix=True)
+    except ValueError:
+        # Unbalanced quotes etc — fall back to "no match" rather than over-firing.
+        return False
+    if not tokens:
+        return False
+    remaining, had_env_test = _strip_leading_env(tokens)
+    if not _matches_test_runner(remaining):
+        return False
+    return not had_env_test
 
 
 def check(input_data: dict) -> dict | None:
@@ -24,23 +101,21 @@ def check(input_data: dict) -> dict | None:
         return None
 
     command = input_data.get("tool_input", {}).get("command", "")
-
-    is_test_cmd = bool(re.search(r"\bpytest\b", command) or re.search(r"\bmake\s+test\b", command))
-
-    if not is_test_cmd:
+    if not command:
         return None
 
-    if re.search(r"\bENVIRONMENT=test\b", command):
-        return None
+    for segment in _split_segments(command):
+        if _segment_is_unenvironmented_test(segment):
+            return {
+                "decision": "block",
+                "reason": (
+                    "ENVIRONMENT=test is required for test commands but was not found in "
+                    "the command. Please prepend ENVIRONMENT=test to the command:\n"
+                    f"  ENVIRONMENT=test {command}"
+                ),
+            }
 
-    return {
-        "decision": "block",
-        "reason": (
-            "ENVIRONMENT=test is required for test commands but was not found in "
-            "the command. Please prepend ENVIRONMENT=test to the command:\n"
-            f"  ENVIRONMENT=test {command}"
-        ),
-    }
+    return None
 
 
 def main() -> None:

--- a/.claude/team/charter/hooks.md
+++ b/.claude/team/charter/hooks.md
@@ -25,9 +25,10 @@ The following charter rules are enforced automatically via Claude Code hooks in 
 
 ## Hook 4: Auto-set `ENVIRONMENT=test` (`auto_set_env_test.py`)
 
-- **What it automates:** Ensures `ENVIRONMENT=test` is set before any `pytest`, `uv run pytest`, or `make test` command. Prevents CI breaks caused by missing environment variable.
+- **What it automates:** Ensures `ENVIRONMENT=test` is set before any `pytest`, `uv run pytest`, `python -m pytest`, or `make test` command. Prevents CI breaks caused by missing environment variable.
 - **Augments:** Testing workflow. This is an automated safeguard, not replacing a prior manual rule.
 - **Manual steps remaining:** None — the hook blocks and instructs the user to prepend `ENVIRONMENT=test`.
+- **Scoping (W9, #114):** The match is anchored to the **effective `argv[0]`** of each shell-chained segment (`&&`, `||`, `|`, `;`). Leading `VAR=value` env assignments are stripped before inspecting `argv[0]`. This means the hook fires on `pytest tests/` and `ENVIRONMENT=test pytest && pytest` (second segment missing env), but does **NOT** fire on substring mentions inside quoted flag values such as `gh pr comment --body "pytest failed"`, `gh issue create --body "... make test ..."`, `git log --grep pytest`, or `echo "run pytest"`. See the hook's `Input Language` docstring for the full spec.
 - **Emergency override:** Remove the hook entry from `.claude/settings.json`.
 
 ## Hook 5: Validate Labels Before `gh issue create` (`validate_labels.py`)


### PR DESCRIPTION
Closes #114

## Summary

Replaces the `\bpytest\b` / `\bmake\s+test\b` substring match in `auto_set_env_test.py` with a per-segment `shlex` parse that inspects the **effective argv[0]** of each shell-chained segment. The hook no longer fires on substring mentions inside quoted flag values (e.g., `gh pr comment --body "pytest failed"`).

## Behavior changes

**Positive cases (still block without `ENVIRONMENT=test`):**
- `pytest tests/`
- `uv run pytest`
- `make test`
- `python -m pytest`
- `ENVIRONMENT=test pytest && pytest tests/` (second segment bare)

**Negative cases (no longer falsely trigger):**
- `gh pr comment --body \"pytest failed\"`
- `gh pr comment --body \"Fix pytest CVE\"` (issue's documented negative-match test)
- `gh issue create --body \"... make test ...\"`
- `git log --grep pytest`
- `echo \"run pytest\"`
- `cat README.md | grep \"make test\"`

## Charter compliance (§ Hook Authorship Requirements)

1. **Input-language docstring** — new `Input Language` section enumerates Fires-on, Matches, Does-NOT-match, Flag pass-through. Follows the `validate_pr_ci_status.py` exemplar.
2. **Charter entry updated** — Hook 4 in `.claude/team/charter/hooks.md` now documents the scoping rules with examples of both positive and negative matches.
3. **Negative-match verification** — the docstring's Does-NOT-match list includes `gh pr comment --body \"pytest failed\"`. Manual verification performed during development (20 cases, all passing).
4. **Dispatcher registration** — unchanged; `auto_set_env_test` is already in `_BASH_HOOKS` (dispatcher.py:34).

## Implementation notes

- Uses `shlex.split(posix=True)` so quoted values are kept as single tokens and their contents are never inspected. On unbalanced quotes, the hook fails **closed** (allows the command) rather than over-firing.
- Leading `VAR=value` env assignments are stripped before inspecting `argv[0]`, preserving the existing `ENVIRONMENT=test pytest` short-circuit.
- Chain splitting covers `&&`, `||`, `|`, `;`. Each segment is evaluated independently so `ENVIRONMENT=test pytest && pytest` still blocks on the second segment.

## LoC delta

`.claude/hooks/auto_set_env_test.py`: +80 / -17 (61 → 124 lines, mostly the new docstring + helper functions)
`.claude/team/charter/hooks.md`: +1 line (scoping note added to Hook 4)

## Peer review request

Requestor: Aisha.Idrissi
Requestee: Wanjiku.Mwangi
RequestOrReplied: Requested