### PR TITLE
skill(wave-kickoff): create wave branch in every repo in scope (#238)

### DIFF
--- a/.claude/scratch/w4-kickoff.py
+++ b/.claude/scratch/w4-kickoff.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""P3W4 kickoff: label + kickoff comment for 31 issues across 6 repos."""
+import json, subprocess, sys, time
+
+# (repo_short, issue_num, assignee_label, branch_slug, reviewers, tier, bundled_with, wave_bootstrap)
+ISSUES = [
+    # T1 — bundle PR (1 PR closing 3 issues): A.Virtanen/0244-pr-review-canonicalization
+    ("noorinalabs-main", 244, "AINO_VIRTANEN", "A.Virtanen/0244-pr-review-canonicalization",
+     ("Wanjiku.Mwangi","Nadia.Khoury"), 1, "#233 #228", False),
+    ("noorinalabs-main", 233, "AINO_VIRTANEN", "A.Virtanen/0244-pr-review-canonicalization",
+     ("Wanjiku.Mwangi","Nadia.Khoury"), 1, "#244 #228", False),
+    ("noorinalabs-main", 228, "AINO_VIRTANEN", "A.Virtanen/0244-pr-review-canonicalization",
+     ("Wanjiku.Mwangi","Nadia.Khoury"), 1, "#244 #233", False),
+    # T2 — main: bundle PR closing 7 issues: A.Virtanen/0226-hook-matcher-sanitization
+    ("noorinalabs-main", 226, "AINO_VIRTANEN", "A.Virtanen/0226-hook-matcher-sanitization",
+     ("Nadia.Khoury","Wanjiku.Mwangi"), 2, "#227 #223 #216 #188 #144 #189", False),
+    ("noorinalabs-main", 227, "AINO_VIRTANEN", "A.Virtanen/0226-hook-matcher-sanitization",
+     ("Nadia.Khoury","Wanjiku.Mwangi"), 2, "#226 #223 #216 #188 #144 #189", False),
+    ("noorinalabs-main", 223, "AINO_VIRTANEN", "A.Virtanen/0226-hook-matcher-sanitization",
+     ("Nadia.Khoury","Wanjiku.Mwangi"), 2, "#226 #227 #216 #188 #144 #189", False),
+    ("noorinalabs-main", 216, "AINO_VIRTANEN", "A.Virtanen/0226-hook-matcher-sanitization",
+     ("Nadia.Khoury","Wanjiku.Mwangi"), 2, "#226 #227 #223 #188 #144 #189", False),
+    ("noorinalabs-main", 188, "AINO_VIRTANEN", "A.Virtanen/0226-hook-matcher-sanitization",
+     ("Nadia.Khoury","Wanjiku.Mwangi"), 2, "#226 #227 #223 #216 #144 #189", False),
+    ("noorinalabs-main", 144, "AINO_VIRTANEN", "A.Virtanen/0226-hook-matcher-sanitization",
+     ("Nadia.Khoury","Wanjiku.Mwangi"), 2, "#226 #227 #223 #216 #188 #189", False),
+    ("noorinalabs-main", 189, "AINO_VIRTANEN", "A.Virtanen/0226-hook-matcher-sanitization",
+     ("Nadia.Khoury","Wanjiku.Mwangi"), 2, "#226 #227 #223 #216 #188 #144", False),
+    # T2 — isnad-graph: 1 PR closing 2 issues: L.Pham/0819-hook-cross-repo-roster
+    ("noorinalabs-isnad-graph", 819, "LINH_PHAM", "L.Pham/0819-hook-cross-repo-roster",
+     ("Jelani.Mwangi","Arjun.Raghavan"), 2, "#814", False),
+    ("noorinalabs-isnad-graph", 814, "LINH_PHAM", "L.Pham/0819-hook-cross-repo-roster",
+     ("Jelani.Mwangi","Arjun.Raghavan"), 2, "#819", False),
+    # T3 — 3 PRs in main
+    ("noorinalabs-main", 238, "WANJIKU_MWANGI", "W.Mwangi/0238-wave-kickoff-multi-repo",
+     ("Aino.Virtanen","Nadia.Khoury"), 3, "(standalone)", False),
+    ("noorinalabs-main", 158, "AINO_VIRTANEN", "A.Virtanen/0158-promotion-audit-fallback",
+     ("Wanjiku.Mwangi","Santiago.Ferreira"), 3, "(standalone)", False),
+    ("noorinalabs-main", 196, "WANJIKU_MWANGI", "W.Mwangi/0196-wave-scope-skill",
+     ("Nadia.Khoury","Aino.Virtanen"), 3, "(standalone)", False),
+    # T4 — main bundle PR: A.Virtanen/0225-charter-docs-sweep (closes 6)
+    ("noorinalabs-main", 225, "AINO_VIRTANEN", "A.Virtanen/0225-charter-docs-sweep",
+     ("Wanjiku.Mwangi","Nadia.Khoury"), 4, "#239 #240 #200 #201 #197", False),
+    ("noorinalabs-main", 239, "AINO_VIRTANEN", "A.Virtanen/0225-charter-docs-sweep",
+     ("Wanjiku.Mwangi","Nadia.Khoury"), 4, "#225 #240 #200 #201 #197", False),
+    ("noorinalabs-main", 240, "AINO_VIRTANEN", "A.Virtanen/0225-charter-docs-sweep",
+     ("Wanjiku.Mwangi","Nadia.Khoury"), 4, "#225 #239 #200 #201 #197", False),
+    ("noorinalabs-main", 200, "AINO_VIRTANEN", "A.Virtanen/0225-charter-docs-sweep",
+     ("Wanjiku.Mwangi","Nadia.Khoury"), 4, "#225 #239 #240 #201 #197", False),
+    ("noorinalabs-main", 201, "AINO_VIRTANEN", "A.Virtanen/0225-charter-docs-sweep",
+     ("Wanjiku.Mwangi","Nadia.Khoury"), 4, "#225 #239 #240 #200 #197", False),
+    ("noorinalabs-main", 197, "AINO_VIRTANEN", "A.Virtanen/0225-charter-docs-sweep",
+     ("Wanjiku.Mwangi","Nadia.Khoury"), 4, "#225 #239 #240 #200 #201", False),
+    # T4 — child doc-sync (single-reviewer wave-bootstrap-class)
+    ("noorinalabs-isnad-graph", 852, "INGRID_LINDQVIST", "I.Lindqvist/0852-claude-md-branching-sync",
+     ("Anya.Kowalczyk",), 4, "(child sync)", True),
+    ("noorinalabs-user-service", 90, "MATEO_SALAZAR", "M.Salazar/0090-claude-md-branching-sync",
+     ("Anya.Kowalczyk",), 4, "(child sync)", True),
+    ("noorinalabs-design-system", 62, "KOFI_MENSAH", "K.Mensah/0062-claude-md-branching-sync",
+     ("Maeve.Callahan",), 4, "(child sync)", True),
+    ("noorinalabs-data-acquisition", 33, "SOFIA_CARDOSO", "S.Cardoso/0033-claude-md-branching-sync",
+     ("Dilara.Erdogan",), 4, "(child sync)", True),
+    # T5 — firm scope per owner directive
+    ("noorinalabs-main", 214, "AINO_VIRTANEN", "A.Virtanen/0214-parent-canonical-hook-paths",
+     ("Wanjiku.Mwangi","Nadia.Khoury"), 5, "(standalone)", False),
+    ("noorinalabs-main", 215, "AINO_VIRTANEN", "A.Virtanen/0215-settings-json-fanout",
+     ("Wanjiku.Mwangi","Santiago.Ferreira"), 5, "(standalone)", False),
+    ("noorinalabs-main", 236, "NADIA_KHOURY", "N.Khoury/0236-pattern-c-promotion",
+     ("Aino.Virtanen","Santiago.Ferreira"), 5, "(standalone)", False),
+    ("noorinalabs-main", 198, "AINO_VIRTANEN", "A.Virtanen/0198-validate-edit-completion",
+     ("Wanjiku.Mwangi","Nadia.Khoury"), 5, "(standalone)", False),
+    ("noorinalabs-main", 203, "AINO_VIRTANEN", "A.Virtanen/0203-validate-workflow-paths-coverage",
+     ("Wanjiku.Mwangi","Nadia.Khoury"), 5, "(standalone)", False),
+    ("noorinalabs-main", 219, "AINO_VIRTANEN", "A.Virtanen/0219-hook14-neutral-bypass",
+     ("Wanjiku.Mwangi","Santiago.Ferreira"), 5, "(standalone)", False),
+]
+
+assert len(ISSUES) == 31, f"Expected 31 issues, got {len(ISSUES)}"
+
+def run(cmd, **kw):
+    return subprocess.run(cmd, capture_output=True, text=True, **kw)
+
+results = {"labeled": [], "label_failed": [], "commented": [], "comment_failed": []}
+
+for repo, num, assignee, branch, revs, tier, bundled, wave_bs in ISSUES:
+    # Step 1: label
+    label_cmd = ["gh", "issue", "edit", str(num), "--repo", f"noorinalabs/{repo}",
+                 "--add-label", "p3-wave-4", "--add-label", assignee]
+    if wave_bs:
+        label_cmd += ["--add-label", "wave-bootstrap"]
+    r = run(label_cmd)
+    if r.returncode == 0:
+        results["labeled"].append(f"{repo}#{num}")
+    else:
+        results["label_failed"].append(f"{repo}#{num}: {r.stderr.strip()[:120]}")
+
+    # Step 2: kickoff comment
+    rev_str = ", ".join(revs) + (" (single-reviewer per wave-bootstrap exception)" if wave_bs else "")
+    body = f"""Requestor: Nadia.Khoury
+Requestee: {assignee.replace('_', '.').title().replace('Mwangi', 'Mwangi').replace('Khoury', 'Khoury')}
+RequestOrReplied: Request
+
+**Wave 4 Kickoff — Phase 3**
+
+This issue is assigned to you for p3-wave-4.
+
+- **Tier:** {tier}
+- **Bundled with:** {bundled}
+- **Branch from:** `deployments/phase-3/wave-4`
+- **Suggested branch name:** `{branch}`
+- **Reviewers:** {rev_str}
+- **Priority:** tech-debt
+
+**Wave theme:** Tooling and process-discipline cleanup — hook bug-class consolidation + charter docs sweep.
+
+Please begin implementation per the charter (`pull-requests.md`, `commits.md`, `branching.md`). Note the **new charter sections** that landed today (commit `8deb979`):
+- § Comment-Based Reviews — canonical Requestor=comment-author / Requestee=comment-target
+- § Additive Commits on ChangesRequested — no force-push during a CR cycle
+- § Pre-Flight Checklist — applied at this kickoff (see meta-issue)
+
+— Nadia Khoury, Program Director"""
+
+    comment_cmd = ["gh", "issue", "comment", str(num), "--repo", f"noorinalabs/{repo}", "--body", body]
+    r = run(comment_cmd)
+    if r.returncode == 0:
+        results["commented"].append(f"{repo}#{num}")
+    else:
+        results["comment_failed"].append(f"{repo}#{num}: {r.stderr.strip()[:200]}")
+
+print(json.dumps({k: len(v) for k,v in results.items()}, indent=2))
+print()
+if results["label_failed"]:
+    print("LABEL FAILURES:")
+    for x in results["label_failed"]: print(" ", x)
+if results["comment_failed"]:
+    print("COMMENT FAILURES:")
+    for x in results["comment_failed"]: print(" ", x)

--- a/.claude/scratch/w4-project-add.py
+++ b/.claude/scratch/w4-project-add.py
@@ -1,0 +1,27 @@
+import subprocess, json
+ISSUES = [
+    ("noorinalabs-main", [244,233,228,226,227,223,216,188,144,189,238,158,196,225,239,240,200,201,197,214,215,236,198,203,219]),
+    ("noorinalabs-isnad-graph", [819,814,852]),
+    ("noorinalabs-user-service", [90]),
+    ("noorinalabs-design-system", [62]),
+    ("noorinalabs-data-acquisition", [33]),
+]
+total = 0
+fail = []
+for repo, nums in ISSUES:
+    for n in nums:
+        url = f"https://github.com/noorinalabs/{repo}/issues/{n}"
+        r = subprocess.run(["gh","project","item-add","2","--owner","noorinalabs","--url",url],
+                           capture_output=True, text=True)
+        if r.returncode == 0:
+            total += 1
+        else:
+            err = r.stderr.strip()[:120]
+            if "already exists" in err.lower() or "already added" in err.lower():
+                total += 1
+            else:
+                fail.append(f"{repo}#{n}: {err}")
+print(f"Added (or already on board): {total}")
+if fail:
+    print("FAILURES:")
+    for f in fail: print(" ", f)

--- a/.claude/skills/wave-kickoff/SKILL.md
+++ b/.claude/skills/wave-kickoff/SKILL.md
@@ -10,15 +10,38 @@ Automate the wave kickoff process for the `{team_name}` team.
 
 ## Instructions
 
-### 0. Pre-flight checklist (Mandatory — Pattern F mitigation)
+### 0. Derive wave repos in scope (Mandatory first step)
+
+The canonical source for the wave's repo list is `cross-repo-status.json` key `wave_{M}_repos_in_scope` (array of `noorinalabs-*` strings). All subsequent steps iterate this list.
+
+```bash
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+WAVE_REPOS_IN_SCOPE=$(jq -r ".wave_{M}_repos_in_scope[]" "$REPO_ROOT/cross-repo-status.json")
+test -n "$WAVE_REPOS_IN_SCOPE" || { echo "ERROR: wave_{M}_repos_in_scope missing or empty in cross-repo-status.json"; exit 1; }
+echo "Wave repos in scope:"
+printf '  - %s\n' $WAVE_REPOS_IN_SCOPE
+```
+
+If the key is missing, STOP — the wave is not properly scoped. Add `wave_{M}_repos_in_scope` to `cross-repo-status.json` before invoking the skill.
+
+For path resolution: each repo `R` lives at `$REPO_ROOT/$R` EXCEPT `noorinalabs-main`, which IS `$REPO_ROOT`. Use this helper:
+
+```bash
+repo_path() {
+  local r="$1"
+  if [ "$r" = "noorinalabs-main" ]; then echo "$REPO_ROOT"; else echo "$REPO_ROOT/$r"; fi
+}
+```
+
+### 0.5. Pre-flight checklist (Mandatory — Pattern F mitigation)
 
 Before any branch creation, label work, or agent spawning, complete this checklist for every repo in the wave's planned scope. The Phase 3 Wave 3 retro identified **6 orchestrator-class pre-flight gaps** (wave-branch creation, attribution, child-repo-implementer rule ×2, 2-reviewer planning, naming, spawn order) — all caught by downstream layers, not pre-flight. This step closes Pattern F.
 
-For each repo `R` in `wave_repos_in_scope`:
+For each repo `R` in `$WAVE_REPOS_IN_SCOPE`:
 
 | # | Check | How to verify |
 |---|---|---|
-| 0.1 | **Wave branch exists in repo `R`** | `git ls-remote origin deployments/phase{N}/wave-{M}` ≠ empty in `R`'s local clone |
+| 0.1 | **Wave branch exists in repo `R`** | `gh api repos/noorinalabs/$R/git/refs/heads/deployments/phase-{N}/wave-{M}` returns 200 (not 404). Step 1 is responsible for creation; this check confirms it landed before subsequent steps run. |
 | 0.2 | **Implementer roster confirmed for `R`** | Per child-repo-implementer rule (memory `feedback_child_repo_implementer_rule.md`): implementers come from `R`'s own team roster, not the orchestrator's parent team |
 | 0.3 | **Every scoped issue's `actual_repo_for_changes` is correct** | Re-read every issue body; sibling-of references can mislead. Concrete example: deploy#242 was filed as "sibling-of isnad-graph" but the actual code change was in landing-page (caught by Idris-853 in P3W3 only after kickoff) |
 | 0.4 | **2-reviewer slate drafted per PR** | `wave_3_scope.tier_*` entries each list `assignee` + `reviewer` (and a 2nd reviewer for charter compliance — see charter `pull-requests.md` § Two-Reviewer Assignment at Wave Kickoff) |
@@ -27,21 +50,102 @@ For each repo `R` in `wave_repos_in_scope`:
 
 If any check fails for any repo, STOP and resolve before proceeding. The output of this step is a 6×N table (6 checks × N repos in scope) with explicit YES/NO/N-A entries — paste it into the kickoff comment on the meta-issue so the gap-resolution audit trail lives on the issue.
 
-### 1. Create the deployments branch
+### 1. Create the deployments branch in every wave repo
 
-For **every** repo `R` in `wave_repos_in_scope` (not just the orchestrator repo — main#238 closed in W4):
+For **every** repo `R` in `$WAVE_REPOS_IN_SCOPE` (not just the orchestrator repo — main#238 closed in W4), create `deployments/phase-{N}/wave-{M}` from `origin/main`. The skill uses `gh api` directly so it does NOT require a clean local checkout — this is intentional, since the orchestrator session may be running in an unrelated worktree.
+
+**Idempotency contract:** if the branch already exists in `R`, the skill MUST NOT fail. It distinguishes three cases via GitHub's `compare` API:
+- `exists-clean` — wave branch SHA == main SHA (just-created or unchanged)
+- `exists-ancestor` — wave branch is an ancestor of main (main advanced after kickoff; expected after the kickoff status commit lands)
+- `exists-drift` — wave branch and main have diverged (someone pushed a non-main commit onto the wave branch — surface, do NOT overwrite)
+
+**Dry-run mode:** if `WAVE_KICKOFF_DRY_RUN=1` is set in the environment, the skill MUST print the per-repo plan but skip the POST that creates the ref. Reads (lookup of existing ref + main SHA) still execute.
 
 ```bash
+BRANCH="deployments/phase-{N}/wave-{M}"
+declare -A BRANCH_SHA  # repo -> resulting SHA (for status-file update + table)
+declare -A BRANCH_STATUS  # repo -> "created" | "exists-clean" | "exists-ancestor" | "exists-drift" | "dry-run-create" | "error:<msg>"
+
 for R in $WAVE_REPOS_IN_SCOPE; do
-  cd "$REPO_ROOT/$R"
-  git fetch origin
-  git checkout main && git pull origin main
-  git checkout -b deployments/phase{N}/wave-{M} 2>/dev/null || git checkout deployments/phase{N}/wave-{M}
-  git push -u origin deployments/phase{N}/wave-{M}
+  MAIN_SHA=$(gh api "repos/noorinalabs/$R/git/refs/heads/main" --jq '.object.sha' 2>/dev/null) || {
+    BRANCH_STATUS[$R]="error:cannot-read-main"; continue;
+  }
+
+  # Probe existing branch
+  EXISTING_SHA=$(gh api "repos/noorinalabs/$R/git/refs/heads/$BRANCH" --jq '.object.sha' 2>/dev/null || true)
+
+  if [ -n "$EXISTING_SHA" ]; then
+    BRANCH_SHA[$R]="$EXISTING_SHA"
+    if [ "$EXISTING_SHA" = "$MAIN_SHA" ]; then
+      BRANCH_STATUS[$R]="exists-clean"
+    else
+      # Use compare API to distinguish ancestor (main moved forward) from real drift (wave branch diverged)
+      STATUS_TYPE=$(gh api "repos/noorinalabs/$R/compare/main...$EXISTING_SHA" --jq '.status' 2>/dev/null || echo "unknown")
+      case "$STATUS_TYPE" in
+        behind|identical) BRANCH_STATUS[$R]="exists-ancestor" ;;  # wave branch behind main = ancestor case
+        ahead|diverged)   BRANCH_STATUS[$R]="exists-drift" ;;     # real drift
+        *)                BRANCH_STATUS[$R]="exists-drift" ;;
+      esac
+    fi
+    continue
+  fi
+
+  if [ "${WAVE_KICKOFF_DRY_RUN:-0}" = "1" ]; then
+    BRANCH_SHA[$R]="$MAIN_SHA"
+    BRANCH_STATUS[$R]="dry-run-create"
+    continue
+  fi
+
+  # Create the ref. 422 means "ref already exists" — race-safe idempotency.
+  CREATE_OUT=$(gh api -X POST "repos/noorinalabs/$R/git/refs" \
+    -f "ref=refs/heads/$BRANCH" -f "sha=$MAIN_SHA" 2>&1) && {
+    BRANCH_SHA[$R]="$MAIN_SHA"
+    BRANCH_STATUS[$R]="created"
+  } || {
+    if echo "$CREATE_OUT" | grep -q "Reference already exists"; then
+      BRANCH_SHA[$R]="$MAIN_SHA"; BRANCH_STATUS[$R]="exists-clean"  # raced; treat as no-op
+    else
+      BRANCH_STATUS[$R]="error:$(echo "$CREATE_OUT" | head -1 | tr -d '"' | cut -c1-80)"
+    fi
+  }
 done
 ```
 
-If the branch already exists in any repo, check it out and pull latest instead. **Verify step 0.1 holds for every repo before moving on** — a missing wave branch in any child repo is a stop-the-line condition.
+Print a status table (always, in both dry-run and live mode):
+
+```
+| Repo                              | Branch SHA  | Status         |
+|-----------------------------------|-------------|----------------|
+| noorinalabs-main                  | 93f3513...  | created        |
+| noorinalabs-isnad-graph           | bbf7073...  | exists-clean   |
+| noorinalabs-user-service          | 8deb979...  | exists-ancestor|
+| noorinalabs-deploy                | 0b3b214...  | exists-drift   |
+| noorinalabs-design-system         |  —          | error:cannot-read-main |
+```
+
+**Stop-the-line conditions:**
+- Any `error:*` — investigate before continuing (likely a missing repo or a permissions gap, not the skill's bug to swallow)
+- Any `exists-drift` — a prior session pushed a non-main commit onto this branch. Surface to the user; do NOT overwrite. Decide whether to rebase, fast-forward, or accept.
+
+**Persist results to `cross-repo-status.json`:**
+
+```bash
+# Build a JSON object {repo: {sha, status}} and merge under wave_{M}_branches
+TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+JSON=$(for R in $WAVE_REPOS_IN_SCOPE; do
+  printf '%s\n' "$R ${BRANCH_SHA[$R]:-null} ${BRANCH_STATUS[$R]}"
+done | jq -Rn --arg ts "$TS" --arg branch "$BRANCH" '
+  [inputs | split(" ")] |
+  map({(.[0]): {sha: (.[1] | if . == "null" then null else . end), status: .[2]}}) |
+  add | {branch: $branch, created_at: $ts, repos: .}')
+
+if [ "${WAVE_KICKOFF_DRY_RUN:-0}" != "1" ]; then
+  jq --argjson b "$JSON" '.wave_{M}_branches = $b' "$REPO_ROOT/cross-repo-status.json" \
+    > "$REPO_ROOT/cross-repo-status.json.tmp" && mv "$REPO_ROOT/cross-repo-status.json.tmp" "$REPO_ROOT/cross-repo-status.json"
+fi
+```
+
+**Verify step 0.1 holds for every repo before moving on** — every entry in the status table must be `created`, `exists-clean`, `exists-ancestor`, or (with explicit user sign-off) `exists-drift`. A missing or errored wave branch in any child repo is a stop-the-line condition.
 
 ### 2. Create wave label
 

--- a/.claude/skills/wave-wrapup/SKILL.md
+++ b/.claude/skills/wave-wrapup/SKILL.md
@@ -197,16 +197,34 @@ Flag any changes to:
 **Next step:** Run `/wave-retro` for full retrospective with assessments and trust updates.
 ```
 
-### 11. Merge to main (final wave only)
+### 11. Merge to main per repo (final wave only)
 
-If this is the final wave of the phase:
+If this is the final wave of the phase, every repo in `wave_{M}_repos_in_scope` has its OWN `deployments/phase-{P}/wave-{M}` branch (created by `/wave-kickoff` step 1) that needs its own PR to main. This is the symmetric counterpart of the multi-repo branch creation gap (main#238).
 
 ```bash
-# Create PR from deployments branch to main
-gh pr create --base main --head "deployments/phase{P}/wave-{M}" \
-    --title "Phase {P} Wave {M} → main" \
-    --body "Final wave merge. All PRs reviewed and merged to deployment branch."
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+WAVE_REPOS_IN_SCOPE=$(jq -r ".wave_{M}_repos_in_scope[]" "$REPO_ROOT/cross-repo-status.json")
+BRANCH="deployments/phase-{P}/wave-{M}"
+
+for R in $WAVE_REPOS_IN_SCOPE; do
+  # Skip repos where the wave branch is already merged or doesn't exist
+  EXISTING=$(gh api "repos/noorinalabs/$R/git/refs/heads/$BRANCH" --jq '.object.sha' 2>/dev/null || true)
+  [ -z "$EXISTING" ] && { echo "$R: no wave branch — skip"; continue; }
+
+  # Check if there's anything to merge (compare branch HEAD vs main HEAD)
+  MAIN_SHA=$(gh api "repos/noorinalabs/$R/git/refs/heads/main" --jq '.object.sha')
+  if [ "$EXISTING" = "$MAIN_SHA" ]; then
+    echo "$R: wave branch ==  main, nothing to merge"; continue
+  fi
+
+  # Create PR from this repo's wave branch to its own main
+  gh pr create --repo "noorinalabs/$R" --base main --head "$BRANCH" \
+    --title "Phase {P} Wave {M} → main ($R)" \
+    --body "Final wave merge for $R. All PRs reviewed and merged to wave branch."
+done
 ```
+
+Print a per-repo PR summary table (PR# or "no merge needed") and **wait for user approval before merging any PR**. Each PR must be merged independently.
 
 **Do NOT merge to main without user approval.** This is a significant action that affects all downstream repos.
 

--- a/cross-repo-status.json
+++ b/cross-repo-status.json
@@ -1,9 +1,84 @@
 {
-  "wave_active": false,
-  "current_wave": null,
+  "wave_active": true,
+  "current_wave": "wave-4",
   "next_wave": null,
   "last_completed_wave": "wave-3",
   "last_completed_at": "2026-05-04T02:35:00Z",
+  "wave_4_kicked_off_at": "2026-05-04T03:15:00Z",
+  "wave_4_branch": "deployments/phase-3/wave-4",
+  "wave_4_theme": "Tooling and process-discipline cleanup — hook bug-class consolidation + charter docs sweep",
+  "wave_4_length_estimate_days": "5-7",
+  "wave_4_repos_in_scope": [
+    "noorinalabs-main",
+    "noorinalabs-isnad-graph",
+    "noorinalabs-user-service",
+    "noorinalabs-design-system",
+    "noorinalabs-data-acquisition",
+    "noorinalabs-isnad-ingest-platform"
+  ],
+  "wave_4_scope_total_issues": 31,
+  "wave_4_scope": {
+    "tier_1_validate_pr_review_family": [
+      {"id": "noorinalabs-main#244", "title": "validate_pr_review.py Requestee-as-reviewer mismatch", "assignee": "Aino Virtanen", "reviewers": ["Wanjiku Mwangi", "Nadia Khoury"], "branch": "A.Virtanen/0244-pr-review-canonicalization", "bundle": "PR closes #244 + #233 + #228"},
+      {"id": "noorinalabs-main#233", "title": "charter Requestor/Requestee directionality ambiguity", "assignee": "Aino Virtanen", "reviewers": ["Wanjiku Mwangi", "Nadia Khoury"], "bundle": "with #244"},
+      {"id": "noorinalabs-main#228", "title": "validate_pr_review hook doesn't honor Single-Reviewer Exception", "assignee": "Aino Virtanen", "reviewers": ["Wanjiku Mwangi", "Nadia Khoury"], "bundle": "with #244"}
+    ],
+    "tier_2_hook_matcher_family": [
+      {"id": "noorinalabs-main#226", "title": "validate_commit_identity slurps -c user.email", "assignee": "Aino Virtanen", "reviewers": ["Nadia Khoury", "Wanjiku Mwangi"], "branch": "A.Virtanen/0226-hook-matcher-sanitization", "bundle": "PR closes #226 + #227 + #223 + #216 + #188 + #144 + #189"},
+      {"id": "noorinalabs-main#227", "title": "validate_branch_freshness uses dispatcher cwd", "bundle": "with #226"},
+      {"id": "noorinalabs-main#223", "title": "block_no_verify trips on heredoc body", "bundle": "with #226"},
+      {"id": "noorinalabs-main#216", "title": "block_git_config trips on heredoc body", "bundle": "with #226"},
+      {"id": "noorinalabs-main#188", "title": "validate_commit_identity heredoc stripping breaks on nested heredoc", "bundle": "with #226"},
+      {"id": "noorinalabs-main#144", "title": "validate_branch_freshness uses parent cwd, not worktree", "bundle": "with #226"},
+      {"id": "noorinalabs-main#189", "title": "block_shutdown_without_retro false-positive on subagent task-complete", "bundle": "with #226"},
+      {"id": "noorinalabs-isnad-graph#819", "title": "validate_commit_identity ignores cross-repo roster lookup", "assignee": "Linh Pham", "reviewers": ["Jelani Mwangi", "Arjun Raghavan"], "branch": "L.Pham/0819-hook-cross-repo-roster", "bundle": "PR closes isnad-graph#819 + #814"},
+      {"id": "noorinalabs-isnad-graph#814", "title": "validate_commit_identity heredoc/quote-strip ordering fragile", "bundle": "with isnad-graph#819"}
+    ],
+    "tier_3_skill_and_retro_action_items": [
+      {"id": "noorinalabs-main#238", "title": "/wave-kickoff multi-repo wave-branch creation", "assignee": "Wanjiku Mwangi", "reviewers": ["Aino Virtanen", "Nadia Khoury"], "branch": "W.Mwangi/0238-wave-kickoff-multi-repo"},
+      {"id": "noorinalabs-main#158", "title": "promotion-audit fall-back signal — stale-memory warning class", "assignee": "Aino Virtanen", "reviewers": ["Wanjiku Mwangi", "Santiago Ferreira"], "branch": "A.Virtanen/0158-promotion-audit-fallback"},
+      {"id": "noorinalabs-main#196", "title": "/wave-scope skill — reconcile meta-issue vs labels", "assignee": "Wanjiku Mwangi", "reviewers": ["Nadia Khoury", "Aino Virtanen"], "branch": "W.Mwangi/0196-wave-scope-skill"}
+    ],
+    "tier_4_charter_docs_sweep": [
+      {"id": "noorinalabs-main#225", "title": "secrets-audit doc sweep §3.0.a TODO + §3.4/§3.8 back-refs", "assignee": "Aino Virtanen", "reviewers": ["Wanjiku Mwangi", "Nadia Khoury"], "branch": "A.Virtanen/0225-charter-docs-sweep", "bundle": "PR closes #225 + #239 + #240 + #200 + #201 + #197"},
+      {"id": "noorinalabs-main#239", "title": "charter base-image-pinning convention", "bundle": "with #225"},
+      {"id": "noorinalabs-main#240", "title": "charter per-env OAuth provisioning convention", "bundle": "with #225"},
+      {"id": "noorinalabs-main#200", "title": "charter wave-branch CI triggers (W10 carry-forward)", "bundle": "with #225"},
+      {"id": "noorinalabs-main#201", "title": "charter spawn-prompt template — reviewer-slate first-line (W10 carry-forward)", "bundle": "with #225"},
+      {"id": "noorinalabs-main#197", "title": "docs: clarify single-leader session-team architecture", "bundle": "with #225"},
+      {"id": "noorinalabs-isnad-graph#852", "title": "CLAUDE.md branching backslash → slash sync", "assignee": "Ingrid Lindqvist", "reviewers": ["Anya Kowalczyk"], "branch": "I.Lindqvist/0852-claude-md-branching-sync", "wave_bootstrap": true},
+      {"id": "noorinalabs-user-service#90", "title": "CLAUDE.md branching backslash → slash sync", "assignee": "Mateo Salazar", "reviewers": ["Anya Kowalczyk"], "branch": "M.Salazar/0090-claude-md-branching-sync", "wave_bootstrap": true},
+      {"id": "noorinalabs-design-system#62", "title": "CLAUDE.md branching backslash → slash sync", "assignee": "Kofi Mensah", "reviewers": ["Maeve Callahan"], "branch": "K.Mensah/0062-claude-md-branching-sync", "wave_bootstrap": true},
+      {"id": "noorinalabs-data-acquisition#33", "title": "CLAUDE.md branching backslash → slash sync", "assignee": "Sofia Cardoso", "reviewers": ["Dilara Erdogan"], "branch": "S.Cardoso/0033-claude-md-branching-sync", "wave_bootstrap": true}
+    ],
+    "tier_5_firm_per_owner_directive_2026_05_04": [
+      {"id": "noorinalabs-main#214", "title": "rationalize parent-canonical hook paths org-wide", "assignee": "Aino Virtanen", "reviewers": ["Wanjiku Mwangi", "Nadia Khoury"], "branch": "A.Virtanen/0214-parent-canonical-hook-paths"},
+      {"id": "noorinalabs-main#215", "title": "settings.json fan-out (US + ingest-platform)", "assignee": "Aino Virtanen", "reviewers": ["Wanjiku Mwangi", "Santiago Ferreira"], "branch": "A.Virtanen/0215-settings-json-fanout", "touches_repos": ["noorinalabs-user-service", "noorinalabs-isnad-ingest-platform"]},
+      {"id": "noorinalabs-main#236", "title": "feedback-promotion: Reviewer Pattern C (TF state-drift)", "assignee": "Nadia Khoury", "reviewers": ["Aino Virtanen", "Santiago Ferreira"], "branch": "N.Khoury/0236-pattern-c-promotion"},
+      {"id": "noorinalabs-main#198", "title": "validate_edit_completion (new hook)", "assignee": "Aino Virtanen", "reviewers": ["Wanjiku Mwangi", "Nadia Khoury"], "branch": "A.Virtanen/0198-validate-edit-completion"},
+      {"id": "noorinalabs-main#203", "title": "validate_workflow_paths_coverage (new hook)", "assignee": "Aino Virtanen", "reviewers": ["Wanjiku Mwangi", "Nadia Khoury"], "branch": "A.Virtanen/0203-validate-workflow-paths-coverage"},
+      {"id": "noorinalabs-main#219", "title": "Hook 14 NEUTRAL conclusion bypass (Chromatic gate gap)", "assignee": "Aino Virtanen", "reviewers": ["Wanjiku Mwangi", "Santiago Ferreira"], "branch": "A.Virtanen/0219-hook14-neutral-bypass"}
+    ],
+    "deliberately_not_in_w4": [
+      "noorinalabs-deploy backlog (~50 issues) — wave is hooks/charter/skill scope; deploy work resumes W5+",
+      "noorinalabs-landing-page #73 (design-system bump) — gated on ds#57 publish (separate workstream)",
+      "noorinalabs-isnad-graph product-feature backlog (#840 design-system bump, #717 billing) — out of W4 theme",
+      "8-repo audits noorinalabs-main#221 #222 — own wave (large surface)",
+      "Pattern E charter promotion (emergency-mode catchup) — no current emergency"
+    ]
+  },
+  "wave_4_decisions": {
+    "scope_signed_off_at": "2026-05-04T03:15:00Z",
+    "scope_signed_off_by": "owner",
+    "stretch_promoted_to_firm": "Owner directive 2026-05-04: T5 6 issues moved into firm scope, not stretch",
+    "single_reviewer_exception": "4 child-repo CLAUDE.md branching syncs use single-reviewer per § Single-Reviewer Exception (Wave-Bootstrap Only); labeled wave-bootstrap; logged here per charter requirement",
+    "charter_changes_applied_pre_kickoff": [
+      "pull-requests.md § Additive Commits on ChangesRequested (NEW) — codifies P3W3 positive (4/4 CR cycles additive, no force-push)",
+      "pull-requests.md § Comment-Based Reviews — disambiguate Requestor/Requestee; canonical Requestor=comment-author. Resolves #233 charter-side; hook-side fix tracked in #244+#228",
+      "/wave-kickoff § 0 Pre-Flight Checklist (NEW) — Pattern F mitigation; 6 per-repo checks; applied at this kickoff"
+    ],
+    "pre_flight_checklist_pass": "All 6 checks passed for 6 in-scope repos (main, isnad-graph, user-service, design-system, data-acquisition, ingest-platform). main#232 (canonical CLAUDE.md fix) detected closed during 0.3 attribution check — dropped from scope; 4 child-sync issues retained as W4 work."
+  },
   "wave_3_kicked_off_at": "2026-05-03T17:55:00Z",
   "wave_3_wrap_status": "CLOSED 2026-05-04T02:35Z. All 14 wave-3 PRs dual-Approved + merged into wave-3 branches across 5 repos (user-service, deploy, isnad-graph, landing-page, main). 5 wave-merge PRs (deployments/phase-3/wave-3 → main) merged in deploy-order: user-service#93 (05d644e) → deploy#270 (c7cfabf) → isnad-graph#856 (bbf7073) → landing-page#76 (4131630) → main#243 (cc6e589). Merges used --admin override for the 2-reviewer hook (validate_pr_review.py treats Requestee as reviewer, mismatched with the wave's Requestee=author format; orchestrator follow-up filed). Pattern B (verify-vs-artifact) crossed 5+ wave-instances across 3 role classes — charter promotion threshold met. 6 orchestrator-class gaps caught by hooks/implementers/reviewers (wave-branch creation, deploy#242 attribution, child-repo-implementer rule for landing-page + user-service, 2-reviewer planning, agent-naming pattern, spawn-brief-reviewer-order-inversion). Wave-completion batch (T2/T3): #266 ChangesRequested → user-service#92 cross-repo Option A → re-Approved; #259 ChangesRequested → 2-line path-A → Approved; #261 ChangesRequested → 14-line perms+runbook → Approved; #267 ChangesRequested → 49-line workflow-input + failure-modes → Approved.",
   "phase": "phase-3",
@@ -73,7 +148,7 @@
   "wave_started": "2026-04-30T21:00:00Z",
   "wave_1_wrap_started": "2026-04-30T23:18:00Z",
   "wave_1_wrap_status": "CLOSED 2026-05-01T01:49:41Z. Both wave-merge PRs landed (deploy#213 merge-commit b6f2cd1; main#235 merge-commit 9a1ef3e). 5/5 Tier-1 + 2/2 Tier-2 + #205 followup-of-spec + #214 wave-tail flake fix (#215 retry-with-backoff JSON-parse classifier) all on main. 8 deploy worktrees pruned. 2 ontology files resolved. 4 charter deltas landed (Patterns A + B unified + C + D). Trust matrix updated (Lucas 4→5; others hold). Promotion audit 0/0/55/4. Wave-tail produced 5 additional retro-pattern data points stress-testing the just-landed charter; all four patterns held. 9 follow-ups filed for next-wave planning (#199 #200 #203 #204 #209 #211 #212 + main#232 + main#233 + main#234). 3 Tier-3 carry-forwards remain operationally gated (deploy#86 async-routine fires post-this-merge; deploy#151 manual SRE B2 tfstate-key migration; user-service#84 manual SRE DEPLOY_REPO_PAT secret).",
-  "last_updated": "2026-05-04T02:55:00Z",
+  "last_updated": "2026-05-04T03:15:00Z",
   "deployments_branch": "deployments/phase-3/wave-3",
   "wave_1_theme": "Promotion pipeline goes prod — owner directive: pipeline running seamlessly so team can refocus on product + process",
   "wave_1_scope": {


### PR DESCRIPTION
## Summary

Closes #238 — `/wave-kickoff` skill now creates `deployments/phase-{N}/wave-{M}` in **every** repo listed under `wave_{M}_repos_in_scope` in `cross-repo-status.json`, not just the orchestrator's repo. P3W3 retro pain-point #1 (6-occurrence orchestrator-class gap) — Aisha-252 (deploy#252) and Idris-853 (isnad-graph#853) both surfaced this within minutes of being spawned.

## Changes

`.claude/skills/wave-kickoff/SKILL.md`:

- **New step 0** — derive `WAVE_REPOS_IN_SCOPE` from `cross-repo-status.json` key `wave_{M}_repos_in_scope` (the canonical shape introduced at W3). Hard-stop if missing.
- **Rewrote step 1** — uses `gh api` (no local clone required, no `cd` polluted across iterations). Iterates the full scope. Idempotency contract distinguishes:
  - `created` — branch did not exist; created from `main`
  - `exists-clean` — branch SHA == main SHA
  - `exists-ancestor` — branch is behind main (main advanced after kickoff; expected once the kickoff status commit lands — re-running kickoff should NOT trip drift here)
  - `exists-drift` — branch and main diverged (surface, do NOT overwrite)
  - `error:<msg>` — repo or permissions issue
- **Dry-run mode** — `WAVE_KICKOFF_DRY_RUN=1` skips the POST while keeping reads.
- **Status table** printed every run (live + dry-run).
- **Persists** per-repo `{sha,status}` to `cross-repo-status.json` `.wave_{M}_branches`.
- **Stop-the-line** on any `error:*` or unsigned-off `exists-drift`.
- **Step 0.5** (formerly step 0) pre-flight checklist updated to reference `gh api` instead of "local clone" for the wave-branch existence check.

`.claude/skills/wave-wrapup/SKILL.md`:

- **Step 11 rewritten** to address acceptance criterion 5 — final-wave merge-to-main now iterates `wave_{M}_repos_in_scope`, opening one PR per repo (the symmetric gap of #238 at the wave-end).

## Verification

Live + dry-run integration test against current W4 state (all 6 in-scope repos):

| Repo                                | Status          |
|-------------------------------------|-----------------|
| noorinalabs-main                    | exists-ancestor |
| noorinalabs-isnad-graph             | exists-clean    |
| noorinalabs-user-service            | exists-clean    |
| noorinalabs-design-system           | exists-clean    |
| noorinalabs-data-acquisition        | exists-clean    |
| noorinalabs-isnad-ingest-platform   | exists-clean    |

Zero `created`, zero errors. `noorinalabs-main` correctly classified as `exists-ancestor` (not drift) because main advanced one commit past the wave branch with the kickoff status commit `93f3513` — the GitHub `compare` API call distinguishes ancestor (`behind`/`identical`) from real drift (`ahead`/`diverged`).

## Test plan

- [ ] Reviewer (Aino primary, Nadia secondary) — confirm idempotency contract is correct: re-running `/wave-kickoff` for an active wave should be a clean no-op
- [ ] Confirm `exists-ancestor` is the right call for the "main moved past wave branch" case (alternative would be to fast-forward the wave branch)
- [ ] Verify `cross-repo-status.json` `.wave_{M}_branches` block placement is acceptable (currently merged at the top level alongside `wave_{M}_scope`, `wave_{M}_repos_in_scope`)
- [ ] wave-wrapup step 11 — confirm one-PR-per-repo at end-of-phase is the right shape (vs. one meta-PR with cross-repo merge instructions)

## Related

- Memory `feedback_wave_kickoff_per_repo_branches.md` — already documents the gap; now resolved
- Companion to charter pre-flight checklist (already landed pre-W4) which only added a *check*; this PR adds the *action* that makes the check pass
