### PR TITLE
tooling(hooks): block stale /tmp/* message/body files (closes #237)

### DIFF
--- a/.claude/hooks/block_stale_tmp_message_file.py
+++ b/.claude/hooks/block_stale_tmp_message_file.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: Block stale /tmp/* message/body files on commit/PR/issue commands.
+
+Refuses commands of the form ``git commit -F /tmp/...`` and ``gh {pr,issue}
+{create,comment} --body-file /tmp/...`` when the target file's mtime is older
+than ~30s. Such files are almost always leftovers from a prior task or session
+that the current command is about to consume by mistake — see
+``feedback_tmp_msg_file_stale.md`` for the three documented surfaces and the
+2026-05-03 ontology-rebuild recurrence that motivated this hook.
+
+Override paths the user can take when blocked:
+  - rename the file to a non-/tmp path (e.g. .claude/scratch/msg.txt)
+  - pass ``--message`` / ``--body`` inline instead of from a file
+  - use a /tmp path that is genuinely fresh (Write the file again, then re-run
+    the command — the freshness window resets to the new mtime)
+
+The 30-second threshold is configurable via the ``STALE_TMP_THRESHOLD_SECONDS``
+constant. Chosen as a balance between: long enough that a Write+Bash batched
+in parallel always passes (Bash sees the file at <1s mtime), short enough that
+a leftover file from a prior task in the same session is reliably caught.
+
+Exit codes:
+  0 — allow (no /tmp/* body-file argument, or file is fresh, or file missing)
+  2 — block (target file mtime older than threshold)
+"""
+
+import json
+import os
+import re
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from annunaki_log import log_pretooluse_block
+
+STALE_TMP_THRESHOLD_SECONDS = 30
+
+# Capture the path argument following each known body-file flag. The patterns
+# look for `-F`, `--file`, `--body-file` followed by a /tmp/... path. We allow
+# either a quoted or bare path, and we deliberately do NOT match the `=` form
+# (e.g. `--body-file=/tmp/x`) — none of the supported callers (git commit / gh)
+# use that form. Path capture stops at the first whitespace or shell operator.
+_PATH_CHARS = r"[^\s;&|<>()`\"']+"
+
+# Path captures for the file-flag patterns. We do NOT try to enclose the entire
+# `git ... commit ... -F path` in a single regex — quoted args (e.g.
+# `-c user.name="Aino Virtanen"`) defeat naive `\S+` skipping. Instead we split
+# the command on shell separators (&&, ||, ;, |) to get one logical command per
+# segment, decide whether the segment is a `git commit` or `gh {pr,issue}
+# {create,comment,edit}` invocation, and only THEN look for the body-file flag
+# anywhere in that segment.
+_BODY_FILE_FLAG_RE = re.compile(
+    rf"\s(?:-F|--file|--body-file)\s+(?P<path>{_PATH_CHARS})",
+)
+
+_SEGMENT_SPLIT_RE = re.compile(r"&&|\|\||;|(?<![|])\|(?![|])")
+
+_GIT_COMMIT_RE = re.compile(r"\bgit\b[^\n]*?\bcommit\b")
+_GH_BODY_RE = re.compile(r"\bgh\b\s+(?:pr|issue)\s+(?:create|comment|edit)\b")
+
+
+def _segment_uses_body_file(segment: str) -> bool:
+    """True if this shell segment is a git-commit or gh-body command we cover."""
+    return bool(_GIT_COMMIT_RE.search(segment) or _GH_BODY_RE.search(segment))
+
+
+def _extract_tmp_paths(command: str) -> list[str]:
+    """Return /tmp/* paths supplied to git-commit -F or gh --body-file."""
+    paths: list[str] = []
+    for segment in _SEGMENT_SPLIT_RE.split(command):
+        if not _segment_uses_body_file(segment):
+            continue
+        for match in _BODY_FILE_FLAG_RE.finditer(segment):
+            raw = match.group("path").strip("\"'")
+            if raw.startswith("/tmp/"):
+                paths.append(raw)
+    return paths
+
+
+def _is_stale(path: str, now: float | None = None) -> bool:
+    """True if the file exists and its mtime is older than the threshold."""
+    try:
+        mtime = os.path.getmtime(path)
+    except OSError:
+        # File doesn't exist (or stat fails). The downstream command will
+        # surface its own error; not our job to pre-empt that.
+        return False
+    cutoff = (now if now is not None else time.time()) - STALE_TMP_THRESHOLD_SECONDS
+    return mtime < cutoff
+
+
+def _format_age(path: str, now: float | None = None) -> str:
+    """Human-friendly age string like '4m 12s ago' for the error message."""
+    try:
+        mtime = os.path.getmtime(path)
+    except OSError:
+        return "unknown age"
+    age = (now if now is not None else time.time()) - mtime
+    if age < 60:
+        return f"{int(age)}s ago"
+    if age < 3600:
+        return f"{int(age // 60)}m {int(age % 60)}s ago"
+    return f"{int(age // 3600)}h {int((age % 3600) // 60)}m ago"
+
+
+def check(input_data: dict) -> dict | None:
+    """Check for stale /tmp body-file args. Returns block dict or None."""
+    if input_data.get("tool_name", "") != "Bash":
+        return None
+
+    command = input_data.get("tool_input", {}).get("command", "")
+    if not command:
+        return None
+
+    tmp_paths = _extract_tmp_paths(command)
+    if not tmp_paths:
+        return None
+
+    now = time.time()
+    stale = [p for p in tmp_paths if _is_stale(p, now=now)]
+    if not stale:
+        return None
+
+    offending = "\n".join(f"  - {p} (mtime {_format_age(p, now=now)})" for p in stale)
+    result = {
+        "decision": "block",
+        "reason": (
+            f"BLOCKED: stale /tmp/* file passed to git/gh body-file flag.\n"
+            f"The following file(s) have an mtime older than "
+            f"{STALE_TMP_THRESHOLD_SECONDS}s — likely leftovers from a prior "
+            f"task or session:\n"
+            f"{offending}\n\n"
+            "This is the /tmp/* race captured in `feedback_tmp_msg_file_stale.md`: "
+            "a Write+Bash pair batched in parallel can let Bash consume a stale "
+            "file written days ago. To proceed, take one of:\n"
+            "  1. Re-write the message/body to the same path (Write tool) and re-run "
+            "this command — the freshness window resets.\n"
+            "  2. Use a non-/tmp path (e.g. .claude/scratch/msg.txt) so the hook "
+            "no longer matches.\n"
+            "  3. Pass the content inline with `--message`/`-m` (git) or "
+            "`--body`/`-b` (gh) instead of from a file."
+        ),
+    }
+    log_pretooluse_block("block_stale_tmp_message_file", command, result["reason"])
+    return result
+
+
+def main() -> None:
+    try:
+        input_data = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        sys.exit(0)
+
+    result = check(input_data)
+    if result and result.get("decision") == "block":
+        print(json.dumps(result))
+        sys.exit(2)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/dispatcher.py
+++ b/.claude/hooks/dispatcher.py
@@ -31,6 +31,7 @@ _BASH_HOOKS = [
     "block_no_verify",
     "block_git_config",
     "block_gh_pr_review",
+    "block_stale_tmp_message_file",
     "no_worktree_self_delete",
     "auto_set_env_test",
     "validate_lockfile_paths",

--- a/.claude/hooks/tests/test_block_stale_tmp_message_file.py
+++ b/.claude/hooks/tests/test_block_stale_tmp_message_file.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Tests for block_stale_tmp_message_file hook.
+
+Run: python3 -m pytest .claude/hooks/tests/test_block_stale_tmp_message_file.py -v
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_HOOKS_DIR = _HERE.parent
+sys.path.insert(0, str(_HOOKS_DIR))
+
+import block_stale_tmp_message_file as hook  # noqa: E402
+
+
+def _bash(command: str) -> dict:
+    return {"tool_name": "Bash", "tool_input": {"command": command}}
+
+
+def _touch(path: str, age_seconds: float) -> None:
+    """Create the file and stamp it with mtime = now - age_seconds."""
+    Path(path).write_text("body", encoding="utf-8")
+    target = time.time() - age_seconds
+    os.utime(path, (target, target))
+
+
+class FreshnessGateTests(unittest.TestCase):
+    """Core acceptance: fresh allowed, stale blocked."""
+
+    def test_fresh_tmp_file_allowed(self):
+        with tempfile.TemporaryDirectory(dir="/tmp") as td:
+            msg = f"{td}/msg.txt"
+            _touch(msg, age_seconds=1)  # well within threshold
+            result = hook.check(_bash(f"git commit -F {msg}"))
+            self.assertIsNone(result)
+
+    def test_stale_tmp_file_blocked_for_git_commit_F(self):
+        with tempfile.TemporaryDirectory(dir="/tmp") as td:
+            msg = f"{td}/msg.txt"
+            _touch(msg, age_seconds=120)  # > 30s threshold
+            result = hook.check(_bash(f"git commit -F {msg}"))
+            self.assertIsNotNone(result)
+            assert result is not None
+            self.assertEqual(result["decision"], "block")
+            self.assertIn(msg, result["reason"])
+
+    def test_stale_tmp_file_blocked_for_git_commit_long_file(self):
+        """`git commit --file <path>` is the long form of -F and must also block."""
+        with tempfile.TemporaryDirectory(dir="/tmp") as td:
+            msg = f"{td}/msg.txt"
+            _touch(msg, age_seconds=120)
+            result = hook.check(_bash(f"git commit --file {msg}"))
+            self.assertIsNotNone(result)
+            assert result is not None
+            self.assertEqual(result["decision"], "block")
+
+    def test_stale_tmp_file_blocked_for_gh_pr_create(self):
+        with tempfile.TemporaryDirectory(dir="/tmp") as td:
+            body = f"{td}/body.md"
+            _touch(body, age_seconds=120)
+            cmd = f"gh pr create --title x --body-file {body}"
+            result = hook.check(_bash(cmd))
+            self.assertIsNotNone(result)
+            assert result is not None
+            self.assertEqual(result["decision"], "block")
+
+    def test_stale_tmp_file_blocked_for_gh_issue_create(self):
+        with tempfile.TemporaryDirectory(dir="/tmp") as td:
+            body = f"{td}/body.md"
+            _touch(body, age_seconds=120)
+            cmd = f"gh issue create --title x --body-file {body}"
+            result = hook.check(_bash(cmd))
+            self.assertIsNotNone(result)
+            assert result is not None
+            self.assertEqual(result["decision"], "block")
+
+    def test_stale_tmp_file_blocked_for_gh_pr_comment(self):
+        with tempfile.TemporaryDirectory(dir="/tmp") as td:
+            body = f"{td}/body.md"
+            _touch(body, age_seconds=120)
+            cmd = f"gh pr comment 42 --body-file {body}"
+            result = hook.check(_bash(cmd))
+            self.assertIsNotNone(result)
+            assert result is not None
+            self.assertEqual(result["decision"], "block")
+
+    def test_stale_tmp_file_blocked_for_gh_issue_comment(self):
+        with tempfile.TemporaryDirectory(dir="/tmp") as td:
+            body = f"{td}/body.md"
+            _touch(body, age_seconds=120)
+            cmd = f"gh issue comment 42 --body-file {body}"
+            result = hook.check(_bash(cmd))
+            self.assertIsNotNone(result)
+            assert result is not None
+            self.assertEqual(result["decision"], "block")
+
+
+class NonMatchingTests(unittest.TestCase):
+    """Cases where the hook must stay out of the way."""
+
+    def test_non_tmp_path_not_matched(self):
+        """Stale file outside /tmp must not trigger — non-/tmp paths are safe.
+
+        Use the cwd (test run dir) for the temp dir, since the system tempfile
+        default is /tmp on Linux which would defeat the purpose of this test.
+        """
+        with tempfile.TemporaryDirectory(dir=os.getcwd()) as td:
+            msg = f"{td}/msg.txt"
+            _touch(msg, age_seconds=120)
+            self.assertFalse(msg.startswith("/tmp/"))
+            result = hook.check(_bash(f"git commit -F {msg}"))
+            self.assertIsNone(result)
+
+    def test_inline_message_flag_not_matched(self):
+        """`git commit -m '...'` does not pass a file → not the hook's concern."""
+        result = hook.check(_bash("git commit -m 'fix stuff'"))
+        self.assertIsNone(result)
+
+    def test_inline_body_flag_not_matched(self):
+        """`gh pr create --body '...'` does not pass a file → not matched."""
+        result = hook.check(_bash("gh pr create --title x --body 'inline body'"))
+        self.assertIsNone(result)
+
+    def test_non_bash_tool_not_matched(self):
+        result = hook.check({"tool_name": "Edit", "tool_input": {"command": "anything"}})
+        self.assertIsNone(result)
+
+    def test_empty_command_not_matched(self):
+        result = hook.check(_bash(""))
+        self.assertIsNone(result)
+
+    def test_missing_tmp_file_does_not_block(self):
+        """A non-existent file must not block — let downstream surface its own error."""
+        result = hook.check(_bash("git commit -F /tmp/does-not-exist-xyz.txt"))
+        self.assertIsNone(result)
+
+    def test_unrelated_git_subcommand_not_matched(self):
+        """`git log --grep /tmp/foo` must not be misread as a body-file."""
+        result = hook.check(_bash("git log --grep /tmp/foo"))
+        self.assertIsNone(result)
+
+    def test_gh_pr_view_not_matched(self):
+        """`gh pr view` has no --body-file; stray /tmp mention must not block."""
+        result = hook.check(_bash("gh pr view 42 > /tmp/out.txt"))
+        self.assertIsNone(result)
+
+    def test_git_commit_with_identity_flags_and_fresh_file_allowed(self):
+        """Realistic charter-format commit with -c identity flags + fresh -F file."""
+        with tempfile.TemporaryDirectory(dir="/tmp") as td:
+            msg = f"{td}/msg.txt"
+            _touch(msg, age_seconds=1)
+            cmd = (
+                'git -c user.name="Aino Virtanen" '
+                '-c user.email="parametrization+Aino.Virtanen@gmail.com" '
+                f"commit -F {msg}"
+            )
+            result = hook.check(_bash(cmd))
+            self.assertIsNone(result)
+
+    def test_git_commit_with_quoted_identity_flags_and_stale_file_blocked(self):
+        """Regression: quoted -c values containing spaces must not defeat detection.
+
+        The first cut of this hook used `(?:\\s+-c\\s+\\S+)*` to skip leading -c
+        flags, which silently failed once a value like
+        `user.name="Aino Virtanen"` introduced a space inside the arg. The
+        end-to-end dispatcher invocation surfaced that the hook never matched.
+        """
+        with tempfile.TemporaryDirectory(dir="/tmp") as td:
+            msg = f"{td}/msg.txt"
+            _touch(msg, age_seconds=120)
+            cmd = (
+                'git -c user.name="Aino Virtanen" '
+                '-c user.email="parametrization+Aino.Virtanen@gmail.com" '
+                f"commit -F {msg}"
+            )
+            result = hook.check(_bash(cmd))
+            self.assertIsNotNone(result)
+            assert result is not None
+            self.assertEqual(result["decision"], "block")
+            self.assertIn(msg, result["reason"])
+
+
+class ExtractionTests(unittest.TestCase):
+    """Direct coverage of _extract_tmp_paths regex behavior."""
+
+    def test_extracts_git_F_path(self):
+        self.assertEqual(
+            hook._extract_tmp_paths("git commit -F /tmp/msg.txt"),
+            ["/tmp/msg.txt"],
+        )
+
+    def test_extracts_gh_body_file_path(self):
+        self.assertEqual(
+            hook._extract_tmp_paths("gh pr create --body-file /tmp/body.md --title x"),
+            ["/tmp/body.md"],
+        )
+
+    def test_skips_non_tmp_paths(self):
+        self.assertEqual(
+            hook._extract_tmp_paths("git commit -F .claude/scratch/msg.txt"),
+            [],
+        )
+
+    def test_extracts_multiple_paths_in_compound_command(self):
+        cmd = "git commit -F /tmp/a.txt && gh pr create --title x --body-file /tmp/b.md"
+        self.assertEqual(
+            sorted(hook._extract_tmp_paths(cmd)),
+            ["/tmp/a.txt", "/tmp/b.md"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds `.claude/hooks/block_stale_tmp_message_file.py`, a PreToolUse Bash hook that refuses `git commit -F /tmp/...`, `git commit --file /tmp/...`, and `gh {pr,issue} {create,comment,edit} --body-file /tmp/...` when the target file's mtime is older than **30 seconds**. Closes #237.

This is the third documented occurrence of the `/tmp/*` file race captured in memory `feedback_tmp_msg_file_stale.md`. The pre-existing mitigation prescribed Issue#-keyed paths (`/tmp/msg-{issue#}.txt`, `/tmp/pr_body_{issue#}.md`), which works for issue/PR-scoped commits but does **not** cover charter rebuilds, ontology resyncs, or retro memory updates — non-issue commits have no issue# to key by. On 2026-05-03 a stale W10-era `/tmp/ontology_msg.txt` slipped a wrong-subject commit through during a session-start ontology rebuild; recovery required a soft reset. Hook > convention per `feedback_enforcement_hierarchy.md`.

## How it works

- Registered in `.claude/hooks/dispatcher.py`'s `_BASH_HOOKS` list (between `block_gh_pr_review` and `no_worktree_self_delete`).
- Splits the command on shell separators (`&&`, `||`, `;`, `|`), per-segment checks for `git commit` or `gh {pr,issue} {create,comment,edit}`, and looks for `-F` / `--file` / `--body-file` followed by a `/tmp/...` path.
- Block fires when `os.path.getmtime(path) < now - 30`. Missing files do not block (let downstream surface its own error).
- The error message names the offending file, its age, and three override paths: re-Write the file (mtime resets), use a non-/tmp path (e.g. `.claude/scratch/msg.txt`), or pass the content inline with `-m` / `--body`.

### Why 30 seconds?

Large enough that a `Write` + `Bash` pair batched in parallel always passes (Bash sees mtime <1s on the just-written file), small enough that a leftover from a prior task or session is reliably caught. The threshold lives in a single constant `STALE_TMP_THRESHOLD_SECONDS` for easy tuning.

### Override paths (printed in the block message)

1. **Rewrite** the file via Write — mtime resets, command re-runs cleanly. This is the canonical way out for in-session reuse.
2. **Use a non-/tmp path** like `.claude/scratch/msg.txt` for housekeeping commits where the issue#-keyed convention doesn't apply.
3. **Inline content** via `-m`/`--message` (git) or `-b`/`--body` (gh) — bypasses the file-flag entirely.

### Quoted identity-flag regression caught during smoke-test

The first cut used a leading `(?:\s+-c\s+\S+)*` to skip `git -c user.name=... -c user.email=... commit -F /tmp/x` style invocations. `\S+` cannot span the space inside `user.name="Aino Virtanen"`, so the match silently failed and the hook never fired through the dispatcher. Fix: split on shell separators and look for the body-file flag anywhere in the command segment. A regression test was added (`test_git_commit_with_quoted_identity_flags_and_stale_file_blocked`) so this can't come back silently.

## Files

- `.claude/hooks/block_stale_tmp_message_file.py` — the hook (~135 lines including module docstring)
- `.claude/hooks/dispatcher.py` — added `"block_stale_tmp_message_file"` to `_BASH_HOOKS`
- `.claude/hooks/tests/test_block_stale_tmp_message_file.py` — 21 tests across `FreshnessGateTests`, `NonMatchingTests`, `ExtractionTests`
- Memory `feedback_tmp_msg_file_stale.md` updated post-merge to reference the hook as primary mitigation (out-of-tree change, not in this PR)

## Test plan

- [x] `ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/` — 239 passed (218 prior + 21 new)
- [x] End-to-end via `dispatcher.py` with a stale `/tmp/stale-test-237.txt` (mtime 10m ago) and a `git -c user.name=... -c user.email=... commit -F` command — blocks with exit 2, error message names the file and its age
- [x] End-to-end with a fresh file — passes through to next hook in chain
- [x] Quoted-identity-flag regression test passes (would have failed against the first regex iteration)
- [x] Pre-commit hooks (ruff-format, ruff-lint, mypy) pass on the committed tree
- [ ] Review by Nadia Khoury

## Charter compliance

- Branch `A.Virtanen/0237-block-stale-tmp-message-file` off `deployments/phase-3/wave-3`
- Per-commit `-c user.name="Aino Virtanen" -c user.email="parametrization+Aino.Virtanen@gmail.com"` flags
- Two `Co-Authored-By:` trailers (Claude + Aino)
- Commit message via `-F /tmp/msg-main-237.txt` (issue#-keyed path per `feedback_tmp_msg_file_stale.md`)
- Labels: `tech-debt`, `process`, `phase-3`, `p3-wave-3` (matching the issue's existing labels — `tooling` label does not exist in this repo, only `process` for this category)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
