### PR TITLE
fix(hooks): validate_branch_freshness honor repo flag (#118)

### DIFF
--- a/.claude/hooks/tests/test_validate_branch_freshness.py
+++ b/.claude/hooks/tests/test_validate_branch_freshness.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Tests for validate_branch_freshness hook.
+
+Covers issue #118: --repo flag must be honored instead of cwd.
+Also covers W8 hook-authorship NEGATIVE-MATCH requirement.
+
+Run: python3 -m pytest .claude/hooks/tests/test_validate_branch_freshness.py -v
+Or:  python3 .claude/hooks/tests/test_validate_branch_freshness.py
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+_HERE = Path(__file__).resolve().parent
+_HOOKS_DIR = _HERE.parent
+sys.path.insert(0, str(_HOOKS_DIR))
+
+import validate_branch_freshness as hook  # noqa: E402
+
+
+class ExtractBaseTests(unittest.TestCase):
+    def test_default(self):
+        self.assertEqual(hook.extract_base("gh pr create"), "main")
+
+    def test_long_flag(self):
+        self.assertEqual(hook.extract_base("gh pr create --base develop"), "develop")
+
+    def test_short_flag(self):
+        self.assertEqual(hook.extract_base("gh pr create -B develop"), "develop")
+
+    def test_equals_form(self):
+        self.assertEqual(hook.extract_base("gh pr create --base=develop"), "develop")
+
+    def test_quoted(self):
+        self.assertEqual(hook.extract_base('gh pr create --base "release/1.0"'), "release/1.0")
+
+
+class ExtractHeadTests(unittest.TestCase):
+    def test_no_head(self):
+        self.assertIsNone(hook.extract_head("gh pr create"))
+
+    def test_long_flag(self):
+        self.assertEqual(hook.extract_head("gh pr create --head feature-x"), "feature-x")
+
+    def test_short_flag(self):
+        self.assertEqual(hook.extract_head("gh pr create -H feature-x"), "feature-x")
+
+    def test_owner_prefix_stripped(self):
+        self.assertEqual(
+            hook.extract_head("gh pr create --head fork-owner:feature-x"),
+            "feature-x",
+        )
+
+    def test_equals_form(self):
+        self.assertEqual(hook.extract_head("gh pr create --head=feature-x"), "feature-x")
+
+
+class ExtractRepoTests(unittest.TestCase):
+    def test_long_flag(self):
+        self.assertEqual(
+            hook.extract_repo("gh pr create --repo noorinalabs/noorinalabs-isnad-graph"),
+            "noorinalabs/noorinalabs-isnad-graph",
+        )
+
+    def test_short_flag(self):
+        self.assertEqual(hook.extract_repo("gh pr create -R owner/repo"), "owner/repo")
+
+    def test_equals_form(self):
+        self.assertEqual(hook.extract_repo("gh pr create --repo=owner/repo"), "owner/repo")
+
+    def test_no_repo_flag(self):
+        self.assertIsNone(hook.extract_repo("gh pr create"))
+
+
+class NegativeMatchTests(unittest.TestCase):
+    """NEGATIVE-MATCH coverage for #118 + W8 spec.
+
+    Flag values must NOT be extracted from inside another flag's body.
+    """
+
+    def test_repo_token_in_body_is_ignored(self):
+        cmd = 'gh pr create --body "see also: gh pr create --repo ghost/ghost" --repo real/real'
+        self.assertEqual(hook.extract_repo(cmd), "real/real")
+
+    def test_base_token_in_body_is_ignored(self):
+        cmd = 'gh pr create --body "rebase onto --base ghost-base before merging" --base develop'
+        self.assertEqual(hook.extract_base(cmd), "develop")
+
+    def test_head_token_in_body_is_ignored(self):
+        cmd = 'gh pr create --body "the --head ghost-branch flag was renamed" --head real-branch'
+        self.assertEqual(hook.extract_head(cmd), "real-branch")
+
+    def test_no_flags_in_body_only(self):
+        """Body documents flags but the actual command has none."""
+        cmd = 'gh pr create --body "example: --base x --head y --repo a/b"'
+        self.assertEqual(hook.extract_base(cmd), "main")  # default
+        self.assertIsNone(hook.extract_head(cmd))
+        self.assertIsNone(hook.extract_repo(cmd))
+
+
+class GateMatchingTests(unittest.TestCase):
+    """The check() gate fires ONLY on the matched command, not siblings."""
+
+    @staticmethod
+    def _input(command: str) -> dict:
+        return {"tool_name": "Bash", "tool_input": {"command": command}}
+
+    def test_gh_pr_list_is_ignored(self):
+        self.assertIsNone(hook.check(self._input("gh pr list")))
+
+    def test_gh_pr_view_is_ignored(self):
+        self.assertIsNone(hook.check(self._input("gh pr view 123")))
+
+    def test_gh_pr_checks_is_ignored(self):
+        self.assertIsNone(hook.check(self._input("gh pr checks")))
+
+    def test_gh_pr_edit_is_ignored(self):
+        self.assertIsNone(hook.check(self._input("gh pr edit 123 --base main")))
+
+    def test_gh_pr_merge_is_ignored(self):
+        self.assertIsNone(hook.check(self._input("gh pr merge 123 --squash")))
+
+    def test_gh_issue_create_is_ignored(self):
+        self.assertIsNone(hook.check(self._input("gh issue create --title x")))
+
+    def test_non_bash_tool_is_ignored(self):
+        self.assertIsNone(
+            hook.check(
+                {
+                    "tool_name": "Edit",
+                    "tool_input": {"command": "gh pr create --base develop"},
+                }
+            )
+        )
+
+    def test_unrelated_command_is_ignored(self):
+        self.assertIsNone(hook.check(self._input('echo "gh pr create"')))
+
+
+class CheckLocalPathTests(unittest.TestCase):
+    """End-to-end check() with the cwd-based (no --repo) path mocked."""
+
+    @staticmethod
+    def _input(command: str) -> dict:
+        return {"tool_name": "Bash", "tool_input": {"command": command}}
+
+    def test_local_fresh_branch_allows(self):
+        with mock.patch.object(hook, "is_branch_fresh_local", return_value=True) as mocked:
+            result = hook.check(self._input("gh pr create"))
+        self.assertIsNone(result)
+        mocked.assert_called_once_with("main")
+
+    def test_local_stale_branch_blocks(self):
+        with mock.patch.object(hook, "is_branch_fresh_local", return_value=False):
+            result = hook.check(self._input("gh pr create"))
+        self.assertIsNotNone(result)
+        self.assertEqual(result["decision"], "block")
+        self.assertIn("origin/main", result["reason"])
+
+    def test_local_path_used_when_no_repo_flag(self):
+        """Without --repo, the cwd-based check is the only path consulted."""
+        with (
+            mock.patch.object(hook, "is_branch_fresh_local", return_value=True) as local_mock,
+            mock.patch.object(hook, "is_branch_fresh_remote") as remote_mock,
+        ):
+            hook.check(self._input("gh pr create --base develop"))
+        local_mock.assert_called_once_with("develop")
+        remote_mock.assert_not_called()
+
+
+class CheckRemotePathTests(unittest.TestCase):
+    """Bug #118 fix: --repo must route to the API path, not cwd."""
+
+    @staticmethod
+    def _input(command: str) -> dict:
+        return {"tool_name": "Bash", "tool_input": {"command": command}}
+
+    def test_repo_flag_uses_remote_path(self):
+        """When --repo is set and --head is given, hit the API not cwd."""
+        cmd = "gh pr create --repo noorinalabs/noorinalabs-isnad-graph --head feature-x --base main"
+        with (
+            mock.patch.object(hook, "is_branch_fresh_remote", return_value=True) as remote_mock,
+            mock.patch.object(hook, "is_branch_fresh_local") as local_mock,
+        ):
+            result = hook.check(self._input(cmd))
+        self.assertIsNone(result)
+        remote_mock.assert_called_once_with(
+            "noorinalabs/noorinalabs-isnad-graph", "main", "feature-x"
+        )
+        local_mock.assert_not_called()
+
+    def test_repo_flag_with_stale_remote_blocks(self):
+        cmd = (
+            "gh pr create --repo noorinalabs/noorinalabs-isnad-graph "
+            "--head feature-x --base develop"
+        )
+        with mock.patch.object(hook, "is_branch_fresh_remote", return_value=False):
+            result = hook.check(self._input(cmd))
+        self.assertIsNotNone(result)
+        self.assertEqual(result["decision"], "block")
+        self.assertIn("noorinalabs/noorinalabs-isnad-graph:develop", result["reason"])
+
+    def test_repo_flag_without_head_skips(self):
+        """We can't infer head reliably for cross-repo without --head -> skip."""
+        cmd = "gh pr create --repo noorinalabs/noorinalabs-isnad-graph"
+        with (
+            mock.patch.object(hook, "is_branch_fresh_remote") as remote_mock,
+            mock.patch.object(hook, "is_branch_fresh_local") as local_mock,
+        ):
+            result = hook.check(self._input(cmd))
+        self.assertIsNone(result)
+        remote_mock.assert_not_called()
+        local_mock.assert_not_called()
+
+    def test_remote_check_failure_allows(self):
+        """API errors fail-open, matching cwd path's behavior."""
+        cmd = "gh pr create --repo noorinalabs/noorinalabs-isnad-graph --head feature-x"
+        with mock.patch.object(hook, "is_branch_fresh_remote", return_value=None):
+            result = hook.check(self._input(cmd))
+        self.assertIsNone(result)
+
+    def test_repro_for_issue_118(self):
+        """Repro from the issue body: cwd is one repo, --repo targets another.
+
+        Before the fix: hook called git fetch + merge-base in cwd, false-
+        positive blocking. After the fix: we hit the gh API for the target.
+        """
+        cmd = (
+            "gh pr create --repo noorinalabs/noorinalabs-isnad-graph "
+            "--head L.Pham/0834-feature --base main "
+            "--title 't' --body 'b'"
+        )
+        with (
+            mock.patch.object(hook, "is_branch_fresh_remote", return_value=True) as remote_mock,
+            mock.patch.object(hook, "is_branch_fresh_local") as local_mock,
+        ):
+            result = hook.check(self._input(cmd))
+        self.assertIsNone(result, "Bug #118: cross-repo PR should not be blocked by cwd state")
+        remote_mock.assert_called_once_with(
+            "noorinalabs/noorinalabs-isnad-graph", "main", "L.Pham/0834-feature"
+        )
+        local_mock.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/hooks/validate_branch_freshness.py
+++ b/.claude/hooks/validate_branch_freshness.py
@@ -1,42 +1,153 @@
 #!/usr/bin/env python3
 """PreToolUse hook: Validate branch freshness before PR creation.
 
-Blocks `gh pr create` if the feature branch is behind the base branch.
+Blocks the gh-pr-create command if the feature branch is behind the base branch.
+
+Input Language:
+  Fires on:      PreToolUse Bash
+  Matches:       gh-pr-create [--repo {OWNER/REPO} | -R {OWNER/REPO}]
+                              [--base {BASE} | -B {BASE}]
+                              [--head {[OWNER:]HEAD} | -H {[OWNER:]HEAD}]
+                              [other flags]
+  (Above shows the literal token sequence: gh, pr, create.)
+  Does NOT match: gh pr list, gh pr view, gh pr checks, gh pr edit, gh pr merge,
+                  gh issue create. Also does NOT match --base/--head/--repo
+                  substrings that appear INSIDE the value of another flag (e.g.
+                  inside --body) -- see Bug #118 below.
+  Flag pass-through:
+    --repo / -R   -> when present, the freshness check uses the GitHub API
+                    compare endpoint against that repo (Bug #118 fix). The
+                    cwd-based git fetch / merge-base path is bypassed because
+                    the cwd repo may be entirely different from the PR target.
+    --base / -B   -> base branch on the target repo (defaults to "main").
+    --head / -H   -> feature branch on the target repo. Accepts the
+                    OWNER:branch cross-fork form; only the branch part is
+                    used. When omitted with --repo, the check skips (we
+                    cannot infer head reliably from cwd in that case).
+                    Without --repo, the cwd path uses HEAD as before.
+
+Tokenization:
+  The command is split with shlex.split(..., posix=True) so quoted argument
+  values become single tokens. We walk the token list and only treat a token
+  as a flag value when the PRECEDING token is the corresponding flag. Same
+  pattern as validate_labels (#113) -- guarantees that text inside a
+  --body "..." heredoc cannot leak into base/head/repo extraction.
 
 Exit codes:
-  0 — allow (not gh pr create, or branch is up to date)
-  2 — block (branch is behind base)
+  0 -- allow (not the matched command, branch is up to date, or check could not run)
+  2 -- block (branch is behind base)
 """
 
 import json
 import os
 import re
+import shlex
 import subprocess
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from annunaki_log import log_pretooluse_block
 
-
-def get_base_branch(command: str) -> str:
-    """Extract --base flag value, default to 'main'."""
-    match = re.search(r"--base\s+[\"']?(\S+)[\"']?", command)
-    if match:
-        return match.group(1)
-    return "main"
+_BASE_FLAGS = {"--base", "-B"}
+_HEAD_FLAGS = {"--head", "-H"}
+_REPO_FLAGS = {"--repo", "-R"}
 
 
-def is_branch_fresh(base: str) -> bool:
-    """Check if HEAD contains the latest commit from origin/base."""
+def _tokenize(command: str) -> list[str] | None:
+    """Tokenize a shell command via shlex. Return None on parse failure."""
     try:
-        # Fetch latest from origin
+        return shlex.split(command, posix=True)
+    except ValueError:
+        return None
+
+
+def _is_gh_pr_create(tokens: list[str]) -> bool:
+    """Return True if tokens contain a gh pr create invocation."""
+    for i in range(len(tokens) - 2):
+        if tokens[i] == "gh" and tokens[i + 1] == "pr" and tokens[i + 2] == "create":
+            return True
+    return False
+
+
+def _walk_flags(tokens: list[str], wanted: set[str]) -> list[str]:
+    """Return values for wanted flag names, only when they appear as flags.
+
+    A token is treated as a wanted-flag value only if the immediately
+    preceding token is exactly one of wanted. The --flag=value form is
+    also handled. Values inside other flags (e.g. inside the value of
+    --body) are ignored because they are a SINGLE shlex token, never
+    preceded by a flag from wanted.
+    """
+    values: list[str] = []
+    i = 0
+    while i < len(tokens):
+        tok = tokens[i]
+        if tok in wanted:
+            if i + 1 < len(tokens):
+                values.append(tokens[i + 1])
+                i += 2
+                continue
+            i += 1
+            continue
+        matched = False
+        for flag in wanted:
+            if flag.startswith("--") and tok.startswith(flag + "="):
+                values.append(tok[len(flag) + 1 :])
+                matched = True
+                break
+        if matched:
+            i += 1
+            continue
+        i += 1
+    return values
+
+
+def _first_flag_value(command: str, wanted: set[str]) -> str | None:
+    """Tokenize and return the first value for any of wanted, or None.
+
+    Falls back to a regex anchored at a shell-token boundary if shlex fails
+    (e.g. malformed quote). The regex tries longer flag names first so that
+    --repo is preferred over a hypothetical shorter prefix collision.
+    """
+    tokens = _tokenize(command)
+    if tokens is None:
+        for flag in sorted(wanted, key=len, reverse=True):
+            pattern = rf"(?:^|\s){re.escape(flag)}(?:=|\s+)(\S+)"
+            match = re.search(pattern, command)
+            if match:
+                return match.group(1)
+        return None
+    values = _walk_flags(tokens, wanted)
+    return values[0] if values else None
+
+
+def extract_base(command: str) -> str:
+    """Extract --base / -B value, default to 'main'."""
+    return _first_flag_value(command, _BASE_FLAGS) or "main"
+
+
+def extract_head(command: str) -> str | None:
+    """Extract --head / -H value. Strips OWNER: prefix if present."""
+    raw = _first_flag_value(command, _HEAD_FLAGS)
+    if raw and ":" in raw:
+        return raw.split(":", 1)[1]
+    return raw
+
+
+def extract_repo(command: str) -> str | None:
+    """Extract --repo / -R OWNER/REPO value, if any."""
+    return _first_flag_value(command, _REPO_FLAGS)
+
+
+def is_branch_fresh_local(base: str) -> bool:
+    """cwd-based check: HEAD contains the latest commit from origin/base."""
+    try:
         subprocess.run(
             ["git", "fetch", "origin", base],
             capture_output=True,
             text=True,
             timeout=30,
         )
-        # Check if origin/base is an ancestor of HEAD
         result = subprocess.run(
             ["git", "merge-base", "--is-ancestor", f"origin/{base}", "HEAD"],
             capture_output=True,
@@ -45,8 +156,36 @@ def is_branch_fresh(base: str) -> bool:
         )
         return result.returncode == 0
     except (subprocess.TimeoutExpired, FileNotFoundError):
-        # If we can't check, allow
         return True
+
+
+def is_branch_fresh_remote(repo: str, base: str, head: str) -> bool | None:
+    """API-based check: behind_by from gh compare endpoint.
+
+    Returns True if head is at-or-ahead of base, False if behind, None if the
+    check could not be performed (network error, missing branch, etc.). None
+    is treated as "allow" by callers -- same fail-open behavior as the local
+    path.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "gh",
+                "api",
+                f"repos/{repo}/compare/{base}...{head}",
+                "--jq",
+                ".behind_by",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            return None
+        behind = int(result.stdout.strip())
+        return behind == 0
+    except (subprocess.TimeoutExpired, FileNotFoundError, ValueError):
+        return None
 
 
 def check(input_data: dict) -> dict | None:
@@ -57,20 +196,40 @@ def check(input_data: dict) -> dict | None:
 
     command = input_data.get("tool_input", {}).get("command", "")
 
-    if not re.search(r"\bgh\s+pr\s+create\b", command):
-        return None
+    tokens = _tokenize(command)
+    if tokens is not None:
+        if not _is_gh_pr_create(tokens):
+            return None
+    else:
+        if not re.search(r"\bgh\s+pr\s+create\b", command):
+            return None
 
-    base = get_base_branch(command)
+    base = extract_base(command)
+    repo = extract_repo(command)
 
-    if is_branch_fresh(base):
-        return None
+    if repo:
+        head = extract_head(command)
+        if not head:
+            return None
+        fresh = is_branch_fresh_remote(repo, base, head)
+        if fresh is None or fresh:
+            return None
+    else:
+        if is_branch_fresh_local(base):
+            return None
 
+    target = f"{repo}:{base}" if repo else f"origin/{base}"
+    rebase_hint = (
+        f"Rebase the head branch onto {target} on the target repo."
+        if repo
+        else f"Run: git fetch origin && git merge origin/{base}"
+    )
     result = {
         "decision": "block",
         "reason": (
-            f"BLOCKED: Your branch is behind origin/{base}. "
+            f"BLOCKED: Your branch is behind {target}. "
             f"Merge or rebase before creating a PR.\n"
-            f"Run: git fetch origin && git merge origin/{base}\n\n"
+            f"{rebase_hint}\n\n"
             "This prevents merge conflicts and ensures CI runs against current code."
         ),
     }

--- a/.claude/team/charter/hooks.md
+++ b/.claude/team/charter/hooks.md
@@ -60,9 +60,9 @@ The following charter rules are enforced automatically via Claude Code hooks in 
 
 ## Hook 9: Validate Branch Freshness (`validate_branch_freshness.py`)
 
-- **What it automates:** Blocks `gh pr create` if the feature branch is behind the base branch. Prevents merge conflicts from stale branches.
+- **What it automates:** Blocks `gh pr create` if the feature branch is behind the base branch. Prevents merge conflicts from stale branches. Honors the `--repo OWNER/REPO` flag (#118 fix): when present, the freshness check uses the GitHub `compare` API against the target repo instead of the cwd-based `git fetch`/`git merge-base`. Without `--repo`, falls back to cwd behavior. Cross-repo PRs without `--head` are skipped (we cannot infer head reliably from cwd).
 - **Augments:** [Branching](branching.md) workflow. Session 4 had RBAC and session hardening PRs conflict because neither was rebased.
-- **Manual steps remaining:** None — the hook runs `git fetch` and `git merge-base --is-ancestor` automatically.
+- **Manual steps remaining:** None — the hook runs `git fetch` and `git merge-base --is-ancestor` (cwd path) or `gh api repos/.../compare/{base}...{head}` (cross-repo path) automatically.
 - **Emergency override:** Remove the hook entry from `.claude/settings.json`.
 
 ## Hook 10: Validate VPS_HOST (`validate_vps_host.py`)


### PR DESCRIPTION
## Summary

`validate_branch_freshness.py` ignored the `--repo OWNER/REPO` flag and ran `git fetch` + `git merge-base --is-ancestor` against the session's cwd repo. When cwd was one repo but the PR target was another (very common in `noorinalabs-main` org-level work), the hook reported a false-positive "branch behind base" using the wrong repo's git state.

This is the same architectural pattern as #113: hooks treating the bash command as an opaque string instead of parsing it as a structured CLI invocation.

## Fix

- Parse `--repo / -R`, `--base / -B`, `--head / -H` via `shlex.split` (consistent with #113).
- When `--repo` is present: route the freshness check through the GitHub `compare` API (`gh api repos/{repo}/compare/{base}...{head}`) instead of the local git path. No local clone required.
- Cross-repo `OWNER:branch` head form is accepted (only the branch suffix is used).
- Cross-repo PR with no `--head` flag: skip the check (cannot infer head reliably from cwd; defer to GitHub branch-protection).
- No `--repo` flag: cwd-based path is preserved exactly (backward compat).
- Module docstring rewritten per W8 § Hook Authorship Requirements with full Input Language section.

## Changes

- `.claude/hooks/validate_branch_freshness.py` — shlex-based tokenization, `--repo` pass-through via gh API, Input Language docstring.
- `.claude/hooks/tests/test_validate_branch_freshness.py` — 34 new tests including negative-match coverage and #118 repro.
- `.claude/team/charter/hooks.md` — Hook 9 entry updated to document the new `--repo` behavior.

## Test Plan

- [x] `ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/test_validate_branch_freshness.py -v` — 34/34 passing
- [x] Full hook test suite still green (111/111 total)
- [x] Positive: long/short flag, `=value` form, `OWNER:branch` head stripping, default base
- [x] Negative-match: `--repo`, `--base`, `--head` substrings inside `--body` are NOT extracted
- [x] Gate: list/view/checks/edit/merge sibling commands and non-Bash tools all bypass
- [x] Repro for #118: cross-repo PR with `--repo OWNER/REPO` + `--head feature` routes to API path, NOT cwd
- [x] Smoke-tested hook end-to-end via stdin JSON
- [x] `ruff check --fix` and `ruff format` clean

Closes #118

## Tech-debt filed
none

🤖 Generated with [Claude Code](https://claude.com/claude-code)
