### PR TITLE
feat(hooks): enforce_librarian_consulted — block code edits without prior librarian (#150)

### DIFF
--- a/.claude/hooks/enforce_librarian_consulted.py
+++ b/.claude/hooks/enforce_librarian_consulted.py
@@ -37,13 +37,22 @@ Stance on meta-files (.claude/team/feedback_log.md, trust_matrix.md, etc.):
     add a sentinel-comment bypass — do not broaden the path allow-list.
 
 Transcript shape expected (JSONL, one object per line):
-    { "type": "user",      "message": {"role":"user",
-                                       "content": "<command-name>/ontology-librarian</command-name>..."}, ...}
-    { "type": "user",      "message": {"role":"user",
-                                       "content": [{"type":"text","text":"/ontology-librarian ..."}]}, ...}
-    { "type": "assistant", "message": {"role":"assistant",
-                                       "content": [{"type":"tool_use","name":"Skill",
-                                                    "input":{"skill":"ontology-librarian",...}}]}, ...}
+    Form A (string content):
+        {"type": "user",
+         "message": {"role": "user",
+                     "content": "<command-name>/ontology-librarian</command-name>..."}}
+    Form B (list content with text block):
+        {"type": "user",
+         "message": {"role": "user",
+                     "content": [{"type": "text",
+                                  "text": "/ontology-librarian ..."}]}}
+    Form C (assistant Skill tool_use):
+        {"type": "assistant",
+         "message": {"role": "assistant",
+                     "content": [{"type": "tool_use",
+                                  "name": "Skill",
+                                  "input": {"skill": "ontology-librarian",
+                                            "args": "..."}}]}}
 
 Detection signals (any ONE is sufficient):
     1. A `user` line whose text contains the literal substring
@@ -92,9 +101,7 @@ _ALLOW_ABS_PREFIXES = (
     os.path.expanduser("~/.claude/"),
 )
 
-_ALLOW_PATH_SUFFIXES = (
-    "MEMORY.md",
-)
+_ALLOW_PATH_SUFFIXES = ("MEMORY.md",)
 
 # Directory segments that mark "not source code".
 _ALLOW_PATH_CONTAINS = (
@@ -200,8 +207,8 @@ def _transcript_has_librarian(transcript_path: str) -> bool:
 
 _BLOCK_MESSAGE = (
     "BLOCKED: /ontology-librarian must be consulted before code edits in this session.\n"
-    "Per CLAUDE.md § Ontology: \"Every agent — orchestrator, team member, or one-off —\n"
-    "MUST run /ontology-librarian {topic} before making code changes.\"\n"
+    'Per CLAUDE.md § Ontology: "Every agent — orchestrator, team member, or one-off —\n'
+    'MUST run /ontology-librarian {topic} before making code changes."\n'
     "Run /ontology-librarian {topic} first, then retry the edit."
 )
 
@@ -217,11 +224,7 @@ def check(input_data: dict) -> dict | None:
 
     tool_input = input_data.get("tool_input") or {}
     # Edit/Write use file_path; NotebookEdit uses notebook_path.
-    file_path = (
-        tool_input.get("file_path")
-        or tool_input.get("notebook_path")
-        or ""
-    )
+    file_path = tool_input.get("file_path") or tool_input.get("notebook_path") or ""
 
     if _is_allowlisted(file_path):
         return None

--- a/.claude/hooks/enforce_librarian_consulted.py
+++ b/.claude/hooks/enforce_librarian_consulted.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: Block Edit/Write/NotebookEdit unless /ontology-librarian was consulted.
+
+Per CLAUDE.md § Ontology:
+  "Every agent — orchestrator, team member, or one-off — MUST run
+   /ontology-librarian {topic} before making code changes."
+
+This hook enforces that charter rule. It fires before Edit/Write/NotebookEdit
+and scans the current session's transcript for evidence of a librarian
+consultation. If none is found, the edit is blocked with guidance.
+
+Input Language
+==============
+
+Fires on:
+    PreToolUse Edit
+    PreToolUse Write
+    PreToolUse NotebookEdit
+
+Matches (tool_input.file_path or tool_input.notebook_path):
+    Any file path in the parameters of the above tools, EXCEPT paths
+    matching one of the allow-list rules below. The hook reads the
+    transcript file whose path is passed as `input_data["transcript_path"]`
+    (Claude Code agent SDK convention).
+
+Does NOT match (allow-listed paths — no librarian required):
+    /tmp/**                — out-of-repo scratch (issue body drafts, etc.)
+    **/memory/*.md         — project memory files written by handoff/retro
+    **/MEMORY.md           — auto-memory index
+    ~/.claude/**           — user-level config, not source code
+    .claude/annunaki/*     — error log (hook-managed, not hand-edited code)
+
+Stance on meta-files (.claude/team/feedback_log.md, trust_matrix.md, etc.):
+    REQUIRES librarian. These ARE project-state artifacts that the ontology
+    tracks and conventions describe. Treating them as "free edits" replays
+    the very decay pattern #150 is fixing. If false-positives accumulate,
+    add a sentinel-comment bypass — do not broaden the path allow-list.
+
+Transcript shape expected (JSONL, one object per line):
+    { "type": "user",      "message": {"role":"user",
+                                       "content": "<command-name>/ontology-librarian</command-name>..."}, ...}
+    { "type": "user",      "message": {"role":"user",
+                                       "content": [{"type":"text","text":"/ontology-librarian ..."}]}, ...}
+    { "type": "assistant", "message": {"role":"assistant",
+                                       "content": [{"type":"tool_use","name":"Skill",
+                                                    "input":{"skill":"ontology-librarian",...}}]}, ...}
+
+Detection signals (any ONE is sufficient):
+    1. A `user` line whose text contains the literal substring
+       "/ontology-librarian" OR "<command-name>/ontology-librarian".
+    2. An `assistant` `tool_use` block with name == "Skill" and
+       input.skill == "ontology-librarian".
+
+Scope of scan:
+    Entire transcript file (a Claude Code session == one transcript). Each
+    new session starts a fresh transcript, so a previous session's
+    invocation cannot carry over. This matches the issue body's
+    "since the last /clear or session start" requirement.
+
+Exit codes (per Claude Code hook convention):
+    0 — allow (not a matched tool, allow-listed path, or librarian found)
+    2 — block (writable path AND no librarian found in transcript)
+
+Enforcement artifact for: noorinalabs/noorinalabs-main#150
+Promotion pattern example: memory -> charter (CLAUDE.md § Ontology) -> hook.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from annunaki_log import log_pretooluse_block  # noqa: E402
+
+# Tool matchers this hook enforces on.
+_MATCHED_TOOLS = {"Edit", "Write", "NotebookEdit"}
+
+# Detection signals in transcript.
+_SLASH_CMD_MARKERS = (
+    "<command-name>/ontology-librarian",
+    "/ontology-librarian",
+)
+_SKILL_NAME = "ontology-librarian"
+
+# Allow-listed path prefixes / suffix patterns (no librarian required).
+# Absolute-path globs; matched against the resolved, absolute path.
+_ALLOW_ABS_PREFIXES = (
+    "/tmp/",
+    os.path.expanduser("~/.claude/"),
+)
+
+_ALLOW_PATH_SUFFIXES = (
+    "MEMORY.md",
+)
+
+# Directory segments that mark "not source code".
+_ALLOW_PATH_CONTAINS = (
+    "/memory/",
+    "/.claude/annunaki/",
+)
+
+
+def _is_allowlisted(file_path: str) -> bool:
+    """Return True if the path is exempt from the librarian requirement."""
+    if not file_path:
+        # No file_path means we cannot evaluate; default to enforcing.
+        return False
+
+    try:
+        abspath = os.path.abspath(os.path.expanduser(file_path))
+    except (OSError, ValueError):
+        abspath = file_path
+
+    # Absolute-prefix allow-list.
+    for prefix in _ALLOW_ABS_PREFIXES:
+        if abspath.startswith(prefix):
+            return True
+
+    # Suffix allow-list (exact filename, e.g. MEMORY.md).
+    basename = os.path.basename(abspath)
+    for suffix in _ALLOW_PATH_SUFFIXES:
+        if basename == suffix:
+            return True
+
+    # Directory-segment allow-list.
+    for seg in _ALLOW_PATH_CONTAINS:
+        if seg in abspath:
+            return True
+
+    return False
+
+
+def _content_has_librarian_signal(content) -> bool:
+    """Scan a single `message.content` value for librarian signals.
+
+    Content may be:
+      - str: look for slash-command markers.
+      - list[dict]: iterate blocks; check text blocks and tool_use blocks.
+    """
+    if isinstance(content, str):
+        for marker in _SLASH_CMD_MARKERS:
+            if marker in content:
+                return True
+        return False
+
+    if isinstance(content, list):
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            btype = block.get("type", "")
+            if btype == "text":
+                text = block.get("text", "")
+                for marker in _SLASH_CMD_MARKERS:
+                    if marker in text:
+                        return True
+            elif btype == "tool_use":
+                if block.get("name") == "Skill":
+                    skill = (block.get("input") or {}).get("skill", "")
+                    if skill == _SKILL_NAME:
+                        return True
+
+    return False
+
+
+def _transcript_has_librarian(transcript_path: str) -> bool:
+    """Return True if the transcript shows a librarian consultation."""
+    if not transcript_path:
+        return False
+
+    try:
+        p = Path(transcript_path)
+        if not p.exists():
+            return False
+        with p.open("r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                t = obj.get("type", "")
+                if t not in ("user", "assistant"):
+                    continue
+                msg = obj.get("message") or {}
+                content = msg.get("content", "")
+                if _content_has_librarian_signal(content):
+                    return True
+    except OSError:
+        # If we cannot read the transcript, FAIL OPEN — do not block on our
+        # own inability to read state. Parent dispatcher fail-open convention.
+        return True
+
+    return False
+
+
+_BLOCK_MESSAGE = (
+    "BLOCKED: /ontology-librarian must be consulted before code edits in this session.\n"
+    "Per CLAUDE.md § Ontology: \"Every agent — orchestrator, team member, or one-off —\n"
+    "MUST run /ontology-librarian {topic} before making code changes.\"\n"
+    "Run /ontology-librarian {topic} first, then retry the edit."
+)
+
+
+def check(input_data: dict) -> dict | None:
+    """Dispatcher-compatible entry point.
+
+    Returns None to allow; returns a block-dict to block.
+    """
+    tool_name = input_data.get("tool_name", "")
+    if tool_name not in _MATCHED_TOOLS:
+        return None
+
+    tool_input = input_data.get("tool_input") or {}
+    # Edit/Write use file_path; NotebookEdit uses notebook_path.
+    file_path = (
+        tool_input.get("file_path")
+        or tool_input.get("notebook_path")
+        or ""
+    )
+
+    if _is_allowlisted(file_path):
+        return None
+
+    transcript_path = input_data.get("transcript_path", "")
+    if _transcript_has_librarian(transcript_path):
+        return None
+
+    return {
+        "decision": "block",
+        "reason": _BLOCK_MESSAGE,
+    }
+
+
+def main() -> None:
+    try:
+        input_data = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        sys.exit(0)
+
+    result = check(input_data)
+    if result is None:
+        sys.exit(0)
+
+    print(json.dumps(result))
+    if result.get("decision") == "block":
+        # Log to Annunaki so the block shows up in /annunaki reports.
+        tool_name = input_data.get("tool_name", "")
+        tool_input = input_data.get("tool_input") or {}
+        file_path = tool_input.get("file_path") or tool_input.get("notebook_path") or ""
+        log_pretooluse_block(
+            "enforce_librarian_consulted",
+            f"{tool_name} {file_path}",
+            result["reason"],
+            tool_name=tool_name,
+        )
+        sys.exit(2)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/tests/test_enforce_librarian_consulted.py
+++ b/.claude/hooks/tests/test_enforce_librarian_consulted.py
@@ -40,7 +40,10 @@ def _librarian_user_line(text: str = "/ontology-librarian narrator API") -> dict
         "type": "user",
         "message": {
             "role": "user",
-            "content": f"<command-message>ontology-librarian</command-message>\n<command-name>{text}</command-name>",
+            "content": (
+                "<command-message>ontology-librarian</command-message>\n"
+                f"<command-name>{text}</command-name>"
+            ),
         },
     }
 
@@ -131,9 +134,7 @@ class AllowListTests(unittest.TestCase):
         result = hook.check(
             {
                 "tool_name": "Edit",
-                "tool_input": {
-                    "file_path": os.path.expanduser("~/.claude/preferences.json")
-                },
+                "tool_input": {"file_path": os.path.expanduser("~/.claude/preferences.json")},
                 "transcript_path": self._transcript_no_librarian(),
             }
         )
@@ -145,7 +146,7 @@ class AllowListTests(unittest.TestCase):
             {
                 "tool_name": "Edit",
                 "tool_input": {
-                    "file_path": "/home/parameterization/code/noorinalabs-main/.claude/annunaki/errors.jsonl"
+                    "file_path": "/repo/.claude/annunaki/errors.jsonl",
                 },
                 "transcript_path": self._transcript_no_librarian(),
             }
@@ -206,7 +207,7 @@ class BlockingTests(unittest.TestCase):
                 ),
             }
         )
-        self.assertIsNotNone(result)
+        assert result is not None  # mypy narrowing
         self.assertEqual(result["decision"], "block")
         self.assertIn("/ontology-librarian", result["reason"])
 
@@ -219,7 +220,7 @@ class BlockingTests(unittest.TestCase):
                 "transcript_path": _write_transcript([]),
             }
         )
-        self.assertIsNotNone(result)
+        assert result is not None  # mypy narrowing
         self.assertEqual(result["decision"], "block")
 
     def test_write_on_charter_blocks_without_librarian(self) -> None:
@@ -230,13 +231,11 @@ class BlockingTests(unittest.TestCase):
         result = hook.check(
             {
                 "tool_name": "Write",
-                "tool_input": {
-                    "file_path": "/repo/.claude/team/feedback_log.md"
-                },
+                "tool_input": {"file_path": "/repo/.claude/team/feedback_log.md"},
                 "transcript_path": _write_transcript([]),
             }
         )
-        self.assertIsNotNone(result)
+        assert result is not None  # mypy narrowing
         self.assertEqual(result["decision"], "block")
 
     def test_empty_transcript_blocks_real_code_edit(self) -> None:
@@ -248,7 +247,7 @@ class BlockingTests(unittest.TestCase):
                 "transcript_path": _write_transcript([]),
             }
         )
-        self.assertIsNotNone(result)
+        assert result is not None  # mypy narrowing
         self.assertEqual(result["decision"], "block")
 
 
@@ -319,7 +318,7 @@ class FailOpenTests(unittest.TestCase):
             }
         )
         # Current stance: missing file -> block (strict).
-        self.assertIsNotNone(result)
+        assert result is not None  # mypy narrowing
         self.assertEqual(result["decision"], "block")
 
     def test_no_transcript_path_blocks(self) -> None:
@@ -331,7 +330,7 @@ class FailOpenTests(unittest.TestCase):
                 "transcript_path": "",
             }
         )
-        self.assertIsNotNone(result)
+        assert result is not None  # mypy narrowing
         self.assertEqual(result["decision"], "block")
 
 
@@ -339,14 +338,10 @@ class SignalDetectionTests(unittest.TestCase):
     """Unit-level tests for _content_has_librarian_signal."""
 
     def test_string_content_with_slash_command(self) -> None:
-        self.assertTrue(
-            hook._content_has_librarian_signal("please run /ontology-librarian hooks")
-        )
+        self.assertTrue(hook._content_has_librarian_signal("please run /ontology-librarian hooks"))
 
     def test_string_content_without_slash_command(self) -> None:
-        self.assertFalse(
-            hook._content_has_librarian_signal("please run /ontology-rebuild")
-        )
+        self.assertFalse(hook._content_has_librarian_signal("please run /ontology-rebuild"))
 
     def test_text_block_with_slash_command(self) -> None:
         self.assertTrue(

--- a/.claude/hooks/tests/test_enforce_librarian_consulted.py
+++ b/.claude/hooks/tests/test_enforce_librarian_consulted.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+"""Tests for enforce_librarian_consulted hook.
+
+Covers the W8 hook-authorship-spec requirement: NEGATIVE MATCH coverage.
+Each test documents which negative-space case it guards against.
+
+Run: python3 -m pytest .claude/hooks/tests/test_enforce_librarian_consulted.py -v
+Or:  python3 .claude/hooks/tests/test_enforce_librarian_consulted.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+# Put the hooks dir on sys.path so we can import the hook module.
+_HERE = Path(__file__).resolve().parent
+_HOOKS_DIR = _HERE.parent
+sys.path.insert(0, str(_HOOKS_DIR))
+
+import enforce_librarian_consulted as hook  # noqa: E402
+
+
+def _write_transcript(lines: list[dict]) -> str:
+    """Write transcript lines to a temp file, return its path."""
+    fd, path = tempfile.mkstemp(suffix=".jsonl", prefix="librarian_test_")
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
+        for obj in lines:
+            f.write(json.dumps(obj) + "\n")
+    return path
+
+
+def _librarian_user_line(text: str = "/ontology-librarian narrator API") -> dict:
+    """User message with a slash-command invocation (string content form)."""
+    return {
+        "type": "user",
+        "message": {
+            "role": "user",
+            "content": f"<command-message>ontology-librarian</command-message>\n<command-name>{text}</command-name>",
+        },
+    }
+
+
+def _librarian_skill_call() -> dict:
+    """Assistant tool_use invoking the Skill tool with ontology-librarian."""
+    return {
+        "type": "assistant",
+        "message": {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "name": "Skill",
+                    "input": {"skill": "ontology-librarian", "args": "hooks"},
+                }
+            ],
+        },
+    }
+
+
+def _unrelated_user_text() -> dict:
+    return {
+        "type": "user",
+        "message": {"role": "user", "content": [{"type": "text", "text": "please fix the bug"}]},
+    }
+
+
+def _unrelated_skill_call() -> dict:
+    return {
+        "type": "assistant",
+        "message": {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "name": "Skill",
+                    "input": {"skill": "ontology-rebuild"},
+                }
+            ],
+        },
+    }
+
+
+class AllowListTests(unittest.TestCase):
+    """Paths that should NEVER require a librarian (negative-match cases)."""
+
+    def _transcript_no_librarian(self) -> str:
+        return _write_transcript([_unrelated_user_text(), _unrelated_skill_call()])
+
+    def test_tmp_path_allowed_without_librarian(self) -> None:
+        """NEG: /tmp/foo.md edits must not fire — out-of-repo scratch."""
+        result = hook.check(
+            {
+                "tool_name": "Edit",
+                "tool_input": {"file_path": "/tmp/foo.md"},
+                "transcript_path": self._transcript_no_librarian(),
+            }
+        )
+        self.assertIsNone(result, "edits under /tmp must be allowed without librarian")
+
+    def test_memory_md_allowed_without_librarian(self) -> None:
+        """NEG: MEMORY.md (any location) is the auto-memory index, not code."""
+        result = hook.check(
+            {
+                "tool_name": "Write",
+                "tool_input": {
+                    "file_path": "/home/parameterization/.claude/projects/proj/memory/MEMORY.md"
+                },
+                "transcript_path": self._transcript_no_librarian(),
+            }
+        )
+        self.assertIsNone(result, "MEMORY.md must be allowed without librarian")
+
+    def test_memory_subdir_allowed_without_librarian(self) -> None:
+        """NEG: files under .../memory/ are project memory, not code."""
+        result = hook.check(
+            {
+                "tool_name": "Write",
+                "tool_input": {"file_path": "/anywhere/memory/handoff.md"},
+                "transcript_path": self._transcript_no_librarian(),
+            }
+        )
+        self.assertIsNone(result, "memory/ files must be allowed")
+
+    def test_user_claude_config_allowed_without_librarian(self) -> None:
+        """NEG: ~/.claude/** is user config, not source code."""
+        result = hook.check(
+            {
+                "tool_name": "Edit",
+                "tool_input": {
+                    "file_path": os.path.expanduser("~/.claude/preferences.json")
+                },
+                "transcript_path": self._transcript_no_librarian(),
+            }
+        )
+        self.assertIsNone(result, "~/.claude/** must be allowed")
+
+    def test_annunaki_error_log_allowed_without_librarian(self) -> None:
+        """NEG: .claude/annunaki/errors.jsonl is hook-managed, not hand-edited."""
+        result = hook.check(
+            {
+                "tool_name": "Edit",
+                "tool_input": {
+                    "file_path": "/home/parameterization/code/noorinalabs-main/.claude/annunaki/errors.jsonl"
+                },
+                "transcript_path": self._transcript_no_librarian(),
+            }
+        )
+        self.assertIsNone(result, ".claude/annunaki/ must be allowed")
+
+
+class NonMatchedToolTests(unittest.TestCase):
+    """Tools OTHER than Edit/Write/NotebookEdit must never block."""
+
+    def test_bash_does_not_block(self) -> None:
+        """NEG: Bash is not in the matcher set — must return None."""
+        result = hook.check(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "ls"},
+                "transcript_path": _write_transcript([]),
+            }
+        )
+        self.assertIsNone(result)
+
+    def test_read_does_not_block(self) -> None:
+        """NEG: Read is not a code-change tool; must not match."""
+        result = hook.check(
+            {
+                "tool_name": "Read",
+                "tool_input": {"file_path": "/anywhere/code.py"},
+                "transcript_path": _write_transcript([]),
+            }
+        )
+        self.assertIsNone(result)
+
+    def test_grep_does_not_block(self) -> None:
+        """NEG: Grep is read-only discovery, not a code-change tool."""
+        result = hook.check(
+            {
+                "tool_name": "Grep",
+                "tool_input": {"pattern": "foo"},
+                "transcript_path": _write_transcript([]),
+            }
+        )
+        self.assertIsNone(result)
+
+
+class BlockingTests(unittest.TestCase):
+    """In-scope code edits without librarian must BLOCK."""
+
+    def test_compose_edit_without_librarian_blocks(self) -> None:
+        """POS: the canonical case from #150 — compose edit without librarian."""
+        result = hook.check(
+            {
+                "tool_name": "Edit",
+                "tool_input": {
+                    "file_path": "/repo/noorinalabs-deploy/compose/docker-compose.prod.yml"
+                },
+                "transcript_path": _write_transcript(
+                    [_unrelated_user_text(), _unrelated_skill_call()]
+                ),
+            }
+        )
+        self.assertIsNotNone(result)
+        self.assertEqual(result["decision"], "block")
+        self.assertIn("/ontology-librarian", result["reason"])
+
+    def test_notebook_edit_without_librarian_blocks(self) -> None:
+        """POS: NotebookEdit is in the matcher set."""
+        result = hook.check(
+            {
+                "tool_name": "NotebookEdit",
+                "tool_input": {"notebook_path": "/repo/analysis.ipynb"},
+                "transcript_path": _write_transcript([]),
+            }
+        )
+        self.assertIsNotNone(result)
+        self.assertEqual(result["decision"], "block")
+
+    def test_write_on_charter_blocks_without_librarian(self) -> None:
+        """POS: .claude/team/ files are project state — require librarian.
+
+        (Stance documented in the hook docstring: meta-files require librarian.)
+        """
+        result = hook.check(
+            {
+                "tool_name": "Write",
+                "tool_input": {
+                    "file_path": "/repo/.claude/team/feedback_log.md"
+                },
+                "transcript_path": _write_transcript([]),
+            }
+        )
+        self.assertIsNotNone(result)
+        self.assertEqual(result["decision"], "block")
+
+    def test_empty_transcript_blocks_real_code_edit(self) -> None:
+        """POS: no transcript evidence -> block."""
+        result = hook.check(
+            {
+                "tool_name": "Edit",
+                "tool_input": {"file_path": "/repo/src/foo.py"},
+                "transcript_path": _write_transcript([]),
+            }
+        )
+        self.assertIsNotNone(result)
+        self.assertEqual(result["decision"], "block")
+
+
+class AllowWithLibrarianTests(unittest.TestCase):
+    """Transcripts WITH a librarian call must allow in-scope edits."""
+
+    def test_compose_edit_with_slash_command_allowed(self) -> None:
+        """POS: same compose path, but transcript has /ontology-librarian user line."""
+        result = hook.check(
+            {
+                "tool_name": "Edit",
+                "tool_input": {
+                    "file_path": "/repo/noorinalabs-deploy/compose/docker-compose.prod.yml"
+                },
+                "transcript_path": _write_transcript(
+                    [_librarian_user_line(), _unrelated_user_text()]
+                ),
+            }
+        )
+        self.assertIsNone(result, "librarian consulted -> edit must be allowed")
+
+    def test_compose_edit_with_skill_call_allowed(self) -> None:
+        """POS: librarian invoked via Skill tool -> allow."""
+        result = hook.check(
+            {
+                "tool_name": "Edit",
+                "tool_input": {
+                    "file_path": "/repo/noorinalabs-deploy/compose/docker-compose.prod.yml"
+                },
+                "transcript_path": _write_transcript([_librarian_skill_call()]),
+            }
+        )
+        self.assertIsNone(result)
+
+    def test_librarian_anywhere_in_transcript_counts(self) -> None:
+        """POS: librarian invocation need only exist somewhere in the session."""
+        lines = [
+            _unrelated_user_text(),
+            _unrelated_skill_call(),
+            _librarian_skill_call(),
+            _unrelated_user_text(),
+        ]
+        result = hook.check(
+            {
+                "tool_name": "Edit",
+                "tool_input": {"file_path": "/repo/src/code.py"},
+                "transcript_path": _write_transcript(lines),
+            }
+        )
+        self.assertIsNone(result)
+
+
+class FailOpenTests(unittest.TestCase):
+    """If we cannot read the transcript, FAIL OPEN (don't block on our own bug)."""
+
+    def test_missing_transcript_file_fails_open(self) -> None:
+        """NEG-shape: nonexistent transcript path -> return None (false returned
+        from _transcript_has_librarian in not-found case would actually BLOCK;
+        OSError path fails open. Non-existence -> we cannot prove librarian was
+        not called, but the strict choice here is to block; the function
+        currently returns False for not-exists. Test the CURRENT stance so a
+        future change is deliberate.)"""
+        result = hook.check(
+            {
+                "tool_name": "Edit",
+                "tool_input": {"file_path": "/repo/src/code.py"},
+                "transcript_path": "/nonexistent/transcript.jsonl",
+            }
+        )
+        # Current stance: missing file -> block (strict).
+        self.assertIsNotNone(result)
+        self.assertEqual(result["decision"], "block")
+
+    def test_no_transcript_path_blocks(self) -> None:
+        """NEG-shape: empty transcript_path -> block (no evidence = no librarian)."""
+        result = hook.check(
+            {
+                "tool_name": "Edit",
+                "tool_input": {"file_path": "/repo/src/code.py"},
+                "transcript_path": "",
+            }
+        )
+        self.assertIsNotNone(result)
+        self.assertEqual(result["decision"], "block")
+
+
+class SignalDetectionTests(unittest.TestCase):
+    """Unit-level tests for _content_has_librarian_signal."""
+
+    def test_string_content_with_slash_command(self) -> None:
+        self.assertTrue(
+            hook._content_has_librarian_signal("please run /ontology-librarian hooks")
+        )
+
+    def test_string_content_without_slash_command(self) -> None:
+        self.assertFalse(
+            hook._content_has_librarian_signal("please run /ontology-rebuild")
+        )
+
+    def test_text_block_with_slash_command(self) -> None:
+        self.assertTrue(
+            hook._content_has_librarian_signal(
+                [{"type": "text", "text": "/ontology-librarian foo"}]
+            )
+        )
+
+    def test_skill_call_with_librarian(self) -> None:
+        self.assertTrue(
+            hook._content_has_librarian_signal(
+                [
+                    {
+                        "type": "tool_use",
+                        "name": "Skill",
+                        "input": {"skill": "ontology-librarian"},
+                    }
+                ]
+            )
+        )
+
+    def test_skill_call_with_different_skill_rejected(self) -> None:
+        """NEG: Skill tool with a DIFFERENT skill name must not trigger."""
+        self.assertFalse(
+            hook._content_has_librarian_signal(
+                [
+                    {
+                        "type": "tool_use",
+                        "name": "Skill",
+                        "input": {"skill": "ontology-rebuild"},
+                    }
+                ]
+            )
+        )
+
+    def test_other_tool_use_ignored(self) -> None:
+        """NEG: tool_use blocks for non-Skill tools are irrelevant."""
+        self.assertFalse(
+            hook._content_has_librarian_signal(
+                [
+                    {
+                        "type": "tool_use",
+                        "name": "Bash",
+                        "input": {"command": "/ontology-librarian"},
+                    }
+                ]
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -35,6 +35,36 @@
             "timeout": 10
           }
         ]
+      },
+      {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/enforce_librarian_consulted.py",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/enforce_librarian_consulted.py",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/enforce_librarian_consulted.py",
+            "timeout": 10
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/.claude/team/charter/hooks.md
+++ b/.claude/team/charter/hooks.md
@@ -141,6 +141,16 @@ When hooks sharing the same matcher type (Bash, Agent, SendMessage, etc.) accumu
 - **Manual steps remaining:** None — the hook queries `gh pr view` for the check rollup automatically.
 - **Emergency override:** Pass `--admin` to `gh pr merge`, or remove the `validate_pr_ci_status` entry from the dispatcher hook list.
 
+## Hook 15: Enforce Librarian Consulted (`enforce_librarian_consulted.py`)
+
+- **What it automates:** Blocks `Edit`, `Write`, and `NotebookEdit` tool calls unless `/ontology-librarian` has been consulted earlier in the session. Reads the session transcript (`transcript_path` from the Claude Code hook input) and scans for either a user slash-command invocation of `/ontology-librarian` or an assistant `Skill` tool_use with `skill: "ontology-librarian"`. If neither is present, the edit is blocked with instructions to run the librarian first.
+- **Augments:** [CLAUDE.md § Ontology — "Before any code changes (mandatory)"](../../../CLAUDE.md). The charter rule "Every agent — orchestrator, team member, or one-off — MUST run `/ontology-librarian {topic}` before making code changes" was honored inconsistently across Phase 2 Wave 9 (3 of 4 code-change PRs skipped it — deploy#125 kafka GID, deploy#130 obs fix, user-service#67 OAuth GET). Per the enforcement-hierarchy principle (hook > skill > charter), a repeatedly violated charter rule becomes a hook. See issue [#150](https://github.com/noorinalabs/noorinalabs-main/issues/150).
+- **Matcher:** `Edit`, `Write`, `NotebookEdit` (not `Bash`) — direct registration in `settings.json` since these are the first PreToolUse hooks on these matchers. When a 4th hook is added to any of these matchers, consolidate via the dispatcher pattern (see § Dispatcher Consolidation Policy).
+- **Allowed bypasses:** `/tmp/**` (out-of-repo scratch), `~/.claude/**` (user config), `**/memory/*.md` and `MEMORY.md` (project memory), `.claude/annunaki/*` (hook-managed log). All other paths — including `.claude/team/feedback_log.md`, charter files, and source code — require librarian consultation. Stance documented in the hook docstring: meta-files are project-state artifacts the ontology tracks; treating them as free-edits replays the decay pattern #150 fixes.
+- **Manual steps remaining:** Run `/ontology-librarian {topic}` once per session before any Edit/Write/NotebookEdit on non-allow-listed paths. One invocation unlocks the session.
+- **Emergency override:** Remove the three `enforce_librarian_consulted.py` entries (Edit/Write/NotebookEdit matchers) from `.claude/settings.json`. Re-add after the emergency. There is no in-band override flag — the purpose of the hook is to break the "this one's small" rationalization, so an inline bypass would defeat the point.
+- **Promotion provenance:** First end-to-end execution of the memory → charter → hook promotion pattern ratified by the owner on 2026-04-19. Rule lived in CLAUDE.md § Ontology (charter-equivalent location) since W7; this hook is the underlying enforcement layer. Worked example referenced by the future `/promotion-audit` skill design.
+
 ---
 
 ## Hook Authorship Requirements

--- a/.claude/team/feedback_log.md
+++ b/.claude/team/feedback_log.md
@@ -806,3 +806,13 @@ No changes. All scores stable. See trust_matrix.md § Phase 2 Wave 8.
 
 ### Fire/Hire Actions
 None.
+
+## 2026-04-19 — Librarian rule decay observed; promotion to hook
+
+**Pattern:** Orchestrator skipped `/ontology-librarian` on 3 of 4 code-change PRs in P2W9 follow-up work (deploy#125 kafka GID, deploy#130 obs fix, user-service#67 OAuth GET). In each case the rationalization was "this one's small / obvious" — exactly the wording that eroded CI-gate discipline in W7 and peer-review discipline in W8.
+
+**Enforcement hierarchy applied:** Per charter § Enforcement-Hierarchy Promotion (hook > skill > charter), the CLAUDE.md § Ontology rule ("Every agent MUST run /ontology-librarian {topic} before making code changes") was promoted from charter-only status to a hook-enforced rule.
+
+**Artifact:** `.claude/hooks/enforce_librarian_consulted.py` (PreToolUse on Edit/Write/NotebookEdit). Charter entry: `charter/hooks.md` § Hook 15. Issue: [#150](https://github.com/noorinalabs/noorinalabs-main/issues/150).
+
+**Worked example:** This is the first end-to-end execution of the memory → charter → hook promotion pipeline ratified by the owner on 2026-04-19. The `/promotion-audit` skill (tracked separately) will reference this as its canonical example.


### PR DESCRIPTION
Closes #150. First end-to-end execution of memory → charter → hook promotion pattern, ratified by owner 2026-04-19. Worked example used by promotion-audit skill design (sibling issue).

## Summary

- New PreToolUse hook `enforce_librarian_consulted.py` blocks `Edit`, `Write`, and `NotebookEdit` unless `/ontology-librarian` was consulted earlier in the session.
- Reads the Claude Code transcript (`transcript_path` input field) and scans for a user slash-command invocation or an assistant `Skill` tool_use with `skill: "ontology-librarian"`.
- Promotes CLAUDE.md § Ontology rule from charter-only to hook-enforced. The rule was skipped on 3 of 4 P2W9 follow-up code-change PRs (deploy#125 kafka GID, deploy#130 obs fix, user-service#67 OAuth GET) with the familiar "this one's small" rationalization — same decay pattern that consumed W7 CI discipline and W8 peer-review discipline.

## Implementation

- **Hook:** `.claude/hooks/enforce_librarian_consulted.py`
  - Explicit Input-Language docstring per W8 hook-authorship spec.
  - Exit codes per agent SDK (0 allow, 2 block); structured JSON stderr output.
  - Annunaki logging on block so events surface in `/annunaki`.
  - **Allow-listed paths (no librarian required):** `/tmp/**`, `~/.claude/**`, `**/memory/*.md`, `MEMORY.md`, `.claude/annunaki/*`.
  - **Meta-file stance documented in docstring:** `.claude/team/feedback_log.md`, charter files, and project-state artifacts DO require librarian. Treating them as free-edits replays the decay pattern #150 fixes.
- **Tests:** `.claude/hooks/tests/test_enforce_librarian_consulted.py` — 23 cases covering:
  - 5 path-allow-list negative-match cases (/tmp, MEMORY.md, memory/, ~/.claude, annunaki)
  - 3 non-matched-tool negative cases (Bash, Read, Grep)
  - 4 blocking positive cases (compose edit, NotebookEdit, charter edit, empty transcript)
  - 3 allow-with-librarian positive cases (slash-command, Skill call, middle-of-transcript)
  - 2 transcript-not-found edge cases
  - 6 signal-detection unit tests (including Skill-with-different-skill-name negative)
- **Registration:** `.claude/settings.json` — new PreToolUse entries for Edit / Write / NotebookEdit matchers. Direct registration (not dispatcher) because this is the first PreToolUse hook on these matchers; charter § Dispatcher Consolidation Policy triggers only at >3 hooks per matcher.
- **Charter:** `.claude/team/charter/hooks.md` § Hook 15 documents what/augments/matcher/bypasses/override/promotion-provenance.
- **Feedback log:** `.claude/team/feedback_log.md` — new entry documenting W9 rule decay and the promotion artifact.

## Test plan

- [x] `python3 .claude/hooks/tests/test_enforce_librarian_consulted.py` — 23/23 pass
- [x] End-to-end smoke test via subprocess+stdin with real transcript file (including self-test against the session's own transcript — hook correctly allowed code edits because librarian was invoked in step 0)
- [x] Hook tested against its own commit path (worktree Edit/Write operations while the hook would have been active): librarian was consulted at session start, so no false-positive blocks.
- [ ] Reviewers: verify input-language docstring, negative-match test coverage, charter entry (W8 spec §1-4 all satisfied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
