### PR TITLE
charter+docs(P3W4-T4): sweep 6 charter/docs followups (closes #225 #239 #240 #200 #201 #197)

### DIFF
--- a/.claude/team/charter/agents.md
+++ b/.claude/team/charter/agents.md
@@ -173,18 +173,21 @@ All spawned agents MUST be named `{repo-name}-{persona-firstname}` (e.g., `main-
 | `noorinalabs-main` (cross-repo) | `main-` |
 
 ## Team Names <!-- promotion-target: none -->
-Each repo defines its own `team_name` in its repo charter. Use that name for all Agent tool calls when working in that repo. For cross-repo coordination, use `team_name: "noorinalabs"`.
+
+> **Single-Leader Constraint applies.** Per § Single-Leader Constraint below, only ONE team can exist per orchestrator session. The per-repo `team_name` rows in this table are therefore **only operative when you open a session dedicated to that one repo for repo-only work**. The common case — wave-kickoff orchestration from `noorinalabs-main` touching multiple child repos — uses `team_name: "noorinalabs"` for every agent regardless of which repo's code they're editing. Read § Single-Leader Constraint first; the rows below are the per-repo-session fallback, not the cross-repo default.
+
+Each repo defines its own `team_name` in its repo charter. For dedicated per-repo sessions, use that name for all Agent tool calls when working in that repo. For cross-repo coordination (the common case), use `team_name: "noorinalabs"`.
 
 | Context | team_name |
 |---------|-----------|
-| Work in noorinalabs-isnad-graph | `noorinalabs-isnad-graph` |
-| Work in noorinalabs-landing-page | `noorinalabs-landing-page` |
-| Work in noorinalabs-deploy | `noorinalabs-deploy` |
-| Work in noorinalabs-design-system | `noorinalabs-design-system` |
-| Work in noorinalabs-data-acquisition | `noorinalabs-data-acquisition` |
-| Cross-repo coordination | `noorinalabs` |
+| Cross-repo coordination (default for wave work orchestrated from `noorinalabs-main`) | `noorinalabs` |
+| Dedicated session in noorinalabs-isnad-graph (repo-only work) | `noorinalabs-isnad-graph` |
+| Dedicated session in noorinalabs-landing-page (repo-only work) | `noorinalabs-landing-page` |
+| Dedicated session in noorinalabs-deploy (repo-only work) | `noorinalabs-deploy` |
+| Dedicated session in noorinalabs-design-system (repo-only work) | `noorinalabs-design-system` |
+| Dedicated session in noorinalabs-data-acquisition (repo-only work) | `noorinalabs-data-acquisition` |
 
-> **Agent tool limitation:** Spawned agents (including the Program Director and team members) do NOT have access to the Agent tool. They cannot spawn other agents. All agent spawning must be done by the orchestrating Claude instance.
+> **Agent tool limitation:** Spawned agents (including the Program Director and team members) do NOT have access to the Agent tool. They cannot spawn other agents. All agent spawning must be done by the orchestrating Claude instance. This is the harness reinforcement of the single-team constraint — see § Hub-and-Spoke Orchestration Model and § Single-Leader Constraint.
 
 ## Single-Leader Constraint: One Team Per Orchestrator Session <!-- promotion-target: none -->
 
@@ -204,15 +207,34 @@ The harness enforces **one team per orchestrator session** — `TeamCreate` fail
 4. **Implementers report** back to their assigning manager via `SendMessage`. Cross-manager coordination is in-band (`SendMessage`) plus on-GitHub (meta-issue comments + Cross-Contract PRs).
 5. **Per-repo rosters remain canonical** for commit identity, domain ownership, and reviewer pairing — the session team is a logical overlay on top of them.
 
+### Reviewer slate discipline (FIRST-LINE in every spawn prompt)
+
+> **Position-first rule (resolves [main#201](https://github.com/noorinalabs/noorinalabs-main/issues/201)).** The reviewer slate is the first decision the spawn prompt forces the orchestrator (or PD-via-spawn-request) to make — not buried mid-checklist where it gets back-filled after scope/branch/sequencing have already framed the assignment. Every spawn prompt template MUST place this section immediately after the identity / git-identity preamble and BEFORE the `## Ontology Context` section.
+>
+> **You MUST NOT name as reviewer:**
+> - The **manager of the implementer's repo** (manager-boundary rule — see `pull-requests.md` § Two-Reviewer Assignment, observed-and-corrected ≥4× across three managers in P2W10).
+> - The **author of the upstream PR being reviewed** (self-review boundary — `block_gh_pr_review.py` enforces, but spawn-time prevention is cheaper than merge-time block).
+> - An agent currently **owning a gating issue** for this PR (independence — the gating-issue owner needs to drive resolution, not bless the implementation).
+> - An **Advisor-only role** on a cross-team consultation (per task-framework Statement A/B distinction — Advisor reviews shape decisions, not PR diffs).
+>
+> **Valid reviewer sources:**
+> - **Same-team technical peers** — primary slot (e.g., user-service tech-lead reviewing user-service implementer).
+> - **Cross-team technical peers with substantive domain overlap** — secondary slot (e.g., deploy SRE reviewing user-service CI workflow change).
+> - **Standards & Quality Lead (Aino Virtanen)** for charter-convention questions only — not as a generic peer-review slot.
+>
+> **Name BOTH reviewers explicitly in the spawn prompt** AND in the kickoff comment AND in the meta-issue execution-plan table BEFORE any branches are created. If the PD's execution-plan table is missing a 2nd reviewer for any expected PR, the orchestrator pauses spawning and asks the PD to fill the gap (see `pull-requests.md` § Two-Reviewer Assignment at Wave Kickoff).
+>
+> **Why position-first:** P2W10 surfaced four+ instances across three managers' spawn prompts where the manager-as-reviewer anti-pattern slipped through despite charter rule existing. Pattern: reviewer-naming had already happened mentally during the early-drafting pass (scope/branch/sequencing first, reviewers as a back-fill). The charter rule was correctly applied in isolated contexts but missed when embedded in a multi-section spawn prompt. Moving the rule to first-line position makes "who reviews this" a first-order architectural decision the template forces the agent to make before advancing. Discipline becomes architectural, not memorial. Co-signed by Bereket (deploy manager), Nadia Boukhari (isnad-graph + user-service manager), Marcia (landing-page manager) — each had a concrete instance during W10.
+
 ### Orchestrator checklist when spawning an implementer
 
-Every implementer spawn prompt MUST include:
+Every implementer spawn prompt MUST include, **in order**:
 
-1. **`## Ontology Context`** section (literal heading) with librarian output baked in — `enforce_ontology_context.py` scans for this heading and blocks the spawn if absent.
-2. **MANDATORY first-action** instruction to run `/ontology-librarian {topic}` in the spawned agent's own session — Hook 15 scans the agent's transcript independently and blocks Edit/Write otherwise.
-3. **Git identity** flags (`git -c user.name="..." -c user.email="parametrization+FirstName.LastName@gmail.com"`).
-4. **Branch name** matching `{FirstInitial}.{LastName}/{IIII}-{slug}` and **PR target** (typically `deployments/phase-{N}/wave-{M}`).
-5. **Reviewer pairings** (2 named reviewers, charter format).
+1. **Reviewer slate** (first-line per § Reviewer slate discipline above) — both reviewers named, manager-boundary verified, valid-source check applied.
+2. **`## Ontology Context`** section (literal heading) with librarian output baked in — `enforce_ontology_context.py` scans for this heading and blocks the spawn if absent.
+3. **MANDATORY first-action** instruction to run `/ontology-librarian {topic}` in the spawned agent's own session — Hook 15 scans the agent's transcript independently and blocks Edit/Write otherwise.
+4. **Git identity** flags (`git -c user.name="..." -c user.email="parametrization+FirstName.LastName@gmail.com"`).
+5. **Branch name** matching `{FirstInitial}.{LastName}/{IIII}-{slug}` and **PR target** (typically `deployments/phase-{N}/wave-{M}`).
 6. **Cross-Contract rule** reference if the PR is part of a cross-contract cluster (charter `pull-requests.md`).
 7. **Charter enforcement reminders** (2 reviewers, CI green before merge, no `--no-verify`, no global/repo git config, `/ontology-librarian` per agent).
 8. **Reporting pattern** — who they report to (usually their manager) and when (draft open, CI green, blocker, merge).

--- a/.claude/team/charter/pull-requests.md
+++ b/.claude/team/charter/pull-requests.md
@@ -155,6 +155,40 @@ This catches semantic conflicts that GitHub's textual merge cannot detect (e.g.,
 
 **CI enforcement:** All repositories must configure CI workflows to trigger on pushes to `deployments/**` branches (not just PRs). This provides automatic verification after each merge, complementing the manager's manual check.
 
+## CI Workflow `pull_request` Triggers Must Cover Wave Branches <!-- promotion-target: none -->
+
+CI workflows using a `pull_request` trigger MUST include active wave branches in the `branches` filter, OR omit the filter entirely so the workflow triggers on any base branch. Workflows whose `branches` filter is locked to `["main"]` (or any other single-branch list) silently skip CI on PRs targeting `deployments/phase-{N}/wave-{M}` — the wave PRs that aggregate before the main merge. This is the inverse of the push-trigger rule above: push triggers must cover `deployments/**`, AND PR triggers must cover them too.
+
+**Required pattern** — explicit branch list including wave branches:
+
+```yaml
+on:
+  pull_request:
+    branches: ["main", "deployments/**"]
+```
+
+**OR — path-filtered (no branches filter at all):**
+
+```yaml
+on:
+  pull_request:
+    paths:
+      - "src/**"
+      - "tests/**"
+```
+
+**Anti-pattern** — main-only filter that drops wave-branch PRs:
+
+```yaml
+on:
+  pull_request:
+    branches: ["main"]   # WRONG: wave-branch PRs skip CI silently
+```
+
+**Reviewer enforcement:** When a PR adds or modifies a `.github/workflows/*.yml` file with a `pull_request: branches:` filter, reviewers MUST flag any single-branch list that does NOT include `deployments/**`, unless the PR body explicitly justifies the exclusion (e.g., "this workflow only runs on main-merge promotions, not pre-merge PRs").
+
+**Why:** P2W10 surfaced this convention gap twice independently. (1) `noorinalabs-user-service/ci.yml` had `branches: ["main"]` — Anya's user-service#80 alembic-merge PR targeting `deployments/phase-2/wave-10` produced an empty `statusCheckRollup` (filed user-service#81). (2) `noorinalabs-deploy/integration-tests.yml` had the same anti-pattern — wave-10 PRs touching `integration-tests/**` would skip CI (filed deploy#152, fix in deploy#154). Both are the same CI-trigger-filter-written-against-single-branch-PR-flow error. Per [`feedback_enforcement_hierarchy.md`](../feedback_log.md), charter codification is step 1 + 2 (rule + reviewer reference); a future `validate_ci_trigger_branches` PreToolUse hook is filed as step 3 if the convention proves robust without manual reviewer reminders.
+
 ## Cross-Contract PRs <!-- promotion-target: skill -->
 When two or more PRs in flight consume/produce from each other (Kafka topics, Parquet schemas, shared API contracts, wire formats between workers or services), the **first PR opened MUST include a "Contract" section** in the PR body. Subsequent PRs that consume or produce against that contract link to it and document any divergence explicitly.
 

--- a/.claude/team/charter/tech-decisions.md
+++ b/.claude/team/charter/tech-decisions.md
@@ -17,3 +17,73 @@ When agreement cannot be reached between parties, the decision escalates to the 
 | TPM ↔ Standards Lead | Program Director (Nadia) |
 | Release Coordinator ↔ Standards Lead | Program Director (Nadia) |
 | Any org-level member ↔ repo manager | Program Director (Nadia) |
+
+## Base Image Pinning <!-- promotion-target: none -->
+
+All Dockerfile `FROM` statements MUST use a **digest-pinned tag** combined with an in-image package upgrade. This closes two failure modes that were each individually surfaced — floating-tag drift and within-tag package drift — by combining the two defenses.
+
+**Required pattern (Alpine-based images):**
+
+```dockerfile
+# Digest-pinned tag + apk upgrade for defense-in-depth
+FROM nginx:stable-alpine3.23@sha256:0272e460...
+RUN apk upgrade --no-cache
+```
+
+**Equivalent for other distro families:**
+
+| Family | Pin shape | Upgrade command |
+|---|---|---|
+| Alpine | `image:tag@sha256:digest` | `RUN apk upgrade --no-cache` |
+| Debian-slim | `image:tag@sha256:digest` | `RUN apt-get update && apt-get -y upgrade && apt-get clean && rm -rf /var/lib/apt/lists/*` |
+| Distroless | `image:tag@sha256:digest` | none — no package manager (pinned-only is sufficient) |
+| Multi-stage with `scratch` final | final layer pinned by upstream stage's digest | n/a (final layer has no package manager) |
+
+**What is prohibited:**
+
+```dockerfile
+# WRONG (floating tag): pulls latest at build time; no reproducibility
+FROM nginx:alpine
+
+# INSUFFICIENT (pin-only): tag is frozen but Alpine packages drift inside the
+# pinned digest's lifetime. CVE class re-emerges silently. This is exactly
+# the shape isnad-graph#853 hit.
+FROM nginx:stable-alpine3.23@sha256:...
+
+# INSUFFICIENT (apk-only): always-current packages but base layer drifts
+# unpredictably; build-time-dependent.
+FROM nginx:alpine
+RUN apk upgrade --no-cache
+```
+
+**Acceptable exemptions:**
+
+- `scratch` final layer in a multi-stage build — final image has no package manager; the upstream stages still follow this rule.
+- Vendor-supplied images that are not redistributable as digest-pinned (rare; document the exemption inline as a `# RATIONALE:` comment on the `FROM` line).
+
+**Reviewer enforcement:** Absence of a digest pin OR absence of the upgrade step on a `Dockerfile` PR is grounds for `ChangesRequested`. The pattern is mechanical; reviewers cite this section.
+
+**Promotion path:** This is step 1 + 2 (charter + memory) of the [enforcement hierarchy](../../../charter/hooks.md). A future `validate_dockerfile_base_pin` PreToolUse hook (step 3) is filed if the convention proves load-bearing across multiple Dockerfile PRs without manual reviewer reminders.
+
+**Why:** Surfaced by Linh-review during P3W3 review of `noorinalabs-isnad-graph#854` (Idris-853's Trivy CVE fix). The combined `digest-pin + apk upgrade` pattern Idris chose was the right shape but had no normative reference; without it the next Dockerfile author would default to a floating `nginx:alpine` (the failure shape that produced #853 in the first place). Codifying the pattern closes that gap.
+
+**Scope:** Applies to all repos under the `noorinalabs` org. Companion issue tracks digest-pin freshness via Renovate/Dependabot (pin-rot is the inverse failure mode — pins must be updated on a cadence, never frozen indefinitely).
+
+## Per-Env OAuth Provisioning <!-- promotion-target: none -->
+
+Every deployment environment (`stg`, `prod`, future `dev` / `canary`) gets its **own** Google OAuth client and its own GitHub OAuth app. They are never shared across environments.
+
+The four `AUTH_GOOGLE_CLIENT_ID/SECRET` + `AUTH_GITHUB_CLIENT_ID/SECRET` secrets resolve from GitHub Environments **env-scope**, not org-scope. Same secret names across envs; env-scope encodes which env you are in.
+
+**Why per-env, not shared:**
+
+- **Google publishing-status is per-app** — `prod` must run `In Production`, `stg` must run `Testing`. The same OAuth app cannot be both.
+- **Credential isolation** — a leaked stg credential does not affect prod login.
+- **Metrics & quota separation** — prod analytics aren't polluted by stg test traffic.
+- **Redirect URI hygiene** — each app's allowed-URI list contains only its env's callback (`/auth/callback` on the env's host).
+
+**How (operations):** see [`noorinalabs-deploy/docs/runbooks/oauth-per-env.md`](https://github.com/noorinalabs/noorinalabs-deploy/blob/main/docs/runbooks/oauth-per-env.md) for the 4-step provisioning + rotation procedure and the redirect-URI convention table.
+
+**Adjacent conventions:** env-scope-by-default for service-internal secrets (`USER_POSTGRES_*`, `JWT_*`, `KAFKA_*`, `NEO4J_PASSWORD`) per [secrets-audit § 3.9](../../../docs/secrets-audit-2026-04-24.md). OAuth credentials follow the same env-scope pattern; this convention codifies the "per-env" requirement that makes the env-scope pattern necessary in the first place.
+
+**Promotion provenance:** Surfaced from [deploy#244](https://github.com/noorinalabs/noorinalabs-deploy/issues/244) — runbook landed in deploy repo, but the org-wide convention is the right altitude for charter. Filed as main#240 to capture in this charter so future env splits inherit the pattern from day 1 instead of re-deriving it from incident reflection.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ This repo (`noorinalabs-main`) is a **parent-level git repo that `.gitignore`s c
 
 ### Team Composition
 
-This is the **org-level coordination team** for `noorinalabs-main`. Each child repo has its own team — this team coordinates across repos.
+This is the **org-level coordination team** for `noorinalabs-main`. Each child repo has its own roster of personas, but every spawned agent in a cross-repo session is a member of the single `noorinalabs` session team — see § Session team architecture below.
 
 | Role | Level | Name | File |
 |------|-------|------|------|
@@ -46,6 +46,18 @@ This is the **org-level coordination team** for `noorinalabs-main`. Each child r
 | Technical Program Manager | Staff | Wanjiku Mwangi | `roster/tpm_wanjiku.md` |
 | Release Coordinator | Senior | Santiago Ferreira | `roster/release_coordinator_santiago.md` |
 | Standards & Quality Lead | Staff | Aino Virtanen | `roster/standards_lead_aino.md` |
+
+### Session team architecture
+
+The harness enforces **one team per orchestrator session**. `TeamCreate` fails with "Already leading team" if a team already exists in the session, and spawned agents do NOT have access to the `Agent` tool — only the orchestrating Claude instance can spawn. Together these eliminate the "each repo is its own team, managers spawn implementers per-repo" mental model and enforce a hub-and-spoke pattern: the team lead spawns everyone, and managers request implementer spawns via `SendMessage`.
+
+**What this means in practice:**
+
+- Cross-repo waves orchestrated from `noorinalabs-main` always use `team_name: "noorinalabs"` for every agent — managers AND implementers across all 7 child repos.
+- Per-repo team names (`noorinalabs-isnad-graph`, `noorinalabs-deploy`, etc.) only apply when a session is opened in isolation in that repo for repo-only work — NOT the common case for wave-kickoff orchestration.
+- Per-repo rosters under `<repo>/.claude/team/roster/` remain canonical for **commit identity, domain ownership, and reviewer pairing** — the session team is a logical overlay on top of them.
+
+The full constraint and delegation mechanics (orchestrator checklist, spawn-request protocol, why this is hub-and-spoke and not recursive delegation) live in [`.claude/team/charter/agents.md` § Single-Leader Constraint](.claude/team/charter/agents.md). Read that section before spawning the team in any new session.
 
 ### Key Rules
 - **Commit identity:** Each team member commits using per-commit `-c` flags with their name and `parametrization+{FirstName}.{LastName}@gmail.com` email — **never** set global/repo git config. See `.claude/team/charter.md` § Commit Identity for the full table.

--- a/docs/secrets-audit-2026-04-24.md
+++ b/docs/secrets-audit-2026-04-24.md
@@ -135,7 +135,7 @@ Each secret's authoritative source lives OUTSIDE GitHub. Before any `set-org` / 
 | `HCLOUD_TOKEN` | Hetzner Cloud Console → (noorinalabs project) → Security → API tokens. Value shown once at creation — regenerate if lost. |
 | `GH_PACKAGES_TOKEN` | GitHub → Developer Settings → Personal access tokens with `read:packages` / `write:packages` for the `@noorinalabs` npm scope. Regenerate if unknown. |
 | `JWT_PRIVATE_KEY` / `JWT_PUBLIC_KEY` | `~/.ssh/jwt_private.pem` and `~/.ssh/jwt_public.pem` on the owner's workstation. If not recoverable, regenerate via `openssl` and re-issue all outstanding JWTs (breaking change — plan a user session-reset window). |
-| `POSTGRES_*`, `USER_POSTGRES_*`, `REDIS_*`, `USER_REDIS_*`, `NEO4J_*` (passwords/users/dbs) | Current VPS filesystem — `TODO(santiago):` confirm canonical path for the rendered env files (e.g., `/opt/noorinalabs/stg/.env` on the staging VPS). These can be `ssh`-copied to the staging tree with a `cat` over the pipe — do NOT scp the whole env file into the staging tree. **Blocked on two-VPS topology discussion — see [noorinalabs/noorinalabs-main#212](https://github.com/noorinalabs/noorinalabs-main/issues/212). Once that issue names canonical env-file paths per VPS, this row and § 3.9 Tier C migration become executable.** |
+| `POSTGRES_*`, `USER_POSTGRES_*`, `REDIS_*`, `USER_REDIS_*`, `NEO4J_*` (passwords/users/dbs) | Current VPS filesystem — rendered `.env` at `/opt/noorinalabs-deploy/.env` on both stg and prod VPSes (resolved via [main#212](https://github.com/noorinalabs/noorinalabs-main/issues/212) walkthrough 2026-04-29). These can be `ssh`-copied to the staging tree with a `cat` over the pipe — do NOT scp the whole env file into the staging tree. **Tier C env-scope migration executed 2026-04-26 against this path (per main#148 closure comments).** |
 | `GRAFANA_ADMIN_PASSWORD` | Same as Postgres — rendered env file on the VPS. |
 | `KAFKA_CLUSTER_ID` | Generated at cluster bootstrap, persisted as a per-env Terraform output in the respective `terraform/kafka/` workspace (stg + prod each get their own cluster ID — promotion does not drag the ID across envs). Retrieval: `terraform output kafka_cluster_id` against the relevant env's state. Not a credential (22-char KRaft quorum UUID); treated as non-secret but persisted for restart stability. |
 | `KAFKA_UI_USER` / `KAFKA_UI_PASSWORD` | Rendered env file on VPS (Kafka-UI container config). |
@@ -260,7 +260,7 @@ done
 
 ### 3.4. JWT keypair — `JWT_PRIVATE_KEY`, `JWT_PUBLIC_KEY`
 
-> Value sources: `$STAGING/org/JWT_PRIVATE_KEY` and `$STAGING/org/JWT_PUBLIC_KEY` (staged per § 3.0.b from canonical keypair custody — see § 3.0.a `TODO(santiago):`). If either value is unrecoverable, regenerate the keypair upstream and plan the JWT re-issue window BEFORE running this section.
+> Value sources: `$STAGING/org/JWT_PRIVATE_KEY` and `$STAGING/org/JWT_PUBLIC_KEY` (staged per § 3.0.b from canonical keypair custody — see § 3.0.a row for `JWT_PRIVATE_KEY` / `JWT_PUBLIC_KEY`). If either value is unrecoverable, regenerate the keypair upstream and plan the JWT re-issue window BEFORE running this section.
 
 ```bash
 for SECRET in JWT_PRIVATE_KEY JWT_PUBLIC_KEY; do
@@ -323,7 +323,7 @@ gh secret delete GH_PACKAGES_TOKEN --repo noorinalabs/noorinalabs-isnad-graph
 ### 3.8. `DEPLOY_SSH_PRIVATE_KEY` — TWO-STAGE migration
 
 > Value sources:
-> - Stage 1 (org-scope transitional): `$STAGING/org/DEPLOY_SSH_PRIVATE_KEY` — current shared keypair per § 3.0.a `TODO(santiago):`.
+> - Stage 1 (org-scope transitional): `$STAGING/org/DEPLOY_SSH_PRIVATE_KEY` — current shared keypair per § 3.0.a row for `DEPLOY_SSH_PRIVATE_KEY`.
 > - Stage 2 (env-scope): `$STAGING/env/staging/DEPLOY_SSH_PRIVATE_KEY` and `$STAGING/env/production/DEPLOY_SSH_PRIVATE_KEY` — generated at per-env Hetzner VPS cutover (main#141); new keypairs, each with its public half added to its env's VPS `authorized_keys`.
 
 **Stage 1 — org-scope (transitional, restores parity with stg/prod split):**


### PR DESCRIPTION
## Summary

T4 charter+docs sweep — 6 P3W4 follow-ups, each landing in the charter file Aino judged the right home. Markdown-only (5 files, +156/-18); no `.claude/hooks/*.py` surface — independent of T1 (#250) merge order, but flagged below.

| Issue | Scope | Target file |
|---|---|---|
| #225 | secrets-audit doc sweep — resolved-marker back-references | `docs/secrets-audit-2026-04-24.md` |
| #239 | base-image-pinning convention (digest-pin + apk upgrade) | `.claude/team/charter/tech-decisions.md` |
| #240 | per-env OAuth provisioning convention | `.claude/team/charter/tech-decisions.md` |
| #200 | CI workflow `pull_request` triggers must cover wave branches | `.claude/team/charter/pull-requests.md` |
| #201 | spawn-prompt reviewer-slate-rule at first-line position | `.claude/team/charter/agents.md` |
| #197 | clarify single-leader session-team architecture | `CLAUDE.md` + `.claude/team/charter/agents.md` |

## Per-issue acceptance

### #225 — `docs/secrets-audit-2026-04-24.md` (3 line edits)
- § 3.0.a row 16 (Postgres/Redis/Neo4j env-file path): replaced dangling `TODO(santiago):` with `/opt/noorinalabs-deploy/.env` (resolved via main#212 walkthrough 2026-04-29; same path on stg + prod).
- § 3.4 line 263 + § 3.8 line 326: swept stale `see § 3.0.a TODO(santiago):` back-references to point at the row directly.
- No other doc changes (sweep-only, per acceptance bullet).

### #239 — `tech-decisions.md` "Base Image Pinning" (new section)
- Required pattern: digest-pin tag + `apk upgrade --no-cache` (Alpine).
- Equivalents: debian-slim (`apt-get update && upgrade && clean`), distroless (pinned-only), multi-stage scratch (final layer pinned by upstream stage).
- Anti-patterns enumerated: floating tag, pin-only, apk-only.
- Reviewer-enforcement clause + promotion-path note for future `validate_dockerfile_base_pin` hook.

### #240 — `tech-decisions.md` "Per-Env OAuth Provisioning" (new section)
- Codifies that every env (stg, prod, future dev/canary) gets its own Google + GitHub OAuth apps. Env-scope via GitHub Environments.
- Why-list: publishing-status per-app, credential isolation, metrics separation, redirect-URI hygiene.
- Cross-refs to deploy#244 runbook + secrets-audit § 3.9 env-scope precedent.

### #200 — `pull-requests.md` "CI Workflow `pull_request` Triggers Must Cover Wave Branches" (new section)
- Required pattern: `branches: ["main", "deployments/**"]` OR omit branches in favor of `paths:`.
- Anti-pattern: `branches: ["main"]` alone (silently skips CI on wave-branch PRs).
- Reviewer-enforcement clause flags single-branch filters without explicit justification.
- Two W10 instances cited: user-service#80 / #81 + deploy#152 / #154.

### #201 — `agents.md` "Reviewer slate discipline (FIRST-LINE in every spawn prompt)" (new section + checklist reorder)
- New first-line callout fires BEFORE `## Ontology Context` and the rest of the spawn-prompt template.
- Encodes 4 forbidden reviewer classes: manager-of-implementer's-repo, upstream-PR-author, gating-issue-owner, Advisor-only.
- Encodes 3 valid sources: same-team peers (primary), cross-team peers with domain overlap (secondary), Standards Lead for charter questions.
- Existing "Orchestrator checklist" reordered: "Reviewer slate" becomes item #1, prior items shift down.
- 4+ W10 instances cited across three managers (Bereket, Boukhari, Marcia).

### #197 — `CLAUDE.md` + `agents.md` § Team Names disclaimer
- New `CLAUDE.md` § "Session team architecture" subsection points to charter `agents.md` § Single-Leader Constraint as canonical.
- `agents.md` § Team Names table reordered: cross-repo `noorinalabs` row first, per-repo rows reframed as "Dedicated session ... for repo-only work" — not the common case. Disclaimer above the table.
- Replaces prior framing that misled fresh readers into expecting multi-team sessions.

Per-repo CLAUDE.md updates (issue acceptance bullet 2) — DEFERRED to a follow-up: the parent repo's `noorinalabs-main/.gitignore`s the child repos, so editing each child's `CLAUDE.md` requires per-repo PRs in those repos. Not in scope for this single-repo PR.

## Test plan

- [x] `gh issue view 225/239/240/200/201/197` — all 6 acceptance bullets covered or scope-justified
- [x] `git diff --stat` — 5 files, +156/-18, exactly the issues' scope; no `.claude/hooks/*.py` or `.py` surface touched
- [x] Pre-commit ruff/mypy skipped (no Python files); markdown-only
- [x] Charter section `<!-- promotion-target: none -->` tags consistent with existing convention
- [x] All cross-references use repo-relative paths matching existing style
- [ ] Reviewer ack from @Wanjiku Mwangi (primary) + @Nadia Khoury (secondary)

## Merge ordering

No `.claude/hooks/*.py` overlap with T1 (#250) — the merge-order constraint Nadia flagged is about `.claude/hooks/` and `.claude/team/charter/` rebase pain. This PR touches `.claude/team/charter/` (3 files) but on different sections than T1's #233 docstring updates already on wave-4 from #248 merge. Reviewers should still confirm there's no rebase conflict if T1 lands first; I lean **block on T1 merge** out of caution since charter/`pull-requests.md` is the area Nadia specifically called out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
