### PR TITLE
build: add version field to noorinalabs-main pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,7 @@
 [project]
 name = "noorinalabs-main"
+version = "0.0.0"
+description = "Org-level coordination root for noorinalabs (not a published package)"
 requires-python = ">=3.12"
 
 [tool.ruff]


### PR DESCRIPTION
Closes #119

## Summary

Parent `noorinalabs-main/pyproject.toml` was missing the `version` field. When `uv` is invoked from any child Python repo, it walks the directory tree, hits this parent file, and errors out:

```
error: Failed to parse: `/home/.../noorinalabs-main/pyproject.toml`
  Caused by: TOML parse error at line 1, column 1
`pyproject.toml` is using the `[project]` table, but the required
`project.version` field is neither set nor present in the `project.dynamic` list
```

Wanjiku worked around this in W8 (#111) by patching + reverting the parent per-run — slow and easy to forget.

## Path chosen: A (one-line fix)

Added `version = "0.0.0"` plus a `description` field clarifying that this pyproject is an org-coordination root, not a published artifact. Path B (true uv workspace with member declarations) was offered in the issue but rejected as overscoped — child repos already work as independent projects, and a workspace conversion risks unintended discovery side effects across 7 child repos.

## Test Plan

Reproduced the failure against an unmodified parent:

```bash
$ cd noorinalabs-isnad-graph && uv sync --dry-run
error: Failed to parse: `/.../noorinalabs-main/pyproject.toml`
  Caused by: ... project.version field is neither set nor present ...
```

Verified the fix by swapping the patched pyproject in and re-running:

```bash
$ cd noorinalabs-isnad-graph && uv sync --dry-run
Would use project environment at: .venv
Resolved 104 packages in 14ms
Found up-to-date lockfile at: uv.lock
Would download 2 packages
Would uninstall 4 packages
Would install 4 packages
 ...
```

uv now walks up cleanly and resolves the child repo. No CI changes required (CI workflow is hooks-only and does not lint pyproject schema).

## Reviewers

Requesting Aino Virtanen (standards/quality — convention compliance) and Aisha Idrissi (deploy SRE — touches build infra adjacent to her domain).