### PR TITLE
hooks: shared shell-arg parser + refactor 5 PreToolUse matchers (closes #226 #227 #223 #216 #188 #144 #189)

### DIFF
--- a/.claude/hooks/_shell_parse.py
+++ b/.claude/hooks/_shell_parse.py
@@ -22,6 +22,11 @@ Public API
         shlex.split with posix semantics. Returns None on parse failure
         (unbalanced quotes, etc.) so callers can fall back to a regex path.
 
+        Caller contract: callers MUST handle None explicitly. Never treat
+        None as "allow" for security-relevant matchers like commit-identity
+        validation — fall back to a regex check or a fail-closed decision.
+        For warn-only matchers, fail-open on None is acceptable.
+
     strip_heredocs(cmd) -> str
         Removes <<DELIM .. DELIM, <<'DELIM' .. DELIM, <<"DELIM" .. DELIM and
         <<-DELIM .. DELIM heredoc bodies (delimiter is rfc-shell-style: any
@@ -47,8 +52,15 @@ Public API
 
     extract_dash_c_pairs(segment) -> list[tuple[str, str]]
         Walks a tokenized git segment and returns (key, value) pairs for
-        every `-c key=value` global option. shlex has already unquoted
-        values, so a simple `split('=', 1)` is correct.
+        every `-c key=value` global option, in source order. shlex has
+        already unquoted values, so a simple `split('=', 1)` is correct.
+
+        Repeated-key contract: `git -c user.name=A -c user.name=B commit`
+        is legal (last wins per git semantics). This helper returns ALL
+        pairs in source order; callers needing last-wins semantics can
+        do `dict(extract_dash_c_pairs(...))` (later keys overwrite
+        earlier in dict construction). Do not rely on first-occurrence
+        unless you handle dedup yourself.
 
     resolve_tool_cwd(input_data) -> str
         Returns input_data["cwd"] if the harness supplied it, else

--- a/.claude/hooks/_shell_parse.py
+++ b/.claude/hooks/_shell_parse.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+"""Shared shell-arg-aware parser helper for PreToolUse Bash hooks.
+
+Background
+==========
+
+Multiple PreToolUse hooks have repeatedly tripped on substring/regex matching
+against the raw Bash command string (issues #118, #134, #144, #188, #189,
+#216, #223, #226, #227). Root cause: the matcher cannot tell *command-position*
+tokens (e.g. an actual `git config` invocation) from *data-position* text
+(e.g. the phrase "git config" inside a heredoc body, a `--body-file` argument
+value, or a documentation string).
+
+This module is the unifying primitive: tokenize once with shlex, segment-split
+on shell operators, then locate command-position tokens explicitly. Hooks call
+the small public API instead of writing one-off regexes.
+
+Public API
+==========
+
+    tokenize(cmd) -> list[str] | None
+        shlex.split with posix semantics. Returns None on parse failure
+        (unbalanced quotes, etc.) so callers can fall back to a regex path.
+
+    strip_heredocs(cmd) -> str
+        Removes <<DELIM .. DELIM, <<'DELIM' .. DELIM, <<"DELIM" .. DELIM and
+        <<-DELIM .. DELIM heredoc bodies (delimiter is rfc-shell-style: any
+        word). Handles repeated/nested heredocs by iterating until the regex
+        is fixed.
+
+    iter_command_segments(tokens) -> Iterator[list[str]]
+        Splits a token list on the shell-control tokens `;`, `&&`, `||`, `|`
+        (these survive shlex.split as their own tokens because they're not
+        inside quotes), strips leading `KEY=value` env-var assignments from
+        each segment, and yields the surviving tokens.
+
+    find_git_subcommand(segment) -> tuple[list[str], list[str]] | None
+        Given a single segment's tokens, returns (global_opts, [subcommand,
+        ...rest]) if it's a `git ...` invocation, else None. Skips git
+        global options (`-c k=v`, `-C dir`, `--git-dir=...`,
+        `--work-tree=...`, etc.) so the returned subcommand is the actual
+        git verb (`commit`, `config`, `worktree`, ...).
+
+    find_gh_subcommand(segment) -> tuple[list[str], list[str]] | None
+        Same shape for `gh ...`. Returns (gh_global_opts, [topic, action,
+        ...rest]) — e.g. ([], ["pr", "create", "--repo", ...]).
+
+    extract_dash_c_pairs(segment) -> list[tuple[str, str]]
+        Walks a tokenized git segment and returns (key, value) pairs for
+        every `-c key=value` global option. shlex has already unquoted
+        values, so a simple `split('=', 1)` is correct.
+
+    resolve_tool_cwd(input_data) -> str
+        Returns input_data["cwd"] if the harness supplied it, else
+        os.getcwd(). The Claude Code harness sets `cwd` on the hook input
+        for tool calls that run from a known cwd; subprocess calls that
+        want to operate on the *user's* cwd (not the hook's parent process
+        cwd) should use this to anchor `subprocess.run(..., cwd=...)`.
+
+    is_shutdown_request_message(message) -> bool
+        True only if `message` is a structured shutdown_request JSON
+        (dict-form OR str-form parseable to a dict with type==
+        "shutdown_request"). Plain prose containing the substring is NOT
+        a shutdown request — that was the #189 false-positive root.
+
+Why not eval / parse the full shell grammar?
+============================================
+
+shlex.split + segment + command-position lookup is the 95% solution. Hooks
+that match against a known shape (`git commit`, `gh pr create`, `git config`)
+need exactly this. Full POSIX shell parsing is overkill and would re-introduce
+the parser-correctness debt the regexes had.
+
+When shlex.split fails (malformed quotes), callers MUST fall back to a regex
+or fail-open (return None to allow the command). Never crash on parse error.
+
+Promotion provenance
+====================
+
+Sibling-bug cluster (P3W4 Tier-2): #226 #227 #223 #216 #188 #144 #189.
+Tracking PR consolidates the parser into one tested helper and refactors
+five hooks (validate_commit_identity, validate_branch_freshness,
+block_git_config, block_no_verify, block_shutdown_without_retro).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+from typing import Iterator
+
+# Shell control tokens that segment a compound command. Any of these,
+# appearing as their OWN token after shlex.split, separates one pipeline
+# segment from the next.
+_SEGMENT_OPS = {";", "&&", "||", "|"}
+
+# Match KEY=value env-var assignment at command position. Must start with a
+# letter or underscore and contain only word chars before the '='. shlex has
+# already de-quoted any quoted value, so the value half is just "everything
+# after the first =".
+_ENV_ASSIGN_RE = re.compile(r"^[A-Za-z_]\w*=")
+
+# Heredoc opener: <<-?\s*['"]?DELIM['"]? on a line, then any content, then
+# the bare DELIM word terminating it. Supports the four shell variants
+# (<<EOF, <<'EOF', <<"EOF", <<-EOF). The `<<-` tabs-stripping form allows
+# leading tabs on the closing delimiter line, so we match optional `\t*`
+# before \1 in the closer position.
+_HEREDOC_RE = re.compile(
+    r"<<-?\s*['\"]?(\w+)['\"]?.*?\n.*?\n\t*\1\b",
+    re.DOTALL,
+)
+
+# git global options that consume a value (two-token form). Equals-form
+# (e.g. `--git-dir=path`) is handled separately as a single token.
+_GIT_VALUE_GLOBALS = {"-c", "-C", "--git-dir", "--work-tree", "--namespace", "--exec-path"}
+
+# git global boolean options (no value).
+_GIT_BOOL_GLOBALS = {
+    "--no-pager",
+    "-p",
+    "--paginate",
+    "--no-replace-objects",
+    "--bare",
+    "--no-optional-locks",
+}
+
+
+def tokenize(cmd: str) -> list[str] | None:
+    """shlex.split the command. Return None on parse error (unbalanced quote)."""
+    try:
+        return shlex.split(cmd, posix=True)
+    except ValueError:
+        return None
+
+
+def strip_heredocs(cmd: str) -> str:
+    """Remove all heredoc bodies. Iterates until no more matches (handles nested)."""
+    prev = None
+    cur = cmd
+    while prev != cur:
+        prev = cur
+        cur = _HEREDOC_RE.sub("", cur)
+    return cur
+
+
+def iter_command_segments(tokens: list[str]) -> Iterator[list[str]]:
+    """Split tokens on `;`, `&&`, `||`, `|` and strip leading KEY=val env vars.
+
+    Each yielded segment is a non-empty list of tokens representing one
+    command in the pipeline. Empty segments (e.g. trailing `;`) are skipped.
+    """
+    if not tokens:
+        return
+
+    cur: list[str] = []
+    for tok in tokens:
+        if tok in _SEGMENT_OPS:
+            if cur:
+                stripped = _strip_leading_env_assignments(cur)
+                if stripped:
+                    yield stripped
+                cur = []
+            continue
+        cur.append(tok)
+    if cur:
+        stripped = _strip_leading_env_assignments(cur)
+        if stripped:
+            yield stripped
+
+
+def _strip_leading_env_assignments(segment: list[str]) -> list[str]:
+    """Drop leading KEY=value tokens from a segment (one-shot env vars)."""
+    i = 0
+    while i < len(segment) and _ENV_ASSIGN_RE.match(segment[i]):
+        i += 1
+    return segment[i:]
+
+
+def _is_equals_form_global(tok: str) -> bool:
+    """True if `tok` is the equals-form of a value-taking git global.
+
+    Examples that return True: `-c=user.name=foo`, `--git-dir=.git`,
+    `--work-tree=/path`. We only care about the prefix; the value half is
+    irrelevant for the skip decision.
+    """
+    return (
+        tok.startswith("-c=")
+        or tok.startswith("-C=")
+        or tok.startswith("--git-dir=")
+        or tok.startswith("--work-tree=")
+        or tok.startswith("--namespace=")
+        or tok.startswith("--exec-path=")
+    )
+
+
+def find_git_subcommand(segment: list[str]) -> tuple[list[str], list[str]] | None:
+    """If `segment` is a `git ...` invocation, return (global_opts, [subcmd, ...]).
+
+    Skips git global options:
+      -c key=value          (consumed as one shlex token, possibly quoted)
+      -C path
+      --git-dir=path / --git-dir path
+      --work-tree=path / --work-tree path
+      --no-pager / -p / --paginate / --no-replace-objects   (no value)
+
+    Returns None if `segment` is empty, doesn't start with `git`, or doesn't
+    have a subcommand after the global-option run.
+    """
+    if not segment or segment[0] != "git":
+        return None
+
+    globals_: list[str] = []
+    i = 1
+    n = len(segment)
+    while i < n:
+        tok = segment[i]
+        if tok in _GIT_BOOL_GLOBALS:
+            globals_.append(tok)
+            i += 1
+            continue
+        if tok in _GIT_VALUE_GLOBALS:
+            globals_.append(tok)
+            if i + 1 < n:
+                globals_.append(segment[i + 1])
+                i += 2
+            else:
+                i += 1
+            continue
+        if _is_equals_form_global(tok):
+            globals_.append(tok)
+            i += 1
+            continue
+        # First non-option token is the subcommand.
+        return globals_, segment[i:]
+    return None
+
+
+def find_gh_subcommand(segment: list[str]) -> tuple[list[str], list[str]] | None:
+    """If `segment` is a `gh ...` invocation, return ([], [topic, action, ...]).
+
+    `gh` has no pre-subcommand global options worth skipping for the matchers
+    in this codebase, so this is a thin shape-mirror of `find_git_subcommand`.
+    """
+    if not segment or segment[0] != "gh":
+        return None
+    if len(segment) < 2:
+        return None
+    return [], segment[1:]
+
+
+def extract_dash_c_pairs(segment: list[str]) -> list[tuple[str, str]]:
+    """Walk a git segment and yield (key, value) for every `-c key=value`.
+
+    Handles `-c k=v` (two tokens) and `-c=k=v` (one token, rare). shlex has
+    already unquoted the value half, so `-c user.name="A B"` arrives here as
+    `["-c", "user.name=A B"]` (two tokens; the inner `=` is the key/value
+    separator handled by `split("=", 1)`).
+    """
+    pairs: list[tuple[str, str]] = []
+    if not segment or segment[0] != "git":
+        return pairs
+
+    i = 1
+    n = len(segment)
+    while i < n:
+        tok = segment[i]
+        if tok == "-c" and i + 1 < n:
+            kv = segment[i + 1]
+            if "=" in kv:
+                key, value = kv.split("=", 1)
+                pairs.append((key, value))
+            i += 2
+            continue
+        if tok.startswith("-c=") and "=" in tok[3:]:
+            kv = tok[3:]
+            key, value = kv.split("=", 1)
+            pairs.append((key, value))
+            i += 1
+            continue
+        # Other value-taking globals — skip the value too.
+        if tok in _GIT_VALUE_GLOBALS:
+            i += 2
+            continue
+        if _is_equals_form_global(tok):
+            i += 1
+            continue
+        if tok in _GIT_BOOL_GLOBALS:
+            i += 1
+            continue
+        # First non-option token is the subcommand — done collecting -c pairs.
+        break
+    return pairs
+
+
+def resolve_tool_cwd(input_data: dict) -> str:
+    """Return the cwd for the tool call.
+
+    The Claude Code harness sets `cwd` on the hook input for tool calls. When
+    present, it is the user's actual working directory at tool-call time —
+    which is what hooks should reason about, NOT the hook's parent process
+    cwd (which is whatever the agent was launched from, often the wrong repo
+    for a worktree subagent — see #144).
+
+    Falls back to os.getcwd() if the field is missing or empty (older
+    harness versions, manual invocations).
+    """
+    cwd = input_data.get("cwd")
+    if cwd and isinstance(cwd, str):
+        return cwd
+    return os.getcwd()
+
+
+def is_shutdown_request_message(message) -> bool:
+    """True iff `message` is a structured shutdown_request, NOT prose containing the phrase.
+
+    Accepts either:
+      - dict with `type: "shutdown_request"` (already-parsed JSON)
+      - str whose JSON-parsed object has `type: "shutdown_request"`
+
+    Plain text messages are NEVER treated as shutdown requests, even if they
+    contain the literal substring. Issue #189: subagents writing
+    "standing down" / "Acknowledge" prose were tripping the substring matcher.
+    """
+    if isinstance(message, dict):
+        return message.get("type") == "shutdown_request"
+    if not isinstance(message, str):
+        return False
+    s = message.strip()
+    if not s.startswith("{"):
+        return False
+    try:
+        obj = json.loads(s)
+    except (json.JSONDecodeError, ValueError):
+        return False
+    return isinstance(obj, dict) and obj.get("type") == "shutdown_request"

--- a/.claude/hooks/block_git_config.py
+++ b/.claude/hooks/block_git_config.py
@@ -5,37 +5,101 @@ The charter mandates per-commit `-c` flags — never modify global or repo-level
 git config. This hook blocks `git config` write commands while allowing reads
 (--get, --get-all, --list, -l) which are needed by Makefile and other tooling.
 
+Input Language
+==============
+
+Fires on:      PreToolUse Bash
+Matches:       git [globals] config [args] (any compound-command segment)
+Does NOT match:
+    - `gh issue create --body-file /tmp/x.md` where the body file mentions
+      "git config" in prose (#216). Tokenized via shlex so data-position
+      "git config" cannot be confused with a command-position invocation.
+    - `grep "git config" /tmp/x` — the literal phrase as an argument value.
+    - `echo "see git config docs"` — prose.
+    - `git -c user.name=X commit` — per-commit identity flags (the very
+      pattern this hook directs callers to).
+    - `git config --get user.name` and other read-only forms.
+
+Flag pass-through:
+    --get / --get-all / --get-regexp / --list / -l / --show-origin /
+    --show-scope → read-only, allowed.
+    Anything else on `git config` → write, blocked.
+
 Exit codes:
   0 — allow (not a git config command, or a read-only operation)
   2 — block (git config write detected)
 """
 
+from __future__ import annotations
+
 import json
 import os
-import re
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from annunaki_log import log_pretooluse_block
-
-# Read-only git config flags/subcommands that should be allowed
-_READ_ONLY_PATTERNS = re.compile(
-    r"--get\b|--get-all\b|--get-regexp\b|--list\b|-l\b|--show-origin\b|--show-scope\b"
+from _shell_parse import (  # noqa: E402
+    find_git_subcommand,
+    iter_command_segments,
+    strip_heredocs,
+    tokenize,
 )
+from annunaki_log import log_pretooluse_block  # noqa: E402
+
+# Read-only flags that mark a `git config` invocation as harmless.
+_READ_ONLY_FLAGS = {
+    "--get",
+    "--get-all",
+    "--get-regexp",
+    "--list",
+    "-l",
+    "--show-origin",
+    "--show-scope",
+}
+
+
+def _is_git_config_write(segment: list[str]) -> bool:
+    """True if `segment` is a `git config <write>` invocation.
+
+    A read-only invocation (any token in `_READ_ONLY_FLAGS` present) returns
+    False; everything else with subcommand `config` returns True.
+    """
+    decoded = find_git_subcommand(segment)
+    if decoded is None:
+        return False
+    _globals, rest = decoded
+    if not rest or rest[0] != "config":
+        return False
+    args = rest[1:]
+    for arg in args:
+        # Match exact token OR equals-form prefix (e.g. --get-regexp=foo).
+        if arg in _READ_ONLY_FLAGS:
+            return False
+        for ro in _READ_ONLY_FLAGS:
+            if arg.startswith(ro + "="):
+                return False
+    return True
 
 
 def check(input_data: dict) -> dict | None:
-    """Check for git config writes. Returns result dict if blocking, None if allowed."""
+    """Check for git config writes. None to allow, dict to block."""
     tool_name = input_data.get("tool_name", "")
     if tool_name != "Bash":
         return None
 
     command = input_data.get("tool_input", {}).get("command", "")
 
-    if not re.search(r"\bgit\s+config\b", command):
-        return None
+    cleaned = strip_heredocs(command)
+    tokens = tokenize(cleaned)
+    if tokens is None:
+        return None  # parse failure → fail open
 
-    if _READ_ONLY_PATTERNS.search(command):
+    triggered = False
+    for segment in iter_command_segments(tokens):
+        if _is_git_config_write(segment):
+            triggered = True
+            break
+
+    if not triggered:
         return None
 
     result = {

--- a/.claude/hooks/block_no_verify.py
+++ b/.claude/hooks/block_no_verify.py
@@ -1,41 +1,101 @@
 #!/usr/bin/env python3
 """PreToolUse hook: Block --no-verify on git commit.
 
-Detects `--no-verify` or `-n` (short form) on git commit commands and requires
-user confirmation before proceeding.
+Detects `--no-verify` or `-n` (short form) on git commit / push commands and
+blocks them — the charter mandates pre-commit hooks must run.
+
+Input Language
+==============
+
+Fires on:      PreToolUse Bash
+Matches:       git [globals] commit [args... including --no-verify or -n]
+               git [globals] push   [args... including --no-verify]
+               (any segment of a compound command)
+Does NOT match:
+    - Heredoc / --body / --body-file argument bodies that mention
+      "--no-verify" in prose (#223). Tokenized via shlex so data-position
+      `--no-verify` cannot be confused with a command-position flag.
+    - `gh issue create --body "..."`, `cat > /tmp/x <<EOF ... --no-verify ... EOF`
+    - `echo "we forbid --no-verify"`
+    - `git commit -F /tmp/msg.txt` where msg.txt happens to contain --no-verify
+      text (the file content is never on the command line at all).
+
+Flag pass-through:
+    --no-verify (long form)  → triggers block
+    -n          (short form) → triggers block ONLY for git commit (`-n` on
+                               git push has different semantics; we keep
+                               coverage commit-only to avoid false-positives).
 
 Exit codes:
-  0 — allow (no --no-verify detected, or not a git commit)
-  2 — block (--no-verify detected, user must confirm)
+  0 — allow (no --no-verify on a git commit/push, or not a git command)
+  2 — block (--no-verify detected on git commit/push)
 """
+
+from __future__ import annotations
 
 import json
 import os
-import re
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from annunaki_log import log_pretooluse_block
+from _shell_parse import (  # noqa: E402
+    find_git_subcommand,
+    iter_command_segments,
+    strip_heredocs,
+    tokenize,
+)
+from annunaki_log import log_pretooluse_block  # noqa: E402
+
+
+def _segment_has_no_verify(segment: list[str]) -> bool:
+    """True if a tokenized git commit/push segment carries --no-verify or -n.
+
+    `-n` is matched only on `git commit` (charter intent: bypassing pre-commit
+    hooks). `git push -n` means dry-run, not bypass; we don't block that.
+    """
+    decoded = find_git_subcommand(segment)
+    if decoded is None:
+        return False
+    _globals, rest = decoded
+    if not rest:
+        return False
+    subcmd = rest[0]
+    if subcmd not in ("commit", "push"):
+        return False
+    args = rest[1:]
+    if "--no-verify" in args:
+        return True
+    if subcmd == "commit" and "-n" in args:
+        return True
+    return False
 
 
 def check(input_data: dict) -> dict | None:
-    """Check for --no-verify. Returns result dict if blocking, None if allowed."""
+    """Check for --no-verify in command-position. None to allow, dict to block."""
     tool_name = input_data.get("tool_name", "")
     if tool_name != "Bash":
         return None
 
     command = input_data.get("tool_input", {}).get("command", "")
 
-    if not re.search(r"\bgit\b.*\bcommit\b", command):
-        return None
+    cleaned = strip_heredocs(command)
+    tokens = tokenize(cleaned)
+    if tokens is None:
+        return None  # parse failure → fail open
 
-    if "--no-verify" not in command:
+    triggered = False
+    for segment in iter_command_segments(tokens):
+        if _segment_has_no_verify(segment):
+            triggered = True
+            break
+
+    if not triggered:
         return None
 
     result = {
         "decision": "block",
         "reason": (
-            "BLOCKED: `--no-verify` detected on git commit. "
+            "BLOCKED: `--no-verify` detected on git commit/push. "
             "This bypasses pre-commit hooks which are required by the charter. "
             "Engineers must not use --no-verify routinely. "
             "If you have a legitimate emergency reason, remove --no-verify and "

--- a/.claude/hooks/block_shutdown_without_retro.py
+++ b/.claude/hooks/block_shutdown_without_retro.py
@@ -1,17 +1,31 @@
 #!/usr/bin/env python3
 """PreToolUse hook: Block agent shutdown until wave retrospective is recorded.
 
-Prevents SendMessage calls containing shutdown_request unless a retrospective
-entry exists in feedback_log.md for today's date.
+Prevents SendMessage calls that carry a structured shutdown_request unless a
+retrospective entry exists in feedback_log.md for today's date.
 
-Exceptions:
-  - Emergency shutdowns (reason: "error" or "crash")
-  - Utility agents (name contains "explorer" or "reviewer")
+Input Language
+==============
+
+Fires on:      PreToolUse SendMessage
+Matches:       SendMessage tool_input where `message` is a STRUCTURED
+               shutdown_request — either a dict with `type: "shutdown_request"`
+               or a JSON-string parseable to such a dict.
+Does NOT match (#189):
+    - Plain prose containing the substring "shutdown_request" but not in a
+      structured JSON object. Subagent stand-down acknowledgments
+      ("standing down", "Acknowledge", "task complete") that happen to
+      mention the phrase in passing are no longer caught.
+    - Utility-agent targets (name contains "explorer", "review", "hook").
+    - Emergency shutdowns where the JSON object's `reason` is "error" or
+      "crash".
 
 Exit codes:
   0 — allow
   2 — block (no retro found for today)
 """
+
+from __future__ import annotations
 
 import json
 import sys
@@ -19,7 +33,8 @@ from datetime import date
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from annunaki_log import log_pretooluse_block
+from _shell_parse import is_shutdown_request_message  # noqa: E402
+from annunaki_log import log_pretooluse_block  # noqa: E402
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 _FEEDBACK_LOG = _REPO_ROOT / ".claude" / "team" / "feedback_log.md"
@@ -39,14 +54,26 @@ def has_retro_for_today() -> bool:
         return False
 
 
-def is_shutdown_request(message: str) -> bool:
-    """Check if the message contains a shutdown request."""
-    return "shutdown_request" in message
+def _parsed_shutdown_obj(message) -> dict | None:
+    """Return the parsed shutdown_request dict, or None if not a structured shutdown."""
+    if isinstance(message, dict) and message.get("type") == "shutdown_request":
+        return message
+    if isinstance(message, str):
+        s = message.strip()
+        if not s.startswith("{"):
+            return None
+        try:
+            obj = json.loads(s)
+        except (json.JSONDecodeError, ValueError):
+            return None
+        if isinstance(obj, dict) and obj.get("type") == "shutdown_request":
+            return obj
+    return None
 
 
-def is_emergency(message: str) -> bool:
-    """Check if this is an emergency shutdown (error/crash)."""
-    return '"reason": "error"' in message or '"reason": "crash"' in message
+def is_emergency(obj: dict) -> bool:
+    """Check if a parsed shutdown_request has reason == error / crash."""
+    return obj.get("reason") in ("error", "crash")
 
 
 def is_utility_agent(tool_input: dict) -> bool:
@@ -55,48 +82,70 @@ def is_utility_agent(tool_input: dict) -> bool:
     return "explorer" in target or "review" in target or "hook" in target
 
 
-def main() -> None:
-    try:
-        input_data = json.load(sys.stdin)
-    except (json.JSONDecodeError, EOFError):
-        sys.exit(0)
+def check(input_data: dict) -> dict | None:
+    """Dispatcher-compatible entry point. None to allow, dict to block.
 
+    Exposed alongside `main()` so tests can drive the hook without going
+    through stdin/exit-code plumbing.
+    """
     tool_name = input_data.get("tool_name", "")
     if tool_name != "SendMessage":
-        sys.exit(0)
+        return None
 
     tool_input = input_data.get("tool_input", {})
     message = tool_input.get("message", "")
 
-    # Only care about shutdown requests
-    if not is_shutdown_request(message):
-        sys.exit(0)
+    # Only care about STRUCTURED shutdown requests (#189 — no more substring
+    # false-positives on prose).
+    if not is_shutdown_request_message(message):
+        return None
+
+    obj = _parsed_shutdown_obj(message)
+    # is_shutdown_request_message returned True, so obj must be parseable;
+    # guard defensively in case of API drift.
+    if obj is None:
+        return None
 
     # Allow emergency shutdowns
-    if is_emergency(message):
-        sys.exit(0)
+    if is_emergency(obj):
+        return None
 
     # Allow utility agent shutdowns
     if is_utility_agent(tool_input):
-        sys.exit(0)
+        return None
 
     # Check for retro
     if has_retro_for_today():
-        sys.exit(0)
+        return None
 
     # Block: no retro found
-    result = {
+    return {
         "decision": "block",
         "reason": (
             "BLOCKED: Cannot shut down agents before running the wave retrospective. "
             "Run /wave-retro or /retro first, then retry shutdown."
         ),
     }
-    log_pretooluse_block(
-        "block_shutdown_without_retro", message, result["reason"], tool_name="SendMessage"
-    )
+
+
+def main() -> None:
+    try:
+        input_data = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        sys.exit(0)
+
+    result = check(input_data)
+    if result is None:
+        sys.exit(0)
+
     print(json.dumps(result))
-    sys.exit(2)
+    if result.get("decision") == "block":
+        message = (input_data.get("tool_input") or {}).get("message", "")
+        log_pretooluse_block(
+            "block_shutdown_without_retro", message, result["reason"], tool_name="SendMessage"
+        )
+        sys.exit(2)
+    sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/.claude/hooks/tests/test_block_git_config.py
+++ b/.claude/hooks/tests/test_block_git_config.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Tests for block_git_config — covers #216 (heredoc-body false-positive).
+
+Run: ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/test_block_git_config.py -v
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_HOOKS_DIR = _HERE.parent
+sys.path.insert(0, str(_HOOKS_DIR))
+
+import block_git_config as hook  # noqa: E402
+
+
+def _input(command: str) -> dict:
+    return {"tool_name": "Bash", "tool_input": {"command": command}}
+
+
+class PositiveMatchTests(unittest.TestCase):
+    """Real `git config` writes MUST be blocked."""
+
+    def test_simple_write(self):
+        result = hook.check(_input("git config --global user.name foo"))
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+
+    def test_repo_level_write(self):
+        result = hook.check(_input("git config user.name foo"))
+        self.assertIsNotNone(result)
+
+    def test_with_dash_C_global(self):
+        result = hook.check(_input("git -C /repo config user.name foo"))
+        self.assertIsNotNone(result)
+
+
+class NegativeMatchTests(unittest.TestCase):
+    """#216: prose / --body / --body-file content must NOT trigger.
+
+    Also covers read-only forms (charter requirement)."""
+
+    def test_per_commit_dash_c_user_name(self):
+        """Per-commit -c flag — the very pattern this hook directs callers to."""
+        cmd = 'git -c user.name="A" -c user.email="a@b.c" commit -m "x"'
+        self.assertIsNone(hook.check(_input(cmd)))
+
+    def test_heredoc_body_mentions_phrase(self):
+        """The exact #216 repro: gh issue body mentioning 'git config'."""
+        cmd = (
+            "gh issue create --repo noorinalabs/noorinalabs-main "
+            "--body-file /tmp/issue_audit_body.md"
+        )
+        # body-file content is not on the command line at all — trivially safe
+        # even before the fix. But:
+        self.assertIsNone(hook.check(_input(cmd)))
+
+    def test_inline_body_mentions_phrase(self):
+        cmd = 'gh issue create --body "the git config write block trips here"'
+        self.assertIsNone(hook.check(_input(cmd)))
+
+    def test_heredoc_inline_mentions_phrase(self):
+        cmd = "cat > /tmp/x.md <<'EOF'\nWe block git config because of the charter rule.\nEOF"
+        self.assertIsNone(hook.check(_input(cmd)))
+
+    def test_grep_for_phrase(self):
+        self.assertIsNone(hook.check(_input('grep "git config" /tmp/foo')))
+
+    def test_echo_phrase(self):
+        self.assertIsNone(hook.check(_input('echo "see git config docs"')))
+
+    def test_read_only_get(self):
+        self.assertIsNone(hook.check(_input("git config --get user.name")))
+
+    def test_read_only_list(self):
+        self.assertIsNone(hook.check(_input("git config --list")))
+
+    def test_read_only_l_short(self):
+        self.assertIsNone(hook.check(_input("git config -l")))
+
+    def test_read_only_get_regexp(self):
+        self.assertIsNone(hook.check(_input("git config --get-regexp ^user")))
+
+    def test_non_bash_tool(self):
+        self.assertIsNone(
+            hook.check(
+                {
+                    "tool_name": "Edit",
+                    "tool_input": {"command": "git config user.name foo"},
+                }
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/hooks/tests/test_block_no_verify.py
+++ b/.claude/hooks/tests/test_block_no_verify.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Tests for block_no_verify — covers #223 (heredoc-body false-positive).
+
+Run: ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/test_block_no_verify.py -v
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_HOOKS_DIR = _HERE.parent
+sys.path.insert(0, str(_HOOKS_DIR))
+
+import block_no_verify as hook  # noqa: E402
+
+
+def _input(command: str) -> dict:
+    return {"tool_name": "Bash", "tool_input": {"command": command}}
+
+
+class PositiveMatchTests(unittest.TestCase):
+    """Real `--no-verify` invocations MUST be blocked."""
+
+    def test_commit_long_form(self):
+        result = hook.check(_input('git commit --no-verify -m "x"'))
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+
+    def test_commit_short_form(self):
+        result = hook.check(_input('git commit -n -m "x"'))
+        self.assertIsNotNone(result)
+
+    def test_commit_with_dash_c_globals(self):
+        result = hook.check(
+            _input('git -c user.name="A" -c user.email="a@b.c" commit --no-verify -m "x"')
+        )
+        self.assertIsNotNone(result)
+
+    def test_commit_flag_after_message(self):
+        result = hook.check(_input('git commit -m "x" --no-verify'))
+        self.assertIsNotNone(result)
+
+    def test_push_long_form(self):
+        result = hook.check(_input("git push --no-verify origin main"))
+        self.assertIsNotNone(result)
+
+
+class NegativeMatchTests(unittest.TestCase):
+    """#223: heredoc / --body / --body-file content must NOT trigger."""
+
+    def test_heredoc_body_mentions_phrase(self):
+        cmd = (
+            "cat > /tmp/x.md <<'EOF'\n"
+            "Requestor: Aino\n"
+            "We never use --no-verify in this codebase.\n"
+            "EOF"
+        )
+        self.assertIsNone(hook.check(_input(cmd)))
+
+    def test_gh_issue_body_mentions_phrase(self):
+        cmd = 'gh issue create --body "see policy on --no-verify"'
+        self.assertIsNone(hook.check(_input(cmd)))
+
+    def test_echo_mentions_phrase(self):
+        self.assertIsNone(hook.check(_input('echo "we do not allow --no-verify"')))
+
+    def test_unrelated_command_with_substring(self):
+        self.assertIsNone(hook.check(_input("grep '\\-\\-no-verify' /tmp/foo")))
+
+    def test_non_bash_tool(self):
+        self.assertIsNone(
+            hook.check(
+                {
+                    "tool_name": "Edit",
+                    "tool_input": {"command": "git commit --no-verify"},
+                }
+            )
+        )
+
+    def test_git_push_with_dash_n_is_dry_run_not_blocked(self):
+        """`git push -n` is dry-run, not bypass — we don't block it."""
+        self.assertIsNone(hook.check(_input("git push -n origin main")))
+
+    def test_no_git_at_all(self):
+        self.assertIsNone(hook.check(_input("ls --no-verify-flag")))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/hooks/tests/test_block_shutdown_without_retro.py
+++ b/.claude/hooks/tests/test_block_shutdown_without_retro.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Tests for block_shutdown_without_retro — covers #189 (prose false-positive).
+
+Run: ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/test_block_shutdown_without_retro.py -v
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+_HERE = Path(__file__).resolve().parent
+_HOOKS_DIR = _HERE.parent
+sys.path.insert(0, str(_HOOKS_DIR))
+
+import block_shutdown_without_retro as hook  # noqa: E402
+
+
+def _input(message, to: str = "team-lead") -> dict:
+    return {
+        "tool_name": "SendMessage",
+        "tool_input": {"to": to, "message": message},
+    }
+
+
+class PositiveMatchTests(unittest.TestCase):
+    """Structured shutdown_request without retro MUST block."""
+
+    def test_dict_form_blocks_when_no_retro(self):
+        with mock.patch.object(hook, "has_retro_for_today", return_value=False):
+            result = hook.check(_input({"type": "shutdown_request", "reason": "done"}))
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+
+    def test_json_string_form_blocks_when_no_retro(self):
+        with mock.patch.object(hook, "has_retro_for_today", return_value=False):
+            result = hook.check(_input('{"type": "shutdown_request", "reason": "done"}'))
+        self.assertIsNotNone(result)
+
+
+class NegativeMatchTests(unittest.TestCase):
+    """#189: prose mentioning the phrase must NOT trigger."""
+
+    def test_prose_with_substring_does_not_block(self):
+        """The exact #189 false-positive: 'standing down' + 'Acknowledge'."""
+        with mock.patch.object(hook, "has_retro_for_today", return_value=False):
+            result = hook.check(
+                _input("Standing down. Acknowledged the shutdown_request from team-lead.")
+            )
+        self.assertIsNone(result)
+
+    def test_subagent_task_complete_does_not_block(self):
+        """Subagent stand-down acknowledgment must not be caught."""
+        with mock.patch.object(hook, "has_retro_for_today", return_value=False):
+            result = hook.check(
+                _input("PR #555 is open with reviewer comments posted. Going idle.")
+            )
+        self.assertIsNone(result)
+
+    def test_unrelated_message(self):
+        with mock.patch.object(hook, "has_retro_for_today", return_value=False):
+            result = hook.check(_input("Hi, please review PR #100."))
+        self.assertIsNone(result)
+
+    def test_emergency_shutdown_allowed(self):
+        with mock.patch.object(hook, "has_retro_for_today", return_value=False):
+            result = hook.check(_input({"type": "shutdown_request", "reason": "error"}))
+        self.assertIsNone(result)
+
+    def test_crash_shutdown_allowed(self):
+        with mock.patch.object(hook, "has_retro_for_today", return_value=False):
+            result = hook.check(_input({"type": "shutdown_request", "reason": "crash"}))
+        self.assertIsNone(result)
+
+    def test_utility_agent_explorer_allowed(self):
+        with mock.patch.object(hook, "has_retro_for_today", return_value=False):
+            result = hook.check(_input({"type": "shutdown_request"}, to="explorer-agent"))
+        self.assertIsNone(result)
+
+    def test_with_retro_allowed(self):
+        with mock.patch.object(hook, "has_retro_for_today", return_value=True):
+            result = hook.check(_input({"type": "shutdown_request"}))
+        self.assertIsNone(result)
+
+    def test_non_sendmessage_tool(self):
+        result = hook.check(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": '{"type": "shutdown_request"}'},
+            }
+        )
+        self.assertIsNone(result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/hooks/tests/test_shell_parse.py
+++ b/.claude/hooks/tests/test_shell_parse.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Tests for `_shell_parse` — the shared shell-arg-aware parser helper.
+
+Covers the public API (tokenize, strip_heredocs, iter_command_segments,
+find_git_subcommand, find_gh_subcommand, extract_dash_c_pairs,
+resolve_tool_cwd, is_shutdown_request_message) and the negative-match
+fixtures from the sibling-bug cluster (#226 #227 #223 #216 #188 #189 #144).
+
+Run: ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/test_shell_parse.py -v
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_HOOKS_DIR = _HERE.parent
+sys.path.insert(0, str(_HOOKS_DIR))
+
+import _shell_parse as sp  # noqa: E402
+
+
+class TokenizeTests(unittest.TestCase):
+    def test_simple(self):
+        self.assertEqual(sp.tokenize("git commit -m foo"), ["git", "commit", "-m", "foo"])
+
+    def test_quoted_value_kept_whole(self):
+        # shlex absorbs the surrounding quotes; "A B" becomes one token "A B".
+        self.assertEqual(
+            sp.tokenize('git -c user.name="A B" commit'),
+            ["git", "-c", "user.name=A B", "commit"],
+        )
+
+    def test_unquoted_value_bounded_by_whitespace(self):
+        """#226 repro: bare email value does NOT slurp to EOL."""
+        cmd = "git -c user.email=a@b.c commit -F /tmp/m.txt 2>&1 | tail -20"
+        toks = sp.tokenize(cmd)
+        # The email arrives as ONE shlex token; not slurped through the rest.
+        self.assertIn("user.email=a@b.c", toks)
+
+    def test_malformed_quote_returns_none(self):
+        self.assertIsNone(sp.tokenize('git commit -m "unterminated'))
+
+
+class StripHeredocsTests(unittest.TestCase):
+    def test_simple_heredoc(self):
+        cmd = "cat <<EOF\nbody\nEOF\necho done"
+        self.assertNotIn("body", sp.strip_heredocs(cmd))
+
+    def test_quoted_delimiter(self):
+        cmd = "cat <<'EOF'\nbody --no-verify\nEOF\necho done"
+        self.assertNotIn("body --no-verify", sp.strip_heredocs(cmd))
+
+    def test_double_quoted_delimiter(self):
+        cmd = 'cat <<"EOF"\ngit config foo bar\nEOF\necho done'
+        self.assertNotIn("git config foo bar", sp.strip_heredocs(cmd))
+
+    def test_dash_form(self):
+        cmd = "cat <<-EOF\n\tinside\n\tEOF\necho done"
+        self.assertNotIn("inside", sp.strip_heredocs(cmd))
+
+    def test_repeated_heredocs(self):
+        cmd = "cat <<EOF\nbody1 git config foo\nEOF\ncat <<EOF\nbody2 --no-verify\nEOF\necho done"
+        out = sp.strip_heredocs(cmd)
+        self.assertNotIn("body1", out)
+        self.assertNotIn("body2", out)
+
+
+class IterCommandSegmentsTests(unittest.TestCase):
+    def test_empty(self):
+        self.assertEqual(list(sp.iter_command_segments([])), [])
+
+    def test_single_segment(self):
+        toks = ["git", "commit", "-m", "x"]
+        self.assertEqual(list(sp.iter_command_segments(toks)), [toks])
+
+    def test_split_on_amp_amp(self):
+        toks = ["cd", "/foo", "&&", "git", "commit"]
+        self.assertEqual(
+            list(sp.iter_command_segments(toks)),
+            [["cd", "/foo"], ["git", "commit"]],
+        )
+
+    def test_split_on_pipe(self):
+        toks = ["echo", "x", "|", "tail"]
+        self.assertEqual(
+            list(sp.iter_command_segments(toks)),
+            [["echo", "x"], ["tail"]],
+        )
+
+    def test_strips_leading_env_assignments(self):
+        toks = ["FOO=bar", "BAR=baz", "git", "commit"]
+        self.assertEqual(
+            list(sp.iter_command_segments(toks)),
+            [["git", "commit"]],
+        )
+
+    def test_env_only_segment_is_skipped(self):
+        toks = ["FOO=bar", ";", "git", "commit"]
+        self.assertEqual(
+            list(sp.iter_command_segments(toks)),
+            [["git", "commit"]],
+        )
+
+
+class FindGitSubcommandTests(unittest.TestCase):
+    def test_plain_git_commit(self):
+        out = sp.find_git_subcommand(["git", "commit", "-m", "x"])
+        self.assertIsNotNone(out)
+        assert out is not None
+        globals_, rest = out
+        self.assertEqual(globals_, [])
+        self.assertEqual(rest, ["commit", "-m", "x"])
+
+    def test_dash_c_globals_skipped(self):
+        out = sp.find_git_subcommand(
+            ["git", "-c", "user.name=A", "-c", "user.email=a@b.c", "commit"]
+        )
+        self.assertIsNotNone(out)
+        assert out is not None
+        globals_, rest = out
+        self.assertEqual(globals_, ["-c", "user.name=A", "-c", "user.email=a@b.c"])
+        self.assertEqual(rest, ["commit"])
+
+    def test_dash_C_globals_skipped(self):
+        out = sp.find_git_subcommand(["git", "-C", "/repo", "config", "--list"])
+        self.assertIsNotNone(out)
+        assert out is not None
+        _globals, rest = out
+        self.assertEqual(rest[0], "config")
+
+    def test_not_git(self):
+        self.assertIsNone(sp.find_git_subcommand(["echo", "git", "commit"]))
+
+    def test_only_git_without_subcommand(self):
+        self.assertIsNone(sp.find_git_subcommand(["git"]))
+
+    def test_only_globals_no_subcommand(self):
+        self.assertIsNone(sp.find_git_subcommand(["git", "-c", "user.name=A"]))
+
+
+class FindGhSubcommandTests(unittest.TestCase):
+    def test_gh_pr_create(self):
+        out = sp.find_gh_subcommand(["gh", "pr", "create", "--repo", "x/y"])
+        self.assertIsNotNone(out)
+        assert out is not None
+        _globals, rest = out
+        self.assertEqual(rest, ["pr", "create", "--repo", "x/y"])
+
+    def test_not_gh(self):
+        self.assertIsNone(sp.find_gh_subcommand(["git", "commit"]))
+
+
+class ExtractDashCPairsTests(unittest.TestCase):
+    def test_simple(self):
+        pairs = sp.extract_dash_c_pairs(
+            ["git", "-c", "user.name=Alice", "-c", "user.email=a@b.c", "commit"]
+        )
+        self.assertEqual(pairs, [("user.name", "Alice"), ("user.email", "a@b.c")])
+
+    def test_quoted_value_unquoted_by_shlex(self):
+        """shlex preserves spaces inside quotes as one token."""
+        # Simulates the post-tokenize state of: -c user.name="Alice Bob"
+        pairs = sp.extract_dash_c_pairs(["git", "-c", "user.name=Alice Bob", "commit"])
+        self.assertEqual(pairs, [("user.name", "Alice Bob")])
+
+    def test_unquoted_email_is_clean_pair(self):
+        """#226 repro: unquoted bare email is correctly bounded."""
+        pairs = sp.extract_dash_c_pairs(
+            ["git", "-c", "user.email=parametrization+Idris.Yusuf@gmail.com", "commit"]
+        )
+        self.assertEqual(
+            pairs,
+            [("user.email", "parametrization+Idris.Yusuf@gmail.com")],
+        )
+
+    def test_no_pairs_when_no_dash_c(self):
+        pairs = sp.extract_dash_c_pairs(["git", "commit", "-m", "x"])
+        self.assertEqual(pairs, [])
+
+    def test_skips_other_globals(self):
+        pairs = sp.extract_dash_c_pairs(["git", "-C", "/repo", "-c", "user.name=Alice", "commit"])
+        self.assertEqual(pairs, [("user.name", "Alice")])
+
+
+class ResolveToolCwdTests(unittest.TestCase):
+    def test_uses_input_cwd(self):
+        self.assertEqual(sp.resolve_tool_cwd({"cwd": "/foo/bar"}), "/foo/bar")
+
+    def test_falls_back_to_getcwd(self):
+        result = sp.resolve_tool_cwd({})
+        self.assertEqual(result, os.getcwd())
+
+    def test_empty_string_falls_back(self):
+        result = sp.resolve_tool_cwd({"cwd": ""})
+        self.assertEqual(result, os.getcwd())
+
+    def test_non_string_falls_back(self):
+        result = sp.resolve_tool_cwd({"cwd": 123})
+        self.assertEqual(result, os.getcwd())
+
+
+class IsShutdownRequestMessageTests(unittest.TestCase):
+    """#189: only structured shutdown_request JSON, not prose."""
+
+    def test_dict_form(self):
+        self.assertTrue(sp.is_shutdown_request_message({"type": "shutdown_request"}))
+
+    def test_dict_with_other_type(self):
+        self.assertFalse(sp.is_shutdown_request_message({"type": "task_complete"}))
+
+    def test_json_string_form(self):
+        self.assertTrue(
+            sp.is_shutdown_request_message('{"type": "shutdown_request", "reason": "done"}')
+        )
+
+    def test_prose_with_substring(self):
+        """The exact #189 false-positive: prose containing the phrase."""
+        self.assertFalse(
+            sp.is_shutdown_request_message(
+                "Standing down. Acknowledged the shutdown_request from the lead."
+            )
+        )
+
+    def test_prose_with_only_keyword(self):
+        self.assertFalse(sp.is_shutdown_request_message("shutdown_request"))
+
+    def test_empty_string(self):
+        self.assertFalse(sp.is_shutdown_request_message(""))
+
+    def test_malformed_json(self):
+        self.assertFalse(sp.is_shutdown_request_message("{ not json"))
+
+    def test_non_string_non_dict(self):
+        self.assertFalse(sp.is_shutdown_request_message(123))
+        self.assertFalse(sp.is_shutdown_request_message(None))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/hooks/tests/test_shell_parse.py
+++ b/.claude/hooks/tests/test_shell_parse.py
@@ -185,6 +185,19 @@ class ExtractDashCPairsTests(unittest.TestCase):
         pairs = sp.extract_dash_c_pairs(["git", "-C", "/repo", "-c", "user.name=Alice", "commit"])
         self.assertEqual(pairs, [("user.name", "Alice")])
 
+    def test_repeated_key_returns_all_pairs_in_source_order(self):
+        """API contract pin: repeated keys returned in source order; callers dedup.
+
+        `git -c user.name=A -c user.name=B commit` is legal git (last wins).
+        Helper returns ALL pairs in source order; callers needing last-wins
+        do `dict(extract_dash_c_pairs(...))` (later-key overwrite-earlier in
+        dict construction).
+        """
+        pairs = sp.extract_dash_c_pairs(["git", "-c", "user.name=A", "-c", "user.name=B", "commit"])
+        self.assertEqual(pairs, [("user.name", "A"), ("user.name", "B")])
+        # dict-cast gives last-wins, matching git semantics.
+        self.assertEqual(dict(pairs), {"user.name": "B"})
+
 
 class ResolveToolCwdTests(unittest.TestCase):
     def test_uses_input_cwd(self):

--- a/.claude/hooks/tests/test_validate_branch_freshness.py
+++ b/.claude/hooks/tests/test_validate_branch_freshness.py
@@ -142,33 +142,49 @@ class GateMatchingTests(unittest.TestCase):
 
 
 class CheckLocalPathTests(unittest.TestCase):
-    """End-to-end check() with the cwd-based (no --repo) path mocked."""
+    """End-to-end check() with the cwd-based (no --repo) path mocked.
+
+    Post-#227: the legacy local path is only consulted when the cwd has no
+    resolvable github `origin` remote. To keep these tests focused on the
+    local path, `_resolve_implicit_repo` is patched to return None — that
+    forces the legacy code path. The implicit-repo path has its own
+    coverage in `CheckImplicitRepoTests`.
+    """
 
     @staticmethod
     def _input(command: str) -> dict:
         return {"tool_name": "Bash", "tool_input": {"command": command}}
 
     def test_local_fresh_branch_allows(self):
-        with mock.patch.object(hook, "is_branch_fresh_local", return_value=True) as mocked:
+        with (
+            mock.patch.object(hook, "_resolve_implicit_repo", return_value=None),
+            mock.patch.object(hook, "is_branch_fresh_local", return_value=True) as mocked,
+        ):
             result = hook.check(self._input("gh pr create"))
         self.assertIsNone(result)
-        mocked.assert_called_once_with("main")
+        mocked.assert_called_once()
+        self.assertEqual(mocked.call_args.args[0], "main")
 
     def test_local_stale_branch_blocks(self):
-        with mock.patch.object(hook, "is_branch_fresh_local", return_value=False):
+        with (
+            mock.patch.object(hook, "_resolve_implicit_repo", return_value=None),
+            mock.patch.object(hook, "is_branch_fresh_local", return_value=False),
+        ):
             result = hook.check(self._input("gh pr create"))
         self.assertIsNotNone(result)
         self.assertEqual(result["decision"], "block")
         self.assertIn("origin/main", result["reason"])
 
     def test_local_path_used_when_no_repo_flag(self):
-        """Without --repo, the cwd-based check is the only path consulted."""
+        """Without --repo and without a github origin, the cwd-based check is consulted."""
         with (
+            mock.patch.object(hook, "_resolve_implicit_repo", return_value=None),
             mock.patch.object(hook, "is_branch_fresh_local", return_value=True) as local_mock,
             mock.patch.object(hook, "is_branch_fresh_remote") as remote_mock,
         ):
             hook.check(self._input("gh pr create --base develop"))
-        local_mock.assert_called_once_with("develop")
+        local_mock.assert_called_once()
+        self.assertEqual(local_mock.call_args.args[0], "develop")
         remote_mock.assert_not_called()
 
 
@@ -244,6 +260,128 @@ class CheckRemotePathTests(unittest.TestCase):
             "noorinalabs/noorinalabs-isnad-graph", "main", "L.Pham/0834-feature"
         )
         local_mock.assert_not_called()
+
+
+class CheckImplicitRepoTests(unittest.TestCase):
+    """#227: when --repo is omitted, route via cwd's origin remote.
+
+    Cross-cwd misattribution protection: orchestrator running `gh pr create`
+    (no --repo) from cwd inside repo Y while feature branch lives in worktree
+    targeting repo X. Without implicit-repo resolution we'd evaluate Y's
+    main staleness, which is unrelated to the X PR.
+    """
+
+    @staticmethod
+    def _input(command: str, cwd: str = "/tmp/worktree-x") -> dict:
+        return {
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+            "cwd": cwd,
+        }
+
+    def test_implicit_repo_routes_to_remote_path(self):
+        with (
+            mock.patch.object(hook, "_resolve_implicit_repo", return_value="x/x"),
+            mock.patch.object(hook, "_current_branch", return_value="feat-x"),
+            mock.patch.object(hook, "is_branch_fresh_remote", return_value=True) as remote_mock,
+            mock.patch.object(hook, "is_branch_fresh_local") as local_mock,
+        ):
+            result = hook.check(self._input("gh pr create"))
+        self.assertIsNone(result)
+        remote_mock.assert_called_once_with("x/x", "main", "feat-x")
+        local_mock.assert_not_called()
+
+    def test_implicit_repo_stale_branch_blocks(self):
+        with (
+            mock.patch.object(hook, "_resolve_implicit_repo", return_value="x/x"),
+            mock.patch.object(hook, "_current_branch", return_value="feat-x"),
+            mock.patch.object(hook, "is_branch_fresh_remote", return_value=False),
+        ):
+            result = hook.check(self._input("gh pr create"))
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertIn("x/x:main", result["reason"])
+
+    def test_implicit_repo_with_explicit_head(self):
+        """Explicit --head wins over the cwd-current-branch fallback."""
+        with (
+            mock.patch.object(hook, "_resolve_implicit_repo", return_value="x/x"),
+            mock.patch.object(hook, "_current_branch") as branch_mock,
+            mock.patch.object(hook, "is_branch_fresh_remote", return_value=True) as remote_mock,
+        ):
+            hook.check(self._input("gh pr create --head explicit-feat"))
+        remote_mock.assert_called_once_with("x/x", "main", "explicit-feat")
+        branch_mock.assert_not_called()
+
+    def test_repro_for_issue_227(self):
+        """#227 exact repro: gh pr create from parent cwd against child user-service.
+
+        Pre-fix: with no `--repo` the hook ran git fetch + merge-base in
+        the parent's cwd and false-positive-blocked on parent's stale main.
+        Post-fix: implicit-repo resolves to the WORKTREE's origin remote
+        (the user-service repo), and we correctly check that branch.
+        """
+        cmd = 'gh pr create --title "fix(ci): trigger ci.yml" --body-file /tmp/uss-81-pr.txt'
+        with (
+            # Worktree resolves to user-service, not the parent repo.
+            mock.patch.object(
+                hook,
+                "_resolve_implicit_repo",
+                return_value="noorinalabs/noorinalabs-user-service",
+            ),
+            mock.patch.object(
+                hook, "_current_branch", return_value="M.Salazar/0081-ci-deployments"
+            ),
+            mock.patch.object(hook, "is_branch_fresh_remote", return_value=True),
+            mock.patch.object(hook, "is_branch_fresh_local") as local_mock,
+        ):
+            result = hook.check(self._input(cmd))
+        self.assertIsNone(
+            result,
+            "#227: cross-cwd `gh pr create` should not be blocked by parent repo state",
+        )
+        local_mock.assert_not_called()
+
+
+class CwdHandlingTests(unittest.TestCase):
+    """#144: is_branch_fresh_local must run with the user's cwd, not the hook's parent cwd."""
+
+    @staticmethod
+    def _input(command: str, cwd: str | None = None) -> dict:
+        d: dict = {"tool_name": "Bash", "tool_input": {"command": command}}
+        if cwd is not None:
+            d["cwd"] = cwd
+        return d
+
+    def test_cwd_passed_through_to_local_check(self):
+        captured: dict[str, object] = {}
+
+        def fake_local(base: str, cwd: str | None = None) -> bool:
+            captured["base"] = base
+            captured["cwd"] = cwd
+            return True
+
+        with (
+            mock.patch.object(hook, "_resolve_implicit_repo", return_value=None),
+            mock.patch.object(hook, "is_branch_fresh_local", side_effect=fake_local),
+        ):
+            hook.check(self._input("gh pr create", cwd="/tmp/worktree-foo"))
+        self.assertEqual(captured.get("cwd"), "/tmp/worktree-foo")
+        self.assertEqual(captured.get("base"), "main")
+
+    def test_implicit_repo_resolution_uses_input_cwd(self):
+        captured: dict[str, object] = {}
+
+        def fake_resolve(cwd):
+            captured["cwd"] = cwd
+            return None  # force fall-through to local path
+
+        with (
+            mock.patch.object(hook, "_resolve_implicit_repo", side_effect=fake_resolve),
+            mock.patch.object(hook, "is_branch_fresh_local", return_value=True),
+        ):
+            hook.check(self._input("gh pr create", cwd="/tmp/worktree-bar"))
+        self.assertEqual(captured.get("cwd"), "/tmp/worktree-bar")
 
 
 if __name__ == "__main__":

--- a/.claude/hooks/tests/test_validate_commit_identity.py
+++ b/.claude/hooks/tests/test_validate_commit_identity.py
@@ -318,5 +318,57 @@ class MatcherRobustnessTests(unittest.TestCase):
         self.assertIsNone(hook.check(self._input(cmd)))
 
 
+class ParseFailureFailClosedTests(unittest.TestCase):
+    """`tokenize` returns None on shlex parse failure. For commit-identity
+    validation this MUST fail-closed: a malformed-but-commit-shaped command
+    should block, not silently allow. (Per `_shell_parse.tokenize` caller
+    contract pinned with Linh.)
+    """
+
+    @staticmethod
+    def _input(command: str) -> dict:
+        return {"tool_name": "Bash", "tool_input": {"command": command}}
+
+    def test_unbalanced_quote_with_commit_blocks(self):
+        """Unterminated quote + git commit shape → block (don't silently allow)."""
+        cmd = 'git -c user.name="Aino Virtanen -c user.email="a@b.c" commit -m "x"'
+        # Above has an unbalanced quote (the `"Aino Virtanen ` opens and
+        # is never closed before the next `"`, so shlex raises).
+        result = hook.check(self._input(cmd))
+        self.assertIsNotNone(
+            result,
+            "parse failure on a commit-shaped command must block, not allow",
+        )
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+        self.assertIn("shlex parsing", result["reason"])
+
+    def test_unbalanced_quote_without_commit_allows(self):
+        """Parse failure on a non-commit command → allow (no commit to validate)."""
+        cmd = 'echo "unterminated'
+        # Not a git commit; allow.
+        self.assertIsNone(hook.check(self._input(cmd)))
+
+    def test_repeated_dash_c_user_name_uses_last_value(self):
+        """Repeated -c user.name → last value wins (matches git semantics).
+
+        `dict(extract_dash_c_pairs(...))` overwrites earlier entries with
+        later ones, mirroring how git itself resolves repeated -c flags.
+        """
+        valid_name = next(iter(hook.ROSTER), None)
+        if not valid_name:
+            self.skipTest("local roster is empty")
+        valid_email = hook.ROSTER[valid_name]
+        # First name is bogus, last is valid → must allow (last wins).
+        cmd = (
+            f'git -c user.name="NotInRoster" -c user.name="{valid_name}" '
+            f'-c user.email="{valid_email}" commit -m "x"'
+        )
+        self.assertIsNone(
+            hook.check(self._input(cmd)),
+            "last-wins semantics: bogus earlier value should be overridden",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.claude/hooks/tests/test_validate_commit_identity.py
+++ b/.claude/hooks/tests/test_validate_commit_identity.py
@@ -238,5 +238,85 @@ class CheckIntegrationTests(unittest.TestCase):
             self.assertEqual(result.get("decision"), "block")
 
 
+class MatcherRobustnessTests(unittest.TestCase):
+    """Negative-match coverage for the substring-bug cluster (#226, #188, #216)."""
+
+    @staticmethod
+    def _input(command: str) -> dict:
+        return {"tool_name": "Bash", "tool_input": {"command": command}}
+
+    def test_unquoted_email_value_bounded_by_whitespace(self):
+        """#226 repro: bare `-c user.email=val` does NOT slurp to EOL.
+
+        Pre-fix: the regex `-c\\s+user\\.email=["']?([^"']+)["']?` slurped
+        from `user.email=` to the next `"` or end-of-line. With a bare value
+        and no closing quote, the entire rest of the command was captured
+        into the email field. Tokenization via shlex bounds at whitespace.
+        """
+        # Use a name that exists in the local roster so we can verify the
+        # email comparison hits the correct value, not the slurped one.
+        valid_name = next(iter(hook.ROSTER), None)
+        if not valid_name:
+            self.skipTest("local roster is empty")
+        valid_email = hook.ROSTER[valid_name]
+        cmd = (
+            f'git -c user.name="{valid_name}" -c user.email={valid_email} '
+            f"commit -F /tmp/commit-msg.txt 2>&1 | tail -20"
+        )
+        result = hook.check(self._input(cmd))
+        self.assertIsNone(
+            result,
+            "#226: unquoted bare email should be allowed, not slurp to EOL",
+        )
+
+    def test_nested_heredoc_in_command_substitution(self):
+        """#188 repro: `git commit -m "$(cat <<'EOF' ... EOF)"` mangles the parser.
+
+        Pre-fix: `_strip_heredocs` + `_strip_quoted_strings` interaction on
+        nested `$(cat <<'EOF' ... EOF)` inside a double-quoted outer string
+        broke the parser's view of `user.name=...`. shlex tokenization
+        treats the entire `"$(cat <<'EOF' ... EOF)"` as one token (the outer
+        quotes are absorbed; the heredoc body is part of the token's value).
+        """
+        valid_name = next(iter(hook.ROSTER), None)
+        if not valid_name:
+            self.skipTest("local roster is empty")
+        valid_email = hook.ROSTER[valid_name]
+        # The nested form: a heredoc inside a command-substitution inside a
+        # double-quoted -m argument.
+        cmd = (
+            f'git -c user.name="{valid_name}" -c user.email="{valid_email}" '
+            "commit -m \"$(cat <<'EOF'\nmulti\nline\nmessage\nEOF\n)\""
+        )
+        result = hook.check(self._input(cmd))
+        self.assertIsNone(
+            result,
+            "#188: nested heredoc-in-command-sub-in-double-quote should not block",
+        )
+
+    def test_heredoc_body_with_git_commit_phrase_does_not_match(self):
+        """#216 sibling: heredoc body containing 'git commit' is not a real commit."""
+        cmd = (
+            "cat > /tmp/x.md <<'EOF'\n"
+            "Here is how to git commit with -c flags:\n"
+            'git -c user.name="X" commit -m "..."\n'
+            "EOF"
+        )
+        # Not a real commit invocation — should not require identity.
+        self.assertIsNone(hook.check(self._input(cmd)))
+
+    def test_label_validator_filename_no_longer_blocks(self):
+        """#226 meta-instance: --body-file path inside --label list.
+
+        The label validator (separate hook) can mistake a file path that
+        appears between `--body-file` and `--label` for a label value. This
+        hook isn't directly affected — covered for adjacency only.
+        """
+        # validate_commit_identity is on git, not gh. Just confirm gh
+        # invocations are not flagged here.
+        cmd = 'gh issue create --body-file /tmp/issue-body.txt --label "tech-debt,infrastructure"'
+        self.assertIsNone(hook.check(self._input(cmd)))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.claude/hooks/validate_branch_freshness.py
+++ b/.claude/hooks/validate_branch_freshness.py
@@ -33,10 +33,36 @@ Tokenization:
   pattern as validate_labels (#113) -- guarantees that text inside a
   --body "..." heredoc cannot leak into base/head/repo extraction.
 
+Cwd handling (#144):
+  The local-path freshness check (`is_branch_fresh_local`) MUST anchor its
+  `git fetch` / `git merge-base` calls in the user's actual cwd at tool-call
+  time, not the hook's parent process cwd. The orchestrator commonly runs
+  from the parent repo while a worktree subagent's `gh pr create` targets
+  the worktree's branch — anchoring on parent cwd evaluates the wrong
+  repo's HEAD against origin. `_shell_parse.resolve_tool_cwd(input_data)`
+  returns `input_data["cwd"]` (set by the harness) when present, falling
+  back to `os.getcwd()`.
+
+Implicit-repo resolution (#227):
+  When `--repo` is omitted, the hook still routes through the API path if
+  the cwd's `origin` remote resolves to a known `OWNER/REPO` slug. This
+  protects against the cross-cwd misattribution case: orchestrator runs
+  `gh pr create` (no --repo) from cwd inside parent repo Y while the actual
+  feature branch lives in worktree X targeting repo X. Without implicit-repo
+  resolution we'd run `git fetch origin main` in repo Y and get a
+  false-positive on Y's stale main. With it, we hit the gh compare API for
+  X (the worktree's actual remote) and check its branch correctly.
+
+  Implementation: `_resolve_implicit_repo(cwd)` parses `git -C <cwd> remote
+  get-url origin` and extracts `OWNER/REPO` from common github URL forms.
+  Returns None on any parse failure → falls back to the legacy local check.
+
 Exit codes:
   0 -- allow (not the matched command, branch is up to date, or check could not run)
   2 -- block (branch is behind base)
 """
+
+from __future__ import annotations
 
 import json
 import os
@@ -46,11 +72,19 @@ import subprocess
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from annunaki_log import log_pretooluse_block
+from _shell_parse import resolve_tool_cwd  # noqa: E402
+from annunaki_log import log_pretooluse_block  # noqa: E402
 
 _BASE_FLAGS = {"--base", "-B"}
 _HEAD_FLAGS = {"--head", "-H"}
 _REPO_FLAGS = {"--repo", "-R"}
+
+# Match an OWNER/REPO suffix on a git remote URL. Handles:
+#   git@github.com:owner/repo.git
+#   https://github.com/owner/repo.git
+#   https://github.com/owner/repo
+#   ssh://git@github.com/owner/repo.git
+_REPO_SLUG_RE = re.compile(r"github\.com[/:]([^/]+/[^/.\s]+?)(?:\.git)?/?$")
 
 
 def _tokenize(command: str) -> list[str] | None:
@@ -139,24 +173,75 @@ def extract_repo(command: str) -> str | None:
     return _first_flag_value(command, _REPO_FLAGS)
 
 
-def is_branch_fresh_local(base: str) -> bool:
-    """cwd-based check: HEAD contains the latest commit from origin/base."""
+def is_branch_fresh_local(base: str, cwd: str | None = None) -> bool:
+    """cwd-based check: HEAD contains the latest commit from origin/base.
+
+    `cwd` anchors the subprocess calls so worktree subagents inspect their
+    own branch state, not the parent process's git state (#144).
+    """
     try:
         subprocess.run(
             ["git", "fetch", "origin", base],
             capture_output=True,
             text=True,
             timeout=30,
+            cwd=cwd,
         )
         result = subprocess.run(
             ["git", "merge-base", "--is-ancestor", f"origin/{base}", "HEAD"],
             capture_output=True,
             text=True,
             timeout=10,
+            cwd=cwd,
         )
         return result.returncode == 0
     except (subprocess.TimeoutExpired, FileNotFoundError):
         return True
+
+
+def _resolve_implicit_repo(cwd: str | None) -> str | None:
+    """Return the OWNER/REPO of `cwd`'s `origin` remote, or None if not on github.
+
+    Used when the user runs `gh pr create` without `--repo`: the implicit
+    target is the cwd's tracked github remote. Anchors the subprocess on
+    `cwd` (a worktree may have a different `origin` than the parent repo).
+    """
+    try:
+        result = subprocess.run(
+            ["git", "remote", "get-url", "origin"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            cwd=cwd,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    url = (result.stdout or "").strip()
+    if not url:
+        return None
+    match = _REPO_SLUG_RE.search(url)
+    if not match:
+        return None
+    return match.group(1)
+
+
+def _current_branch(cwd: str | None) -> str | None:
+    """Return the current branch in `cwd`, or None on failure."""
+    try:
+        result = subprocess.run(
+            ["git", "symbolic-ref", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            cwd=cwd,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    return (result.stdout or "").strip() or None
 
 
 def is_branch_fresh_remote(repo: str, base: str, head: str) -> bool | None:
@@ -204,26 +289,43 @@ def check(input_data: dict) -> dict | None:
         if not re.search(r"\bgh\s+pr\s+create\b", command):
             return None
 
+    cwd = resolve_tool_cwd(input_data)
     base = extract_base(command)
     repo = extract_repo(command)
+    head = extract_head(command)
 
     if repo:
-        head = extract_head(command)
+        # Explicit --repo target: API path requires --head to know what branch
+        # to compare. Without --head we cannot reliably infer; skip.
         if not head:
             return None
         fresh = is_branch_fresh_remote(repo, base, head)
         if fresh is None or fresh:
             return None
+        target = f"{repo}:{base}"
+        rebase_hint = f"Rebase the head branch onto {target} on the target repo."
     else:
-        if is_branch_fresh_local(base):
-            return None
+        # No --repo: prefer the implicit-repo API path when we can resolve
+        # the cwd's `origin` to a github slug (#227 — cross-cwd misattribution
+        # protection). Fall back to the local-cwd path if not on github.
+        implicit_repo = _resolve_implicit_repo(cwd)
+        if implicit_repo:
+            implicit_head = head or _current_branch(cwd)
+            if not implicit_head:
+                # Cannot determine the head branch — fail open (same as
+                # explicit --repo without --head).
+                return None
+            fresh = is_branch_fresh_remote(implicit_repo, base, implicit_head)
+            if fresh is None or fresh:
+                return None
+            target = f"{implicit_repo}:{base}"
+            rebase_hint = f"Rebase the head branch onto {target} on the target repo."
+        else:
+            if is_branch_fresh_local(base, cwd=cwd):
+                return None
+            target = f"origin/{base}"
+            rebase_hint = f"Run: git fetch origin && git merge origin/{base}"
 
-    target = f"{repo}:{base}" if repo else f"origin/{base}"
-    rebase_hint = (
-        f"Rebase the head branch onto {target} on the target repo."
-        if repo
-        else f"Run: git fetch origin && git merge origin/{base}"
-    )
     result = {
         "decision": "block",
         "reason": (

--- a/.claude/hooks/validate_commit_identity.py
+++ b/.claude/hooks/validate_commit_identity.py
@@ -136,7 +136,10 @@ def _find_commit_segment(command: str) -> list[str] | None:
     the first segment whose `find_git_subcommand` resolves to subcommand
     `commit`.
 
-    Returns None on tokenization failure (caller treats as "not a commit").
+    Returns None on parse failure OR when there is no commit. The caller
+    distinguishes the two via `_looks_like_git_commit` so a malformed-but-
+    suspicious command falls through to a fail-closed regex path instead
+    of being silently allowed (per `_shell_parse.tokenize` contract).
     """
     cleaned = strip_heredocs(command)
     tokens = tokenize(cleaned)
@@ -152,6 +155,29 @@ def _find_commit_segment(command: str) -> list[str] | None:
     return None
 
 
+# Regex-only heuristic for the parse-failure fallback: did the command,
+# after stripping heredocs, contain `git ... commit` at command position?
+# Anchored at start-of-line or after a shell operator. Liberal on purpose
+# — when shlex fails we want to err on the side of validating identity.
+_COMMIT_FALLBACK_RE = re.compile(
+    r"(?:^|[;&|]\s*|&&\s*|\|\|\s*)\s*git\b[^;&|]*?\bcommit\b",
+    re.MULTILINE,
+)
+
+
+def _looks_like_git_commit(command: str) -> bool:
+    """Regex fallback used when shlex.split fails (unbalanced quotes etc.).
+
+    Strips heredocs, then searches for `git ... commit` in command position.
+    This is a deliberately broad heuristic: a parse-failure-and-no-commit-
+    looking command falls through to allow, but a parse-failure-with-commit-
+    looking command blocks (fail-closed for security-relevant validation,
+    per the `_shell_parse.tokenize` caller contract).
+    """
+    cleaned = strip_heredocs(command)
+    return bool(_COMMIT_FALLBACK_RE.search(cleaned))
+
+
 def check(input_data: dict) -> dict | None:
     """Check commit identity. Returns result dict if blocking, None if allowed."""
     tool_name = input_data.get("tool_name", "")
@@ -162,7 +188,24 @@ def check(input_data: dict) -> dict | None:
 
     commit_segment = _find_commit_segment(command)
     if commit_segment is None:
-        return None
+        # Parse-failure fail-closed path: shlex couldn't tokenize, but the
+        # command LOOKS like it contains a `git commit`. Block with a
+        # parse-failure-specific message so the operator can fix the quoting
+        # and retry. Allowing here would create a hole — paste a malformed
+        # `git commit` and bypass identity validation.
+        if not _looks_like_git_commit(command):
+            return None
+        result = {
+            "decision": "block",
+            "reason": (
+                "BLOCKED: git commit detected but command failed shlex parsing "
+                "(likely unbalanced quotes). Cannot validate `-c user.name=` / "
+                "`-c user.email=` flags from a malformed command. Fix the "
+                "quoting and retry."
+            ),
+        }
+        log_pretooluse_block("validate_commit_identity", command, result["reason"])
+        return result
 
     # Cross-repo support: if the command `cd`s into another repo, load that
     # repo's roster instead of the local one.

--- a/.claude/hooks/validate_commit_identity.py
+++ b/.claude/hooks/validate_commit_identity.py
@@ -13,10 +13,34 @@ Parent+child roster merge (#112 part a):
   coordinators commit in child repos without duplicating their entries into
   every child `roster.json`.
 
+Input Language
+==============
+
+Fires on:      PreToolUse Bash
+Matches:       git [-c k=v ...] [-C path] [other globals] commit [args]
+               (any segment in the compound command — split on ;, &&, ||, |;
+               leading KEY=value env-vars are stripped)
+Does NOT match: prose containing the literal "git commit" inside heredoc
+                bodies, --body / --body-file argument values, $(cat <<'EOF' …)
+                command substitutions. Tokenized via shlex; the matcher only
+                fires on actual command-position git invocations.
+
+Flag pass-through:
+    -c user.name=<value>   → required, validated against roster
+    -c user.email=<value>  → required, validated against roster
+    cd <path> && git ...   → loads <path>'s merged roster (cross-repo commit)
+
+Substring-bug history fixed by tokenization:
+    #226 — unquoted -c user.email=val no longer slurps to EOL
+    #188 — nested $(cat <<'EOF' ... EOF) no longer mangles the parser
+    Both root in regex-against-raw-string parsing; switched to shlex tokens.
+
 Exit codes:
   0 — allow (not a git commit, or identity is valid)
   2 — block (missing or invalid identity flags)
 """
+
+from __future__ import annotations
 
 import json
 import re
@@ -24,7 +48,14 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from annunaki_log import log_pretooluse_block
+from _shell_parse import (  # noqa: E402
+    extract_dash_c_pairs,
+    find_git_subcommand,
+    iter_command_segments,
+    strip_heredocs,
+    tokenize,
+)
+from annunaki_log import log_pretooluse_block  # noqa: E402
 
 
 def _read_roster(roster_path: Path) -> dict[str, str]:
@@ -96,49 +127,29 @@ def _detect_target_roster(command: str) -> dict[str, str] | None:
     return merged or None
 
 
-def _strip_heredocs(text: str) -> str:
-    """Remove heredoc bodies (<<'DELIM' ... DELIM and <<DELIM ... DELIM)."""
-    return re.sub(
-        r"<<-?\s*['\"]?(\w+)['\"]?.*?\n.*?\n\1\b",
-        "",
-        text,
-        flags=re.DOTALL,
-    )
+def _find_commit_segment(command: str) -> list[str] | None:
+    """Find the `git ... commit ...` segment in `command`. None if absent.
 
+    Strips heredocs first so a heredoc body containing the literal phrase
+    "git commit" cannot be confused with a real invocation. Tokenizes the
+    cleaned command with shlex, walks each pipeline segment, and returns
+    the first segment whose `find_git_subcommand` resolves to subcommand
+    `commit`.
 
-def _strip_quoted_strings(text: str) -> str:
-    """Remove content of single- and double-quoted strings."""
-    # Remove single-quoted strings (no escaping inside single quotes in shell)
-    text = re.sub(r"'[^']*'", "''", text)
-    # Remove double-quoted strings (handle escaped quotes)
-    text = re.sub(r'"(?:[^"\\]|\\.)*"', '""', text)
-    return text
-
-
-def _is_git_commit_command(command: str) -> bool:
-    """Return True only if the command invokes `git ... commit` as a real command.
-
-    Strips heredoc bodies and quoted strings first so that mentions of
-    "git commit" inside string literals do not trigger a false positive.
-    Then requires `git` to appear as a command — at the start of the
-    (trimmed) command or after a shell operator (&&, ||, ;, |).
+    Returns None on tokenization failure (caller treats as "not a commit").
     """
-    cleaned = _strip_heredocs(command)
-    cleaned = _strip_quoted_strings(cleaned)
-
-    # Match `git [options] commit` where commit is the subcommand.
-    # Git options before the subcommand are: -c key=val, -C path, --flag, etc.
-    # We skip those and check if the first non-option argument is "commit".
-    return bool(
-        re.search(
-            r"(?:^|[;&|]\s*|&&\s*|\|\|\s*)\s*git\b"
-            r"(?:\s+-c\s+\S+)*"  # skip -c key=val pairs
-            r"(?:\s+-[A-Za-z]\s+\S+)*"  # skip other -X val options
-            r"\s+commit(?:\s|$)",
-            cleaned,
-            re.MULTILINE,
-        )
-    )
+    cleaned = strip_heredocs(command)
+    tokens = tokenize(cleaned)
+    if tokens is None:
+        return None
+    for segment in iter_command_segments(tokens):
+        decoded = find_git_subcommand(segment)
+        if decoded is None:
+            continue
+        _globals, rest = decoded
+        if rest and rest[0] == "commit":
+            return segment
+    return None
 
 
 def check(input_data: dict) -> dict | None:
@@ -149,18 +160,19 @@ def check(input_data: dict) -> dict | None:
 
     command = input_data.get("tool_input", {}).get("command", "")
 
-    if not _is_git_commit_command(command):
+    commit_segment = _find_commit_segment(command)
+    if commit_segment is None:
         return None
 
     # Cross-repo support: if the command `cd`s into another repo, load that
-    # repo's roster instead of the local one. This allows the orchestration
-    # layer (noorinalabs-main) to commit in child repos using their team members.
+    # repo's roster instead of the local one.
     roster = _detect_target_roster(command) or ROSTER
 
-    name_match = re.search(r'-c\s+user\.name=["\']?([^"\']+)["\']?', command)
-    email_match = re.search(r'-c\s+user\.email=["\']?([^"\']+)["\']?', command)
+    pairs = dict(extract_dash_c_pairs(commit_segment))
+    name = pairs.get("user.name")
+    email = pairs.get("user.email")
 
-    if not name_match:
+    if not name:
         result = {
             "decision": "block",
             "reason": (
@@ -173,7 +185,7 @@ def check(input_data: dict) -> dict | None:
         log_pretooluse_block("validate_commit_identity", command, result["reason"])
         return result
 
-    if not email_match:
+    if not email:
         result = {
             "decision": "block",
             "reason": (
@@ -185,9 +197,6 @@ def check(input_data: dict) -> dict | None:
         }
         log_pretooluse_block("validate_commit_identity", command, result["reason"])
         return result
-
-    name = name_match.group(1).strip()
-    email = email_match.group(1).strip()
 
     if name not in roster:
         result = {


### PR DESCRIPTION
## Summary

Closes 7 sibling-bug-cluster issues by replacing per-hook substring/regex matching against the raw Bash command string with shlex-tokenized command-position lookup via a new shared helper `_shell_parse.py`.

| Issue | Hook | Failure shape |
|---|---|---|
| #226 | `validate_commit_identity` | unquoted `-c user.email=val` slurped to EOL |
| #188 | `validate_commit_identity` | nested `$(cat <<'EOF'..EOF)` mangled the parser |
| #216 | `block_git_config` | trips on heredoc body / `--body-file` content mentioning the phrase |
| #223 | `block_no_verify` | trips on heredoc body mentioning `--no-verify` |
| #144 | `validate_branch_freshness` | uses dispatcher's parent cwd, not the worktree's, for local check |
| #227 | `validate_branch_freshness` | no implicit-repo resolution → cross-cwd `gh pr create --repo X` from cwd Y false-positive blocks on Y's stale main |
| #189 | `block_shutdown_without_retro` | substring-matches prose containing `shutdown_request` keyword |

All seven share one root anti-pattern: the matcher reasons against the raw command string without distinguishing command-position tokens from data-position text.

## Approach

New `.claude/hooks/_shell_parse.py` exposes the unifying primitive — `tokenize`, `strip_heredocs`, `iter_command_segments`, `find_git_subcommand`, `find_gh_subcommand`, `extract_dash_c_pairs`, `resolve_tool_cwd`, `is_shutdown_request_message`. Every refactored hook now: (1) shlex-tokenizes the command, (2) splits on `;`/`&&`/`||`/`|` and strips leading env-var assignments, (3) looks up command-position tokens explicitly. Heredoc bodies and `--body`/`--body-file`/`-F` argument values become single shlex tokens (or are stripped) and can never be confused with command-position invocations.

`validate_branch_freshness` additionally:
- anchors `subprocess.run(..., cwd=resolve_tool_cwd(input_data))` so the worktree's branch state (not the parent's) is checked (#144);
- when `--repo` is omitted, parses the cwd's `origin` remote URL into an `OWNER/REPO` slug and routes through the API path; falls back to legacy local-cwd path only when the cwd has no github origin (#227).

## Cross-repo coordination

Helper landed in parent `noorinalabs-main`. Linh Pham (isnad-graph#819+#814 — same anti-pattern in cross-repo roster lookup) was looped in via team-lead relay before implementation. Child repos can import the helper via the existing parent+child hook sync pattern (matches the `validate_commit_identity` merged-roster precedent).

## Test plan

- [x] `_shell_parse` direct API + negative-match fixtures (#226 unquoted email; heredoc-body forms for #216/#223; #189 prose vs structured shutdown JSON)
- [x] `validate_commit_identity` extended: #226 unquoted-email-bounded, #188 nested-heredoc-in-cmd-sub, heredoc-body-with-phrase
- [x] `validate_branch_freshness` extended: #144 cwd pass-through, #227 implicit-repo routing including the user-service#81 repro; legacy `CheckLocalPathTests` updated to mock `_resolve_implicit_repo` → None so they exercise the cwd path
- [x] New `test_block_git_config.py`, `test_block_no_verify.py`, `test_block_shutdown_without_retro.py` (the three previously had zero test coverage)
- [x] `ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/` → **325 passed** (was 239)
- [x] Worktree-dispatcher smoke harness: 6/6 negative-match issue repros ALLOW post-fix; 5/5 positive cases still BLOCK
- [ ] Reviewer ack from @Nadia Khoury (primary) + @Wanjiku Mwangi (secondary)

## Charter compliance

- Hook Authorship Requirements § 1 (input-language docstring): all 5 refactored hook docstrings updated with `Input Language` / `Matches` / `Does NOT match` / `Flag pass-through` sections.
- Hook Authorship § 3 (negative-match coverage): every refactored hook now has at least one negative-match test for the substring-bug pattern.
- Sibling siblings list expanded in each docstring referencing the cluster issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
