### PR TITLE
fix(hooks): validate_pr_review — TechDebt verdict-only + reviewer full-name dedup (#147, #164)

### DIFF
--- a/.claude/hooks/tests/test_validate_pr_review.py
+++ b/.claude/hooks/tests/test_validate_pr_review.py
@@ -118,8 +118,7 @@ class TechDebtFilterTests(_CheckCommentReviewsHarness):
         """NEGATIVE MATCH for #147: Request comment lacking TechDebt must NOT be flagged."""
         comments = [
             self._comment(
-                "Requestor: Linh Pham\nRequestee: Jelani Mwangi\n"
-                "RequestOrReplied: Request"
+                "Requestor: Linh Pham\nRequestee: Jelani Mwangi\nRequestOrReplied: Request"
             ),
         ]
         result = self._run_with_fake_api(comments, self.BRANCH_AUTHOR, repo=self.REPO)
@@ -129,8 +128,7 @@ class TechDebtFilterTests(_CheckCommentReviewsHarness):
         """NEGATIVE MATCH for #147: Replied comment lacking TechDebt must NOT be flagged."""
         comments = [
             self._comment(
-                "Requestor: Linh Pham\nRequestee: Anya Kowalczyk\n"
-                "RequestOrReplied: Replied"
+                "Requestor: Linh Pham\nRequestee: Anya Kowalczyk\nRequestOrReplied: Replied"
             ),
         ]
         result = self._run_with_fake_api(comments, self.BRANCH_AUTHOR, repo=self.REPO)
@@ -140,8 +138,7 @@ class TechDebtFilterTests(_CheckCommentReviewsHarness):
         """Positive: Approved lacking TechDebt MUST still be flagged — #147 does NOT weaken this."""
         comments = [
             self._comment(
-                "Requestor: Linh Pham\nRequestee: Mateo Santos\n"
-                "RequestOrReplied: Approved"
+                "Requestor: Linh Pham\nRequestee: Mateo Santos\nRequestOrReplied: Approved"
             ),
         ]
         result = self._run_with_fake_api(comments, self.BRANCH_AUTHOR, repo=self.REPO)
@@ -189,12 +186,10 @@ class TechDebtFilterTests(_CheckCommentReviewsHarness):
         comments = [
             # Review requests (no TechDebt line — must be accepted after fix)
             self._comment(
-                "Requestor: Linh Pham\nRequestee: Jelani Mwangi\n"
-                "RequestOrReplied: Request"
+                "Requestor: Linh Pham\nRequestee: Jelani Mwangi\nRequestOrReplied: Request"
             ),
             self._comment(
-                "Requestor: Linh Pham\nRequestee: Anya Kowalczyk\n"
-                "RequestOrReplied: Request"
+                "Requestor: Linh Pham\nRequestee: Anya Kowalczyk\nRequestOrReplied: Request"
             ),
             # Actual reviews with TechDebt
             self._comment(
@@ -207,13 +202,11 @@ class TechDebtFilterTests(_CheckCommentReviewsHarness):
             ),
             # Author reply (no TechDebt line — must be accepted after fix)
             self._comment(
-                "Requestor: Linh Pham\nRequestee: Anya Kowalczyk\n"
-                "RequestOrReplied: Replied"
+                "Requestor: Linh Pham\nRequestee: Anya Kowalczyk\nRequestOrReplied: Replied"
             ),
             # Re-request for re-review after changes
             self._comment(
-                "Requestor: Linh Pham\nRequestee: Anya Kowalczyk\n"
-                "RequestOrReplied: Request"
+                "Requestor: Linh Pham\nRequestee: Anya Kowalczyk\nRequestOrReplied: Request"
             ),
             # Re-review approval
             self._comment(
@@ -222,8 +215,9 @@ class TechDebtFilterTests(_CheckCommentReviewsHarness):
             ),
         ]
         result = self._run_with_fake_api(comments, self.BRANCH_AUTHOR, repo=self.REPO)
-        self.assertEqual(result.reviews_missing_tech_debt, [],
-                         "non-verdict comments must not be flagged")
+        self.assertEqual(
+            result.reviews_missing_tech_debt, [], "non-verdict comments must not be flagged"
+        )
         self.assertEqual(sorted(result.tech_debt_issue_numbers), ["200"])
 
     def test_markdown_bold_ror_value_still_filtered(self):

--- a/.claude/hooks/tests/test_validate_pr_review.py
+++ b/.claude/hooks/tests/test_validate_pr_review.py
@@ -1,9 +1,15 @@
 #!/usr/bin/env python3
 """Tests for validate_pr_review hook.
 
-Covers issue #147: TechDebt attestation must be required ONLY on actual
-review verdicts (Approved / Changes Requested), NOT on Request or Replied
-comments. Also covers the W8 hook-authorship NEGATIVE-MATCH requirement.
+Covers:
+- Issue #147: TechDebt attestation must be required ONLY on actual review
+  verdicts (Approved / Changes Requested), NOT on Request or Replied
+  comments.
+- Issue #164: reviewer set must dedup on full Requestee name, NOT on
+  lastname — two distinct reviewers sharing a lastname (e.g.,
+  Lucas Ferreira and Santiago Ferreira) count as TWO reviewers.
+
+Also covers the W8 hook-authorship NEGATIVE-MATCH requirement.
 
 Run: python3 -m pytest .claude/hooks/tests/test_validate_pr_review.py -v
 Or:  python3 .claude/hooks/tests/test_validate_pr_review.py
@@ -242,6 +248,70 @@ class TechDebtFilterTests(_CheckCommentReviewsHarness):
         ]
         result = self._run_with_fake_api(comments, self.BRANCH_AUTHOR, repo=self.REPO)
         self.assertEqual(result.reviews_missing_tech_debt, ["Mateo Santos"])
+
+
+class ReviewerDedupTests(_CheckCommentReviewsHarness):
+    """Issue #164: reviewer set must dedup on full name, NOT on lastname.
+
+    Prior behavior keyed the set on lastname, so Lucas Ferreira and Santiago
+    Ferreira counted as one reviewer. Guard tests for the full-name fix.
+    """
+
+    @staticmethod
+    def _comment(body: str) -> dict:
+        return {"body": body, "user": {"login": "anyone"}}
+
+    def test_two_reviewers_same_lastname_count_as_two(self):
+        """NEGATIVE MATCH for #164: two Ferreiras must count as 2, not 1."""
+        comments = [
+            self._comment(
+                "Requestor: Linh Pham\nRequestee: Lucas Ferreira\n"
+                "RequestOrReplied: Approved\nTechDebt: none"
+            ),
+            self._comment(
+                "Requestor: Linh Pham\nRequestee: Santiago Ferreira\n"
+                "RequestOrReplied: Approved\nTechDebt: none"
+            ),
+        ]
+        result = self._run_with_fake_api(comments, self.BRANCH_AUTHOR, repo=self.REPO)
+        self.assertEqual(
+            len(result.reviewers),
+            2,
+            f"two distinct reviewers sharing lastname collapsed into: {result.reviewers}",
+        )
+        self.assertIn("lucas ferreira", result.reviewers)
+        self.assertIn("santiago ferreira", result.reviewers)
+
+    def test_same_person_counted_once_across_multiple_comments(self):
+        """Positive: same reviewer making Request + Approved counts as one."""
+        comments = [
+            self._comment(
+                "Requestor: Linh Pham\nRequestee: Mateo Santos\nRequestOrReplied: Request"
+            ),
+            self._comment(
+                "Requestor: Linh Pham\nRequestee: Mateo Santos\n"
+                "RequestOrReplied: Approved\nTechDebt: none"
+            ),
+        ]
+        result = self._run_with_fake_api(comments, self.BRANCH_AUTHOR, repo=self.REPO)
+        self.assertEqual(len(result.reviewers), 1)
+        self.assertIn("mateo santos", result.reviewers)
+
+    def test_branch_author_lastname_still_excluded(self):
+        """Author-equality check still works (it uses lastname, correctly).
+
+        Branch author has lastname `Pham`. A Pham-surnamed reviewer must still
+        be excluded from the reviewer set — regression guard for the
+        author-equality branch of the logic after the dedup-key change.
+        """
+        comments = [
+            self._comment(
+                "Requestor: Linh Pham\nRequestee: Linh Pham\n"
+                "RequestOrReplied: Approved\nTechDebt: none"
+            ),
+        ]
+        result = self._run_with_fake_api(comments, self.BRANCH_AUTHOR, repo=self.REPO)
+        self.assertEqual(result.reviewers, set(), "branch author must not self-review")
 
 
 class MergeCommandMatchTests(unittest.TestCase):

--- a/.claude/hooks/tests/test_validate_pr_review.py
+++ b/.claude/hooks/tests/test_validate_pr_review.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""Tests for validate_pr_review hook.
+
+Covers issue #147: TechDebt attestation must be required ONLY on actual
+review verdicts (Approved / Changes Requested), NOT on Request or Replied
+comments. Also covers the W8 hook-authorship NEGATIVE-MATCH requirement.
+
+Run: python3 -m pytest .claude/hooks/tests/test_validate_pr_review.py -v
+Or:  python3 .claude/hooks/tests/test_validate_pr_review.py
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+_HERE = Path(__file__).resolve().parent
+_HOOKS_DIR = _HERE.parent
+sys.path.insert(0, str(_HOOKS_DIR))
+
+import validate_pr_review as hook  # noqa: E402
+
+
+class IsVerdictTests(unittest.TestCase):
+    """Unit tests for the _is_verdict helper — the core filter for #147."""
+
+    def test_approved_is_verdict(self):
+        self.assertTrue(hook._is_verdict("Approved"))
+
+    def test_changes_requested_is_verdict(self):
+        self.assertTrue(hook._is_verdict("Changes Requested"))
+
+    def test_changes_alone_is_verdict(self):
+        """Some teammates use the shorter `Changes` form — accepted per charter."""
+        self.assertTrue(hook._is_verdict("Changes"))
+
+    def test_case_insensitive(self):
+        self.assertTrue(hook._is_verdict("approved"))
+        self.assertTrue(hook._is_verdict("APPROVED"))
+        self.assertTrue(hook._is_verdict("Changes REQUESTED"))
+
+    def test_whitespace_trimmed(self):
+        self.assertTrue(hook._is_verdict("  Approved  "))
+        self.assertTrue(hook._is_verdict("\tApproved\n"))
+
+    def test_markdown_bold_trailing_stripped(self):
+        self.assertTrue(hook._is_verdict("Approved*"))
+        self.assertTrue(hook._is_verdict("Approved**"))
+
+    # NEGATIVE MATCHES — the whole point of #147.
+    def test_request_is_not_verdict(self):
+        """RequestOrReplied: Request is NOT a verdict (review request)."""
+        self.assertFalse(hook._is_verdict("Request"))
+
+    def test_replied_is_not_verdict(self):
+        """RequestOrReplied: Replied is NOT a verdict (author reply)."""
+        self.assertFalse(hook._is_verdict("Replied"))
+
+    def test_empty_is_not_verdict(self):
+        self.assertFalse(hook._is_verdict(""))
+        self.assertFalse(hook._is_verdict("   "))
+
+    def test_unknown_value_is_not_verdict(self):
+        self.assertFalse(hook._is_verdict("Maybe"))
+        self.assertFalse(hook._is_verdict("Questioned"))
+
+
+class _CheckCommentReviewsHarness(unittest.TestCase):
+    """Common helpers for driving check_comment_reviews() with fake API data."""
+
+    PR_NUMBER = 99
+    BRANCH_AUTHOR = "pham"  # matches branch L.Pham/0001-...
+    REPO = "noorinalabs/noorinalabs-isnad-graph"
+
+    @staticmethod
+    def _run_with_fake_api(comments_list: list[dict], branch_author: str, repo: str | None = None):
+        """Run check_comment_reviews with subprocess.run mocked to return the given comments."""
+        # First call is gh repo view (owner/name), skipped if repo is provided.
+        # Second call is gh api .../issues/{n}/comments.
+        repo_view_stdout = json.dumps({"owner": {"login": "noorinalabs"}, "name": "r"})
+        comments_stdout = json.dumps(comments_list)
+
+        call_count = {"n": 0}
+
+        def fake_run(args, capture_output, text, timeout):
+            call_count["n"] += 1
+            result = mock.MagicMock()
+            result.returncode = 0
+            if args[0] == "gh" and args[1:3] == ["repo", "view"]:
+                result.stdout = repo_view_stdout
+            else:
+                result.stdout = comments_stdout
+            return result
+
+        with mock.patch.object(hook.subprocess, "run", side_effect=fake_run):
+            return hook.check_comment_reviews(
+                _CheckCommentReviewsHarness.PR_NUMBER,
+                branch_author,
+                repo=repo,
+            )
+
+
+class TechDebtFilterTests(_CheckCommentReviewsHarness):
+    """Issue #147: TechDebt line required only on Approved/Changes Requested.
+
+    Each test builds a fake comment list and verifies the
+    reviews_missing_tech_debt list contains exactly the expected names.
+    """
+
+    @staticmethod
+    def _comment(body: str) -> dict:
+        return {"body": body, "user": {"login": "anyone"}}
+
+    def test_request_without_techdebt_does_not_block(self):
+        """NEGATIVE MATCH for #147: Request comment lacking TechDebt must NOT be flagged."""
+        comments = [
+            self._comment(
+                "Requestor: Linh Pham\nRequestee: Jelani Mwangi\n"
+                "RequestOrReplied: Request"
+            ),
+        ]
+        result = self._run_with_fake_api(comments, self.BRANCH_AUTHOR, repo=self.REPO)
+        self.assertEqual(result.reviews_missing_tech_debt, [])
+
+    def test_replied_without_techdebt_does_not_block(self):
+        """NEGATIVE MATCH for #147: Replied comment lacking TechDebt must NOT be flagged."""
+        comments = [
+            self._comment(
+                "Requestor: Linh Pham\nRequestee: Anya Kowalczyk\n"
+                "RequestOrReplied: Replied"
+            ),
+        ]
+        result = self._run_with_fake_api(comments, self.BRANCH_AUTHOR, repo=self.REPO)
+        self.assertEqual(result.reviews_missing_tech_debt, [])
+
+    def test_approved_without_techdebt_does_block(self):
+        """Positive: Approved lacking TechDebt MUST still be flagged — #147 does NOT weaken this."""
+        comments = [
+            self._comment(
+                "Requestor: Linh Pham\nRequestee: Mateo Santos\n"
+                "RequestOrReplied: Approved"
+            ),
+        ]
+        result = self._run_with_fake_api(comments, self.BRANCH_AUTHOR, repo=self.REPO)
+        self.assertEqual(result.reviews_missing_tech_debt, ["Mateo Santos"])
+
+    def test_changes_requested_without_techdebt_does_block(self):
+        comments = [
+            self._comment(
+                "Requestor: Linh Pham\nRequestee: Anya Kowalczyk\n"
+                "RequestOrReplied: Changes Requested"
+            ),
+        ]
+        result = self._run_with_fake_api(comments, self.BRANCH_AUTHOR, repo=self.REPO)
+        self.assertEqual(result.reviews_missing_tech_debt, ["Anya Kowalczyk"])
+
+    def test_approved_with_techdebt_none_passes(self):
+        comments = [
+            self._comment(
+                "Requestor: Linh Pham\nRequestee: Mateo Santos\n"
+                "RequestOrReplied: Approved\nTechDebt: none"
+            ),
+        ]
+        result = self._run_with_fake_api(comments, self.BRANCH_AUTHOR, repo=self.REPO)
+        self.assertEqual(result.reviews_missing_tech_debt, [])
+
+    def test_approved_with_techdebt_issues_passes_and_collects(self):
+        comments = [
+            self._comment(
+                "Requestor: Linh Pham\nRequestee: Mateo Santos\n"
+                "RequestOrReplied: Approved\nTechDebt: #15, #16"
+            ),
+        ]
+        result = self._run_with_fake_api(comments, self.BRANCH_AUTHOR, repo=self.REPO)
+        self.assertEqual(result.reviews_missing_tech_debt, [])
+        self.assertEqual(sorted(result.tech_debt_issue_numbers), ["15", "16"])
+
+    def test_pr_821_scenario(self):
+        """Exact scenario from issue #147 repro.
+
+        PR #821 had 3 real reviews (Jelani+Anya approved, Anya changes-requested —
+        all with TechDebt) and 4 non-review comments (3 Request, 1 Replied — no
+        TechDebt). The hook blocked on the 4 non-review comments. After the fix,
+        only actual-verdict comments without TechDebt should be flagged.
+        """
+        comments = [
+            # Review requests (no TechDebt line — must be accepted after fix)
+            self._comment(
+                "Requestor: Linh Pham\nRequestee: Jelani Mwangi\n"
+                "RequestOrReplied: Request"
+            ),
+            self._comment(
+                "Requestor: Linh Pham\nRequestee: Anya Kowalczyk\n"
+                "RequestOrReplied: Request"
+            ),
+            # Actual reviews with TechDebt
+            self._comment(
+                "Requestor: Linh Pham\nRequestee: Jelani Mwangi\n"
+                "RequestOrReplied: Approved\nTechDebt: none"
+            ),
+            self._comment(
+                "Requestor: Linh Pham\nRequestee: Anya Kowalczyk\n"
+                "RequestOrReplied: Changes Requested\nTechDebt: #200"
+            ),
+            # Author reply (no TechDebt line — must be accepted after fix)
+            self._comment(
+                "Requestor: Linh Pham\nRequestee: Anya Kowalczyk\n"
+                "RequestOrReplied: Replied"
+            ),
+            # Re-request for re-review after changes
+            self._comment(
+                "Requestor: Linh Pham\nRequestee: Anya Kowalczyk\n"
+                "RequestOrReplied: Request"
+            ),
+            # Re-review approval
+            self._comment(
+                "Requestor: Linh Pham\nRequestee: Anya Kowalczyk\n"
+                "RequestOrReplied: Approved\nTechDebt: none"
+            ),
+        ]
+        result = self._run_with_fake_api(comments, self.BRANCH_AUTHOR, repo=self.REPO)
+        self.assertEqual(result.reviews_missing_tech_debt, [],
+                         "non-verdict comments must not be flagged")
+        self.assertEqual(sorted(result.tech_debt_issue_numbers), ["200"])
+
+    def test_markdown_bold_ror_value_still_filtered(self):
+        """`**RequestOrReplied:** Request` with markdown bold — still not a verdict."""
+        comments = [
+            self._comment(
+                "**Requestor:** Linh Pham\n"
+                "**Requestee:** Jelani Mwangi\n"
+                "**RequestOrReplied:** Request"
+            ),
+        ]
+        result = self._run_with_fake_api(comments, self.BRANCH_AUTHOR, repo=self.REPO)
+        self.assertEqual(result.reviews_missing_tech_debt, [])
+
+    def test_markdown_bold_approved_still_requires_techdebt(self):
+        comments = [
+            self._comment(
+                "**Requestor:** Linh Pham\n"
+                "**Requestee:** Mateo Santos\n"
+                "**RequestOrReplied:** Approved"
+            ),
+        ]
+        result = self._run_with_fake_api(comments, self.BRANCH_AUTHOR, repo=self.REPO)
+        self.assertEqual(result.reviews_missing_tech_debt, ["Mateo Santos"])
+
+
+class MergeCommandMatchTests(unittest.TestCase):
+    """Regression tests for the merge-command gate."""
+
+    def test_gh_pr_merge_matches(self):
+        self.assertTrue(hook.is_merge_command("gh pr merge 123"))
+        self.assertTrue(hook.is_merge_command("gh pr merge 123 --squash"))
+        self.assertTrue(hook.is_merge_command("gh pr merge --repo x/y 123"))
+
+    def test_chained_matches(self):
+        self.assertTrue(hook.is_merge_command("foo && gh pr merge 1"))
+        self.assertTrue(hook.is_merge_command("ENV=1 gh pr merge 1"))
+
+    def test_non_merge_does_not_match(self):
+        self.assertFalse(hook.is_merge_command("gh pr list"))
+        self.assertFalse(hook.is_merge_command("gh pr view 1"))
+        self.assertFalse(hook.is_merge_command("gh pr create"))
+        self.assertFalse(hook.is_merge_command("git merge main"))
+        self.assertFalse(hook.is_merge_command("gh pr checks"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/hooks/validate_pr_review.py
+++ b/.claude/hooks/validate_pr_review.py
@@ -34,6 +34,15 @@ Charter-format review comments:
   Replied comments are process metadata and must NOT be required to carry the
   TechDebt attestation line. This is the fix for issue #147.
 
+Reviewer dedup key:
+  The reviewer set is keyed on the FULL requestee name (lowercased), not on
+  the lastname. Two distinct reviewers with the same lastname (e.g.,
+  "Lucas Ferreira" and "Santiago Ferreira") are counted as TWO reviewers
+  toward the two-peer-review requirement. This is the fix for issue #164.
+  The author-equality check still uses lastname because branches are named
+  `{Initial}.{Lastname}/...` and we only have the author's lastname to
+  compare against.
+
 Exit codes:
   0 — allow (not a merge command, or two reviews exist)
   2 — block (fewer than two peer reviews found, or a verdict is missing TechDebt)
@@ -225,13 +234,19 @@ def check_comment_reviews(
             else:
                 reviewer_lastname = requestee_name
 
-            # Reviewer must differ from branch author.
+            # Reviewer must differ from branch author. Author check stays on
+            # lastname (branch format is `{Initial}.{Lastname}/...`), but the
+            # dedup key for the reviewer set is the FULL requestee name —
+            # otherwise two distinct reviewers sharing a lastname collapse
+            # into one (issue #164 fix: Lucas Ferreira + Santiago Ferreira
+            # were counted as 1/2 on deploy#81).
+            #
             # NOTE: Reviewer counting is NOT filtered by verdict type. It
             # continues to use all Requestee+RequestOrReplied comments as in
             # prior behavior; issue #147 addresses the TechDebt filter only,
             # and weakening the reviewer count would break existing flows.
             if reviewer_lastname.lower() != branch_author_lastname.lower():
-                result.reviewers.add(reviewer_lastname.lower())
+                result.reviewers.add(requestee_name.lower())
 
             ror_value = ror_match.group(1).strip()
             # Keep only the first line of the value, in case the regex greedy-

--- a/.claude/hooks/validate_pr_review.py
+++ b/.claude/hooks/validate_pr_review.py
@@ -5,9 +5,38 @@ Blocks `gh pr merge` unless the PR has at least two reviews from distinct
 non-authors, using either formal GitHub reviews or charter-format
 comment-based reviews from different team members.
 
+Input Language:
+  Fires on:      PreToolUse Bash
+  Matches:       gh pr merge [{N}] [--repo {OWNER/REPO}] [--squash|--merge|--rebase]
+                             [--admin] [--auto]   — including when chained via
+                             && / || / | / ; after env-var assignments.
+  Does NOT match: gh pr list, gh pr view, gh pr checks, gh pr create,
+                  git merge, git pull.
+  Flag pass-through:
+    --repo   → forwarded to `gh pr view` and comment fetch so the hook checks
+               the PR in the repo the user named, not the cwd-resolved repo.
+    --admin  → short-circuits (emergency override — allows merge).
+
+Charter-format review comments:
+  Each comment is expected to include:
+    Requestor: <branch author>
+    Requestee: <reviewer>
+    RequestOrReplied: <Request|Replied|Approved|Changes Requested>
+    TechDebt: none | #15, #16, ...
+
+  Canonical RequestOrReplied values (verified on PR #821 comments):
+    - Request            — requesting review (NOT a verdict)
+    - Replied            — author responding to review (NOT a verdict)
+    - Approved           — actual review verdict (TechDebt line REQUIRED)
+    - Changes Requested  — actual review verdict (TechDebt line REQUIRED)
+
+  Only Approved and Changes Requested comments are ACTUAL REVIEWS. Request /
+  Replied comments are process metadata and must NOT be required to carry the
+  TechDebt attestation line. This is the fix for issue #147.
+
 Exit codes:
   0 — allow (not a merge command, or two reviews exist)
-  2 — block (fewer than two peer reviews found)
+  2 — block (fewer than two peer reviews found, or a verdict is missing TechDebt)
 """
 
 import json
@@ -113,6 +142,28 @@ class CommentReviewResult:
         self.tech_debt_issue_numbers: list[str] = []  # issue numbers from TechDebt: lines
 
 
+# Only these RequestOrReplied values represent actual review verdicts that
+# REQUIRE the TechDebt attestation line. Request / Replied comments are
+# process metadata (review requests, author replies) and do NOT require it.
+# Issue #147: the prior implementation flagged any Requestee+RequestOrReplied
+# comment, which over-enforced TechDebt on Request/Replied traffic.
+_VERDICT_REQUIRING_TECH_DEBT = {"approved", "changes requested", "changes"}
+
+
+def _is_verdict(value: str) -> bool:
+    """Return True if a RequestOrReplied value is an actual review verdict.
+
+    Comparison is case-insensitive and whitespace-trimmed. Accepts both the
+    canonical `Changes Requested` and the shorter `Changes` variant noted in
+    charter discussion as seen in practice. Does NOT accept Request (a review
+    request) or Replied (an author's reply).
+    """
+    normalized = value.strip().lower()
+    # Strip trailing markdown markers and stray punctuation
+    normalized = normalized.rstrip("*").strip()
+    return normalized in _VERDICT_REQUIRING_TECH_DEBT
+
+
 def check_comment_reviews(
     pr_number: str | int,
     branch_author_lastname: str,
@@ -157,26 +208,40 @@ def check_comment_reviews(
             # Check for charter-format review: must contain Requestee: and RequestOrReplied:
             # Handles markdown bold (**Requestee:**) and plain text (Requestee:)
             has_requestee = re.search(r"\*{0,2}Requestee:\*{0,2}\s*(.+)", body)
-            has_request_or_replied = re.search(r"RequestOrReplied:", body)
+            ror_match = re.search(r"\*{0,2}RequestOrReplied:\*{0,2}\s*(.+)", body)
 
-            if has_requestee and has_request_or_replied:
-                # Extract Requestee name (the reviewer)
-                requestee_raw = has_requestee.group(1).strip()
-                # Strip markdown bold markers and parenthetical role descriptions
-                requestee_raw = requestee_raw.strip("*").strip()
-                requestee_name = re.sub(r"\s*\(.*?\)\s*$", "", requestee_raw).strip()
-                # Extract last name — handle "Firstname Lastname" and "Firstname.Lastname"
-                parts = re.split(r"[\s.]+", requestee_name)
-                if len(parts) >= 2:
-                    reviewer_lastname = parts[-1]
-                else:
-                    reviewer_lastname = requestee_name
+            if not (has_requestee and ror_match):
+                continue
 
-                # Reviewer must differ from branch author
-                if reviewer_lastname.lower() != branch_author_lastname.lower():
-                    result.reviewers.add(reviewer_lastname.lower())
+            # Extract Requestee name (the reviewer)
+            requestee_raw = has_requestee.group(1).strip()
+            # Strip markdown bold markers and parenthetical role descriptions
+            requestee_raw = requestee_raw.strip("*").strip()
+            requestee_name = re.sub(r"\s*\(.*?\)\s*$", "", requestee_raw).strip()
+            # Extract last name — handle "Firstname Lastname" and "Firstname.Lastname"
+            parts = re.split(r"[\s.]+", requestee_name)
+            if len(parts) >= 2:
+                reviewer_lastname = parts[-1]
+            else:
+                reviewer_lastname = requestee_name
 
-                # Check for mandatory TechDebt: attestation line
+            # Reviewer must differ from branch author.
+            # NOTE: Reviewer counting is NOT filtered by verdict type. It
+            # continues to use all Requestee+RequestOrReplied comments as in
+            # prior behavior; issue #147 addresses the TechDebt filter only,
+            # and weakening the reviewer count would break existing flows.
+            if reviewer_lastname.lower() != branch_author_lastname.lower():
+                result.reviewers.add(reviewer_lastname.lower())
+
+            ror_value = ror_match.group(1).strip()
+            # Keep only the first line of the value, in case the regex greedy-
+            # matched into following content on the same line.
+            ror_value = ror_value.split("\n", 1)[0].strip()
+
+            # TechDebt attestation is REQUIRED only on actual verdicts
+            # (Approved / Changes Requested). Request / Replied comments do
+            # NOT require it (issue #147 fix).
+            if _is_verdict(ror_value):
                 has_tech_debt = re.search(r"\*{0,2}TechDebt:\*{0,2}\s*(.+)", body)
                 if not has_tech_debt:
                     result.reviews_missing_tech_debt.append(requestee_name)


### PR DESCRIPTION
## Summary

Folds TWO hook bugs in `.claude/hooks/validate_pr_review.py` into one PR — same file, same W9 hook-sprint scope, same standards-lens reviewer.

### Issue #147 — TechDebt over-enforcement on Request / Replied

The hook required a `TechDebt:` attestation line on EVERY comment matching the `Requestor:/Requestee:/RequestOrReplied:` format. Per charter, only actual review verdicts (`Approved` / `Changes Requested`) need TechDebt attestation; `Request` (review requests) and `Replied` (author replies) are process metadata.

**Repro (issue #147):** PR `noorinalabs-isnad-graph#821` had 3 real reviews (all with valid TechDebt) plus 4 non-review comments (3 `Request`, 1 `Replied`, none with TechDebt). The hook blocked merge naming all 4 non-review commenters as missing TechDebt.

**Fix:** extract the `RequestOrReplied` value, gate the TechDebt check on `_is_verdict(value)` — True only for `Approved` / `Changes Requested` / `Changes`. `Request` and `Replied` bypass the TechDebt requirement.

### Issue #164 — reviewer dedup collapses distinct reviewers with shared lastname

The reviewer set was keyed on `reviewer_lastname.lower()`, so when Lucas Ferreira and Santiago Ferreira both approved, the set deduplicated them as one reviewer and the hook reported `1/2 required peer reviews`.

**Repro (issue #164):** deploy#81 had both Ferreiras' Approved comments with valid TechDebt lines. Hook blocked merge. Workaround required dispatching a third reviewer with a different lastname.

**Fix:** switch the dedup key to the full Requestee name (lowercased). Author-equality check still uses lastname (branch format is `{Initial}.{Lastname}/...` so we only have the author's lastname to compare).

### Deliberate non-changes

- `Approved` / `Changes Requested` still block when TechDebt is missing. Existing verdict enforcement is preserved.
- Reviewer counting for the two-peer-review requirement is NOT filtered by verdict type — continues to include all Requestee+RequestOrReplied comments as prior. Narrower than #147 strictly requires but avoids touching unrelated merge-flow semantics.

## Changes

- `.claude/hooks/validate_pr_review.py`:
  - New `_is_verdict()` filter.
  - Gate TechDebt enforcement on `_is_verdict()`.
  - Switch reviewer-set dedup key from lastname to full name.
  - Input Language docstring per W8 § Hook Authorship Requirements — documents canonical `RequestOrReplied` values AND the new dedup key rule.
- `.claude/hooks/tests/test_validate_pr_review.py` — 25 tests:
  - `IsVerdictTests` (10): positive verdicts, case-insensitivity, markdown-bold tolerance, NEGATIVE-MATCH for `Request` / `Replied` / empty / unknown.
  - `TechDebtFilterTests` (9): Request-without-TechDebt does NOT flag; Replied-without-TechDebt does NOT flag; Approved-without-TechDebt DOES flag; Changes-Requested-without-TechDebt DOES flag; PR #821 full repro (0 flagged after fix).
  - `ReviewerDedupTests` (3): NEGATIVE MATCH for #164 — two Ferreiras count as 2/2; same person across Request+Approved counts as 1; branch author self-review still excluded.
  - `MergeCommandMatchTests` (3): merge-command gate regression.

## Test Plan

- [x] `ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/test_validate_pr_review.py -v` — 25/25 passing
- [x] All hook tests still green
- [x] `ruff check` — clean
- [x] `ruff format --check` — clean

Closes #147
Closes #164

## Tech-debt filed
none
