### PR TITLE
fix(hooks): validate_pr_review — accept dash-separator branches in author-lastname regex (#179)

### DIFF
--- a/.claude/hooks/tests/test_validate_pr_review.py
+++ b/.claude/hooks/tests/test_validate_pr_review.py
@@ -314,6 +314,37 @@ class ReviewerDedupTests(_CheckCommentReviewsHarness):
         self.assertEqual(result.reviewers, set(), "branch author must not self-review")
 
 
+class ExtractBranchAuthorLastnameTests(unittest.TestCase):
+    """Regression tests for issue #179.
+
+    The regex must accept BOTH separator styles seen in practice — the
+    charter-spec slash and the dash-separator that recent branches actually
+    use. When the regex missed dash-separator branches, reviewer-counting
+    never ran and merges blocked on 0/2 reviews.
+    """
+
+    def test_slash_separator_legacy(self):
+        """Legacy slash separator still extracts lastname."""
+        self.assertEqual(hook.extract_branch_author_lastname("A.Virtanen/0001-foo"), "Virtanen")
+
+    def test_dash_separator_current(self):
+        """Dash separator — the fix for #179."""
+        self.assertEqual(hook.extract_branch_author_lastname("A.Virtanen-0001-foo"), "Virtanen")
+
+    # NEGATIVE MATCHES — hook-authorship spec requires neg coverage.
+    def test_underscore_separator_rejected(self):
+        """Underscore is NOT an accepted separator."""
+        self.assertIsNone(hook.extract_branch_author_lastname("A.Virtanen_0001-foo"))
+
+    def test_plain_branch_name_rejected(self):
+        """A branch without the `{Initial}.{LastName}` prefix returns None."""
+        self.assertIsNone(hook.extract_branch_author_lastname("main"))
+
+    def test_no_separator_rejected(self):
+        """Prefix present but no separator before trailing content returns None."""
+        self.assertIsNone(hook.extract_branch_author_lastname("A.Virtanen0001"))
+
+
 class MergeCommandMatchTests(unittest.TestCase):
     """Regression tests for the merge-command gate."""
 

--- a/.claude/hooks/validate_pr_review.py
+++ b/.claude/hooks/validate_pr_review.py
@@ -131,8 +131,16 @@ def get_pr_data(pr_number: str | None, repo: str | None = None) -> dict | None:
 
 
 def extract_branch_author_lastname(head_ref: str) -> str | None:
-    """Extract the last name from branch format '{FirstInitial}.{LastName}/...'."""
-    match = re.match(r"[A-Za-z]\.([A-Za-z]+)/", head_ref)
+    """Extract the last name from branch format '{FirstInitial}.{LastName}[-/]...'.
+
+    Accepts both separator styles seen in practice:
+    - slash: `A.Virtanen/0179-branch-regex-fix` (legacy/charter spec)
+    - dash:  `A.Virtanen-0179-branch-regex-fix` (observed on recent branches)
+
+    Returns None if the head_ref does not match the `{Initial}.{LastName}` prefix
+    followed by one of the accepted separators.
+    """
+    match = re.match(r"[A-Za-z]\.([A-Za-z]+)[-/]", head_ref)
     if match:
         return match.group(1)
     return None


### PR DESCRIPTION
## Summary

One-line regex fix. `extract_branch_author_lastname` in `.claude/hooks/validate_pr_review.py` required a slash after `{Initial}.{LastName}`, so branches using the dash separator (e.g. `A.Virtanen-0179-...`) fell through to None. With no branch-author extracted, reviewer-counting never ran and merges blocked on 0/2 reviews.

Fix: accept either `-` or `/` as the separator.

```python
match = re.match(r"[A-Za-z]\.([A-Za-z]+)[-/]", head_ref)
```

Docstring updated to reflect both forms. No other behavior change.

## Repro (from #179)

A branch like `W.Mwangi-0147-foo` with two valid charter-format `Approved` reviews would still be reported by the hook as `0/2 reviewers`, blocking merge.

## Test coverage

New `ExtractBranchAuthorLastnameTests` class in `test_validate_pr_review.py`:

- `A.Virtanen/0001-foo` → `Virtanen` (legacy slash — still works)
- `A.Virtanen-0001-foo` → `Virtanen` (new dash — the fix)
- `A.Virtanen_0001-foo` → `None` (underscore rejected — negative match)
- `main` → `None` (no prefix — negative match / regression guard)
- `A.Virtanen0001` → `None` (prefix but no separator — negative match)

Full suite: 30/30 pass. `ruff check` clean. `ruff format --check` clean.

## Notes

- This PR's branch uses the **slash** form (`A.Virtanen/0179-branch-regex-fix`) intentionally, so it passes the very regex it's fixing under the current on-main hook.
- The broader slash-vs-dash branch-naming convention question (CLAUDE.md says slash; many branches use dash) is **not** in scope here. This fix makes the hook lenient; the convention decision stays open for owner sign-off.

## Test plan

- [x] All existing tests pass (30/30)
- [x] New negative-match coverage added
- [x] Ruff check + format clean
- [ ] Reviewer verification: `gh pr view <N> --json headRefName -q .headRefName` on a dash-separator PR no longer reports `0 reviewers`

Closes #179

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>