### PR TITLE
skill(wave-scope): reconcile meta-issue vs labels between retro and kickoff (#196)

### DIFF
--- a/.claude/skills/wave-scope/SKILL.md
+++ b/.claude/skills/wave-scope/SKILL.md
@@ -1,0 +1,331 @@
+---
+name: wave-scope
+description: Reconcile declared-vs-labeled wave scope between /wave-retro and /wave-kickoff — collect dispositions, fold in retro carry-forwards and memory must-includes, and refresh the meta-issue
+args: Phase number, Wave number
+---
+
+Reconcile **declared scope** (next-wave meta-issue body) with **actual scope** (issues labeled `p{P}-wave-{M}` across all repos) before kickoff. Surfaces drift that accumulated during the prior wave, folds in retro carry-forwards and memory-tracked must-includes, and produces a clean meta-issue + label set for `/wave-kickoff` to act on.
+
+> Note: all repo paths in bash blocks below are rooted at `$REPO_ROOT` to avoid cwd drift when the skill is invoked from a worktree or child-repo subdirectory (#149).
+
+## When to use
+
+- **Between `/wave-retro` (wave N done) and `/wave-kickoff` (wave N+1 launching).** Owner-confirmed cadence; running it inside an active wave is fine but lower-value.
+- **Triggered by drift signal** — e.g. last-wave audit found multiple unscoped labels, or memory contains `W{N+1} must include` entries that weren't surfaced at retro.
+
+## What this skill is NOT
+
+- Not a branch-creation step — that's `/wave-start`.
+- Not a kickoff-comment step — that's `/wave-kickoff`.
+- Not an end-of-wave audit — that's `/wave-audit` (close orphans against merged PRs).
+
+## Instructions
+
+### 0. Inputs and prerequisites
+
+Before invoking, the user provides:
+- `{P}` — phase number for the next wave (e.g. `3`)
+- `{M}` — wave number for the next wave (e.g. `5`)
+
+The skill expects the next-wave **meta-issue** to already exist (drafted at the prior retro or before). If it does not, STOP and ask the user to create it first — `/wave-scope` reconciles a meta-issue, it does not author one.
+
+```bash
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+WAVE_LABEL="p{P}-wave-{M}"
+PRIOR_WAVE_LABEL="p{P}-wave-$(({M} - 1))"  # for retro carry-forward cross-ref
+```
+
+### 1. Read previous-wave retro carry-forward
+
+`/wave-retro` writes carry-forward items to two places:
+- `.claude/team/feedback_log.md` — most recent `## Retrospective: Phase {P} Wave {M-1}` section, "Deferred to next wave" / "Carry-forward" subsections.
+- `cross-repo-status.json` — `phase_{P}_carry_forwards` array (canonical structured list, post-W10).
+
+```bash
+# Structured carry-forwards (preferred — survives feedback_log churn)
+jq -r '.phase_{P}_carry_forwards[]? | "\(.id)\t\(.type)\t\(.note)"' "$REPO_ROOT/cross-repo-status.json"
+
+# Free-text carry-forwards (fallback / supplement)
+awk '/^## Retrospective: Phase {P} Wave '$((M-1))'/,/^## /' "$REPO_ROOT/.claude/team/feedback_log.md" \
+    | sed -n '/[Cc]arry.forward\|[Dd]efer/,/^### \|^## /p'
+```
+
+Collect into a `CARRY_FORWARDS=[]` working list. Each entry: `{id, source: "retro", type, note}`.
+
+### 2. Read memory must-includes
+
+Project memory may carry must-include directives keyed to the next wave (e.g. `W{N+1} must include user-service#63`). Scan the project memory dir:
+
+```bash
+MEMORY_DIR="$HOME/.claude/projects/-home-parameterization-code-noorinalabs-main/memory"
+# `|| true` because grep -l exits 1 when there are no matches, which is the
+# normal case for waves with no filed must-includes — not an error.
+MUST_INCLUDE_FILES=$(grep -l -i "W{M} must include\|wave-{M} must\|w{M}.must.include" "$MEMORY_DIR"/*.md 2>/dev/null || true)
+[ -z "$MUST_INCLUDE_FILES" ] && echo "  (no must-includes filed for W{M})"
+```
+
+For each match, read the file and extract the issue references. Memory naming convention: `project_w{M}_*.md` (e.g. `project_w10_user_service_alembic.md` — the W10 example matched on the literal phrase `W10 must include` in MEMORY.md and the file body itself). Add to working list as `MUST_INCLUDES=[]`. Each entry: `{id, source: "memory", file, note}`.
+
+If a referenced issue ID does not parse to a `repo#N` shape, surface to the user before proceeding — memories with vague references are a process gap that should be fixed at the source.
+
+### 3. Read next-wave meta-issue → declared scope
+
+The meta-issue body + comments are the canonical declared scope.
+
+```bash
+# Find the meta-issue. Canonical pattern: title contains "Phase {P} Wave {M}" and is in noorinalabs-main.
+META_ISSUE=$(gh issue list --repo noorinalabs/noorinalabs-main \
+    --search "Phase {P} Wave {M} in:title" \
+    --json number,title --jq '.[0].number')
+
+if [ -z "$META_ISSUE" ] || [ "$META_ISSUE" = "null" ]; then
+    echo "ERROR: no meta-issue found for Phase {P} Wave {M}. Create one before running /wave-scope."
+    exit 1
+fi
+
+# Pull body + every comment (declared scope can land in either)
+gh issue view "$META_ISSUE" --repo noorinalabs/noorinalabs-main --json body,comments \
+    --jq '.body, (.comments[] | .body)' > /tmp/wavescope-{M}-declared.txt
+```
+
+Extract every `repo#N` reference from the body and comments. Use a permissive regex to catch the common shapes:
+
+```bash
+grep -oE '\b(noorinalabs-[a-z-]+|main|deploy|isnad-graph|user-service|design-system|landing-page|data-acquisition|isnad-ingest-platform)#[0-9]+' \
+    /tmp/wavescope-{M}-declared.txt | sort -u > /tmp/wavescope-{M}-declared-issues.txt
+```
+
+This is the `DECLARED=[]` set.
+
+### 4. Query labeled scope across all repos
+
+Use the canonical cross-repo audit primitive (charter `skills.md` § Wave Lifecycle — Open-Item Audit):
+
+```bash
+REPOS=(
+    noorinalabs-main noorinalabs-isnad-graph noorinalabs-user-service
+    noorinalabs-deploy noorinalabs-design-system noorinalabs-landing-page
+    noorinalabs-data-acquisition noorinalabs-isnad-ingest-platform
+)
+> /tmp/wavescope-{M}-actual-issues.txt
+for repo in "${REPOS[@]}"; do
+    # 2>/dev/null suppresses "label not found" stderr — labels are per-repo so
+    # not every repo will have $WAVE_LABEL until step 9 (or a prior /wave-start).
+    # Non-zero exit on missing-label is normal and ignored.
+    gh issue list --repo "noorinalabs/$repo" --state open --label "$WAVE_LABEL" \
+        --json number,title,createdAt \
+        --jq '.[] | "'"$repo"'#\(.number)\t\(.title)\t\(.createdAt)"' \
+        2>/dev/null >> /tmp/wavescope-{M}-actual-issues.txt || true
+done
+echo "  Actual labeled: $(wc -l < /tmp/wavescope-{M}-actual-issues.txt) items across ${#REPOS[@]} repos"
+```
+
+This is the `ACTUAL=[]` set (with title and creation date).
+
+### 5. Compute scope drift
+
+The drift is `ACTUAL − DECLARED`. Two complementary deltas:
+
+| Delta | Meaning | Default action |
+|---|---|---|
+| `ACTUAL − DECLARED` | Items labeled but not declared (silent label-drift) | Review per-item: keep, defer, strip-label, close |
+| `DECLARED − ACTUAL` | Items declared but not labeled (forgot-to-tag) | Apply label after user confirms still-in-scope |
+| `MUST_INCLUDES − ACTUAL` | Memory must-includes missing the wave label | Apply label (these are non-negotiable per their memory entries) |
+| `CARRY_FORWARDS − ACTUAL` | Retro carry-forwards missing the wave label | Apply label after user confirms still applicable |
+
+```bash
+comm -23 <(cut -f1 /tmp/wavescope-{M}-actual-issues.txt | sort) \
+         <(sort /tmp/wavescope-{M}-declared-issues.txt) > /tmp/wavescope-{M}-unscoped-drift.txt
+
+comm -13 <(cut -f1 /tmp/wavescope-{M}-actual-issues.txt | sort) \
+         <(sort /tmp/wavescope-{M}-declared-issues.txt) > /tmp/wavescope-{M}-unlabeled-declared.txt
+```
+
+### 6. Present unscoped items in repo-batched review
+
+For each item in `ACTUAL − DECLARED`, group by repo and show:
+
+```
+**Unscoped Drift — `p{P}-wave-{M}` labeled but not in meta-issue**
+
+### noorinalabs-deploy ({count} items)
+
+| Issue | Title | Created | Body excerpt |
+|---|---|---|---|
+| #N | ...  | YYYY-MM-DD | First 80 chars of body... |
+| #N | ...  | YYYY-MM-DD | ... |
+
+### noorinalabs-isnad-graph ({count} items)
+...
+```
+
+Per-item body excerpt:
+
+```bash
+gh issue view {N} --repo "noorinalabs/{repo}" --json body --jq '.body | .[0:80]'
+```
+
+### 7. Collect dispositions per item (manual — owner judgment)
+
+For each unscoped item, the owner picks one of:
+
+| Disposition | Mechanic |
+|---|---|
+| `keep-in-w{M}` | Add to declared scope (step 11 will fold it into the meta-issue body) |
+| `defer-to-w{M+1}` | Strip `p{P}-wave-{M}` label, apply `p{P}-wave-{M+1}` (create label if needed in step 9) |
+| `strip-label` | Strip `p{P}-wave-{M}` label, no other label change |
+| `close-as-obsolete` | Close issue with a comment referencing the disposition |
+
+Record dispositions in a working table. Do NOT apply any label changes until step 10. Do NOT close any issues until step 10.
+
+This step is the orchestration's only blocking owner-judgment gate. Empty dispositions = STOP.
+
+### 8. Verify must-includes and carry-forwards are labeled
+
+For each entry in `MUST_INCLUDES` and `CARRY_FORWARDS`:
+
+```bash
+HAS_LABEL=$(gh issue view {N} --repo "noorinalabs/{repo}" --json labels \
+    --jq '.labels[] | select(.name == "'"$WAVE_LABEL"'") | .name')
+[ -z "$HAS_LABEL" ] && echo "MISSING LABEL: {repo}#{N}"
+```
+
+For each missing-label item, queue a label-apply for step 10.
+
+If a `MUST_INCLUDES` entry is closed or non-existent, the source memory file is stale — surface to the user with a recommendation to remove or update the memory entry. Do NOT silently drop a must-include.
+
+### 9. Create next-wave label (`p{P}-wave-{M+1}`) if any defer dispositions
+
+If any disposition in step 7 was `defer-to-w{M+1}`, ensure the label exists in every relevant repo:
+
+```bash
+NEXT_LABEL="p{P}-wave-$(({M} + 1))"
+# Match the color/description of the current wave label for consistency
+CURRENT_COLOR=$(gh label list --repo noorinalabs/noorinalabs-main --search "$WAVE_LABEL" --json color --jq '.[0].color')
+
+for repo in $REPOS_WITH_DEFER; do
+    gh label list --repo "noorinalabs/$repo" --search "$NEXT_LABEL" --json name --jq '.[].name' | grep -q "$NEXT_LABEL" || \
+        gh label create "$NEXT_LABEL" --repo "noorinalabs/$repo" \
+            --description "Phase {P} Wave $(({M} + 1))" --color "$CURRENT_COLOR"
+done
+```
+
+### 10. Apply label churn in one batch per repo
+
+Group all label edits per repo and apply with explicit user confirmation:
+
+```
+**Label changes about to apply** ({total} edits across {repos} repos)
+
+### noorinalabs-deploy
+- Add `p{P}-wave-{M}` to: #A, #B
+- Strip `p{P}-wave-{M}` from: #C
+- Strip `p{P}-wave-{M}` AND add `p{P}-wave-{M+1}` to: #D, #E
+- Close as obsolete (with comment): #F
+
+### noorinalabs-isnad-graph
+...
+
+Confirm to apply, or send back individual reversals.
+```
+
+After confirmation:
+
+```bash
+# Add label
+gh issue edit {N} --repo "noorinalabs/{repo}" --add-label "$WAVE_LABEL"
+# Strip label
+gh issue edit {N} --repo "noorinalabs/{repo}" --remove-label "$WAVE_LABEL"
+# Defer (strip current, add next)
+gh issue edit {N} --repo "noorinalabs/{repo}" --remove-label "$WAVE_LABEL" --add-label "$NEXT_LABEL"
+# Close as obsolete
+gh issue close {N} --repo "noorinalabs/{repo}" --comment "Closed via /wave-scope: out-of-scope for $WAVE_LABEL and not warranted on its own — see meta-issue #$META_ISSUE"
+```
+
+### 11. Refresh meta-issue body
+
+Rewrite the meta-issue body with the post-disposition scope. Categorize kept items into sections (the categories are owner-proposable; the skill suggests but does not decide):
+
+- **Promotion-pathway core** — issues that drive the wave's primary theme
+- **Precursors** — must-merge-first dependencies for the core
+- **Memory must-includes** — items from step 2
+- **Retro-mandated work** — items from step 1
+- **Direct blockers** — anything blocking promotion of the wave's theme
+
+Append a `## Deferred to W{M+1}` section listing the deferred items + a one-line reason each.
+
+```bash
+# Build new body via heredoc, then PATCH via gh api (gh issue edit --body has the same
+# silent-no-op risk as gh pr edit per memory feedback_gh_pr_edit_silent_noop.md — use
+# gh api PATCH and read-back-verify)
+NEW_BODY=$(cat <<'EOF'
+{post-disposition body}
+EOF
+)
+echo "{\"body\": $(printf '%s' "$NEW_BODY" | jq -Rs .)}" > /tmp/wavescope-{M}-meta-body.json
+gh api -X PATCH "repos/noorinalabs/noorinalabs-main/issues/$META_ISSUE" \
+    --input /tmp/wavescope-{M}-meta-body.json --silent
+
+# Read-back verify
+READBACK=$(gh api "repos/noorinalabs/noorinalabs-main/issues/$META_ISSUE" --jq '.body | .[0:120]')
+echo "$READBACK" | grep -q "Phase {P} Wave {M}" || echo "WARN: meta-issue body update may not have landed"
+```
+
+Do NOT delete the original body — copy it (or post the pre-update version as a comment) so the audit trail survives.
+
+### 12. Emit summary
+
+```
+**Wave Scope: Phase {P} Wave {M}**
+
+| Metric | Count |
+|---|---|
+| Declared (pre-scope) | N |
+| Labeled actual (pre-scope) | M |
+| Drift (actual − declared) | M − N |
+| Kept in scope | K |
+| Deferred to W{M+1} | D |
+| Stripped (no longer in any wave) | S |
+| Closed as obsolete | C |
+| Memory must-includes folded in | MI |
+| Retro carry-forwards folded in | CF |
+
+**Final declared scope:** {final count} items, ready for `/wave-kickoff`.
+
+**Label edits applied:** {edit count} across {repo count} repos.
+**Meta-issue refreshed:** noorinalabs-main#$META_ISSUE
+```
+
+If any step surfaced a process gap (stale memory, missing meta-issue, vague reference), include a `**Process gaps surfaced**` section so the next retro can address them.
+
+## Relationship to other wave skills
+
+| Skill | Timing | Output |
+|---|---|---|
+| `/wave-retro` | End of wave N | Carry-forward list, deferred items, trust updates |
+| **`/wave-scope`** | **Between waves** | **Declared-vs-labeled reconciled; meta-issue refreshed** |
+| `/wave-start` | Start of wave N+1 | Branch creation, label setup |
+| `/wave-kickoff` | Start of wave N+1 | Issue assignment, kickoff comments, execution plan |
+| `/wave-wrapup` | Near end of wave N | PR merge sequencing |
+| `/wave-audit` | End of wave N | Close orphans against merged PRs |
+
+`/wave-kickoff` currently assumes the meta-issue reflects reality. This skill makes that assumption true.
+
+## What remains manual
+
+- **Step 7** — disposition per unscoped item is owner judgment. The skill cannot decide keep-vs-defer-vs-close; it can only present the items and apply the result.
+- **Step 11** — section categories on the refreshed meta-issue are owner judgment. The skill proposes; owner confirms.
+- **Process-gap escalation** — when a memory must-include points to a closed/non-existent issue, the skill surfaces but does not auto-clean the memory file (that's a follow-up the owner triages).
+
+## Idempotency
+
+Re-running `/wave-scope` after an initial pass should:
+- Find drift = 0 if labels match the refreshed meta-issue.
+- Re-fold any new must-includes added to memory since the prior pass (cheap re-check).
+- Be safe to abort at any step before step 10 — only step 10 (label churn) and step 11 (meta-issue PATCH) mutate state.
+
+## Promotion provenance
+
+- **Origin:** Conversation during W10 planning (2026-04-23) — owner walked through the 10-step pattern manually after the W10 scope-pass found 30 drift items and a missing must-include (`user-service#63`).
+- **Promotion target:** skill (orchestration with one human-judgment gate; not a hook).
+- **Issue:** noorinalabs-main#196.


### PR DESCRIPTION
## Summary

Closes #196 — new `/wave-scope` skill that reconciles **declared scope** (next-wave meta-issue body) with **actual scope** (issues labeled `p{P}-wave-{M}` across all repos) before kickoff. Sits between `/wave-retro` and `/wave-kickoff` in the wave lifecycle.

Owner-proposed pattern from W10 planning conversation (2026-04-23). W10 manual scope-pass found 30 silently-labeled items not in meta-issue #141 and missed `user-service#63` (a memory must-include) until visual catch. This skill templates the pattern.

## Approach

12 steps, matching #196 acceptance one-for-one:

| Step | Action | Mutates? |
|---|---|---|
| 0 | Inputs and prerequisites — STOP if no meta-issue exists | No |
| 1 | Read prior-wave retro carry-forward (cross-repo-status.json `phase_{P}_carry_forwards` + feedback_log.md fallback) | No |
| 2 | Scan project memory for `W{M} must include` directives | No |
| 3 | Read meta-issue body + comments → DECLARED set | No |
| 4 | Cross-repo audit (canonical 8-repo loop) → ACTUAL set | No |
| 5 | Compute 4 drift deltas (ACTUAL − DECLARED, etc.) | No |
| 6 | Present unscoped items in repo-batched table | No |
| 7 | **Owner judgment gate** — disposition per item | No |
| 8 | Verify must-includes + carry-forwards are labeled | No |
| 9 | Create next-wave label if any defer dispositions | Yes (label create) |
| 10 | Apply label churn in one batch per repo + close-as-obsolete | Yes (label edits, issue closes) |
| 11 | Refresh meta-issue body via `gh api PATCH` + read-back-verify | Yes (issue body edit) |
| 12 | Emit summary table | No |

Two manual carve-outs per #196 spec:
- **Step 7** — per-item disposition is owner judgment; skill cannot decide keep-vs-defer-vs-close.
- **Step 11** — section categories on the refreshed meta-issue are owner-proposable; skill suggests, owner confirms.

## Verification (current W4 state)

Tested all read-only primitives against current cross-repo-status:

- `gh issue list "Phase 3 Wave 4 in:title"` → empty. **Skill's step 0 STOP-and-ask correctly halts** (no W4 meta-issue exists; the skill would not have run for W4 because the prerequisite isn't met). This is the right behavior — the skill should not silently proceed against a non-existent declared scope.
- `jq -r '.phase_3_carry_forwards[]?'` → 3 structured entries (deploy#86, deploy#151, user-service#84). Carry-forward extraction works.
- Cross-repo audit primitive (8-repo loop) → 21 items labeled `p3-wave-4` across 5 of 8 repos. The `2>/dev/null || true` correctly handles the 3 repos where the label hasn't been created yet (normal case for repos with no scoped work).
- Memory must-include grep → matches the canonical W10 case (`project_w10_user_service_alembic.md` + MEMORY.md index entry); returns empty for W4 (no W4 must-includes filed — also the normal case).

## Idempotency

Re-running after an initial pass:
- Drift = 0 if labels match the refreshed meta-issue.
- Re-fold any new must-includes added since prior pass (cheap).
- Steps 1-9 read-only; only step 10 (label churn) and step 11 (meta-issue PATCH) mutate state. Abortable at any prior step.

## Sibling skill cross-ref

Documented `/wave-scope`'s position in the wave lifecycle:

| Skill | Timing | Output |
|---|---|---|
| `/wave-retro` | End of wave N | Carry-forward list, deferred items, trust updates |
| **`/wave-scope`** | **Between waves** | **Declared-vs-labeled reconciled; meta-issue refreshed** |
| `/wave-start` | Start of wave N+1 | Branch creation, label setup |
| `/wave-kickoff` | Start of wave N+1 | Issue assignment, kickoff comments |
| `/wave-wrapup` | Near end of wave N | PR merge sequencing |
| `/wave-audit` | End of wave N | Close orphans against merged PRs |

`/wave-kickoff` currently assumes the meta-issue reflects reality. This skill makes that assumption true.

## Test plan

- [ ] Reviewer (Nadia primary, Aino secondary) — confirm 12-step structure matches the W10 manual pattern they observed
- [ ] Confirm step 0 STOP-on-missing-meta-issue is the right behavior (vs. auto-creating a placeholder)
- [ ] Confirm step 7 manual gate (per-item disposition) is correctly the only blocking judgment point
- [ ] Verify step 11 audit-trail discipline ("Do NOT delete original body — copy or post pre-update version as comment") matches process expectations

## Related

- Memory `project_w10_user_service_alembic.md` — canonical must-include exemplar
- Charter `skills.md` § Wave Lifecycle — Open-Item Audit (canonical 8-repo audit primitive consumed by step 4)
- #195 wave-audit — same primitive, end-of-wave timing instead of between-wave
- Memory `feedback_gh_pr_edit_silent_noop.md` — drives the `gh api PATCH + read-back-verify` choice in step 11
