### PR TITLE
hooks+charter(P3W4 T5 #214 Phase 1): canonical hook-sync doc + _shell_parse.py wave-4 sync

### DIFF
--- a/.claude/hooks/_shell_parse.py
+++ b/.claude/hooks/_shell_parse.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""Shared shell-arg-aware parser helper for PreToolUse Bash hooks.
+
+Background
+==========
+
+Multiple PreToolUse hooks have repeatedly tripped on substring/regex matching
+against the raw Bash command string (issues #118, #134, #144, #188, #189,
+#216, #223, #226, #227). Root cause: the matcher cannot tell *command-position*
+tokens (e.g. an actual `git config` invocation) from *data-position* text
+(e.g. the phrase "git config" inside a heredoc body, a `--body-file` argument
+value, or a documentation string).
+
+This module is the unifying primitive: tokenize once with shlex, segment-split
+on shell operators, then locate command-position tokens explicitly. Hooks call
+the small public API instead of writing one-off regexes.
+
+Public API
+==========
+
+    tokenize(cmd) -> list[str] | None
+        shlex.split with posix semantics. Returns None on parse failure
+        (unbalanced quotes, etc.) so callers can fall back to a regex path.
+
+        Caller contract: callers MUST handle None explicitly. Never treat
+        None as "allow" for security-relevant matchers like commit-identity
+        validation — fall back to a regex check or a fail-closed decision.
+        For warn-only matchers, fail-open on None is acceptable.
+
+    strip_heredocs(cmd) -> str
+        Removes <<DELIM .. DELIM, <<'DELIM' .. DELIM, <<"DELIM" .. DELIM and
+        <<-DELIM .. DELIM heredoc bodies (delimiter is rfc-shell-style: any
+        word). Handles repeated/nested heredocs by iterating until the regex
+        is fixed.
+
+    iter_command_segments(tokens) -> Iterator[list[str]]
+        Splits a token list on the shell-control tokens `;`, `&&`, `||`, `|`
+        (these survive shlex.split as their own tokens because they're not
+        inside quotes), strips leading `KEY=value` env-var assignments from
+        each segment, and yields the surviving tokens.
+
+    find_git_subcommand(segment) -> tuple[list[str], list[str]] | None
+        Given a single segment's tokens, returns (global_opts, [subcommand,
+        ...rest]) if it's a `git ...` invocation, else None. Skips git
+        global options (`-c k=v`, `-C dir`, `--git-dir=...`,
+        `--work-tree=...`, etc.) so the returned subcommand is the actual
+        git verb (`commit`, `config`, `worktree`, ...).
+
+    find_gh_subcommand(segment) -> tuple[list[str], list[str]] | None
+        Same shape for `gh ...`. Returns (gh_global_opts, [topic, action,
+        ...rest]) — e.g. ([], ["pr", "create", "--repo", ...]).
+
+    extract_dash_c_pairs(segment) -> list[tuple[str, str]]
+        Walks a tokenized git segment and returns (key, value) pairs for
+        every `-c key=value` global option, in source order. shlex has
+        already unquoted values, so a simple `split('=', 1)` is correct.
+
+        Repeated-key contract: `git -c user.name=A -c user.name=B commit`
+        is legal (last wins per git semantics). This helper returns ALL
+        pairs in source order; callers needing last-wins semantics can
+        do `dict(extract_dash_c_pairs(...))` (later keys overwrite
+        earlier in dict construction). Do not rely on first-occurrence
+        unless you handle dedup yourself.
+
+    resolve_tool_cwd(input_data) -> str
+        Returns input_data["cwd"] if the harness supplied it, else
+        os.getcwd(). The Claude Code harness sets `cwd` on the hook input
+        for tool calls that run from a known cwd; subprocess calls that
+        want to operate on the *user's* cwd (not the hook's parent process
+        cwd) should use this to anchor `subprocess.run(..., cwd=...)`.
+
+    is_shutdown_request_message(message) -> bool
+        True only if `message` is a structured shutdown_request JSON
+        (dict-form OR str-form parseable to a dict with type==
+        "shutdown_request"). Plain prose containing the substring is NOT
+        a shutdown request — that was the #189 false-positive root.
+
+Why not eval / parse the full shell grammar?
+============================================
+
+shlex.split + segment + command-position lookup is the 95% solution. Hooks
+that match against a known shape (`git commit`, `gh pr create`, `git config`)
+need exactly this. Full POSIX shell parsing is overkill and would re-introduce
+the parser-correctness debt the regexes had.
+
+When shlex.split fails (malformed quotes), callers MUST fall back to a regex
+or fail-open (return None to allow the command). Never crash on parse error.
+
+Promotion provenance
+====================
+
+Sibling-bug cluster (P3W4 Tier-2): #226 #227 #223 #216 #188 #144 #189.
+Tracking PR consolidates the parser into one tested helper and refactors
+five hooks (validate_commit_identity, validate_branch_freshness,
+block_git_config, block_no_verify, block_shutdown_without_retro).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+from typing import Iterator
+
+# Shell control tokens that segment a compound command. Any of these,
+# appearing as their OWN token after shlex.split, separates one pipeline
+# segment from the next.
+_SEGMENT_OPS = {";", "&&", "||", "|"}
+
+# Match KEY=value env-var assignment at command position. Must start with a
+# letter or underscore and contain only word chars before the '='. shlex has
+# already de-quoted any quoted value, so the value half is just "everything
+# after the first =".
+_ENV_ASSIGN_RE = re.compile(r"^[A-Za-z_]\w*=")
+
+# Heredoc opener: <<-?\s*['"]?DELIM['"]? on a line, then any content, then
+# the bare DELIM word terminating it. Supports the four shell variants
+# (<<EOF, <<'EOF', <<"EOF", <<-EOF). The `<<-` tabs-stripping form allows
+# leading tabs on the closing delimiter line, so we match optional `\t*`
+# before \1 in the closer position.
+_HEREDOC_RE = re.compile(
+    r"<<-?\s*['\"]?(\w+)['\"]?.*?\n.*?\n\t*\1\b",
+    re.DOTALL,
+)
+
+# git global options that consume a value (two-token form). Equals-form
+# (e.g. `--git-dir=path`) is handled separately as a single token.
+_GIT_VALUE_GLOBALS = {"-c", "-C", "--git-dir", "--work-tree", "--namespace", "--exec-path"}
+
+# git global boolean options (no value).
+_GIT_BOOL_GLOBALS = {
+    "--no-pager",
+    "-p",
+    "--paginate",
+    "--no-replace-objects",
+    "--bare",
+    "--no-optional-locks",
+}
+
+
+def tokenize(cmd: str) -> list[str] | None:
+    """shlex.split the command. Return None on parse error (unbalanced quote)."""
+    try:
+        return shlex.split(cmd, posix=True)
+    except ValueError:
+        return None
+
+
+def strip_heredocs(cmd: str) -> str:
+    """Remove all heredoc bodies. Iterates until no more matches (handles nested)."""
+    prev = None
+    cur = cmd
+    while prev != cur:
+        prev = cur
+        cur = _HEREDOC_RE.sub("", cur)
+    return cur
+
+
+def iter_command_segments(tokens: list[str]) -> Iterator[list[str]]:
+    """Split tokens on `;`, `&&`, `||`, `|` and strip leading KEY=val env vars.
+
+    Each yielded segment is a non-empty list of tokens representing one
+    command in the pipeline. Empty segments (e.g. trailing `;`) are skipped.
+    """
+    if not tokens:
+        return
+
+    cur: list[str] = []
+    for tok in tokens:
+        if tok in _SEGMENT_OPS:
+            if cur:
+                stripped = _strip_leading_env_assignments(cur)
+                if stripped:
+                    yield stripped
+                cur = []
+            continue
+        cur.append(tok)
+    if cur:
+        stripped = _strip_leading_env_assignments(cur)
+        if stripped:
+            yield stripped
+
+
+def _strip_leading_env_assignments(segment: list[str]) -> list[str]:
+    """Drop leading KEY=value tokens from a segment (one-shot env vars)."""
+    i = 0
+    while i < len(segment) and _ENV_ASSIGN_RE.match(segment[i]):
+        i += 1
+    return segment[i:]
+
+
+def _is_equals_form_global(tok: str) -> bool:
+    """True if `tok` is the equals-form of a value-taking git global.
+
+    Examples that return True: `-c=user.name=foo`, `--git-dir=.git`,
+    `--work-tree=/path`. We only care about the prefix; the value half is
+    irrelevant for the skip decision.
+    """
+    return (
+        tok.startswith("-c=")
+        or tok.startswith("-C=")
+        or tok.startswith("--git-dir=")
+        or tok.startswith("--work-tree=")
+        or tok.startswith("--namespace=")
+        or tok.startswith("--exec-path=")
+    )
+
+
+def find_git_subcommand(segment: list[str]) -> tuple[list[str], list[str]] | None:
+    """If `segment` is a `git ...` invocation, return (global_opts, [subcmd, ...]).
+
+    Skips git global options:
+      -c key=value          (consumed as one shlex token, possibly quoted)
+      -C path
+      --git-dir=path / --git-dir path
+      --work-tree=path / --work-tree path
+      --no-pager / -p / --paginate / --no-replace-objects   (no value)
+
+    Returns None if `segment` is empty, doesn't start with `git`, or doesn't
+    have a subcommand after the global-option run.
+    """
+    if not segment or segment[0] != "git":
+        return None
+
+    globals_: list[str] = []
+    i = 1
+    n = len(segment)
+    while i < n:
+        tok = segment[i]
+        if tok in _GIT_BOOL_GLOBALS:
+            globals_.append(tok)
+            i += 1
+            continue
+        if tok in _GIT_VALUE_GLOBALS:
+            globals_.append(tok)
+            if i + 1 < n:
+                globals_.append(segment[i + 1])
+                i += 2
+            else:
+                i += 1
+            continue
+        if _is_equals_form_global(tok):
+            globals_.append(tok)
+            i += 1
+            continue
+        # First non-option token is the subcommand.
+        return globals_, segment[i:]
+    return None
+
+
+def find_gh_subcommand(segment: list[str]) -> tuple[list[str], list[str]] | None:
+    """If `segment` is a `gh ...` invocation, return ([], [topic, action, ...]).
+
+    `gh` has no pre-subcommand global options worth skipping for the matchers
+    in this codebase, so this is a thin shape-mirror of `find_git_subcommand`.
+    """
+    if not segment or segment[0] != "gh":
+        return None
+    if len(segment) < 2:
+        return None
+    return [], segment[1:]
+
+
+def extract_dash_c_pairs(segment: list[str]) -> list[tuple[str, str]]:
+    """Walk a git segment and yield (key, value) for every `-c key=value`.
+
+    Handles `-c k=v` (two tokens) and `-c=k=v` (one token, rare). shlex has
+    already unquoted the value half, so `-c user.name="A B"` arrives here as
+    `["-c", "user.name=A B"]` (two tokens; the inner `=` is the key/value
+    separator handled by `split("=", 1)`).
+    """
+    pairs: list[tuple[str, str]] = []
+    if not segment or segment[0] != "git":
+        return pairs
+
+    i = 1
+    n = len(segment)
+    while i < n:
+        tok = segment[i]
+        if tok == "-c" and i + 1 < n:
+            kv = segment[i + 1]
+            if "=" in kv:
+                key, value = kv.split("=", 1)
+                pairs.append((key, value))
+            i += 2
+            continue
+        if tok.startswith("-c=") and "=" in tok[3:]:
+            kv = tok[3:]
+            key, value = kv.split("=", 1)
+            pairs.append((key, value))
+            i += 1
+            continue
+        # Other value-taking globals — skip the value too.
+        if tok in _GIT_VALUE_GLOBALS:
+            i += 2
+            continue
+        if _is_equals_form_global(tok):
+            i += 1
+            continue
+        if tok in _GIT_BOOL_GLOBALS:
+            i += 1
+            continue
+        # First non-option token is the subcommand — done collecting -c pairs.
+        break
+    return pairs
+
+
+def resolve_tool_cwd(input_data: dict) -> str:
+    """Return the cwd for the tool call.
+
+    The Claude Code harness sets `cwd` on the hook input for tool calls. When
+    present, it is the user's actual working directory at tool-call time —
+    which is what hooks should reason about, NOT the hook's parent process
+    cwd (which is whatever the agent was launched from, often the wrong repo
+    for a worktree subagent — see #144).
+
+    Falls back to os.getcwd() if the field is missing or empty (older
+    harness versions, manual invocations).
+    """
+    cwd = input_data.get("cwd")
+    if cwd and isinstance(cwd, str):
+        return cwd
+    return os.getcwd()
+
+
+def is_shutdown_request_message(message) -> bool:
+    """True iff `message` is a structured shutdown_request, NOT prose containing the phrase.
+
+    Accepts either:
+      - dict with `type: "shutdown_request"` (already-parsed JSON)
+      - str whose JSON-parsed object has `type: "shutdown_request"`
+
+    Plain text messages are NEVER treated as shutdown requests, even if they
+    contain the literal substring. Issue #189: subagents writing
+    "standing down" / "Acknowledge" prose were tripping the substring matcher.
+    """
+    if isinstance(message, dict):
+        return message.get("type") == "shutdown_request"
+    if not isinstance(message, str):
+        return False
+    s = message.strip()
+    if not s.startswith("{"):
+        return False
+    try:
+        obj = json.loads(s)
+    except (json.JSONDecodeError, ValueError):
+        return False
+    return isinstance(obj, dict) and obj.get("type") == "shutdown_request"

