### PR TITLE
fix(hooks): validate_labels — forward --repo and scope extraction to actual flags (#113)

### DIFF
--- a/.claude/hooks/tests/test_validate_labels.py
+++ b/.claude/hooks/tests/test_validate_labels.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""Tests for validate_labels hook.
+
+Covers the W8 hook-authorship-spec requirement: NEGATIVE MATCH coverage for
+the two W9 bugs (issue #113) plus regression coverage for positive cases.
+
+Run: python3 -m pytest .claude/hooks/tests/test_validate_labels.py -v
+Or:  python3 .claude/hooks/tests/test_validate_labels.py
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+_HERE = Path(__file__).resolve().parent
+_HOOKS_DIR = _HERE.parent
+sys.path.insert(0, str(_HOOKS_DIR))
+
+import validate_labels as hook  # noqa: E402
+
+
+class ExtractLabelsTests(unittest.TestCase):
+    """Positive regression tests — labels appearing on the actual flag."""
+
+    def test_long_flag_quoted(self):
+        self.assertEqual(
+            hook.extract_labels('gh issue create --label "bug"'),
+            ["bug"],
+        )
+
+    def test_long_flag_unquoted(self):
+        self.assertEqual(
+            hook.extract_labels("gh issue create --label bug"),
+            ["bug"],
+        )
+
+    def test_short_flag(self):
+        self.assertEqual(
+            hook.extract_labels('gh issue create -l "tech-debt"'),
+            ["tech-debt"],
+        )
+
+    def test_equals_form(self):
+        self.assertEqual(
+            hook.extract_labels("gh issue create --label=bug"),
+            ["bug"],
+        )
+
+    def test_multiple_flags(self):
+        self.assertEqual(
+            hook.extract_labels(
+                'gh issue create --label "bug" --label "tech-debt"'
+            ),
+            ["bug", "tech-debt"],
+        )
+
+    def test_comma_separated_in_one_flag(self):
+        self.assertEqual(
+            hook.extract_labels('gh issue create --label "bug,tech-debt,p2-wave-9"'),
+            ["bug", "tech-debt", "p2-wave-9"],
+        )
+
+    def test_mixed_short_and_long(self):
+        self.assertEqual(
+            hook.extract_labels('gh issue create -l bug --label "tech-debt"'),
+            ["bug", "tech-debt"],
+        )
+
+
+class NegativeMatchLabelsTests(unittest.TestCase):
+    """NEGATIVE-MATCH coverage for Bug 2 (#113) — label extraction false positives.
+
+    Each test documents which negative-space case it guards against. The hook
+    MUST NOT extract labels from text that appears inside the value of
+    another flag (e.g. --body).
+    """
+
+    def test_body_containing_example_label_flag_is_ignored(self):
+        """Body documents an example gh command — its --label must NOT leak."""
+        cmd = (
+            'gh issue create --title "real title" '
+            '--body "Example: gh issue create --label fake-label-xyz" '
+            '--label real-label'
+        )
+        labels = hook.extract_labels(cmd)
+        self.assertIn("real-label", labels)
+        self.assertNotIn("fake-label-xyz", labels)
+
+    def test_body_with_code_block_label_flag_is_ignored(self):
+        """Body includes a fenced code block with --label; still must not leak."""
+        cmd = (
+            "gh issue create "
+            "--body '```bash\\ngh issue create --label ghost\\n```' "
+            "--label actual"
+        )
+        labels = hook.extract_labels(cmd)
+        self.assertIn("actual", labels)
+        self.assertNotIn("ghost", labels)
+
+    def test_body_with_short_flag_variant_is_ignored(self):
+        cmd = (
+            'gh issue create --body "see: gh issue create -l phantom" '
+            '-l real'
+        )
+        labels = hook.extract_labels(cmd)
+        self.assertIn("real", labels)
+        self.assertNotIn("phantom", labels)
+
+    def test_title_with_label_flag_text_is_ignored(self):
+        """Prose in --title that contains `--label X` must not be extracted."""
+        cmd = (
+            'gh issue create '
+            '--title "use --label flag correctly" '
+            '--label documentation'
+        )
+        labels = hook.extract_labels(cmd)
+        self.assertEqual(labels, ["documentation"])
+
+    def test_no_label_flag_returns_empty(self):
+        self.assertEqual(
+            hook.extract_labels('gh issue create --title "x" --body "y"'),
+            [],
+        )
+
+    def test_unrelated_command_returns_empty(self):
+        self.assertEqual(
+            hook.extract_labels("echo hello --label world"),
+            ["world"],  # extract_labels is pure; the gate in check() filters
+        )
+
+
+class ExtractRepoTests(unittest.TestCase):
+    """Coverage for Bug 1 (#113) — --repo flag pass-through."""
+
+    def test_long_flag(self):
+        self.assertEqual(
+            hook.extract_repo(
+                "gh issue create --repo noorinalabs/noorinalabs-isnad-graph --label bug"
+            ),
+            "noorinalabs/noorinalabs-isnad-graph",
+        )
+
+    def test_short_flag(self):
+        self.assertEqual(
+            hook.extract_repo("gh issue create -R owner/repo --label bug"),
+            "owner/repo",
+        )
+
+    def test_equals_form(self):
+        self.assertEqual(
+            hook.extract_repo("gh issue create --repo=owner/repo --label bug"),
+            "owner/repo",
+        )
+
+    def test_no_repo_flag(self):
+        self.assertIsNone(
+            hook.extract_repo("gh issue create --label bug"),
+        )
+
+    def test_repo_token_in_body_is_ignored(self):
+        """`--repo ghost/ghost` inside --body must not leak as the target repo."""
+        cmd = (
+            'gh issue create '
+            '--body "sample: gh issue create --repo ghost/ghost" '
+            '--repo real/real --label bug'
+        )
+        self.assertEqual(hook.extract_repo(cmd), "real/real")
+
+
+class GateMatchingTests(unittest.TestCase):
+    """The `check()` gate fires ONLY on gh issue create, not siblings."""
+
+    @staticmethod
+    def _input(command: str) -> dict:
+        return {"tool_name": "Bash", "tool_input": {"command": command}}
+
+    def test_gh_issue_list_is_ignored(self):
+        self.assertIsNone(hook.check(self._input("gh issue list --label bug")))
+
+    def test_gh_issue_view_is_ignored(self):
+        self.assertIsNone(hook.check(self._input("gh issue view 1 --label bug")))
+
+    def test_gh_pr_create_is_ignored(self):
+        self.assertIsNone(hook.check(self._input("gh pr create --label bug")))
+
+    def test_non_bash_tool_is_ignored(self):
+        self.assertIsNone(
+            hook.check({"tool_name": "Edit", "tool_input": {"command": "gh issue create --label bug"}})
+        )
+
+    def test_command_without_label_flag_is_allowed(self):
+        self.assertIsNone(
+            hook.check(self._input('gh issue create --title "x" --body "y"'))
+        )
+
+
+class CheckEndToEndTests(unittest.TestCase):
+    """End-to-end `check()` with get_existing_labels mocked.
+
+    These verify that Bug 1 is fixed: when the user passes --repo OWNER/REPO,
+    we forward it to get_existing_labels() so label validation hits the
+    correct repo.
+    """
+
+    @staticmethod
+    def _input(command: str) -> dict:
+        return {"tool_name": "Bash", "tool_input": {"command": command}}
+
+    def test_repo_is_forwarded_to_get_existing_labels(self):
+        """Bug 1: --repo must be passed through to the label fetch."""
+        with mock.patch.object(
+            hook, "get_existing_labels", return_value={"frontend", "bug"}
+        ) as mocked:
+            result = hook.check(
+                self._input(
+                    "gh issue create --repo noorinalabs/noorinalabs-isnad-graph "
+                    '--title "t" --body "b" --label frontend'
+                )
+            )
+        self.assertIsNone(result)
+        mocked.assert_called_once_with(repo="noorinalabs/noorinalabs-isnad-graph")
+
+    def test_missing_label_blocks(self):
+        with mock.patch.object(
+            hook, "get_existing_labels", return_value={"bug"}
+        ):
+            result = hook.check(
+                self._input('gh issue create --label does-not-exist')
+            )
+        self.assertIsNotNone(result)
+        self.assertEqual(result["decision"], "block")
+        self.assertIn("does-not-exist", result["reason"])
+
+    def test_body_containing_fake_label_does_not_block(self):
+        """Bug 2: a body-quoted --label must NOT cause a spurious block."""
+        with mock.patch.object(
+            hook, "get_existing_labels", return_value={"bug"}
+        ):
+            result = hook.check(
+                self._input(
+                    'gh issue create '
+                    '--body "example: gh issue create --label fake" '
+                    '--label bug'
+                )
+            )
+        self.assertIsNone(result, f"unexpected block: {result}")
+
+    def test_body_plus_wrong_repo_would_block_without_bug1_fix(self):
+        """Combined scenario from issue #113: body-leak + cross-repo label.
+
+        The user creates an issue in repo A with a real label that exists in
+        repo A. Body documents an example command referencing repo B and a
+        non-existent label. Neither the body's --repo nor --label may leak.
+        """
+        def fake_get_existing_labels(repo=None):
+            if repo == "noorinalabs/noorinalabs-isnad-graph":
+                return {"frontend"}
+            return {"other-label"}  # would be returned if cwd-resolved
+
+        with mock.patch.object(
+            hook, "get_existing_labels", side_effect=fake_get_existing_labels
+        ):
+            result = hook.check(
+                self._input(
+                    "gh issue create --repo noorinalabs/noorinalabs-isnad-graph "
+                    '--body "example: gh issue create --repo ghost/ghost --label nope" '
+                    '--label frontend'
+                )
+            )
+        self.assertIsNone(result, f"unexpected block: {result}")
+
+    def test_no_labels_to_validate_is_allowed(self):
+        with mock.patch.object(
+            hook, "get_existing_labels", return_value={"bug"}
+        ) as mocked:
+            result = hook.check(
+                self._input('gh issue create --title "t" --body "b"')
+            )
+        self.assertIsNone(result)
+        mocked.assert_not_called()
+
+    def test_label_fetch_failure_warns_not_blocks(self):
+        with mock.patch.object(hook, "get_existing_labels", return_value=set()):
+            result = hook.check(self._input("gh issue create --label any"))
+        self.assertIsNotNone(result)
+        self.assertEqual(result["decision"], "allow")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/hooks/tests/test_validate_labels.py
+++ b/.claude/hooks/tests/test_validate_labels.py
@@ -51,9 +51,7 @@ class ExtractLabelsTests(unittest.TestCase):
 
     def test_multiple_flags(self):
         self.assertEqual(
-            hook.extract_labels(
-                'gh issue create --label "bug" --label "tech-debt"'
-            ),
+            hook.extract_labels('gh issue create --label "bug" --label "tech-debt"'),
             ["bug", "tech-debt"],
         )
 
@@ -83,7 +81,7 @@ class NegativeMatchLabelsTests(unittest.TestCase):
         cmd = (
             'gh issue create --title "real title" '
             '--body "Example: gh issue create --label fake-label-xyz" '
-            '--label real-label'
+            "--label real-label"
         )
         labels = hook.extract_labels(cmd)
         self.assertIn("real-label", labels)
@@ -92,30 +90,21 @@ class NegativeMatchLabelsTests(unittest.TestCase):
     def test_body_with_code_block_label_flag_is_ignored(self):
         """Body includes a fenced code block with --label; still must not leak."""
         cmd = (
-            "gh issue create "
-            "--body '```bash\\ngh issue create --label ghost\\n```' "
-            "--label actual"
+            "gh issue create --body '```bash\\ngh issue create --label ghost\\n```' --label actual"
         )
         labels = hook.extract_labels(cmd)
         self.assertIn("actual", labels)
         self.assertNotIn("ghost", labels)
 
     def test_body_with_short_flag_variant_is_ignored(self):
-        cmd = (
-            'gh issue create --body "see: gh issue create -l phantom" '
-            '-l real'
-        )
+        cmd = 'gh issue create --body "see: gh issue create -l phantom" -l real'
         labels = hook.extract_labels(cmd)
         self.assertIn("real", labels)
         self.assertNotIn("phantom", labels)
 
     def test_title_with_label_flag_text_is_ignored(self):
         """Prose in --title that contains `--label X` must not be extracted."""
-        cmd = (
-            'gh issue create '
-            '--title "use --label flag correctly" '
-            '--label documentation'
-        )
+        cmd = 'gh issue create --title "use --label flag correctly" --label documentation'
         labels = hook.extract_labels(cmd)
         self.assertEqual(labels, ["documentation"])
 
@@ -163,9 +152,9 @@ class ExtractRepoTests(unittest.TestCase):
     def test_repo_token_in_body_is_ignored(self):
         """`--repo ghost/ghost` inside --body must not leak as the target repo."""
         cmd = (
-            'gh issue create '
+            "gh issue create "
             '--body "sample: gh issue create --repo ghost/ghost" '
-            '--repo real/real --label bug'
+            "--repo real/real --label bug"
         )
         self.assertEqual(hook.extract_repo(cmd), "real/real")
 
@@ -188,13 +177,16 @@ class GateMatchingTests(unittest.TestCase):
 
     def test_non_bash_tool_is_ignored(self):
         self.assertIsNone(
-            hook.check({"tool_name": "Edit", "tool_input": {"command": "gh issue create --label bug"}})
+            hook.check(
+                {
+                    "tool_name": "Edit",
+                    "tool_input": {"command": "gh issue create --label bug"},
+                }
+            )
         )
 
     def test_command_without_label_flag_is_allowed(self):
-        self.assertIsNone(
-            hook.check(self._input('gh issue create --title "x" --body "y"'))
-        )
+        self.assertIsNone(hook.check(self._input('gh issue create --title "x" --body "y"')))
 
 
 class CheckEndToEndTests(unittest.TestCase):
@@ -224,26 +216,18 @@ class CheckEndToEndTests(unittest.TestCase):
         mocked.assert_called_once_with(repo="noorinalabs/noorinalabs-isnad-graph")
 
     def test_missing_label_blocks(self):
-        with mock.patch.object(
-            hook, "get_existing_labels", return_value={"bug"}
-        ):
-            result = hook.check(
-                self._input('gh issue create --label does-not-exist')
-            )
+        with mock.patch.object(hook, "get_existing_labels", return_value={"bug"}):
+            result = hook.check(self._input("gh issue create --label does-not-exist"))
         self.assertIsNotNone(result)
         self.assertEqual(result["decision"], "block")
         self.assertIn("does-not-exist", result["reason"])
 
     def test_body_containing_fake_label_does_not_block(self):
         """Bug 2: a body-quoted --label must NOT cause a spurious block."""
-        with mock.patch.object(
-            hook, "get_existing_labels", return_value={"bug"}
-        ):
+        with mock.patch.object(hook, "get_existing_labels", return_value={"bug"}):
             result = hook.check(
                 self._input(
-                    'gh issue create '
-                    '--body "example: gh issue create --label fake" '
-                    '--label bug'
+                    'gh issue create --body "example: gh issue create --label fake" --label bug'
                 )
             )
         self.assertIsNone(result, f"unexpected block: {result}")
@@ -255,30 +239,25 @@ class CheckEndToEndTests(unittest.TestCase):
         repo A. Body documents an example command referencing repo B and a
         non-existent label. Neither the body's --repo nor --label may leak.
         """
+
         def fake_get_existing_labels(repo=None):
             if repo == "noorinalabs/noorinalabs-isnad-graph":
                 return {"frontend"}
             return {"other-label"}  # would be returned if cwd-resolved
 
-        with mock.patch.object(
-            hook, "get_existing_labels", side_effect=fake_get_existing_labels
-        ):
+        with mock.patch.object(hook, "get_existing_labels", side_effect=fake_get_existing_labels):
             result = hook.check(
                 self._input(
                     "gh issue create --repo noorinalabs/noorinalabs-isnad-graph "
                     '--body "example: gh issue create --repo ghost/ghost --label nope" '
-                    '--label frontend'
+                    "--label frontend"
                 )
             )
         self.assertIsNone(result, f"unexpected block: {result}")
 
     def test_no_labels_to_validate_is_allowed(self):
-        with mock.patch.object(
-            hook, "get_existing_labels", return_value={"bug"}
-        ) as mocked:
-            result = hook.check(
-                self._input('gh issue create --title "t" --body "b"')
-            )
+        with mock.patch.object(hook, "get_existing_labels", return_value={"bug"}) as mocked:
+            result = hook.check(self._input('gh issue create --title "t" --body "b"'))
         self.assertIsNone(result)
         mocked.assert_not_called()
 

--- a/.claude/hooks/validate_labels.py
+++ b/.claude/hooks/validate_labels.py
@@ -43,7 +43,6 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from annunaki_log import log_pretooluse_block
 
-
 # Flags whose VALUE is a label list (comma-separated allowed by gh).
 _LABEL_FLAGS = {"--label", "-l"}
 
@@ -205,9 +204,7 @@ def check(input_data: dict) -> dict | None:
         return None
 
     create_repo_flag = f" --repo {repo}" if repo else ""
-    suggestions = "\n".join(
-        f'  gh label create "{label}"{create_repo_flag}' for label in missing
-    )
+    suggestions = "\n".join(f'  gh label create "{label}"{create_repo_flag}' for label in missing)
     repo_note = f" in {repo}" if repo else ""
     result = {
         "decision": "block",

--- a/.claude/hooks/validate_labels.py
+++ b/.claude/hooks/validate_labels.py
@@ -4,6 +4,30 @@
 Extracts --label values from `gh issue create` commands and verifies each
 label exists in the repository. Blocks execution if any label is missing.
 
+Input Language:
+  Fires on:      PreToolUse Bash
+  Matches:       gh issue create [--repo {OWNER/REPO} | -R {OWNER/REPO}]
+                                 [--label {NAME} | -l {NAME}]... [other flags]
+  Does NOT match: gh issue list, gh issue view, gh issue edit, gh label create,
+                  gh pr create. Also does NOT match `--label` substrings that
+                  appear INSIDE the value of another flag (e.g. inside `--body`)
+                  — see Bug 2 below.
+  Flag pass-through:
+    --repo / -R   → forwarded to `gh label list` so we query the same repo
+                    the user is creating the issue in (Bug 1 fix). Without
+                    this, cwd determines which repo's labels are checked,
+                    which rejects valid labels when cwd != target repo.
+    --label / -l  → only the actual flag values are extracted as labels;
+                    comma-separated values inside one flag are split. Body
+                    content is NEVER scanned for labels (Bug 2 fix).
+
+Tokenization:
+  The command is split with `shlex.split(..., posix=True)` so quoted argument
+  values become single tokens. We then walk the token list and only treat a
+  token as a label/repo if the PRECEDING token is the corresponding flag.
+  This guarantees that text appearing inside a `--body "..."` heredoc/string
+  cannot leak into label or repo extraction.
+
 Exit codes:
   0 — allow (not gh issue create, or all labels exist)
   2 — block (missing labels detected)
@@ -12,6 +36,7 @@ Exit codes:
 import json
 import os
 import re
+import shlex
 import subprocess
 import sys
 
@@ -19,11 +44,74 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from annunaki_log import log_pretooluse_block
 
 
-def get_existing_labels() -> set[str]:
-    """Fetch all existing labels from the repository."""
+# Flags whose VALUE is a label list (comma-separated allowed by gh).
+_LABEL_FLAGS = {"--label", "-l"}
+
+# Flags whose VALUE is a repo specifier (OWNER/REPO).
+_REPO_FLAGS = {"--repo", "-R"}
+
+
+def _tokenize(command: str) -> list[str] | None:
+    """Tokenize a shell command via shlex. Return None if it cannot be parsed."""
     try:
+        return shlex.split(command, posix=True)
+    except ValueError:
+        return None
+
+
+def _is_gh_issue_create(tokens: list[str]) -> bool:
+    """Return True if tokens contain a `gh issue create` invocation."""
+    for i in range(len(tokens) - 2):
+        if tokens[i] == "gh" and tokens[i + 1] == "issue" and tokens[i + 2] == "create":
+            return True
+    return False
+
+
+def _walk_flags(tokens: list[str], wanted: set[str]) -> list[str]:
+    """Return values for wanted flag names, only when they appear as flags.
+
+    A token is treated as a wanted-flag value only if the immediately
+    preceding token is exactly one of `wanted` (e.g. `--label`). The
+    `--flag=value` form is also handled. Values inside other flags
+    (e.g. inside the value of `--body`) are ignored because they are a
+    SINGLE shlex token, never preceded by a flag from `wanted`.
+    """
+    values: list[str] = []
+    i = 0
+    while i < len(tokens):
+        tok = tokens[i]
+        if tok in wanted:
+            if i + 1 < len(tokens):
+                values.append(tokens[i + 1])
+                i += 2
+                continue
+            i += 1
+            continue
+        matched = False
+        for flag in wanted:
+            if flag.startswith("--") and tok.startswith(flag + "="):
+                values.append(tok[len(flag) + 1 :])
+                matched = True
+                break
+        if matched:
+            i += 1
+            continue
+        i += 1
+    return values
+
+
+def get_existing_labels(repo: str | None = None) -> set[str]:
+    """Fetch all existing labels from the repository.
+
+    When `repo` is provided (OWNER/REPO), forward it to `gh label list` so we
+    query the same repo the user is creating the issue in (Bug 1 fix).
+    """
+    try:
+        cmd = ["gh", "label", "list", "--limit", "500", "--json", "name"]
+        if repo:
+            cmd.extend(["--repo", repo])
         result = subprocess.run(
-            ["gh", "label", "list", "--limit", "500", "--json", "name"],
+            cmd,
             capture_output=True,
             text=True,
             timeout=30,
@@ -37,20 +125,48 @@ def get_existing_labels() -> set[str]:
 
 
 def extract_labels(command: str) -> list[str]:
-    """Extract all --label and -l values from a gh issue create command."""
-    labels = []
+    """Extract label names from --label / -l flags ONLY.
 
-    # Match --label "value" or --label value or -l "value" or -l value
-    # Also handles comma-separated labels in a single --label flag
-    for match in re.finditer(r'(?:--label|-l)\s+["\']?([^"\']+?)["\']?(?:\s|$)', command):
-        raw = match.group(1).strip()
-        # gh CLI accepts comma-separated labels
+    Uses `shlex.split` to tokenize, then walks tokens. Quoted body content,
+    code blocks, and any text that is part of another flag's value are
+    treated as opaque single tokens and cannot leak into the label set
+    (Bug 2 fix). Comma-separated values within a single flag are split.
+
+    Falls back to a conservative regex on shlex parse failure (e.g. command
+    contains a malformed quote). The fallback still anchors on `--label`
+    appearing at a shell-token boundary.
+    """
+    tokens = _tokenize(command)
+    if tokens is None:
+        labels: list[str] = []
+        for match in re.finditer(
+            r'(?:^|\s)(?:--label|-l)(?:=|\s+)["\']?([^"\'\s]+)["\']?',
+            command,
+        ):
+            raw = match.group(1).strip()
+            for label in raw.split(","):
+                label = label.strip()
+                if label:
+                    labels.append(label)
+        return labels
+
+    labels = []
+    for raw in _walk_flags(tokens, _LABEL_FLAGS):
         for label in raw.split(","):
             label = label.strip()
             if label:
                 labels.append(label)
-
     return labels
+
+
+def extract_repo(command: str) -> str | None:
+    """Extract the --repo / -R OWNER/REPO value from the command, if any."""
+    tokens = _tokenize(command)
+    if tokens is None:
+        match = re.search(r"(?:^|\s)(?:--repo|-R)(?:=|\s+)(\S+)", command)
+        return match.group(1) if match else None
+    values = _walk_flags(tokens, _REPO_FLAGS)
+    return values[0] if values else None
 
 
 def check(input_data: dict) -> dict | None:
@@ -61,14 +177,20 @@ def check(input_data: dict) -> dict | None:
 
     command = input_data.get("tool_input", {}).get("command", "")
 
-    if not re.search(r"\bgh\s+issue\s+create\b", command):
-        return None
+    tokens = _tokenize(command)
+    if tokens is not None:
+        if not _is_gh_issue_create(tokens):
+            return None
+    else:
+        if not re.search(r"\bgh\s+issue\s+create\b", command):
+            return None
 
     labels = extract_labels(command)
     if not labels:
         return None
 
-    existing = get_existing_labels()
+    repo = extract_repo(command)
+    existing = get_existing_labels(repo=repo)
     if not existing:
         return {
             "decision": "allow",
@@ -82,11 +204,16 @@ def check(input_data: dict) -> dict | None:
     if not missing:
         return None
 
-    suggestions = "\n".join(f'  gh label create "{label}"' for label in missing)
+    create_repo_flag = f" --repo {repo}" if repo else ""
+    suggestions = "\n".join(
+        f'  gh label create "{label}"{create_repo_flag}' for label in missing
+    )
+    repo_note = f" in {repo}" if repo else ""
     result = {
         "decision": "block",
         "reason": (
-            f"BLOCKED: The following label(s) do not exist: {', '.join(missing)}\n"
+            f"BLOCKED: The following label(s) do not exist{repo_note}: "
+            f"{', '.join(missing)}\n"
             f"Create them first:\n{suggestions}\n\n"
             "See charter § GitHub Label Hygiene: verify labels exist before creating issues."
         ),


### PR DESCRIPTION
## Summary

Two bugs in `.claude/hooks/validate_labels.py` surfaced during W9 cross-repo issue filing. Both are fixed in this PR.

### Bug 1 — cwd/repo mismatch
`get_existing_labels()` ignored the user's `--repo` flag and always queried whichever repo `gh` resolved from cwd. When cwd was noorinalabs-main but the issue targeted `noorinalabs-isnad-graph`, the hook checked main's labels and rejected `frontend` (which exists in isnad-graph). Fix: parse `--repo/-R` from the command and forward it to `gh label list`.

### Bug 2 — `extract_labels` false positives from body content
The regex scanned the entire command string, so any `--label` substring inside a quoted `--body` value (example commands, code blocks, prose) leaked into the validated label set. Fix: tokenize with `shlex.split`, walk tokens and only treat a value as a label when the preceding token is the actual `--label/-l` flag. Text inside another flag's value becomes a single opaque token and cannot leak.

## Changes

- `.claude/hooks/validate_labels.py` — shlex-based tokenization, `--repo` pass-through, Input Language docstring per W8 § Hook Authorship Requirements.
- `.claude/hooks/tests/test_validate_labels.py` — 29 new tests including negative-match coverage for both bugs.

## Test Plan

- [x] `ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/test_validate_labels.py -v` — 29/29 passing
- [x] All existing hook tests still green (52/52 total)
- [x] Positive regression: long/short flag, `=value` form, comma-split values, multiple flags
- [x] Negative-match (Bug 2): body with example `--label` command, body with fenced code block, body with short `-l` variant, `--title` containing `--label` prose
- [x] Repo pass-through (Bug 1): `extract_repo` handles long/short/=value, ignores body-quoted `--repo`; `check()` forwards extracted repo to `get_existing_labels`
- [x] Gate: `gh issue list`, `gh issue view`, `gh pr create`, non-Bash tool names all bypass the hook

Closes #113

## Tech-debt filed
none

🤖 Generated with [Claude Code](https://claude.com/claude-code)