### PR TITLE
feat(hooks): validate_commit_identity — merge parent+child rosters at load time (#112 part a)

### DIFF
--- a/.claude/hooks/tests/test_validate_commit_identity.py
+++ b/.claude/hooks/tests/test_validate_commit_identity.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Tests for validate_commit_identity hook.
+
+Covers the W9 parent+child roster merge feature (issue #112 part a) plus
+regression coverage for the pre-existing cross-repo `cd <path>` detection.
+
+Run: python3 -m pytest .claude/hooks/tests/test_validate_commit_identity.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_HOOKS_DIR = _HERE.parent
+sys.path.insert(0, str(_HOOKS_DIR))
+
+import validate_commit_identity as hook  # noqa: E402
+
+
+def _git_init(path: Path) -> None:
+    """Init a bare git repo at `path` by creating `.git` as a dir stub.
+
+    We don't need `git` to work — the hook only checks `(path / ".git").exists()`.
+    Creating `.git` as a directory satisfies the check deterministically and
+    without spawning subprocesses.
+    """
+    (path / ".git").mkdir(parents=True, exist_ok=True)
+
+
+def _write_roster(repo_path: Path, roster: dict[str, str]) -> None:
+    team_dir = repo_path / ".claude" / "team"
+    team_dir.mkdir(parents=True, exist_ok=True)
+    (team_dir / "roster.json").write_text(json.dumps(roster), encoding="utf-8")
+
+
+class LoadMergedRosterTests(unittest.TestCase):
+    """Unit tests for `_load_merged_roster` — parent+child merge semantics."""
+
+    def test_child_only_no_parent(self):
+        """Parent roster missing → returns child roster unchanged."""
+        with tempfile.TemporaryDirectory() as td:
+            outer = Path(td)
+            _git_init(outer)  # parent IS a git repo, but has no roster
+            child = outer / "child"
+            child.mkdir()
+            _git_init(child)
+            _write_roster(child, {"Alice": "alice@example.com"})
+
+            merged = hook._load_merged_roster(child)
+            self.assertEqual(merged, {"Alice": "alice@example.com"})
+
+    def test_parent_not_a_git_repo(self):
+        """Parent dir exists but is NOT a git repo → parent ignored."""
+        with tempfile.TemporaryDirectory() as td:
+            outer = Path(td)
+            # Intentionally do NOT `_git_init(outer)` — parent has no `.git`
+            _write_roster(outer, {"ShouldNotAppear": "nope@example.com"})
+            child = outer / "child"
+            child.mkdir()
+            _git_init(child)
+            _write_roster(child, {"Alice": "alice@example.com"})
+
+            merged = hook._load_merged_roster(child)
+            self.assertEqual(merged, {"Alice": "alice@example.com"})
+            self.assertNotIn("ShouldNotAppear", merged)
+
+    def test_parent_is_git_repo_without_roster(self):
+        """Parent is a git repo but has no `.claude/team/roster.json` → ignored."""
+        with tempfile.TemporaryDirectory() as td:
+            outer = Path(td)
+            _git_init(outer)
+            # no roster written for outer
+            child = outer / "child"
+            child.mkdir()
+            _git_init(child)
+            _write_roster(child, {"Alice": "alice@example.com"})
+
+            merged = hook._load_merged_roster(child)
+            self.assertEqual(merged, {"Alice": "alice@example.com"})
+
+    def test_child_plus_parent_merge_union(self):
+        """Parent + child with disjoint names → union of both."""
+        with tempfile.TemporaryDirectory() as td:
+            outer = Path(td)
+            _git_init(outer)
+            _write_roster(outer, {"Nadia": "nadia@example.com"})
+            child = outer / "child"
+            child.mkdir()
+            _git_init(child)
+            _write_roster(child, {"Alice": "alice@example.com"})
+
+            merged = hook._load_merged_roster(child)
+            self.assertEqual(
+                merged,
+                {
+                    "Nadia": "nadia@example.com",
+                    "Alice": "alice@example.com",
+                },
+            )
+
+    def test_child_wins_on_name_collision(self):
+        """Same name in both with different emails → child email wins."""
+        with tempfile.TemporaryDirectory() as td:
+            outer = Path(td)
+            _git_init(outer)
+            _write_roster(outer, {"Alice": "alice-parent@example.com"})
+            child = outer / "child"
+            child.mkdir()
+            _git_init(child)
+            _write_roster(child, {"Alice": "alice-child@example.com"})
+
+            merged = hook._load_merged_roster(child)
+            self.assertEqual(merged, {"Alice": "alice-child@example.com"})
+
+    def test_walk_only_one_level_grandparent_ignored(self):
+        """Grandparent has roster, parent does not → grandparent NOT loaded."""
+        with tempfile.TemporaryDirectory() as td:
+            grand = Path(td)
+            _git_init(grand)
+            _write_roster(grand, {"Grandparent": "gp@example.com"})
+            parent = grand / "parent"
+            parent.mkdir()
+            # parent is NOT a git repo and has no roster
+            child = parent / "child"
+            child.mkdir()
+            _git_init(child)
+            _write_roster(child, {"Alice": "alice@example.com"})
+
+            merged = hook._load_merged_roster(child)
+            self.assertEqual(merged, {"Alice": "alice@example.com"})
+            self.assertNotIn("Grandparent", merged)
+
+    def test_malformed_parent_roster_does_not_block(self):
+        """A broken parent roster.json must fail-open — child roster is returned."""
+        with tempfile.TemporaryDirectory() as td:
+            outer = Path(td)
+            _git_init(outer)
+            team_dir = outer / ".claude" / "team"
+            team_dir.mkdir(parents=True)
+            (team_dir / "roster.json").write_text("{ this is not valid json", encoding="utf-8")
+            child = outer / "child"
+            child.mkdir()
+            _git_init(child)
+            _write_roster(child, {"Alice": "alice@example.com"})
+
+            merged = hook._load_merged_roster(child)
+            self.assertEqual(merged, {"Alice": "alice@example.com"})
+
+
+class DetectTargetRosterTests(unittest.TestCase):
+    """Regression tests for `cd <path> && git commit` target-roster detection."""
+
+    def test_cd_target_returns_merged_roster(self):
+        """`cd <child> && git commit` loads child+parent merged roster."""
+        with tempfile.TemporaryDirectory() as td:
+            outer = Path(td)
+            _git_init(outer)
+            _write_roster(outer, {"Nadia": "nadia@example.com"})
+            child = outer / "child"
+            child.mkdir()
+            _git_init(child)
+            _write_roster(child, {"Alice": "alice@example.com"})
+
+            command = f"cd {child} && git commit -m 'x'"
+            detected = hook._detect_target_roster(command)
+            self.assertIsNotNone(detected)
+            assert detected is not None  # for type-narrowing
+            self.assertEqual(
+                detected,
+                {
+                    "Nadia": "nadia@example.com",
+                    "Alice": "alice@example.com",
+                },
+            )
+
+    def test_cd_target_with_no_roster_returns_none(self):
+        """`cd <dir>` where dir has no roster → None (fall back to local)."""
+        with tempfile.TemporaryDirectory() as td:
+            target = Path(td) / "nonroster"
+            target.mkdir()
+            # no .claude/team/roster.json
+
+            command = f"cd {target} && git commit -m 'x'"
+            self.assertIsNone(hook._detect_target_roster(command))
+
+    def test_no_cd_returns_none(self):
+        """Command without `cd` → None (use local ROSTER)."""
+        self.assertIsNone(hook._detect_target_roster("git commit -m 'x'"))
+
+
+class CheckIntegrationTests(unittest.TestCase):
+    """Integration: `check()` accepts a name present only in the parent roster.
+
+    Verifies the end-to-end merge path: an org-level coordinator defined ONLY
+    in the parent repo's roster is accepted when committing in a child repo.
+    """
+
+    def test_parent_only_name_accepted_in_child_commit(self):
+        with tempfile.TemporaryDirectory() as td:
+            outer = Path(td)
+            _git_init(outer)
+            _write_roster(outer, {"Nadia": "nadia@example.com"})
+            child = outer / "child"
+            child.mkdir()
+            _git_init(child)
+            _write_roster(child, {"Alice": "alice@example.com"})
+
+            command = (
+                f'cd {child} && git -c user.name="Nadia" '
+                f'-c user.email="nadia@example.com" commit -m "x"'
+            )
+            result = hook.check({"tool_name": "Bash", "tool_input": {"command": command}})
+            self.assertIsNone(result, f"expected allow, got block: {result}")
+
+    def test_child_email_override_blocks_parent_email(self):
+        """When child overrides a name's email, the parent email is rejected."""
+        with tempfile.TemporaryDirectory() as td:
+            outer = Path(td)
+            _git_init(outer)
+            _write_roster(outer, {"Alice": "alice-parent@example.com"})
+            child = outer / "child"
+            child.mkdir()
+            _git_init(child)
+            _write_roster(child, {"Alice": "alice-child@example.com"})
+
+            command = (
+                f'cd {child} && git -c user.name="Alice" '
+                f'-c user.email="alice-parent@example.com" commit -m "x"'
+            )
+            result = hook.check({"tool_name": "Bash", "tool_input": {"command": command}})
+            self.assertIsNotNone(result)
+            assert result is not None
+            self.assertEqual(result.get("decision"), "block")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/hooks/validate_commit_identity.py
+++ b/.claude/hooks/validate_commit_identity.py
@@ -4,6 +4,15 @@
 Ensures every `git commit` command includes `-c user.name=` and `-c user.email=`
 flags matching a roster member from the charter's Commit Identity table.
 
+Parent+child roster merge (#112 part a):
+  When the target repo (either the local repo or a `cd <path>` target) is a
+  child of another git repo that itself has `.claude/team/roster.json`, the
+  parent roster is loaded and merged with the child roster. Same-name entries
+  in the child override the parent (child wins). Walk-up is limited to ONE
+  level to avoid false positives in nested `code/` trees. This lets org-level
+  coordinators commit in child repos without duplicating their entries into
+  every child `roster.json`.
+
 Exit codes:
   0 — allow (not a git commit, or identity is valid)
   2 — block (missing or invalid identity flags)
@@ -17,23 +26,62 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from annunaki_log import log_pretooluse_block
 
-# Load local roster from shared JSON file — single source of truth for all hooks
-_ROSTER_PATH = Path(__file__).resolve().parent.parent / "team" / "roster.json"
-try:
-    ROSTER: dict[str, str] = json.loads(_ROSTER_PATH.read_text(encoding="utf-8"))
-except (FileNotFoundError, json.JSONDecodeError):
-    # Fallback: allow if roster file is missing (don't block all commits)
-    ROSTER = {}
+
+def _read_roster(roster_path: Path) -> dict[str, str]:
+    """Read a roster.json file, returning {} on any failure (fail-open)."""
+    try:
+        data = json.loads(roster_path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _load_merged_roster(repo_path: Path) -> dict[str, str]:
+    """Load `repo_path`'s roster, merged with its parent repo's roster if any.
+
+    Parent detection (ONE level up only):
+      1. `repo_path/..` must be a directory containing `.git` (i.e. a git repo).
+      2. `repo_path/../.claude/team/roster.json` must exist.
+    If both hold, the parent roster is loaded and merged under the child roster
+    — child keys override parent keys, so a same-name entry in the child wins.
+    Any OSError / malformed JSON at any step is swallowed; a broken parent
+    roster must never block a child repo's valid commit.
+    """
+    child_path = repo_path / ".claude" / "team" / "roster.json"
+    child_roster = _read_roster(child_path)
+
+    try:
+        parent_dir = repo_path.parent
+        if (
+            parent_dir != repo_path
+            and (parent_dir / ".git").exists()
+            and (parent_dir / ".claude" / "team" / "roster.json").is_file()
+        ):
+            parent_roster = _read_roster(parent_dir / ".claude" / "team" / "roster.json")
+        else:
+            parent_roster = {}
+    except OSError:
+        parent_roster = {}
+
+    # Child wins on key collision.
+    return {**parent_roster, **child_roster}
+
+
+# Module-level roster for the repo hosting this hook. `_load_merged_roster`
+# walks up one level; at this repo (noorinalabs-main) there is no parent repo
+# with a roster, so this collapses to the local roster only.
+ROSTER: dict[str, str] = _load_merged_roster(Path(__file__).resolve().parent.parent.parent)
 
 
 def _detect_target_roster(command: str) -> dict[str, str] | None:
-    """Detect cross-repo commits and load the target repo's roster.
+    """Detect cross-repo commits and load the target repo's merged roster.
 
     When the command contains `cd /path/to/repo && git commit ...`, the
-    commit targets a different repo. Load that repo's roster.json so we
-    validate against the correct team, not the local one.
+    commit targets a different repo. Load that repo's roster.json (merged
+    with its parent repo's roster if applicable — see `_load_merged_roster`)
+    so we validate against the correct team, not the local one.
 
-    Returns the target roster dict, or None to use the local ROSTER.
+    Returns the target merged roster dict, or None to use the local ROSTER.
     """
     cd_match = re.search(r"cd\s+([^\s;&|]+)", command)
     if not cd_match:
@@ -44,10 +92,8 @@ def _detect_target_roster(command: str) -> dict[str, str] | None:
     roster_path = target_dir / ".claude" / "team" / "roster.json"
     if not roster_path.is_file():
         return None
-    try:
-        return json.loads(roster_path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
-        return None
+    merged = _load_merged_roster(target_dir)
+    return merged or None
 
 
 def _strip_heredocs(text: str) -> str:

--- a/.claude/team/charter/hooks.md
+++ b/.claude/team/charter/hooks.md
@@ -5,8 +5,9 @@ The following charter rules are enforced automatically via Claude Code hooks in 
 ## Hook 1: Validate Commit Identity (`validate_commit_identity.py`)
 
 - **What it automates:** Commit Identity rules — validates that every `git commit` command includes `-c user.name=` and `-c user.email=` flags matching a roster member.
+- **Parent+child roster merge (#112 part a):** When the target repo (either the repo hosting this hook, or the `cd <path>` target of a cross-repo commit) sits inside another git repo that itself has `.claude/team/roster.json`, the hook loads the parent roster and merges it under the child roster at load time. Child entries win on name collision. Walk-up is limited to ONE level to avoid false positives in nested `code/` trees. This lets org-level coordinators (e.g. Nadia.Khoury, Wanjiku, Santiago, Aino) commit in any child repo without duplicating their entries into every child `roster.json`.
 - **Augments:** The [Commit Identity](commits.md) section. The manual rule still applies; this hook enforces it automatically.
-- **Manual steps remaining:** When a new team member is hired, add their name and email to `.claude/team/roster.json` (the single source of truth for all hooks and skills).
+- **Manual steps remaining:** When a new team member is hired, add their name and email to the appropriate `.claude/team/roster.json` — org-level coordinators go in `noorinalabs-main`'s roster, per-repo members go in that repo's roster.
 - **Emergency override:** Remove or comment out the hook entry in `.claude/settings.json`. Re-add after the emergency.
 
 ## Hook 2: Block `--no-verify` (`block_no_verify.py`)


### PR DESCRIPTION
## Summary

Implements **part (a) only** of issue #112 — the runtime parent+child roster
merge in `validate_commit_identity.py`. Part (b) (syncing the hook to the 7
child repos + removing duplicated org-level entries from child rosters) is
**deferred** to a dedicated multi-repo session. See the issue's acceptance
criteria for the full two-part breakdown.

Fixes: #112 (part a only — issue stays OPEN for part b)

## What changes

`validate_commit_identity.py` now loads BOTH the target repo's
`.claude/team/roster.json` AND its parent repo's roster (when the parent
is itself a git repo with `.claude/team/roster.json`), merged at hook load
time. Org-level coordinators defined only in the parent roster are now
accepted for commits in child repos — no more duplicating Nadia.Khoury,
Wanjiku, Santiago, Aino into every child `roster.json`.

## Design

- New helper `_load_merged_roster(repo_path)` is the single load path.
  `_read_roster()` wraps `json.loads` with broad exception handling for
  fail-open semantics.
- Module-level `ROSTER` = `_load_merged_roster(repo-hosting-this-hook)`.
  At `noorinalabs-main` the parent detection returns an empty roster
  (no grandparent repo with `.claude/team/roster.json`), so `ROSTER`
  collapses to the local roster only — no behavior change in the
  mainline path today.
- `_detect_target_roster(command)` (the `cd <path> && git commit`
  branch) now also returns the merged roster for the target.
- **Parent detection — ONE level up only.** If `repo_path/..` is not a
  git repo OR has no `.claude/team/roster.json`, the parent is ignored.
  The walk does not continue to the grandparent — this prevents false
  positives in nested `code/` trees.
- **Child wins on name collision.** `{**parent_roster, **child_roster}`
  — parent keys first, so child keys override on conflict.
- **Fail-open.** A broken / malformed parent roster never blocks a child
  repo's valid commit. `FileNotFoundError`, `json.JSONDecodeError`, and
  `OSError` are all swallowed in `_read_roster` and `_load_merged_roster`.
- **Deterministic.** No `os.environ`, no time-based behavior — same
  inputs yield same output.

## Acceptance criteria mapping (from #112)

- [x] Hook auto-detects parent `.claude/` and merges both rosters
- [x] Per-repo override semantics: child wins if same name in both with
  different emails
- [ ] All 7 child repos have the same `validate_commit_identity.py` as
  `noorinalabs-main` — **deferred to part (b)**
- [ ] After merge runtime works, REMOVE the duplicated org-level entries
  from child rosters — **deferred to part (b)**
- [ ] Sync script or hook generator — **deferred to part (b)**

## Files changed

- `.claude/hooks/validate_commit_identity.py` — refactor load sites
  through `_load_merged_roster()`; updated module docstring to document
  the merge behavior
- `.claude/hooks/tests/test_validate_commit_identity.py` — new file,
  12 tests (see coverage below)
- `.claude/team/charter/hooks.md` — Hook 1 entry updated with a short
  paragraph describing the merge

## Test coverage

12 new tests across three classes, all passing. Full hook test suite:
169 passed.

**`LoadMergedRosterTests`** (unit — merge semantics):
- `test_child_only_no_parent` — parent has no roster → child returned unchanged
- `test_parent_not_a_git_repo` — parent dir has roster but no `.git` → ignored (STOP condition)
- `test_parent_is_git_repo_without_roster` — parent is git repo but no roster → ignored (STOP condition)
- `test_child_plus_parent_merge_union` — disjoint names → union
- `test_child_wins_on_name_collision` — same name, different emails → child wins
- `test_walk_only_one_level_grandparent_ignored` — grandparent has roster, parent doesn't → NOT loaded
- `test_malformed_parent_roster_does_not_block` — invalid JSON in parent → fail-open, child returned

**`DetectTargetRosterTests`** (regression — `cd <path> && git commit`):
- `test_cd_target_returns_merged_roster` — cross-repo path returns merged roster
- `test_cd_target_with_no_roster_returns_none` — target without roster → None (fall back to local)
- `test_no_cd_returns_none` — no `cd` → None (pre-existing behavior preserved)

**`CheckIntegrationTests`** (end-to-end `check()`):
- `test_parent_only_name_accepted_in_child_commit` — org-level coordinator in parent roster accepted for child-repo commit
- `test_child_email_override_blocks_parent_email` — when child overrides a name's email, parent email is rejected

Fixtures use `tempfile.TemporaryDirectory()` + stub `.git` directories +
synthetic `roster.json` files — no dependency on the real repo roster.

## Verification

```
ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/test_validate_commit_identity.py -v  # 12 passed
ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/ -q                                  # 169 passed
python3 -m ruff check   .claude/hooks/validate_commit_identity.py .claude/hooks/tests/test_validate_commit_identity.py  # clean
python3 -m ruff format --check .claude/hooks/validate_commit_identity.py .claude/hooks/tests/test_validate_commit_identity.py  # clean
```

## Notes

- No dispatcher changes. Python-only, no new dependencies.
- Existing `cd <path> && git commit` detection remains intact — it now
  just routes through `_load_merged_roster()` so the target gets the
  same parent-merge treatment.
- Part (b) intentionally out of scope — per @team-lead direction, the
  cross-repo sync is its own session because it touches all 7 child
  repos and will require coordinated PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)