### PR TITLE
fix(hooks): auto_set_env_test — skip gh subcommands + --body flag to prevent substring false-positives (#114)

### DIFF
--- a/.claude/hooks/auto_set_env_test.py
+++ b/.claude/hooks/auto_set_env_test.py
@@ -2,16 +2,95 @@
 """PreToolUse hook: Auto-set ENVIRONMENT=test before pytest/make test.
 
 Ensures ENVIRONMENT=test is present in the environment for any pytest or
-`make test` command. If not already set, prepends ENVIRONMENT=test to the
-command.
+`make test` command. If not already set, blocks with a corrected command
+that prepends ENVIRONMENT=test.
+
+Input Language
+==============
+
+Fires on:
+    PreToolUse Bash
+
+Matches (blocks if ENVIRONMENT=test missing):
+    Any Bash command whose token stream, after stripping leading
+    `VAR=value` environment assignments, contains a real test-runner
+    invocation detected by the regexes `\\bpytest\\b` or `\\bmake\\s+test\\b`.
+    Typical matched forms:
+        pytest tests/
+        uv run pytest
+        python -m pytest
+        make test
+        DEBUG=1 pytest tests/            (env prefix preserved; still matches)
+
+Does NOT match (short-circuit skips — #114 fix):
+    1. Command whose effective argv[0] is `gh` — `gh` is a GitHub API
+       client, never a test runner. `ENVIRONMENT=test gh pr comment ...`
+       is nonsensical. Skip even if pytest/make-test text appears inside
+       the command (almost always inside --body / --title content).
+    2. Command containing a `--body` or `--body-file` flag — structured
+       body content almost always contains user-supplied text that may
+       mention pytest or `make test` without invoking them. This skip is
+       intentionally broad: a non-gh tool like
+       `some-tool --body "$(cat pytest.txt)"` is also skipped. The cost
+       of a rare false negative on an exotic non-gh tool is lower than
+       the cost of blocking every review / issue / comment that
+       references pytest.
+
+Both short-circuits run BEFORE the pytest/make-test regex check.
+
+Detection order:
+    1. Strip leading `VAR=value` tokens from the command.
+    2. If the next token is `gh`, ALLOW (return None).
+    3. If the command contains `--body` or `--body-file`, ALLOW.
+    4. If `\\bpytest\\b` or `\\bmake\\s+test\\b` matches, require
+       `\\bENVIRONMENT=test\\b` somewhere in the command; else BLOCK.
 
 Exit codes:
-  0 — allow (always; modifies command if needed via JSON output)
+    0 — allow (not a Bash tool, or skip condition met, or already has
+        ENVIRONMENT=test)
+    2 — block (real test command missing ENVIRONMENT=test)
+
+Enforcement artifact for: noorinalabs/noorinalabs-main#114
 """
 
 import json
+import os
 import re
 import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from annunaki_log import log_pretooluse_block  # noqa: E402
+
+# Matches a leading `VAR=value` token (simple unquoted value).
+_ENV_ASSIGN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=\S*\s+")
+
+# `--body` or `--body-file` as a standalone flag. The trailing lookahead
+# prevents matching `--body-foo` but still matches both `--body x`,
+# `--body=x`, and `--body-file path`.
+_BODY_FLAG = re.compile(r"(?<![\w-])--body(?:-file)?(?=[\s=]|$)")
+
+
+def _strip_leading_env(command: str) -> str:
+    """Remove leading `VAR=value ` assignments, return the remainder."""
+    while True:
+        m = _ENV_ASSIGN.match(command)
+        if not m:
+            return command
+        command = command[m.end():]
+
+
+def _is_gh_invocation(command: str) -> bool:
+    """True if the effective argv[0] (after env assignments) is `gh`."""
+    stripped = _strip_leading_env(command).lstrip()
+    if not stripped:
+        return False
+    token = stripped.split(None, 1)[0]
+    return token == "gh"
+
+
+def _has_body_flag(command: str) -> bool:
+    """True if the command contains a --body or --body-file flag."""
+    return bool(_BODY_FLAG.search(command))
 
 
 def check(input_data: dict) -> dict | None:
@@ -25,8 +104,17 @@ def check(input_data: dict) -> dict | None:
 
     command = input_data.get("tool_input", {}).get("command", "")
 
-    is_test_cmd = bool(re.search(r"\bpytest\b", command) or re.search(r"\bmake\s+test\b", command))
+    # Short-circuit 1: gh subcommands are never test runners.
+    if _is_gh_invocation(command):
+        return None
 
+    # Short-circuit 2: --body/--body-file flag implies structured content.
+    if _has_body_flag(command):
+        return None
+
+    is_test_cmd = bool(
+        re.search(r"\bpytest\b", command) or re.search(r"\bmake\s+test\b", command)
+    )
     if not is_test_cmd:
         return None
 
@@ -52,6 +140,13 @@ def main() -> None:
     result = check(input_data)
     if result and result.get("decision") == "block":
         print(json.dumps(result))
+        command = input_data.get("tool_input", {}).get("command", "")
+        log_pretooluse_block(
+            "auto_set_env_test",
+            command,
+            result["reason"],
+            tool_name="Bash",
+        )
         sys.exit(2)
     sys.exit(0)
 

--- a/.claude/hooks/tests/test_auto_set_env_test.py
+++ b/.claude/hooks/tests/test_auto_set_env_test.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Tests for auto_set_env_test hook.
+
+Covers hook-authorship-spec requirement: NEGATIVE MATCH coverage.
+Each test documents which negative-space case it guards against.
+
+Run: python3 -m pytest .claude/hooks/tests/test_auto_set_env_test.py -v
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_HOOKS_DIR = _HERE.parent
+sys.path.insert(0, str(_HOOKS_DIR))
+
+import auto_set_env_test as hook  # noqa: E402
+
+
+def _bash(command: str) -> dict:
+    return {"tool_name": "Bash", "tool_input": {"command": command}}
+
+
+class NonMatchedToolTests(unittest.TestCase):
+    """Tools OTHER than Bash must never block."""
+
+    def test_edit_does_not_block(self) -> None:
+        """NEG: Edit is not in the matcher set."""
+        result = hook.check({"tool_name": "Edit", "tool_input": {"file_path": "x.py"}})
+        self.assertIsNone(result)
+
+    def test_write_does_not_block(self) -> None:
+        """NEG: Write is not in the matcher set."""
+        result = hook.check({"tool_name": "Write", "tool_input": {"file_path": "x.py"}})
+        self.assertIsNone(result)
+
+
+class GhSubcommandSkipTests(unittest.TestCase):
+    """Short-circuit #1: any command whose argv[0] is `gh` is exempt (#114)."""
+
+    def test_gh_pr_comment_with_pytest_in_body(self) -> None:
+        """NEG: `gh pr comment ... --body "...pytest..."` — repro case from #114."""
+        result = hook.check(
+            _bash(
+                'gh pr comment 808 --repo noorinalabs/x --body "fixing pytest CVE"'
+            )
+        )
+        self.assertIsNone(result, "gh pr comment mentioning pytest in body must be allowed")
+
+    def test_gh_issue_create_with_make_test_in_body(self) -> None:
+        """NEG: `gh issue create --body "make test broke"` — substring false-positive."""
+        result = hook.check(
+            _bash('gh issue create --title "x" --body "make test broke"')
+        )
+        self.assertIsNone(result, "gh issue create mentioning make test in body must be allowed")
+
+    def test_gh_pr_create_runs_pytest_mention(self) -> None:
+        """NEG: `gh pr create --body "runs pytest in CI"` — PR description text."""
+        result = hook.check(_bash('gh pr create --body "runs pytest in CI"'))
+        self.assertIsNone(result, "gh pr create mentioning pytest must be allowed")
+
+    def test_gh_skip_beats_env_prefix(self) -> None:
+        """NEG: `ENVIRONMENT=test gh pr comment ... --body "pytest"` — gh skip
+        takes precedence; we don't want to accidentally encourage the env prefix
+        on gh commands by only allowing them if ENVIRONMENT=test is present."""
+        result = hook.check(
+            _bash('ENVIRONMENT=test gh pr comment 1 --body "pytest"')
+        )
+        self.assertIsNone(
+            result,
+            "gh after env-assignment prefix is still a gh invocation, not a test",
+        )
+
+    def test_gh_with_multiple_env_prefixes(self) -> None:
+        """NEG: multiple leading env assignments still resolve to `gh` argv[0]."""
+        result = hook.check(
+            _bash('FOO=1 BAR=2 gh pr comment 1 --body "pytest note"')
+        )
+        self.assertIsNone(result)
+
+
+class BodyFlagSkipTests(unittest.TestCase):
+    """Short-circuit #2: --body / --body-file flags exempt the whole command."""
+
+    def test_body_flag_in_non_gh_command(self) -> None:
+        """NEG: `some-tool --body "$(cat pytest.txt)"` — intentionally broad skip
+        per hook docstring. False-negatives on exotic tools are acceptable."""
+        result = hook.check(_bash('some-tool --body "$(cat pytest.txt)"'))
+        self.assertIsNone(result)
+
+    def test_body_file_flag(self) -> None:
+        """NEG: --body-file also triggers the skip (same rationale)."""
+        result = hook.check(_bash('gh pr create --body-file /tmp/body.md'))
+        self.assertIsNone(result)
+
+    def test_body_equals_form(self) -> None:
+        """NEG: --body=value (no space) also triggers the skip."""
+        result = hook.check(_bash('gh pr comment 1 --body="pytest CVE"'))
+        self.assertIsNone(result)
+
+    def test_body_flag_false_friend_not_matched(self) -> None:
+        """POS: `--body-foo` should NOT count as a body flag. With pytest present
+        and no ENVIRONMENT=test, this should block (not gh, no real --body)."""
+        result = hook.check(_bash('custom-tool --body-foo pytest'))
+        self.assertIsNotNone(result, "--body-foo is not --body or --body-file")
+        self.assertEqual(result.get("decision"), "block")
+
+
+class PositiveMatchTests(unittest.TestCase):
+    """Real test-runner commands must still block without ENVIRONMENT=test."""
+
+    def test_bare_pytest_blocks(self) -> None:
+        """POS: `pytest` alone — classic invocation."""
+        result = hook.check(_bash("pytest"))
+        self.assertIsNotNone(result)
+        self.assertEqual(result.get("decision"), "block")
+
+    def test_pytest_with_path_blocks(self) -> None:
+        """POS: `pytest tests/` — typical invocation."""
+        result = hook.check(_bash("pytest tests/"))
+        self.assertIsNotNone(result)
+        self.assertEqual(result.get("decision"), "block")
+
+    def test_make_test_blocks(self) -> None:
+        """POS: `make test` — make target."""
+        result = hook.check(_bash("make test"))
+        self.assertIsNotNone(result)
+
+    def test_python_m_pytest_blocks(self) -> None:
+        """POS: `python -m pytest` — module invocation."""
+        result = hook.check(_bash("python -m pytest"))
+        self.assertIsNotNone(result)
+
+    def test_uv_run_pytest_blocks(self) -> None:
+        """POS: `uv run pytest` — uv tool runner."""
+        result = hook.check(_bash("uv run pytest"))
+        self.assertIsNotNone(result)
+
+    def test_env_prefix_with_real_pytest_still_blocks(self) -> None:
+        """POS regression: leading env prefix with real test command must still
+        block. `DEBUG=1 pytest tests/` has `pytest` as effective argv[0]."""
+        result = hook.check(_bash("DEBUG=1 pytest tests/"))
+        self.assertIsNotNone(result)
+        self.assertEqual(result.get("decision"), "block")
+
+
+class EnvAlreadySetTests(unittest.TestCase):
+    """ENVIRONMENT=test already present — must allow."""
+
+    def test_env_set_on_pytest(self) -> None:
+        """NEG: ENVIRONMENT=test already prepended — allow."""
+        result = hook.check(_bash("ENVIRONMENT=test pytest tests/"))
+        self.assertIsNone(result)
+
+    def test_env_set_on_make_test(self) -> None:
+        """NEG: ENVIRONMENT=test on make test — allow."""
+        result = hook.check(_bash("ENVIRONMENT=test make test"))
+        self.assertIsNone(result)
+
+
+class NonTestCommandTests(unittest.TestCase):
+    """Commands that don't match pytest/make-test regex must allow."""
+
+    def test_ls_allowed(self) -> None:
+        """NEG: `ls` — not a test command."""
+        result = hook.check(_bash("ls -la"))
+        self.assertIsNone(result)
+
+    def test_empty_command_allowed(self) -> None:
+        """NEG: empty command."""
+        result = hook.check(_bash(""))
+        self.assertIsNone(result)
+
+    def test_make_other_target_allowed(self) -> None:
+        """NEG: `make build` — not `make test`."""
+        result = hook.check(_bash("make build"))
+        self.assertIsNone(result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/team/charter/hooks.md
+++ b/.claude/team/charter/hooks.md
@@ -28,6 +28,9 @@ The following charter rules are enforced automatically via Claude Code hooks in 
 - **What it automates:** Ensures `ENVIRONMENT=test` is set before any `pytest`, `uv run pytest`, or `make test` command. Prevents CI breaks caused by missing environment variable.
 - **Augments:** Testing workflow. This is an automated safeguard, not replacing a prior manual rule.
 - **Manual steps remaining:** None — the hook blocks and instructs the user to prepend `ENVIRONMENT=test`.
+- **Skip conditions (#114):** Two short-circuits run before the pytest/make-test regex to prevent substring false-positives in GitHub API calls and body content:
+  1. **`gh` subcommands** — if the effective argv[0] (after stripping leading `VAR=value` assignments) is `gh`, the hook skips. `gh` is a GitHub API client, never a test runner.
+  2. **`--body` / `--body-file` flags** — if the command contains either flag, the hook skips. Structured bodies almost always contain user-supplied text mentioning `pytest` or `make test`. This skip is intentionally broad — a rare false negative on an exotic `--body`-using tool is cheaper than blocking every review/issue/comment that references pytest.
 - **Emergency override:** Remove the hook entry from `.claude/settings.json`.
 
 ## Hook 5: Validate Labels Before `gh issue create` (`validate_labels.py`)


### PR DESCRIPTION
## Summary

Fixes #114. The `auto_set_env_test` PreToolUse hook was matching `\bpytest\b` / `\bmake\s+test\b` anywhere in a Bash command, including inside `gh pr comment --body "..."` or `gh issue create --body "..."` bodies that merely *mentioned* tests. This blocked legitimate GitHub API calls demanding `ENVIRONMENT=test`, which is semantically wrong — the command is not a test runner.

## Reproduction (from #114)

```
gh pr comment 808 --repo ... --body "...pytest CVE..."
```
was blocked with:
```
ENVIRONMENT=test is required for test commands but was not found in the command.
```

## Design — two short-circuits (options 2+3 from the issue)

Both run BEFORE the pytest/make-test regex:

1. **Skip if effective argv[0] is `gh`.** After stripping leading `VAR=value ` env assignments, if the next token is `gh`, the hook allows. `gh` is a GitHub API client, never a test runner.
2. **Skip if `--body` / `--body-file` flag is present.** Structured body content almost always contains user-supplied text. This skip is intentionally broad — a non-gh tool like `some-tool --body "$(cat pytest.txt)"` is also skipped. Documented as intentional in the module docstring (the cost of a rare false negative is lower than blocking every review/issue comment that references pytest).

Option 1 from the issue (full argv parsing) was rejected — overkill for this hook.

## Test coverage (22 tests, all passing)

- **Gh skip:** `gh pr comment ... --body "pytest CVE"`, `gh issue create --body "make test broke"`, `gh pr create --body "runs pytest in CI"`, `ENVIRONMENT=test gh pr comment --body "pytest"` (gh skip beats env prefix), multi-env-prefix
- **Body flag skip:** non-gh `some-tool --body "$(cat pytest.txt)"`, `--body-file`, `--body=value`, `--body-foo` false-friend still blocks
- **Positive regressions:** bare `pytest`, `pytest tests/`, `make test`, `python -m pytest`, `uv run pytest`, `DEBUG=1 pytest tests/` — all still block without `ENVIRONMENT=test`
- **Env-set cases:** `ENVIRONMENT=test pytest`, `ENVIRONMENT=test make test` — both allowed
- **Non-test commands:** `ls`, empty, `make build` — allowed
- **Non-Bash tools:** Edit, Write — allowed

## Other hook-authorship-spec compliance

- Added **Input Language / Matches / Does NOT match** docstring section per W8 hook authorship spec (charter `hooks.md` § Hook Authorship Requirements).
- Added **Annunaki logging on block** via `log_pretooluse_block` (was missing before; parallel to `enforce_librarian_consulted`).
- Updated `.claude/team/charter/hooks.md` § Hook 4 with the skip conditions.
- stdlib-only; no new dependencies.

## Test plan

- [x] `python3 -m pytest .claude/hooks/tests/test_auto_set_env_test.py -v` — 22 passed
- [x] `ruff check .claude/hooks/auto_set_env_test.py .claude/hooks/tests/test_auto_set_env_test.py` — clean
- [ ] Manual: run a `gh pr comment --body "pytest"` after merge and confirm it no longer blocks

TechDebt: none