--- a/.claude/team/charter/hooks.md
+++ b/.claude/team/charter/hooks.md
@@ -191,6 +191,62 @@ When hooks sharing the same matcher type (Bash, Agent, SendMessage, etc.) accumu
 - **Out of scope for v1:** Net-zero infra-revert orphan detection (`statusCheckRollup: []` + non-base HEAD) — requires re-running GitHub's paths-filter evaluator at hook time. Filed as follow-up. Cross-repo reusable-workflow inheritance (`workflow_call`/`uses:`) — reviewer responsibility.
 - **Promotion provenance:** P2W10 retro-candidate (2026-04-24, deploy#153 76d7d7f orphan). Filed as [#203](https://github.com/noorinalabs/noorinalabs-main/issues/203) sibling of [#200](https://github.com/noorinalabs/noorinalabs-main/issues/200) — different layer of the same trigger-gap class. Promoted to hook in P3W4 T5.
 
+## Hook Sync Across Child Repos <!-- promotion-target: none -->
+
+Shared hooks live in `noorinalabs-main/.claude/hooks/` (the parent repo's hooks tree). Child repos consume them via **parent-canonical paths** — their own `.claude/settings.json` registers each hook by absolute path into the parent's hooks tree, e.g.:
+
+```jsonc
+{
+  "matcher": "Bash",
+  "hooks": [{
+    "type": "command",
+    "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/dispatcher.py",
+    "timeout": 30
+  }]
+}
+```
+
+**The parent's `.claude/hooks/` is the single source of truth for shared hook code.** Child repos do NOT keep local `.py` copies of shared hooks; they reference the parent's files by path. This makes a new shared hook a configuration change in each child's `settings.json`, not a code-fan-out across child repos — eliminating the drift risk that surfaced in P2W9 (Hook 14 was registered in the parent for ~2 weeks before #194 surfaced no child had it).
+
+### Required pattern
+
+For every shared hook (i.e., a hook that exists at `noorinalabs-main/.claude/hooks/<name>.py` and applies to multiple repos):
+
+1. Hook source code lives at `noorinalabs-main/.claude/hooks/<name>.py` ONLY. No copies in child repos.
+2. Each child repo's `.claude/settings.json` registers the hook under the appropriate matcher with a `command` of `python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/<name>.py` (or the dispatcher path for Bash hooks).
+3. Child repos do NOT have their own `annunaki_log.py`, `_shell_parse.py`, `dispatcher.py`, or other shared support files. They reference the parent's copies.
+
+### Anti-pattern: copy-resident hooks
+
+Do NOT copy `.py` hook files into a child repo's `.claude/hooks/` and register them via relative paths. This is the **copy-resident anti-pattern**:
+
+- Forces a per-repo PR to ship every shared-hook update (versus a single line in each child's `settings.json`).
+- Two distinct mental models in flight whenever some children are copy-resident and others are symlink-style.
+- Drift is permanent — no compile-time check that all copies are in sync with the parent's source of truth.
+
+If you find a child repo using copy-resident hooks during routine work, file a tracking issue and align on the next hook-sync wave's plan rather than mixing the cleanup into an unrelated PR.
+
+### Anti-pattern: empty child config
+
+A child repo that participates in hook-gated workflows (commits, PRs, merges) MUST have a `.claude/settings.json` registering at least the parent dispatcher and matcher hooks relevant to that repo's surface (Edit/Write for sources, SendMessage for cross-repo coordination, etc.). An **empty child config** is a silent gap — hooks the parent enforces simply don't fire in that repo. Audit during wave-kickoff and file `tech-debt` if any in-scope repo is empty.
+
+### Reviewer enforcement
+
+When a PR adds or modifies a child repo's `.claude/settings.json`, reviewers verify:
+- Each hook entry uses an absolute path into `noorinalabs-main/.claude/hooks/`, not a relative path.
+- No new `.py` hook files are added to the child's `.claude/hooks/` (the dir should be empty or contain only child-local hooks specific to that repo's surface — none currently exist).
+- Coverage matches the parent's matcher list for the equivalent surface (e.g., a child with code-editing tools should register PreToolUse Edit/Write hooks that the parent registers for the same purposes).
+
+### Caveats acknowledged
+
+- Symlink-style is fragile to parent-dir layout changes — but the org-canonical workstation layout (`/home/parameterization/code/noorinalabs-main/...`) has been stable since project inception.
+- Symlink-style breaks when a child repo is cloned standalone OUTSIDE the parent. Hooks fail to invoke (no matching path); the harness gracefully falls through (no hook = allow). Document this in any per-child-repo CLAUDE.md that anticipates standalone cloning.
+- Hook updates require a child-side `settings.json` edit when hook count changes (new hook added; matcher consolidation per § Dispatcher Consolidation Policy). This is one line per child — significantly cheaper than the per-repo PR cost the copy-resident pattern imposes.
+
+### Promotion provenance
+
+Surfaced during execution of [#194](https://github.com/noorinalabs/noorinalabs-main/issues/194) (Hook 14 sync to 7 child repos) — Aino's survey found 3 copy-resident, 3 symlink-style, 2 empty across the 7 child repos. Owner-greenlit the canonicalization 2026-04-27. Phase 1 (this section, charter codification) lands in P3W4. Phase 2 (per-child-repo sweep migrating the 3 copy-resident repos to symlink-style + scaffolding any empty repos) is tracked separately for P3W5. See [#214](https://github.com/noorinalabs/noorinalabs-main/issues/214).
+
 ---
 
 ## Hook Authorship Requirements <!-- promotion-target: none -->


### PR DESCRIPTION
## Summary

Phase 1 (W4) of #214's parent-canonical-hook-paths sweep. Per coordination with team-lead (single-leader checkpoint applied per `feedback_child_repo_implementer_rule`), the multi-repo work splits into two phases:

- **Phase 1 (this PR, W4)**: parent-side charter doc + `_shell_parse.py` helper sync.
- **Phase 2 (W5, tracked in #263)**: per-child-repo execution — 7 child PRs sweeping copy-resident → symlink-style + scaffolding empty configs.

This PR does NOT close #214 (the issue is the umbrella; closes when #263 merges all 7 child PRs).

## What changed

### `charter/hooks.md § Hook Sync Across Child Repos` (new section)

Codifies:
- **Required pattern**: child `settings.json` registers hooks via absolute paths into `noorinalabs-main/.claude/hooks/`; no `.py` copies in child repos.
- **Anti-pattern**: copy-resident hooks. Forces a per-repo PR every shared-hook update; permanent drift risk; surfaced in P2W9 (Hook 14 was registered in parent for ~2 weeks before #194 surfaced no child had it).
- **Anti-pattern**: empty child config. Silent gap on hook-gated workflows.
- **Reviewer enforcement**: spelled out for `settings.json` PRs.
- **Caveats acknowledged**: workstation-layout fragility, standalone-clone break, hook-count-change touches every child once.
- **Promotion provenance**: surfaced during #194 execution (Aino's survey of 7 child repos found 3 copy-resident / 3 symlink-style / 2 empty); owner-greenlit 2026-04-27.

### `_shell_parse.py` sync from main

Replicated byte-identical from parent `main` (sha256 `9f59c95e9c3a64a4e04589b2c912b7f6365ae70272827fa32fefd3f1c599c9d1`) into `deployments/phase-3/wave-4`. This **resolves the PR#248-base-divergence**: PR#248 (T2 hook bundle) merged directly to `main` rather than to wave-4 — leaving wave-4 missing the helper. With this sync, future #260 (regex→`_shell_parse` sweep) and any other wave-4-based PR can rely on the helper being present.

## What this PR does NOT ship

The 7 child-repo migrations:
- 3 copy-resident → symlink-style: isnad-graph, user-service, deploy
- 1 empty scaffold (per #214 issue body): user-service `settings.json` (currently orphan — `.py` copies present but no settings.json)
- 3 audit-only: design-system, data-acquisition, isnad-ingest-platform, landing-page

All tracked in **#263** with per-child implementer assignments + expected diffs.

## Why phased

`feedback_child_repo_implementer_rule` says child PRs come from each child's own roster. The 7-repo sweep is a coherent multi-repo sub-wave that benefits from focused W5 execution — running it end-of-W4 would inflate the merge queue beyond what wave-wrapup needs and force 7 cross-repo agent spawns mid-wave. Phase 2 fits cleanly into a W5 sub-wave with cross-repo retros lining up.

Symmetric phasing applied to #215 (settings.json fan-out to user-service + ingest-platform) — tracked in #264. Parent #214 + #215 updated with phasing-framing comments (issuecomments 4376430815 + 4376430849).

## Test plan

- [x] 373 hook tests pass (no regression — `_shell_parse.py` is additive, none of the existing tests reference it; it'll be exercised when #260 sweep refactors the 4 hooks onto it)
- [x] `uvx ruff@0.15.11 check .claude/hooks/` clean
- [x] `uvx ruff@0.15.11 format --check .claude/hooks/` clean
- [x] mypy clean (pre-commit verified)
- [x] `_shell_parse.py` sha256 matches main's blob (`9f59c95e9c3a64a4e04589b2c912b7f6365ae70272827fa32fefd3f1c599c9d1`)
- [x] Charter section uses `<!-- promotion-target: none -->` per convention
- [ ] Reviewer ack from @Wanjiku Mwangi (primary) + @Nadia Khoury (secondary)

## Forward unblocking

- **#260 W5 sweep**: now has `_shell_parse.py` available on wave-4 → can refactor `validate_pr_review` / `validate_edit_completion` / `validate_workflow_paths_coverage` / `validate_pr_ci_status` onto it without a base-update merge.
- **#263 / #264 W5 fan-out**: charter doc gives the spec; child implementers can quote it directly.

## Charter compliance

- Branch `A.Virtanen/0214-parent-canonical-hook-paths` matches `{FirstInitial}.{LastName}/{IIII}-{slug}` per `branching.md`.
- Single-issue PR (umbrella; closes via #263 child PRs in W5).
- 2-reviewer slate: Wanjiku primary + Nadia secondary per cross-repo-status.json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
