### PR TITLE
hooks(validate_pr_review): canonicalize Requestor=reviewer + Single-Reviewer Exception (closes #244 #233 #228)

### DIFF
--- a/.claude/hooks/tests/test_validate_pr_review.py
+++ b/.claude/hooks/tests/test_validate_pr_review.py
@@ -3,16 +3,27 @@
 
 Covers:
 - Issue #147: TechDebt attestation must be required ONLY on actual review
-  verdicts (Approved / Changes Requested), NOT on Request or Replied
-  comments.
-- Issue #164: reviewer set must dedup on full Requestee name, NOT on
+  verdicts (Approved / ChangesRequested), NOT on Request or Reply comments.
+- Issue #164: reviewer set must dedup on full reviewer name, NOT on
   lastname — two distinct reviewers sharing a lastname (e.g.,
   Lucas Ferreira and Santiago Ferreira) count as TWO reviewers.
+- Issue #244: reviewer for verdict comments is the Requestor (comment
+  author), NOT the Requestee. Resolves the prior Requestee-as-reviewer
+  mismatch with the canonical charter format (resolves #233).
+- Issue #228: Single-Reviewer Exception for wave-bootstrap PRs reviewed
+  by a charter-enforcer role.
+
+Charter format used in fixtures (canonical per `pull-requests.md`
+§ Comment-Based Reviews — Requestor=comment-author, Requestee=comment-target):
+- Request comments     → Requestor=PR author,  Requestee=reviewer
+- Reply comments       → Requestor=replier,    Requestee=being-replied-to
+- Approved verdicts    → Requestor=reviewer,   Requestee=PR author
+- ChangesRequested     → Requestor=reviewer,   Requestee=PR author
 
 Also covers the W8 hook-authorship NEGATIVE-MATCH requirement.
 
-Run: python3 -m pytest .claude/hooks/tests/test_validate_pr_review.py -v
-Or:  python3 .claude/hooks/tests/test_validate_pr_review.py
+Run: ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/test_validate_pr_review.py -v
+Or:  ENVIRONMENT=test python3 .claude/hooks/tests/test_validate_pr_review.py
 """
 
 from __future__ import annotations
@@ -141,10 +152,13 @@ class TechDebtFilterTests(_CheckCommentReviewsHarness):
         self.assertEqual(result.reviews_missing_tech_debt, [])
 
     def test_approved_without_techdebt_does_block(self):
-        """Positive: Approved lacking TechDebt MUST still be flagged — #147 does NOT weaken this."""
+        """Positive: Approved lacking TechDebt MUST still be flagged — #147 does NOT weaken this.
+
+        Canonical format (resolves #244): Requestor=reviewer, Requestee=PR author.
+        """
         comments = [
             self._comment(
-                "Requestor: Linh Pham\nRequestee: Mateo Santos\nRequestOrReplied: Approved"
+                "Requestor: Mateo Santos\nRequestee: Linh Pham\nRequestOrReplied: Approved"
             ),
         ]
         result = self._run_with_fake_api(comments, self.BRANCH_AUTHOR, repo=self.REPO)
@@ -153,7 +167,7 @@ class TechDebtFilterTests(_CheckCommentReviewsHarness):
     def test_changes_requested_without_techdebt_does_block(self):
         comments = [
             self._comment(
-                "Requestor: Linh Pham\nRequestee: Anya Kowalczyk\n"
+                "Requestor: Anya Kowalczyk\nRequestee: Linh Pham\n"
                 "RequestOrReplied: Changes Requested"
             ),
         ]
@@ -163,7 +177,7 @@ class TechDebtFilterTests(_CheckCommentReviewsHarness):
     def test_approved_with_techdebt_none_passes(self):
         comments = [
             self._comment(
-                "Requestor: Linh Pham\nRequestee: Mateo Santos\n"
+                "Requestor: Mateo Santos\nRequestee: Linh Pham\n"
                 "RequestOrReplied: Approved\nTechDebt: none"
             ),
         ]
@@ -173,7 +187,7 @@ class TechDebtFilterTests(_CheckCommentReviewsHarness):
     def test_approved_with_techdebt_issues_passes_and_collects(self):
         comments = [
             self._comment(
-                "Requestor: Linh Pham\nRequestee: Mateo Santos\n"
+                "Requestor: Mateo Santos\nRequestee: Linh Pham\n"
                 "RequestOrReplied: Approved\nTechDebt: #15, #16"
             ),
         ]
@@ -182,31 +196,33 @@ class TechDebtFilterTests(_CheckCommentReviewsHarness):
         self.assertEqual(sorted(result.tech_debt_issue_numbers), ["15", "16"])
 
     def test_pr_821_scenario(self):
-        """Exact scenario from issue #147 repro.
+        """Exact scenario from issue #147 repro, in canonical #244 format.
 
         PR #821 had 3 real reviews (Jelani+Anya approved, Anya changes-requested —
-        all with TechDebt) and 4 non-review comments (3 Request, 1 Replied — no
+        all with TechDebt) and 4 non-review comments (3 Request, 1 Reply — no
         TechDebt). The hook blocked on the 4 non-review comments. After the fix,
         only actual-verdict comments without TechDebt should be flagged.
