### PR TITLE
fix(hook): validate_branch_freshness honors --repo flag (#118)

### DIFF
--- a/.claude/hooks/validate_branch_freshness.py
+++ b/.claude/hooks/validate_branch_freshness.py
@@ -3,8 +3,26 @@
 
 Blocks `gh pr create` if the feature branch is behind the base branch.
 
+Input Language:
+  Fires on:      PreToolUse Bash
+  Matches:       gh pr create [--repo {OWNER/REPO}] [--base {BRANCH}] [...]
+  Does NOT match: gh pr list, gh pr view, gh pr merge, gh pr checks, git push
+  Flag pass-through:
+    --repo   → if present and differs from the cwd-resolved repo, skip the
+               freshness check with a warning (the local git state belongs
+               to a different repo, so origin/{base} cannot be checked
+               meaningfully). GitHub's branch-protection still gates the
+               actual merge.
+    --base   → the base branch name used for origin/{base} ancestry check.
+               Defaults to "main".
+
+Negative-match verification:
+  Running `gh pr create --repo noorinalabs/noorinalabs-user-service ...` from
+  cwd=noorinalabs-main MUST emit only a non-blocking warning (cross-repo
+  skip), never a false "behind base" block. See is_cross_repo_target().
+
 Exit codes:
-  0 — allow (not gh pr create, or branch is up to date)
+  0 — allow (not gh pr create, cross-repo skip, or branch is up to date)
   2 — block (branch is behind base)
 """
 
@@ -24,6 +42,47 @@ def get_base_branch(command: str) -> str:
     if match:
         return match.group(1)
     return "main"
+
+
+def extract_repo_from_command(command: str) -> str | None:
+    """Extract --repo value (OWNER/REPO) from a gh command."""
+    match = re.search(r"--repo\s+[\"']?(\S+?)[\"']?(?:\s|$)", command)
+    if match:
+        return match.group(1)
+    return None
+
+
+def get_cwd_repo() -> str | None:
+    """Return cwd's OWNER/REPO via `gh repo view`. None if unavailable."""
+    try:
+        result = subprocess.run(
+            ["gh", "repo", "view", "--json", "nameWithOwner"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            return None
+        data = json.loads(result.stdout)
+        name = data.get("nameWithOwner")
+        return name if isinstance(name, str) and name else None
+    except (subprocess.TimeoutExpired, json.JSONDecodeError, FileNotFoundError):
+        return None
+
+
+def is_cross_repo_target(target_repo: str | None) -> bool:
+    """True when --repo points to a different repo than cwd.
+
+    Returns False when target_repo is None (no --repo flag), when cwd's repo
+    cannot be resolved (be permissive — skip the cross-repo shortcut and fall
+    through to the regular check), or when target_repo matches cwd's repo.
+    """
+    if not target_repo:
+        return False
+    cwd_repo = get_cwd_repo()
+    if cwd_repo is None:
+        return False
+    return target_repo.lower() != cwd_repo.lower()
 
 
 def is_branch_fresh(base: str) -> bool:
@@ -60,6 +119,18 @@ def check(input_data: dict) -> dict | None:
     if not re.search(r"\bgh\s+pr\s+create\b", command):
         return None
 
+    target_repo = extract_repo_from_command(command)
+    if is_cross_repo_target(target_repo):
+        return {
+            "decision": "allow",
+            "systemMessage": (
+                f"NOTE: Skipping branch-freshness check — --repo {target_repo} "
+                "differs from the current working directory's repo. Local git "
+                "state cannot validate freshness against a different repo. "
+                "GitHub's branch-protection will still gate the merge."
+            ),
+        }
+
     base = get_base_branch(command)
 
     if is_branch_fresh(base):
@@ -85,8 +156,10 @@ def main() -> None:
         sys.exit(0)
 
     result = check(input_data)
-    if result and result.get("decision") == "block":
-        print(json.dumps(result))
+    if result is None:
+        sys.exit(0)
+    print(json.dumps(result))
+    if result.get("decision") == "block":
         sys.exit(2)
     sys.exit(0)
 

--- a/.claude/team/charter/hooks.md
+++ b/.claude/team/charter/hooks.md
@@ -63,6 +63,7 @@ The following charter rules are enforced automatically via Claude Code hooks in 
 - **What it automates:** Blocks `gh pr create` if the feature branch is behind the base branch. Prevents merge conflicts from stale branches.
 - **Augments:** [Branching](branching.md) workflow. Session 4 had RBAC and session hardening PRs conflict because neither was rebased.
 - **Manual steps remaining:** None — the hook runs `git fetch` and `git merge-base --is-ancestor` automatically.
+- **`--repo` flag handling:** If `gh pr create --repo {OWNER/REPO}` targets a repo that differs from the cwd-resolved repo, the hook emits a non-blocking warning and skips the local-git freshness check. Rationale: the local worktree belongs to a different repo, so `origin/{base}` there is unrelated to the PR target; GitHub's branch-protection still gates the actual merge. Fixed in #118 (W9) as the third hook in the W8 substring/cwd-bug cluster (#113 labels, #114 env-test, #118 freshness).
 - **Emergency override:** Remove the hook entry from `.claude/settings.json`.
 
 ## Hook 10: Validate VPS_HOST (`validate_vps_host.py`)


### PR DESCRIPTION
## Summary

Closes #118.

`validate_branch_freshness.py` previously ran `git fetch` and `git merge-base --is-ancestor` against the session cwd, regardless of the `--repo OWNER/REPO` flag on the `gh pr create` command. When the cwd was in a different repo than the PR target, this produced false-positive "branch behind base" blocks — Wanjiku hit this during W8 #111 while opening cross-repo PRs from `noorinalabs-main`.

This is the third hook in the W8 cwd/substring-bug cluster (#113 labels, #114 env-test, #118 freshness). Per the issue's recommended fix: detect cross-repo targets and skip with a non-blocking warning, deferring to GitHub's branch-protection at merge time.

## Changes

- Parse `--repo` from the command (`extract_repo_from_command`).
- Resolve cwd's `OWNER/REPO` via `gh repo view --json nameWithOwner` (`get_cwd_repo`).
- If the target repo differs from cwd's repo, emit `decision: allow` with a `systemMessage` explaining the skip — no local git invoked in that path.
- Same-repo targets and commands without `--repo` fall through to the existing ancestry check (unchanged behavior).
- Add the Input-Language docstring required by charter § Hook Authorship Requirements — documents matches, negative matches, and flag pass-through.
- Update charter Hook 9 entry to document the `--repo` handling.

## Acceptance criteria

- [x] Hook parses `--repo` flag and either uses correct repo path or skips gracefully (chose skip-with-warning, per issue recommendation)
- [x] No false positives when cwd does not match target repo
- [x] Existing happy path (cwd == target-repo) continues to work
- [x] Negative-match verification: `gh pr create --repo noorinalabs/noorinalabs-user-service ...` from `noorinalabs-main` cwd does NOT emit false "behind base" error — emits only a non-blocking warning

## Charter § Hook Authorship Requirements

- [x] Input-language docstring at top of file (Fires on / Matches / Does NOT match / Flag pass-through / Negative-match verification)
- [x] Charter Hook 9 entry updated with `--repo` flag semantics
- [x] Negative-match test: cross-repo PR create returns `allow` (not `block`); same-repo stale branch still blocks. Verified with 10 in-process assertions against `check()`
- [x] Dispatcher registration preserved in `.claude/hooks/dispatcher.py` `_BASH_HOOKS` (line 40)

## Review

Requestor: Lucas.Ferreira
Requestee: Aino.Virtanen
RequestOrReplied: Requested