### PR TITLE
fix(skills): root bash paths at $REPO_ROOT to survive cwd drift (#149)

### DIFF
--- a/.claude/skills/annunaki-attack/SKILL.md
+++ b/.claude/skills/annunaki-attack/SKILL.md
@@ -5,6 +5,8 @@ description: Analyze captured errors, propose automation (hooks/skills/charter),
 
 Process the Annunaki error log, deduplicate errors, propose preventative automation, create GitHub issues, and implement fixes. This is the **action** counterpart to the `/annunaki` status viewer.
 
+> Note: all repo paths in bash blocks below are rooted at `$REPO_ROOT` to avoid cwd drift when the skill is invoked from a worktree or child-repo subdirectory (#149).
+
 ## When to run
 
 - Before `/wave-wrapup` hands off to retro (integrated into wave-wrapup step 11.5)
@@ -16,7 +18,8 @@ Process the Annunaki error log, deduplicate errors, propose preventative automat
 ### 1. Read and deduplicate the error log
 
 ```bash
-cat .claude/annunaki/errors.jsonl 2>/dev/null
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cat "$REPO_ROOT/.claude/annunaki/errors.jsonl" 2>/dev/null
 ```
 
 If the file is empty or missing, report "No errors to process" and exit.
@@ -29,7 +32,8 @@ If the file is empty or missing, report "No errors to process" and exit.
 
 ```bash
 # Back up the original
-cp .claude/annunaki/errors.jsonl .claude/annunaki/errors.jsonl.bak.$(date +%Y%m%d%H%M%S)
+cp "$REPO_ROOT/.claude/annunaki/errors.jsonl" \
+   "$REPO_ROOT/.claude/annunaki/errors.jsonl.bak.$(date +%Y%m%d%H%M%S)"
 
 # Write deduplicated version (done in the analysis step below)
 ```
@@ -133,7 +137,7 @@ After all issues are created and fixes implemented, clear the processed errors:
 ```bash
 # Keep only errors that were classified as noise (they'll naturally age out)
 # Write a fresh errors.jsonl with only unprocessed entries (if any)
-echo "" > .claude/annunaki/errors.jsonl
+: > "$REPO_ROOT/.claude/annunaki/errors.jsonl"
 ```
 
 ### 7. Report

--- a/.claude/skills/annunaki/SKILL.md
+++ b/.claude/skills/annunaki/SKILL.md
@@ -5,6 +5,8 @@ description: View Annunaki error monitor status — shows recent captured errors
 
 Display the current state of the Annunaki error monitor. This skill is the **status viewer** for the always-on error monitoring hook (`annunaki_monitor.py`).
 
+> Note: all repo paths in bash blocks below are rooted at `$REPO_ROOT` to avoid cwd drift when the skill is invoked from a worktree or child-repo subdirectory (#149).
+
 ## How it works
 
 The Annunaki system has two parts:
@@ -18,7 +20,8 @@ The Annunaki system has two parts:
 Check that `annunaki_monitor.py` is registered in `.claude/settings.json` under `PostToolUse`:
 
 ```bash
-cat .claude/settings.json | grep -c annunaki_monitor
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+grep -c annunaki_monitor "$REPO_ROOT/.claude/settings.json"
 ```
 
 If 0, warn the user that monitoring is not active and offer to wire it up.
@@ -26,7 +29,7 @@ If 0, warn the user that monitoring is not active and offer to wire it up.
 ### 2. Read the error log
 
 ```bash
-wc -l .claude/annunaki/errors.jsonl 2>/dev/null || echo "0 (no errors logged yet)"
+wc -l "$REPO_ROOT/.claude/annunaki/errors.jsonl" 2>/dev/null || echo "0 (no errors logged yet)"
 ```
 
 ### 3. Show recent errors
@@ -34,7 +37,7 @@ wc -l .claude/annunaki/errors.jsonl 2>/dev/null || echo "0 (no errors logged yet
 Display the last 20 errors with timestamps and commands:
 
 ```bash
-tail -20 .claude/annunaki/errors.jsonl 2>/dev/null
+tail -20 "$REPO_ROOT/.claude/annunaki/errors.jsonl" 2>/dev/null
 ```
 
 Parse and present them in a readable table:

--- a/.claude/skills/handoff/SKILL.md
+++ b/.claude/skills/handoff/SKILL.md
@@ -6,6 +6,8 @@ args: notes
 
 Generate a handoff summary for the next session. The optional `notes` argument lets the user add specific context (e.g., "was debugging the auth flow" or "next step is PR review").
 
+> Note: all repo paths in bash blocks below are rooted at `$REPO_ROOT` to avoid cwd drift when the skill is invoked from a worktree or child-repo subdirectory (#149).
+
 ## Instructions
 
 ### 1. Gather current state
@@ -14,9 +16,10 @@ Collect the following in parallel:
 
 **Git state:**
 ```bash
-git status
-git log --oneline -10
-git branch --show-current
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+git -C "$REPO_ROOT" status
+git -C "$REPO_ROOT" log --oneline -10
+git -C "$REPO_ROOT" branch --show-current
 ```
 
 **Open PRs across all repos:**

--- a/.claude/skills/ontology-librarian/SKILL.md
+++ b/.claude/skills/ontology-librarian/SKILL.md
@@ -6,6 +6,8 @@ args: query
 
 The ontology librarian provides read-only access to the project ontology. It checks for staleness, retrieves relevant context, and reports which references may be out of date. It never modifies the ontology — that's the resolver's job.
 
+> Note: all repo paths in bash blocks below are rooted at `$REPO_ROOT` to avoid cwd drift when the skill is invoked from a worktree or child-repo subdirectory (#149).
+
 The `query` argument is optional. If provided, it's a natural language question or entity/service name to look up. If omitted, runs a staleness check and provides a summary.
 
 ## When to use
@@ -22,7 +24,8 @@ The `query` argument is optional. If provided, it's a natural language question 
 Read `ontology/checksums.json` and count dirty files (where `last_tracked != last_resolved`):
 
 ```bash
-cat ontology/checksums.json
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cat "$REPO_ROOT/ontology/checksums.json"
 ```
 
 Report staleness status:

--- a/.claude/skills/ontology-rebuild/SKILL.md
+++ b/.claude/skills/ontology-rebuild/SKILL.md
@@ -6,6 +6,8 @@ args: scope
 
 Rebuild the ontology for files that have changed since the last resolution pass. The `scope` argument is optional — if omitted, processes all dirty files. If provided, can be `code`, `docs`, or a specific repo name to limit scope.
 
+> Note: all repo paths in bash blocks below are rooted at `$REPO_ROOT` to avoid cwd drift when the skill is invoked from a worktree or child-repo subdirectory (#149).
+
 ## Context
 
 The ontology system has three roles:
@@ -20,7 +22,8 @@ A file is "dirty" when `last_tracked != last_resolved` in `checksums.json`.
 ### 1. Read checksums and identify dirty files
 
 ```bash
-cat ontology/checksums.json
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cat "$REPO_ROOT/ontology/checksums.json"
 ```
 
 Build a list of all files where `last_tracked != last_resolved`. If no dirty files exist, report "Ontology is up to date — no dirty files" and stop.
@@ -85,9 +88,11 @@ Also update checksums for any ontology files that were modified during this pass
 Stage and commit all ontology changes and any auto-updated docs. Use the Standards & Quality Lead identity (Aino Virtanen) for ontology commits:
 
 ```bash
-git add ontology/
-# Also add any auto-updated docs
-git -c user.name="Aino Virtanen" -c user.email="parametrization+Aino.Virtanen@gmail.com" commit -m "ontology: rebuild — {summary of changes}"
+cd "$(git rev-parse --show-toplevel)" && \
+  git add ontology/ && \
+  git -c user.name="Aino Virtanen" -c user.email="parametrization+Aino.Virtanen@gmail.com" \
+      commit -m "ontology: rebuild — {summary of changes}"
+# Also add any auto-updated docs before committing.
 ```
 
 ## Docs update policy

--- a/.claude/skills/ontology-rebuild/SKILL.md
+++ b/.claude/skills/ontology-rebuild/SKILL.md
@@ -88,7 +88,7 @@ Also update checksums for any ontology files that were modified during this pass
 Stage and commit all ontology changes and any auto-updated docs. Use the Standards & Quality Lead identity (Aino Virtanen) for ontology commits:
 
 ```bash
-cd "$(git rev-parse --show-toplevel)" && \
+cd "$REPO_ROOT" && \
   git add ontology/ && \
   git -c user.name="Aino Virtanen" -c user.email="parametrization+Aino.Virtanen@gmail.com" \
       commit -m "ontology: rebuild — {summary of changes}"

--- a/.claude/skills/plan-phase/SKILL.md
+++ b/.claude/skills/plan-phase/SKILL.md
@@ -6,6 +6,8 @@ args: team_name, Phase number
 
 Plan a phase of work for the `{team_name}` team. Decomposes phase scope into GitHub Issues, assigns them, reviews from multiple perspectives, and proposes a wave structure.
 
+> Note: all repo paths in bash blocks below are rooted at `$REPO_ROOT` to avoid cwd drift when the skill is invoked from a worktree or child-repo subdirectory (#149).
+
 ## Instructions
 
 ### 1. Gather phase scope
@@ -17,8 +19,9 @@ Read available context to determine what this phase should accomplish:
 - Cross-repo status (`cross-repo-status.json`) for dependency context
 
 ```bash
+REPO_ROOT="$(git rev-parse --show-toplevel)"
 gh issue list --state open --label "tech-debt" --json number,title,labels
-cat .claude/cross-repo-status.json 2>/dev/null
+cat "$REPO_ROOT/cross-repo-status.json" 2>/dev/null
 ```
 
 ### 2. Decompose into issues

--- a/.claude/skills/retro/SKILL.md
+++ b/.claude/skills/retro/SKILL.md
@@ -6,6 +6,8 @@ args: team_name
 
 Run a lightweight retrospective for the `{team_name}` team. This is a **mid-wave health check**, not a full end-of-wave retrospective. Use `/wave-retro` for the comprehensive end-of-wave engine with trust matrix updates and charter proposals.
 
+> Note: all repo paths in bash blocks below are rooted at `$REPO_ROOT` to avoid cwd drift when the skill is invoked from a worktree or child-repo subdirectory (#149).
+
 ## When to use
 
 - Mid-wave checkpoint to surface blockers early
@@ -19,7 +21,8 @@ Run a lightweight retrospective for the `{team_name}` team. This is a **mid-wave
 Determine the active wave from `cross-repo-status.json` or ask the user:
 
 ```bash
-cat .claude/cross-repo-status.json 2>/dev/null
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cat "$REPO_ROOT/cross-repo-status.json" 2>/dev/null
 ```
 
 ### 2. Collect progress data

--- a/.claude/skills/session-start/SKILL.md
+++ b/.claude/skills/session-start/SKILL.md
@@ -7,6 +7,8 @@ description: "MANDATORY first action in every session — runs full startup prot
 
 **This skill MUST be invoked as the FIRST action in every new session.** Do not respond to the user's message, do not read files, do not run any other tool — invoke `/session-start` first. The user's actual request is handled AFTER this completes.
 
+> Note: all repo paths in bash blocks below are rooted at `$REPO_ROOT` to avoid cwd drift when the skill is invoked from a worktree or child-repo subdirectory (#149).
+
 ## Instructions
 
 Execute all 7 steps below. Steps that are independent of each other SHOULD run in parallel. Present results in a single concise status table at the end.
@@ -14,8 +16,9 @@ Execute all 7 steps below. Steps that are independent of each other SHOULD run i
 ### Step 0 — Worktree cleanup
 
 ```bash
-git worktree prune
-git worktree list
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+git -C "$REPO_ROOT" worktree prune
+git -C "$REPO_ROOT" worktree list
 ```
 
 Verify only the main repo root is listed. Remove any stale worktrees.
@@ -66,7 +69,7 @@ Run `/annunaki` to check the error monitor.
 Read the current project state:
 
 ```bash
-cat cross-repo-status.json
+cat "$REPO_ROOT/.claude/cross-repo-status.json"
 gh issue list --repo noorinalabs/noorinalabs-main --state open --limit 10 --json number,title,labels
 ```
 
@@ -81,7 +84,7 @@ Report:
 Read the tail of the feedback log:
 
 ```bash
-tail -40 .claude/team/feedback_log.md
+tail -40 "$REPO_ROOT/.claude/team/feedback_log.md"
 ```
 
 Check for:

--- a/.claude/skills/session-start/SKILL.md
+++ b/.claude/skills/session-start/SKILL.md
@@ -69,7 +69,7 @@ Run `/annunaki` to check the error monitor.
 Read the current project state:
 
 ```bash
-cat "$REPO_ROOT/.claude/cross-repo-status.json"
+cat "$REPO_ROOT/cross-repo-status.json"
 gh issue list --repo noorinalabs/noorinalabs-main --state open --limit 10 --json number,title,labels
 ```
 

--- a/.claude/skills/wave-kickoff/SKILL.md
+++ b/.claude/skills/wave-kickoff/SKILL.md
@@ -6,11 +6,15 @@ args: team_name, Phase number, Wave number
 
 Automate the wave kickoff process for the `{team_name}` team.
 
+> Note: all repo paths in bash blocks below are rooted at `$REPO_ROOT` to avoid cwd drift when the skill is invoked from a worktree or child-repo subdirectory (#149).
+
 ## Instructions
 
 ### 1. Create the deployments branch
 
 ```bash
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
 git fetch origin
 git checkout main && git pull origin main
 git checkout -b deployments/phase{N}/wave-{M}

--- a/.claude/skills/wave-start/SKILL.md
+++ b/.claude/skills/wave-start/SKILL.md
@@ -6,6 +6,8 @@ args: team_name, Phase number, Wave number
 
 Initialize infrastructure for a new wave. This is the **setup step** that creates the deployment branch and cleans up stale worktrees. For full wave planning with issue assignment and kickoff comments, use `/wave-kickoff` after this completes.
 
+> Note: all repo paths in bash blocks below are rooted at `$REPO_ROOT` to avoid cwd drift when the skill is invoked from a worktree or child-repo subdirectory (#149).
+
 ## Instructions
 
 ### 1. Clean stale worktrees
@@ -13,8 +15,9 @@ Initialize infrastructure for a new wave. This is the **setup step** that create
 Remove any leftover worktrees from previous waves:
 
 ```bash
-git worktree prune
-git worktree list
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+git -C "$REPO_ROOT" worktree prune
+git -C "$REPO_ROOT" worktree list
 ```
 
 Report any worktrees that were pruned. If active worktrees remain, list them and confirm with the user before proceeding (they may belong to in-progress work).
@@ -26,7 +29,7 @@ Report any worktrees that were pruned. If active worktrees remain, list them and
 
 ```bash
 # Check if previous wave branch exists
-git ls-remote --heads origin "deployments/phase{P}/wave-{M-1}"
+git -C "$REPO_ROOT" ls-remote --heads origin "deployments/phase{P}/wave-{M-1}"
 ```
 
 If the previous wave branch exists but has not been merged to main, warn the user:
@@ -40,6 +43,7 @@ are integrated before merging this wave.
 ### 3. Create the deployment branch
 
 ```bash
+cd "$REPO_ROOT"
 git fetch origin
 git checkout main && git pull origin main
 git checkout -b "deployments/phase{P}/wave-{M}"
@@ -49,6 +53,7 @@ git push -u origin "deployments/phase{P}/wave-{M}"
 If the branch already exists on the remote:
 
 ```bash
+cd "$REPO_ROOT"
 git fetch origin "deployments/phase{P}/wave-{M}"
 git checkout "deployments/phase{P}/wave-{M}"
 git pull origin "deployments/phase{P}/wave-{M}"
@@ -81,12 +86,13 @@ Update `cross-repo-status.json` to reflect the new active wave:
 
 ```bash
 # Read current status
-cat cross-repo-status.json
+cat "$REPO_ROOT/cross-repo-status.json"
 ```
 
 Set the active wave fields for this repo. Commit directly to the wave branch:
 
 ```bash
+cd "$REPO_ROOT"
 git -c user.name="{Manager Name}" -c user.email="{manager email}" \
     add cross-repo-status.json && \
 git -c user.name="{Manager Name}" -c user.email="{manager email}" \

--- a/.claude/skills/wave-wrapup/SKILL.md
+++ b/.claude/skills/wave-wrapup/SKILL.md
@@ -6,6 +6,8 @@ args: team_name, Phase number, Wave number
 
 Finalize a wave by reviewing all open PRs, merging in dependency order, closing resolved issues, and cleaning up. This is the **exit gate** before running `/wave-retro`.
 
+> Note: all repo paths in bash blocks below are rooted at `$REPO_ROOT` to avoid cwd drift when the skill is invoked from a worktree or child-repo subdirectory (#149).
+
 ## Instructions
 
 ### 1. Inventory open PRs
@@ -128,14 +130,15 @@ For any remaining open issues:
 **All wave worktrees MUST be removed before the wrapup is considered complete.** Stale worktrees accumulate across waves and cause branch contention.
 
 ```bash
+REPO_ROOT="$(git rev-parse --show-toplevel)"
 # Prune any stale worktree metadata
-git worktree prune
+git -C "$REPO_ROOT" worktree prune
 
 # List all worktrees and identify wave-related ones
-git worktree list
+git -C "$REPO_ROOT" worktree list
 
 # Remove each wave worktree (branches matching wave assignees)
-# Example: git worktree remove .claude/worktrees/W.Mwangi+0063-fix-branch-freshness-worktree --force
+# Example: git -C "$REPO_ROOT" worktree remove "$REPO_ROOT/.claude/worktrees/W.Mwangi+0063-fix-branch-freshness-worktree" --force
 ```
 
 For each worktree:


### PR DESCRIPTION
## Summary

Skills referenced repo-relative paths like `ontology/checksums.json` and `.claude/annunaki/errors.jsonl` in their bash blocks. When the Bash tool's `cwd` drifted into a worktree or child-repo subdirectory before skill invocation, those reads silently failed — `FileNotFoundError` on `/ontology-rebuild`, empty grep on `/annunaki`, etc. (See issue for the 2026-04-19 repro.)

## Fix

Each affected skill now derives `REPO_ROOT` via `git rev-parse --show-toplevel` at the top of its first bash block and anchors every subsequent repo path as `"$REPO_ROOT/..."`. For git mutations that must operate on a specific working tree (`git checkout -b ...`, `git push origin ...`), `cd "$REPO_ROOT"` is prepended so state lands where the operator expects.

A one-line header note was added to each skill to document the convention:

> Note: all repo paths in bash blocks below are rooted at `$REPO_ROOT` to avoid cwd drift when the skill is invoked from a worktree or child-repo subdirectory (#149).

## Files changed

| Skill | Nature of change |
|---|---|
| `ontology-librarian` | `cat ontology/checksums.json` → `"$REPO_ROOT/ontology/checksums.json"` |
| `ontology-rebuild` | checksums read + commit block anchored to `$REPO_ROOT` |
| `annunaki` | settings.json grep, errors.jsonl wc/tail anchored |
| `annunaki-attack` | errors.jsonl cat/cp/truncate anchored (`echo "" >` → `: >` for clean truncate) |
| `handoff` | `git status/log/branch` → `git -C "$REPO_ROOT" ...` |
| `plan-phase` | cross-repo-status.json path anchored + corrected to repo root (was `.claude/...`) |
| `retro` | cross-repo-status.json path anchored + corrected to repo root (was `.claude/...`) |
| `session-start` | worktree commands, cross-repo-status.json (also corrected), feedback_log.md anchored |
| `wave-start` | worktree commands, cross-repo-status.json, branch checkout/commit/push all anchored |
| `wave-kickoff` | wave-branch checkout/push anchored |
| `wave-wrapup` | worktree prune/list/remove anchored |

## Incidental bug-fix (called out)

`plan-phase` and `retro` referenced `.claude/cross-repo-status.json`, but the file actually lives at repo root (`cross-repo-status.json`). I corrected the path while rewriting — calling it out explicitly so reviewers can flag if they'd prefer a separate PR. Rationale for bundling: the lines were being rewritten anyway; leaving a known-broken path in a cwd-anchored form would be worse than fixing.

## What was NOT changed

- No CLAUDE.md convention update — out of scope per #149.
- Skills with only `gh ...` commands (cwd-independent by default) — left alone.
- No charter changes.

## Manual test plan

Skills don't have unit tests, so I simulated the failure modes from the worktree cwd (`/.claude/worktrees/A.Virtanen-0149-skill-cwd-drift`):

- [x] `REPO_ROOT="$(git rev-parse --show-toplevel)" && cat "$REPO_ROOT/ontology/checksums.json"` — succeeds from worktree, main root, and subdir.
- [x] `grep -c annunaki_monitor "$REPO_ROOT/.claude/settings.json"` — returns 1 from worktree cwd.
- [x] `wc -l "$REPO_ROOT/.claude/annunaki/errors.jsonl"` — works from worktree cwd.
- [x] `test -f "$REPO_ROOT/cross-repo-status.json"` — confirms file exists at the corrected path (not under `.claude/`).
- [x] `git -C "$REPO_ROOT" worktree list` — works from any cwd inside the repo tree.

**Reviewer verification** (optional):
```bash
cd .claude/worktrees/A.Virtanen-0149-skill-cwd-drift
REPO_ROOT="$(git rev-parse --show-toplevel)"
cat "$REPO_ROOT/ontology/checksums.json" | head -5
grep -c annunaki_monitor "$REPO_ROOT/.claude/settings.json"
```
Both should succeed without FileNotFoundError.

## Notes

- This PR will be blocked by #179 (dash-separator branch-regex) until PR #180 lands, per standard wave-9 stacking.
- The ontology-librarian sentinel-mkdir footgun from #174 review is NOT on main (it's introduced by #174 itself). When #174 merges, the same `$REPO_ROOT` anchoring convention should be applied to that step — I left a note for the team-lead rather than modifying #174 from this PR.

Closes #149
Closes #184

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