+
+        Canonical format (#244): verdict comments swap to Requestor=reviewer.
         """
         comments = [
-            # Review requests (no TechDebt line — must be accepted after fix)
+            # Review requests — Requestor=PR author, Requestee=reviewer (no TechDebt required)
             self._comment(
                 "Requestor: Linh Pham\nRequestee: Jelani Mwangi\nRequestOrReplied: Request"
             ),
             self._comment(
                 "Requestor: Linh Pham\nRequestee: Anya Kowalczyk\nRequestOrReplied: Request"
             ),
-            # Actual reviews with TechDebt
+            # Verdicts — Requestor=reviewer, Requestee=PR author
             self._comment(
-                "Requestor: Linh Pham\nRequestee: Jelani Mwangi\n"
+                "Requestor: Jelani Mwangi\nRequestee: Linh Pham\n"
                 "RequestOrReplied: Approved\nTechDebt: none"
             ),
             self._comment(
-                "Requestor: Linh Pham\nRequestee: Anya Kowalczyk\n"
+                "Requestor: Anya Kowalczyk\nRequestee: Linh Pham\n"
                 "RequestOrReplied: Changes Requested\nTechDebt: #200"
             ),
-            # Author reply (no TechDebt line — must be accepted after fix)
+            # Author reply — Requestor=replier (Linh), Requestee=being-replied-to (Anya)
             self._comment(
                 "Requestor: Linh Pham\nRequestee: Anya Kowalczyk\nRequestOrReplied: Replied"
             ),
@@ -214,9 +230,9 @@ class TechDebtFilterTests(_CheckCommentReviewsHarness):
             self._comment(
                 "Requestor: Linh Pham\nRequestee: Anya Kowalczyk\nRequestOrReplied: Request"
             ),
-            # Re-review approval
+            # Re-review approval — Requestor=reviewer (Anya)
             self._comment(
-                "Requestor: Linh Pham\nRequestee: Anya Kowalczyk\n"
+                "Requestor: Anya Kowalczyk\nRequestee: Linh Pham\n"
                 "RequestOrReplied: Approved\nTechDebt: none"
             ),
         ]
@@ -241,8 +257,8 @@ class TechDebtFilterTests(_CheckCommentReviewsHarness):
     def test_markdown_bold_approved_still_requires_techdebt(self):
         comments = [
             self._comment(
-                "**Requestor:** Linh Pham\n"
-                "**Requestee:** Mateo Santos\n"
+                "**Requestor:** Mateo Santos\n"
+                "**Requestee:** Linh Pham\n"
                 "**RequestOrReplied:** Approved"
             ),
         ]
@@ -255,6 +271,9 @@ class ReviewerDedupTests(_CheckCommentReviewsHarness):
 
     Prior behavior keyed the set on lastname, so Lucas Ferreira and Santiago
     Ferreira counted as one reviewer. Guard tests for the full-name fix.
+
+    Post-#244 reviewer identification uses Requestor on verdict comments;
+    fixtures updated to canonical format (Requestor=reviewer).
     """
 
     @staticmethod
@@ -262,14 +281,18 @@ class ReviewerDedupTests(_CheckCommentReviewsHarness):
         return {"body": body, "user": {"login": "anyone"}}
 
     def test_two_reviewers_same_lastname_count_as_two(self):
-        """NEGATIVE MATCH for #164: two Ferreiras must count as 2, not 1."""
+        """NEGATIVE MATCH for #164: two Ferreiras must count as 2, not 1.
+
+        Canonical format: each reviewer is the Requestor of their own
+        Approved verdict comment.
+        """
         comments = [
             self._comment(
-                "Requestor: Linh Pham\nRequestee: Lucas Ferreira\n"
+                "Requestor: Lucas Ferreira\nRequestee: Linh Pham\n"
                 "RequestOrReplied: Approved\nTechDebt: none"
             ),
             self._comment(
-                "Requestor: Linh Pham\nRequestee: Santiago Ferreira\n"
+                "Requestor: Santiago Ferreira\nRequestee: Linh Pham\n"
                 "RequestOrReplied: Approved\nTechDebt: none"
             ),
         ]
@@ -283,13 +306,20 @@ class ReviewerDedupTests(_CheckCommentReviewsHarness):
         self.assertIn("santiago ferreira", result.reviewers)
 
     def test_same_person_counted_once_across_multiple_comments(self):
-        """Positive: same reviewer making Request + Approved counts as one."""
+        """Positive: same reviewer's verdict counts once even across re-cycles.
+
+        Canonical format: the Approved verdict has Requestor=reviewer.
+        Request comments (Requestor=PR author) do NOT contribute to the
+        reviewer set after the #244 fix — only Approved verdicts count.
+        """
         comments = [
+            # Initial review request (Requestor=PR author) — does NOT count toward reviewers
             self._comment(
                 "Requestor: Linh Pham\nRequestee: Mateo Santos\nRequestOrReplied: Request"
             ),
+            # Verdict (Requestor=reviewer) — counts
             self._comment(
-                "Requestor: Linh Pham\nRequestee: Mateo Santos\n"
+                "Requestor: Mateo Santos\nRequestee: Linh Pham\n"
                 "RequestOrReplied: Approved\nTechDebt: none"
             ),
         ]
@@ -298,11 +328,12 @@ class ReviewerDedupTests(_CheckCommentReviewsHarness):
         self.assertIn("mateo santos", result.reviewers)
 
     def test_branch_author_lastname_still_excluded(self):
-        """Author-equality check still works (it uses lastname, correctly).
+        """Author-equality check still works on Requestor (post-#244).
 
-        Branch author has lastname `Pham`. A Pham-surnamed reviewer must still
-        be excluded from the reviewer set — regression guard for the
-        author-equality branch of the logic after the dedup-key change.
+        Branch author has lastname `Pham`. If a Pham-surnamed Requestor
+        somehow appears on an Approved verdict (a self-approval attempt),
+        it must be excluded. Regression guard for the author-equality
+        branch on the now-canonical Requestor field.
         """
         comments = [
             self._comment(
@@ -363,6 +394,289 @@ class MergeCommandMatchTests(unittest.TestCase):
         self.assertFalse(hook.is_merge_command("gh pr create"))
         self.assertFalse(hook.is_merge_command("git merge main"))
         self.assertFalse(hook.is_merge_command("gh pr checks"))
+
+
+class IsApprovedTests(unittest.TestCase):
+    """Issue #244: only Approved comments count toward the 2-reviewer rule.
+
+    ChangesRequested is a verdict (TechDebt required) but does NOT contribute
+    to the 2-Approved-distinct-reviewer threshold per charter line 36.
+    """
+
+    def test_approved_is_approved(self):
+        self.assertTrue(hook._is_approved("Approved"))
+
+    def test_lowercase_approved(self):
+        self.assertTrue(hook._is_approved("approved"))
+
+    def test_changes_requested_is_not_approved(self):
+        self.assertFalse(hook._is_approved("Changes Requested"))
+
+    def test_changesrequested_camelcase_is_not_approved(self):
+        self.assertFalse(hook._is_approved("ChangesRequested"))
+
+    def test_request_is_not_approved(self):
+        self.assertFalse(hook._is_approved("Request"))
+
+    def test_replied_is_not_approved(self):
+        self.assertFalse(hook._is_approved("Replied"))
+
+
+class RequestorCountingTests(_CheckCommentReviewsHarness):
+    """Issue #244: reviewer for verdict comments is the Requestor (comment author).
+
+    Pre-#244 the hook counted distinct Requestee values. Post-#244 it counts
+    distinct Requestor values across Approved comments only.
+    """
+
+    @staticmethod
+    def _comment(body: str) -> dict:
+        return {"body": body, "user": {"login": "anyone"}}
+
+    def test_approved_counts_requestor(self):
+        """Two Approved verdicts from distinct Requestors → 2 reviewers."""
+        comments = [
+            self._comment(
+                "Requestor: Anya Kowalczyk\nRequestee: Linh Pham\n"
+                "RequestOrReplied: Approved\nTechDebt: none"
+            ),
+            self._comment(
+                "Requestor: Jelani Mwangi\nRequestee: Linh Pham\n"
+                "RequestOrReplied: Approved\nTechDebt: none"
+            ),
+        ]
+        result = self._run_with_fake_api(comments, self.BRANCH_AUTHOR, repo=self.REPO)
+        self.assertEqual(len(result.reviewers), 2)
+        self.assertIn("anya kowalczyk", result.reviewers)
+        self.assertIn("jelani mwangi", result.reviewers)
+
+    def test_request_does_not_count_toward_reviewers(self):
+        """A Request comment (Requestor=PR author) is NOT a review verdict."""
+        comments = [
+            self._comment(
+                "Requestor: Linh Pham\nRequestee: Anya Kowalczyk\nRequestOrReplied: Request"
+            ),
+        ]
+        result = self._run_with_fake_api(comments, self.BRANCH_AUTHOR, repo=self.REPO)
+        self.assertEqual(result.reviewers, set())
+
+    def test_changes_requested_does_not_count_toward_approved_threshold(self):
+        """ChangesRequested is a verdict but NOT toward the 2-Approved threshold.
+
+        Charter line 36: "two distinct Requestor values" specifically across
+        `Approved` comments. CR comments do not satisfy the threshold.
+        """
+        comments = [
+            self._comment(
+                "Requestor: Anya Kowalczyk\nRequestee: Linh Pham\n"
+                "RequestOrReplied: Changes Requested\nTechDebt: none"
+            ),
+        ]
+        result = self._run_with_fake_api(comments, self.BRANCH_AUTHOR, repo=self.REPO)
+        # ChangesRequested has TechDebt so it's a verdict (no missing-attestation
+        # error), but the reviewer set stays empty because only Approved counts.
+        self.assertEqual(result.reviewers, set())
+        self.assertEqual(result.reviews_missing_tech_debt, [])
+
+    def test_p3w3_wave_merge_repro(self):
+        """Exact repro of the P3W3 wave-merge --admin episode (issue #244).
+
+        Wave-merge PRs had 2 distinct Approveds, but the prior hook counted
+        Requestee (= PR author) and saw 1 distinct value → blocked. With
+        #244 fix counting Requestor, both reviewers are recognized.
+        """
+        comments = [
+            # Two distinct reviewers Approved — canonical Requestor=reviewer
+            self._comment(
+                "Requestor: Bereket Tadesse\nRequestee: Aino Virtanen\n"
+                "RequestOrReplied: Approved\nTechDebt: none"
+            ),
+            self._comment(
+                "Requestor: Lucas Ferreira\nRequestee: Aino Virtanen\n"
+                "RequestOrReplied: Approved\nTechDebt: none"
+            ),
+        ]
+        # Branch author lastname is "Virtanen" (Aino's wave-merge PR).
+        result = self._run_with_fake_api(comments, "Virtanen", repo=self.REPO)
+        self.assertEqual(
+            len(result.reviewers),
+            2,
+            "P3W3 #244 repro: should count Bereket + Lucas as 2 distinct Requestors",
+        )
+
+
+class LoadCharterEnforcerNamesTests(unittest.TestCase):
+    """Issue #228: charter-enforcer names parsed from local roster filenames.
+
+    Tests against the parent repo's actual roster (Aino Virtanen as
+    standards_lead, Nadia Khoury as program_director). The hook uses
+    `_ROSTER_DIR` resolved relative to the hook file at module import.
+    """
+
+    def test_parent_roster_includes_aino(self):
+        """Parent's standards_lead_aino.md → Aino Virtanen is an enforcer."""
+        enforcers = hook.load_charter_enforcer_names()
+        self.assertIn(
+            "aino virtanen",
+            enforcers,
+            f"Standards Lead missing from charter enforcers: {enforcers}",
+        )
+
+    def test_parent_roster_includes_nadia(self):
+        """Parent's program_director_nadia.md → Nadia Khoury is an enforcer."""
+        enforcers = hook.load_charter_enforcer_names()
+        self.assertIn("nadia khoury", enforcers)
+
+    def test_engineer_roles_excluded(self):
+        """`sre_engineer_*`, `security_engineer_*`, etc. are NOT enforcers."""
+        enforcers = hook.load_charter_enforcer_names()
+        # Aisha (sre_engineer) and Nino (security_engineer) must NOT be in the set.
+        self.assertNotIn("aisha idrissi", enforcers)
+        self.assertNotIn("nino kavtaradze", enforcers)
+
+
+class SingleReviewerExceptionTests(unittest.TestCase):
+    """Issue #228: hook honors charter's Single-Reviewer Exception."""
+
+    def test_exception_grants_with_label_and_enforcer(self):
+        """Label `wave-bootstrap` + sole reviewer is a charter enforcer → exception applies."""
+        # Use Aino's lowercased full name (matches what reviewers set holds).
+        self.assertTrue(
+            hook.is_single_reviewer_exception(
+                pr_labels=["wave-bootstrap", "tech-debt"],
+                reviewers={"aino virtanen"},
+            )
+        )
+
+    def test_exception_denied_without_label(self):
+        """No `wave-bootstrap` label → exception does NOT apply."""
+        self.assertFalse(
+            hook.is_single_reviewer_exception(
+                pr_labels=["tech-debt"],
+                reviewers={"aino virtanen"},
+            )
+        )
+
+    def test_exception_denied_with_zero_reviewers(self):
+        """Zero reviewers is not "exactly one" — exception does NOT apply."""
+        self.assertFalse(
+            hook.is_single_reviewer_exception(
+                pr_labels=["wave-bootstrap"],
+                reviewers=set(),
+            )
+        )
+
+    def test_exception_denied_with_two_reviewers(self):
+        """Two reviewers means the strict rule is already satisfied — exception unnecessary."""
+        self.assertFalse(
+            hook.is_single_reviewer_exception(
+                pr_labels=["wave-bootstrap"],
+                reviewers={"aino virtanen", "nadia khoury"},
+            )
+        )
+
+    def test_exception_denied_with_non_enforcer_reviewer(self):
+        """`wave-bootstrap` label + sole reviewer is NOT a charter enforcer → no exception."""
+        self.assertFalse(
+            hook.is_single_reviewer_exception(
+                pr_labels=["wave-bootstrap"],
+                reviewers={"some random engineer"},
+            )
+        )
+
+
+class CheckEndToEndTests(unittest.TestCase):
+    """End-to-end check() integration tests for #244 + #228 paths."""
+
+    @staticmethod
+    def _input(command: str) -> dict:
+        return {"tool_name": "Bash", "tool_input": {"command": command}}
+
+    def _patch_pr_data(self, **overrides) -> dict:
+        """Build a stub PR-data dict with sensible defaults; override per test."""
+        base = {
+            "author": "parametrization",
+            "number": 100,
+            "reviews": [],  # no formal GitHub reviews in any of these tests
+            "headRefName": "L.Pham/0001-fix",
+            "labels": [],
+        }
+        base.update(overrides)
+        return base
+
+    def test_two_distinct_approved_requestors_allows_merge(self):
+        """Canonical happy path: 2 distinct Requestors on Approved comments → allow."""
+        review_result = hook.CommentReviewResult()
+        review_result.reviewers = {"anya kowalczyk", "jelani mwangi"}
+        with (
+            mock.patch.object(hook, "get_pr_data", return_value=self._patch_pr_data()),
+            mock.patch.object(hook, "check_comment_reviews", return_value=review_result),
+        ):
+            result = hook.check(self._input("gh pr merge 100 --squash"))
+        self.assertIsNone(result, "2 distinct Requestor Approveds should allow merge")
+
+    def test_one_reviewer_without_wave_bootstrap_blocks(self):
+        """Strict rule: 1 reviewer + no wave-bootstrap label → block."""
+        review_result = hook.CommentReviewResult()
+        review_result.reviewers = {"anya kowalczyk"}
+        with (
+            mock.patch.object(hook, "get_pr_data", return_value=self._patch_pr_data()),
+            mock.patch.object(hook, "check_comment_reviews", return_value=review_result),
+        ):
+            result = hook.check(self._input("gh pr merge 100 --squash"))
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+        self.assertIn("1/2", result["reason"])
+
+    def test_one_reviewer_with_wave_bootstrap_and_enforcer_allows(self):
+        """Single-Reviewer Exception (#228): wave-bootstrap + charter enforcer → allow.
+
+        Uses the actual parent roster — Aino Virtanen is the Standards Lead.
+        """
+        review_result = hook.CommentReviewResult()
+        review_result.reviewers = {"aino virtanen"}
+        with (
+            mock.patch.object(
+                hook,
+                "get_pr_data",
+                return_value=self._patch_pr_data(labels=["wave-bootstrap", "tech-debt"]),
+            ),
+            mock.patch.object(hook, "check_comment_reviews", return_value=review_result),
+        ):
+            result = hook.check(self._input("gh pr merge 100 --squash"))
+        self.assertIsNone(
+            result,
+            "wave-bootstrap PR with charter-enforcer Approved should merge with 1 reviewer",
+        )
+
+    def test_one_reviewer_with_wave_bootstrap_but_non_enforcer_blocks(self):
+        """Single-Reviewer Exception requires a charter-enforcer reviewer.
+
+        wave-bootstrap label alone does NOT grant the exception — the sole
+        reviewer must also be a charter-enforcer per local roster.
+        """
+        review_result = hook.CommentReviewResult()
+        review_result.reviewers = {"some engineer"}
+        with (
+            mock.patch.object(
+                hook,
+                "get_pr_data",
+                return_value=self._patch_pr_data(labels=["wave-bootstrap"]),
+            ),
+            mock.patch.object(hook, "check_comment_reviews", return_value=review_result),
+        ):
+            result = hook.check(self._input("gh pr merge 100 --squash"))
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+
+    def test_admin_short_circuits(self):
+        """--admin allows merge regardless of reviewer count (emergency override)."""
+        with mock.patch.object(hook, "get_pr_data") as get_mock:
+            result = hook.check(self._input("gh pr merge 100 --admin"))
+        self.assertIsNone(result)
+        get_mock.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/.claude/hooks/validate_pr_review.py
+++ b/.claude/hooks/validate_pr_review.py
@@ -3,7 +3,9 @@
 
 Blocks `gh pr merge` unless the PR has at least two reviews from distinct
 non-authors, using either formal GitHub reviews or charter-format
-comment-based reviews from different team members.
+comment-based reviews from different team members. Honors the
+Single-Reviewer Exception for wave-bootstrap PRs reviewed by a charter-
+enforcer role.
 
 Input Language:
   Fires on:      PreToolUse Bash
@@ -17,35 +19,60 @@ Input Language:
                the PR in the repo the user named, not the cwd-resolved repo.
     --admin  → short-circuits (emergency override — allows merge).
 
-Charter-format review comments:
-  Each comment is expected to include:
-    Requestor: <branch author>
-    Requestee: <reviewer>
-    RequestOrReplied: <Request|Replied|Approved|Changes Requested>
-    TechDebt: none | #15, #16, ...
+Charter-format review comments (canonical per `pull-requests.md` § Comment-Based Reviews,
+resolves #233):
 
-  Canonical RequestOrReplied values (verified on PR #821 comments):
-    - Request            — requesting review (NOT a verdict)
-    - Replied            — author responding to review (NOT a verdict)
-    - Approved           — actual review verdict (TechDebt line REQUIRED)
-    - Changes Requested  — actual review verdict (TechDebt line REQUIRED)
+  Requestor: <comment author>     # always the team member POSTING the comment
+  Requestee: <comment target>     # always the team member ADDRESSED by the comment
+  RequestOrReplied: <Request|Reply|Approved|ChangesRequested>
+  TechDebt: none | #15, #16, ...
 
-  Only Approved and Changes Requested comments are ACTUAL REVIEWS. Request /
-  Replied comments are process metadata and must NOT be required to carry the
-  TechDebt attestation line. This is the fix for issue #147.
+  Direction by RequestOrReplied:
+    - Request          — Requestor=PR author,  Requestee=reviewer (NOT a verdict)
+    - Reply / Replied  — Requestor=replier,    Requestee=person-being-replied-to (NOT a verdict)
+    - Approved         — Requestor=reviewer,   Requestee=PR author (verdict)
+    - ChangesRequested — Requestor=reviewer,   Requestee=PR author (verdict)
+
+  The reviewer for a verdict comment is the comment AUTHOR — i.e. the
+  Requestor. The prior hook counted distinct Requestee values across
+  Approved/ChangesRequested comments, which on verdicts is always the PR
+  author and so collapsed to a single value (resolves #244).
+
+Reviewer counting rule (resolves #244):
+  - Verdict comments (Approved / ChangesRequested) → Requestor is the reviewer
+  - Request / Reply comments → not reviews; do not contribute to reviewer count
+  - Two-reviewer rule satisfied when there are TWO DISTINCT REVIEWER NAMES across
+    Approved comments, neither of which is the PR author.
 
 Reviewer dedup key:
-  The reviewer set is keyed on the FULL requestee name (lowercased), not on
+  The reviewer set is keyed on the FULL reviewer name (lowercased), not on
   the lastname. Two distinct reviewers with the same lastname (e.g.,
   "Lucas Ferreira" and "Santiago Ferreira") are counted as TWO reviewers
-  toward the two-peer-review requirement. This is the fix for issue #164.
-  The author-equality check still uses lastname because branches are named
+  toward the two-peer-review requirement (issue #164).
+  The author-equality check uses lastname because branches are named
   `{Initial}.{Lastname}/...` and we only have the author's lastname to
   compare against.
 
+Single-Reviewer Exception (resolves #228):
+  When the PR is labeled `wave-bootstrap` AND there is exactly ONE distinct
+  reviewer who is a charter-enforcer role in the local roster, the hook
+  permits merge with one Approved comment instead of two. Charter
+  `pull-requests.md` § Single-Reviewer Exception (Wave-Bootstrap Only)
+  defines the policy; this is its hook-side enforcement.
+
+  Charter-enforcer roles are derived from the local repo's
+  `.claude/team/roster/` filenames matching the prefix allowlist:
+    standards_lead_*    (parent: Aino)
+    program_director_*  (parent: Nadia)
+    manager_*           (children: e.g. Maeve, Dilara, Bereket)
+    project_lead_*      (children: e.g. Marcia)
+    tech_lead_*         (children: e.g. Anya)
+  Each file's `**Name:** <Full Name>` line is parsed for the canonical name.
+
 Exit codes:
-  0 — allow (not a merge command, or two reviews exist)
-  2 — block (fewer than two peer reviews found, or a verdict is missing TechDebt)
+  0 — allow (not a merge command, two reviews, or single-reviewer exception)
+  2 — block (fewer than two reviews and exception does not apply, or a
+      verdict is missing TechDebt)
 """
 
 import json
@@ -53,9 +80,24 @@ import os
 import re
 import subprocess
 import sys
+from pathlib import Path
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from annunaki_log import log_pretooluse_block
+
+# Charter-enforcer role prefixes for the Single-Reviewer Exception. Derived
+# from `pull-requests.md § Single-Reviewer Exception (Wave-Bootstrap Only)`
+# "Standards & Quality Lead (Aino) or a comparable charter enforcer". The
+# prefix list captures the equivalent roles across parent + child rosters
+# observed in the org: standards_lead, program_director (parent), manager,
+# project_lead, tech_lead (children).
+_CHARTER_ENFORCER_ROLE_PREFIXES = (
+    "standards_lead_",
+    "program_director_",
+    "manager_",
+    "project_lead_",
+    "tech_lead_",
+)
 
 
 def is_merge_command(command: str) -> bool:
@@ -99,7 +141,8 @@ def extract_repo_from_command(command: str) -> str | None:
 def get_pr_data(pr_number: str | None, repo: str | None = None) -> dict | None:
     """Fetch all needed PR data in a single gh pr view call.
 
-    Returns dict with keys: author (login str), number, reviews, headRefName.
+    Returns dict with keys: author (login str), number, reviews, headRefName,
+    labels (list of label-name strings).
     Returns None if the fetch fails.
     """
     try:
@@ -108,7 +151,7 @@ def get_pr_data(pr_number: str | None, repo: str | None = None) -> dict | None:
             cmd.append(pr_number)
         if repo:
             cmd.extend(["--repo", repo])
-        cmd.extend(["--json", "author,number,reviews,headRefName"])
+        cmd.extend(["--json", "author,number,reviews,headRefName,labels"])
         result = subprocess.run(
             cmd,
             capture_output=True,
@@ -119,11 +162,13 @@ def get_pr_data(pr_number: str | None, repo: str | None = None) -> dict | None:
             return None
 
         data = json.loads(result.stdout)
+        labels = [label.get("name", "") for label in data.get("labels", [])]
         return {
             "author": data.get("author", {}).get("login", ""),
             "number": data.get("number", pr_number),
             "reviews": data.get("reviews", []),
             "headRefName": data.get("headRefName", ""),
+            "labels": labels,
         }
 
     except (subprocess.TimeoutExpired, json.JSONDecodeError, FileNotFoundError):
@@ -149,6 +194,10 @@ def extract_branch_author_lastname(head_ref: str) -> str | None:
 PROJECT_NUMBER = 2
 ORG = "noorinalabs"
 
+# Path to the local repo's roster directory. Resolved relative to the hook
+# file: /<repo_root>/.claude/hooks/validate_pr_review.py → /<repo_root>/.claude/team/roster.
+_ROSTER_DIR = Path(__file__).resolve().parent.parent / "team" / "roster"
+
 
 class CommentReviewResult:
     """Result of checking PR comments for charter-format reviews."""
@@ -160,25 +209,74 @@ class CommentReviewResult:
 
 
 # Only these RequestOrReplied values represent actual review verdicts that
-# REQUIRE the TechDebt attestation line. Request / Replied comments are
+# REQUIRE the TechDebt attestation line. Request / Reply comments are
 # process metadata (review requests, author replies) and do NOT require it.
 # Issue #147: the prior implementation flagged any Requestee+RequestOrReplied
 # comment, which over-enforced TechDebt on Request/Replied traffic.
-_VERDICT_REQUIRING_TECH_DEBT = {"approved", "changes requested", "changes"}
+#
+# Includes both the canonical `ChangesRequested` (one word, charter-line-14)
+# and the spaced/short variants observed in practice.
+_VERDICT_REQUIRING_TECH_DEBT = {
+    "approved",
+    "changes requested",
+    "changesrequested",
+    "changes",
+}
 
 
 def _is_verdict(value: str) -> bool:
     """Return True if a RequestOrReplied value is an actual review verdict.
 
-    Comparison is case-insensitive and whitespace-trimmed. Accepts both the
-    canonical `Changes Requested` and the shorter `Changes` variant noted in
-    charter discussion as seen in practice. Does NOT accept Request (a review
-    request) or Replied (an author's reply).
+    Comparison is case-insensitive and whitespace-trimmed. Accepts the
+    canonical `ChangesRequested` (per charter line 14), the spaced
+    `Changes Requested` form, and the shorter `Changes` variant noted in
+    charter discussion as seen in practice. Does NOT accept Request (a
+    review request) or Reply / Replied (an author's reply).
     """
     normalized = value.strip().lower()
     # Strip trailing markdown markers and stray punctuation
     normalized = normalized.rstrip("*").strip()
     return normalized in _VERDICT_REQUIRING_TECH_DEBT
+
+
+def _is_approved(value: str) -> bool:
+    """Return True if a RequestOrReplied value is specifically Approved.
+
+    The 2-reviewer rule (charter line 36) counts distinct Requestor values
+    across `Approved` comments only — NOT ChangesRequested. A
+    ChangesRequested comment is a verdict (TechDebt required) but does not
+    contribute to the 2-reviewer threshold.
+    """
+    normalized = value.strip().lower().rstrip("*").strip()
+    return normalized == "approved"
+
+
+def _extract_charter_field(field_name: str, body: str) -> str | None:
+    """Extract a charter-format field value from a comment body.
+
+    Handles markdown bold (`**Field:**`) and plain (`Field:`) variants.
+    Returns the first-line value with markdown markers and parenthetical
+    role descriptions stripped. Returns None if the field is not present.
+    """
+    pattern = rf"\*{{0,2}}{re.escape(field_name)}:\*{{0,2}}\s*(.+)"
+    match = re.search(pattern, body)
+    if not match:
+        return None
+    value = match.group(1).strip()
+    # Drop trailing content after first newline (single-line field).
+    value = value.split("\n", 1)[0].strip()
+    # Strip markdown bold and parenthetical role descriptions.
+    value = value.strip("*").strip()
+    value = re.sub(r"\s*\(.*?\)\s*$", "", value).strip()
+    return value or None
+
+
+def _name_lastname(full_name: str) -> str:
+    """Return the last name from a `Firstname Lastname` or `Firstname.Lastname` string."""
+    parts = re.split(r"[\s.]+", full_name)
+    if len(parts) >= 2:
+        return parts[-1]
+    return full_name
 
 
 def check_comment_reviews(
@@ -188,8 +286,15 @@ def check_comment_reviews(
 ) -> CommentReviewResult:
     """Check PR comments for charter-format review comments from different authors.
 
-    Returns a CommentReviewResult with distinct reviewer last names and any
-    reviews missing the mandatory TechDebt: attestation line.
+    Returns a CommentReviewResult with distinct reviewer names (keyed on full
+    name, lowercased) and any reviews missing the mandatory TechDebt line.
+
+    Reviewer identification per charter (resolves #244):
+      - Approved / ChangesRequested → reviewer is the Requestor (comment author)
+      - Request / Reply → not a review; does not contribute to reviewer set
+      - 2-reviewer threshold counts distinct Requestor values across Approved
+        comments only (ChangesRequested is a verdict-with-TechDebt but does
+        not count toward the threshold).
     """
     result = CommentReviewResult()
     try:
@@ -222,52 +327,31 @@ def check_comment_reviews(
         comments = json.loads(comments_result.stdout)
         for comment in comments:
             body = comment.get("body", "")
-            # Check for charter-format review: must contain Requestee: and RequestOrReplied:
-            # Handles markdown bold (**Requestee:**) and plain text (Requestee:)
-            has_requestee = re.search(r"\*{0,2}Requestee:\*{0,2}\s*(.+)", body)
-            ror_match = re.search(r"\*{0,2}RequestOrReplied:\*{0,2}\s*(.+)", body)
+            requestor = _extract_charter_field("Requestor", body)
+            ror_value = _extract_charter_field("RequestOrReplied", body)
 
-            if not (has_requestee and ror_match):
+            # A charter-format comment must have BOTH Requestor and
+            # RequestOrReplied. Comments missing either are not parsed.
+            if not (requestor and ror_value):
                 continue
 
-            # Extract Requestee name (the reviewer)
-            requestee_raw = has_requestee.group(1).strip()
-            # Strip markdown bold markers and parenthetical role descriptions
-            requestee_raw = requestee_raw.strip("*").strip()
-            requestee_name = re.sub(r"\s*\(.*?\)\s*$", "", requestee_raw).strip()
-            # Extract last name — handle "Firstname Lastname" and "Firstname.Lastname"
-            parts = re.split(r"[\s.]+", requestee_name)
-            if len(parts) >= 2:
-                reviewer_lastname = parts[-1]
-            else:
-                reviewer_lastname = requestee_name
+            is_verdict_comment = _is_verdict(ror_value)
+            is_approved_comment = _is_approved(ror_value)
 
-            # Reviewer must differ from branch author. Author check stays on
-            # lastname (branch format is `{Initial}.{Lastname}/...`), but the
-            # dedup key for the reviewer set is the FULL requestee name —
-            # otherwise two distinct reviewers sharing a lastname collapse
-            # into one (issue #164 fix: Lucas Ferreira + Santiago Ferreira
-            # were counted as 1/2 on deploy#81).
-            #
-            # NOTE: Reviewer counting is NOT filtered by verdict type. It
-            # continues to use all Requestee+RequestOrReplied comments as in
-            # prior behavior; issue #147 addresses the TechDebt filter only,
-            # and weakening the reviewer count would break existing flows.
-            if reviewer_lastname.lower() != branch_author_lastname.lower():
-                result.reviewers.add(requestee_name.lower())
+            # Only Approved comments contribute to the reviewer set toward
+            # the 2-reviewer threshold (charter line 36, resolves #244).
+            if is_approved_comment:
+                reviewer_lastname = _name_lastname(requestor)
+                if reviewer_lastname.lower() != branch_author_lastname.lower():
+                    result.reviewers.add(requestor.lower())
 
-            ror_value = ror_match.group(1).strip()
-            # Keep only the first line of the value, in case the regex greedy-
-            # matched into following content on the same line.
-            ror_value = ror_value.split("\n", 1)[0].strip()
-
-            # TechDebt attestation is REQUIRED only on actual verdicts
-            # (Approved / Changes Requested). Request / Replied comments do
-            # NOT require it (issue #147 fix).
-            if _is_verdict(ror_value):
+            # TechDebt attestation is required on every verdict
+            # (Approved + ChangesRequested) — issue #147 fix.
+            if is_verdict_comment:
                 has_tech_debt = re.search(r"\*{0,2}TechDebt:\*{0,2}\s*(.+)", body)
                 if not has_tech_debt:
-                    result.reviews_missing_tech_debt.append(requestee_name)
+                    # Reviewer name = Requestor on verdicts (charter line 30).
+                    result.reviews_missing_tech_debt.append(requestor)
                 else:
                     td_value = has_tech_debt.group(1).strip().strip("*").strip()
                     if td_value.lower() != "none":
@@ -279,6 +363,64 @@ def check_comment_reviews(
 
     except (subprocess.TimeoutExpired, json.JSONDecodeError, FileNotFoundError):
         return result
+
+
+def load_charter_enforcer_names() -> set[str]:
+    """Read the local roster dir and return canonical names of charter enforcers.
+
+    Charter enforcers are roster files matching the
+    `_CHARTER_ENFORCER_ROLE_PREFIXES` allowlist. Each file's
+    `**Name:** <Full Name>` line is parsed for the canonical name.
+    Returns an empty set on any I/O failure (fail-closed for the exception
+    path: if we can't read the roster, we don't grant the exception).
+
+    Names are returned in lowercase to match `CommentReviewResult.reviewers`'
+    dedup key (full name, lowercased).
+    """
+    enforcers: set[str] = set()
+    try:
+        if not _ROSTER_DIR.is_dir():
+            return enforcers
+        for entry in _ROSTER_DIR.iterdir():
+            if entry.suffix != ".md":
+                continue
+            if not any(entry.name.startswith(p) for p in _CHARTER_ENFORCER_ROLE_PREFIXES):
+                continue
+            try:
+                content = entry.read_text(encoding="utf-8")
+            except OSError:
+                continue
+            # Look for `**Name:** <Full Name>` (charter persona convention).
+            match = re.search(r"\*\*Name:\*\*\s*([^\n]+)", content)
+            if match:
+                enforcers.add(match.group(1).strip().lower())
+    except OSError:
+        return set()
+    return enforcers
+
+
+def is_single_reviewer_exception(
+    pr_labels: list[str],
+    reviewers: set[str],
+) -> bool:
+    """Return True if the PR qualifies for the Single-Reviewer Exception.
+
+    Strict conditions per charter `pull-requests.md` § Single-Reviewer Exception
+    (Wave-Bootstrap Only):
+      1. PR is labeled `wave-bootstrap`
+      2. There is EXACTLY ONE distinct reviewer in `reviewers`
+      3. That reviewer is a charter-enforcer role in the local roster
+
+    Resolves #228 — hook-side enforcement of the charter exception that was
+    previously not honored.
+    """
+    if "wave-bootstrap" not in pr_labels:
+        return False
+    if len(reviewers) != 1:
+        return False
+    sole_reviewer = next(iter(reviewers))
+    enforcers = load_charter_enforcer_names()
+    return sole_reviewer in enforcers
 
 
 def ensure_issues_on_board(repo: str, issue_numbers: list[str]) -> None:
@@ -336,6 +478,7 @@ def check(input_data: dict) -> dict | None:
     reviews = pr_data["reviews"]
     head_ref = pr_data["headRefName"]
     number = pr_data["number"]
+    labels = pr_data["labels"]
 
     formal_reviewers: set[str] = set()
     for review in reviews:
@@ -350,21 +493,32 @@ def check(input_data: dict) -> dict | None:
         if branch_author_lastname:
             comment_review_result = check_comment_reviews(number, branch_author_lastname, repo=repo)
 
-    total_distinct = len(formal_reviewers) + len(comment_review_result.reviewers)
+    distinct_reviewers = formal_reviewers | comment_review_result.reviewers
+    total_distinct = len(distinct_reviewers)
 
     pr_display = f"#{pr_number}" if pr_number else "(current branch)"
 
-    if total_distinct < 2:
-        found = total_distinct
+    # Single-Reviewer Exception (resolves #228) — wave-bootstrap PRs reviewed
+    # by a charter enforcer may merge with one Approved comment instead of
+    # two. Charter-enforcer role check uses the local roster.
+    if total_distinct == 1 and is_single_reviewer_exception(labels, distinct_reviewers):
+        # Exception applies — fall through to TechDebt check, then allow.
+        pass
+    elif total_distinct < 2:
         result = {
             "decision": "block",
             "reason": (
-                f"BLOCKED: PR {pr_display} has {found}/2 required peer reviews. "
-                "At least TWO reviews from distinct non-authors are required before merge.\n"
-                "Charter § Pull Requests requires two comment-based peer reviews for all merges.\n"
+                f"BLOCKED: PR {pr_display} has {total_distinct}/2 required peer reviews. "
+                "At least TWO Approved reviews from distinct non-authors are required before "
+                "merge.\n"
+                "Charter § Comment-Based Reviews counts distinct Requestor values across "
+                "Approved comments (resolves main#244).\n"
                 "Use `gh pr comment <PR#> --body '...'` with charter format:\n"
-                "  Requestor: <branch author>  Requestee: <reviewer>  "
+                "  Requestor: <reviewer>  Requestee: <PR author>  "
                 "RequestOrReplied: Approved  TechDebt: none | #issue, ...\n"
+                "Single-Reviewer Exception (charter § Single-Reviewer Exception (Wave-Bootstrap "
+                "Only)): label PR `wave-bootstrap` AND have a charter-enforcer review (Standards "
+                "Lead, Manager, Tech Lead, Project Lead, or Program Director).\n"
                 "Pass `--admin` for emergency overrides only."
             ),
         }
@@ -380,11 +534,12 @@ def check(input_data: dict) -> dict | None:
                 f"BLOCKED: PR {pr_display} has review(s) missing the mandatory "
                 f"TechDebt: attestation line.\n"
                 f"Reviewers without TechDebt line: {names}\n"
-                "Charter § Pull Requests requires every review to include:\n"
+                "Charter § Comment-Based Reviews requires every Approved/ChangesRequested "
+                "comment to include:\n"
                 "  TechDebt: none        (if no tech-debt found)\n"
                 "  TechDebt: #15, #16    (if issues were filed)\n"
                 "Reviewer must create tech-debt labeled issues for all non-blocking "
-                "findings BEFORE posting the review.\n"
+                "findings BEFORE posting the verdict.\n"
                 "Pass `--admin` for emergency overrides only."
             ),
         }


### PR DESCRIPTION
## Summary

Closes 3 sibling issues (charter ambiguity → hook alignment → exception support) by aligning `validate_pr_review.py` with the canonical charter-format reading codified pre-W4-kickoff in `pull-requests.md § Comment-Based Reviews`.

| Issue | Subject | Resolved by |
|---|---|---|
| #233 | Charter ambiguity: Requestor/Requestee directionality | Charter side already in commit `8deb979`; this hook aligns implementation |
| #244 | Hook treats Requestee as reviewer; mismatched with charter | Count distinct **Requestor** values across **Approved comments** only |
| #228 | Hook doesn't honor Single-Reviewer Exception | New `is_single_reviewer_exception()`: wave-bootstrap label + charter-enforcer reviewer |

## What changed

### `validate_pr_review.py`

- **Reviewer counting flipped (#244)** — for `Approved` comments, the reviewer is the **Requestor** (comment author per charter line 22). The prior hook counted distinct Requestee values, which on verdicts is always the PR author and so collapsed to a single value. The P3W3 wave-merge `--admin` cascade was the live trip.
- **Threshold narrowed to Approved-only (charter line 36)** — `ChangesRequested` is still a verdict for TechDebt-attestation purposes (TechDebt line required) but does NOT count toward the 2-Approved threshold. Two distinct Approveds satisfy the rule; CR comments alone do not.
- **`ChangesRequested` (camelCase) added** to the verdict-recognition set alongside `Changes Requested` and `Changes`.
- **Single-Reviewer Exception (#228)** — `is_single_reviewer_exception(labels, reviewers)` returns True when ALL of:
  1. PR labeled `wave-bootstrap`
  2. Exactly ONE distinct reviewer
  3. That reviewer is a charter-enforcer per local roster

  Charter-enforcer roles derived from the local `.claude/team/roster/` filenames matching the prefix allowlist: `standards_lead_*`, `program_director_*`, `manager_*`, `project_lead_*`, `tech_lead_*`. Each persona file's `**Name:**` line is parsed for the canonical name. Works across parent (Aino as Standards Lead) and children (Anya as Tech Lead, Maeve/Dilara/Bereket as Manager, Marcia as Project Lead) without hardcoding names.
- **New helpers** for code clarity: `_is_approved()`, `_extract_charter_field()`, `_name_lastname()`, `load_charter_enforcer_names()`, `is_single_reviewer_exception()`.
- **Block-message updated** to reference Single-Reviewer Exception path explicitly.
- **Hook docstring updated** with full Input Language spec, charter-format direction table, and reviewer-counting rule.

### `tests/test_validate_pr_review.py`

- **All 30 existing tests migrated** to canonical format. Verdict-comment fixtures swap Requestor↔Requestee. Migration is intentional: the tests embedded the OLD format from before the charter clarification landed pre-kickoff. New file header documents the canonical direction table.
- **23 new tests across 5 new classes:**
  - `IsApprovedTests` (6) — Approved vs other verdicts
  - `RequestorCountingTests` (4) — including a P3W3 wave-merge repro
  - `LoadCharterEnforcerNamesTests` (3) — roster filename parsing against the actual parent roster
  - `SingleReviewerExceptionTests` (5) — exception logic isolated
  - `CheckEndToEndTests` (5) — integration paths through `check()`

Total: **53 tests in `test_validate_pr_review.py`** (was 30); **262 across the full hooks test suite** (262 passed).

## Test plan

- [x] `ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/test_validate_pr_review.py` → 53 passed
- [x] `ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/` → 262 passed
- [x] P3W3 wave-merge repro test verifies the `--admin` cascade no longer occurs (2 distinct Requestors recognized)
- [x] Single-Reviewer Exception integration tests cover all four logical branches (label-yes/no × enforcer-yes/no, plus "two reviewers" early-exit)
- [x] Existing `--admin` short-circuit, `is_merge_command`, `extract_branch_author_lastname` all preserved unchanged
- [ ] Reviewer ack from @Wanjiku Mwangi (primary) + @Nadia Khoury (secondary)

## Charter compliance

- All four Hook Authorship Requirements satisfied: input-language docstring, charter entry (Hook 7 already present, semantics now match), negative-match coverage, dispatcher registration unchanged.
- Branch `A.Virtanen/0244-pr-review-canonicalization` matches `{FirstInitial}.{LastName}/{IIII}-{slug}` per `branching.md`.
- Bundle PR closes 3 issues per Nadia's serialization plan (T1 in P3W4).
- 2-reviewer slate: Wanjiku primary + Nadia secondary.

## Post-merge expectations (revised per Wanjiku's CR — issuecomment-4375093593)

This PR enables the **canonical hook reading** of charter `pull-requests.md § Comment-Based Reviews` (Requestor=reviewer on Approved verdicts; Approved-only counting toward the 2-reviewer threshold). The hook code is correct and passes Wanjiku's 4 scrutiny points + Nadia's empirical roster verification.

The 4 W4 wave-bootstrap PRs (`isnad-graph#857`, `user-service#94`, `design-system#63`, `data-acquisition#34`) currently carry reviewer comments shaped as `RequestOrReplied: Request` with prose-`Approved` content. Under the canonical hook, those are not recognized as Approved verdicts — `_is_approved("Request")` is False, the reviewer set stays empty, and `is_single_reviewer_exception` requires `len(reviewers) == 1` so the exception path doesn't fire on 0 either.

**Therefore, after this PR merges, the 4 wave-bootstrap PRs still need their reviewer comments re-posted in canonical `RequestOrReplied: Approved` format BEFORE they can merge.** That re-comment work is tracked in **#252**, owned by team-lead, executed post-#250-merge (~5 min). Once the re-comments land, the Single-Reviewer Exception path correctly fires per the existing `test_one_reviewer_with_wave_bootstrap_and_enforcer_allows` test.

End-to-end test coverage gap (the existing exception test mocks `check_comment_reviews`, so doesn't exercise the actual wave-bootstrap comment-shape parsing) is tracked in **#253** for future hardening.

The earlier "this PR is the unblocker" framing in this PR body was a load-bearing over-statement — Wanjiku live-traced the 4 wave-bootstrap PRs against the canonical hook semantics and caught it. Memory `feedback_live_trace_over_synthetic_acceptance` correctly applied at the reviewer layer; my own PR-body framing didn't. Captured for retro.

_Body revision: post-CR clarification at 2026-05-04T22:54Z; hook code unchanged at HEAD `31cdb12`._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
