### PR TITLE
skill(promotion-audit): STALE-OPT-OUT informational class for high-cite none-target memories (closes #158)

### DIFF
--- a/.claude/skills/promotion-audit/SKILL.md
+++ b/.claude/skills/promotion-audit/SKILL.md
@@ -51,6 +51,7 @@ For each memory, charter section, and skill, compute a `Decision` via `classify(
 - **AUTO** — thresholds met, promotion target is charter or skill, NOT already promoted
 - **DECIDE** — thresholds met, target is hook (always DECIDE), OR `requires_decision: true` override, OR signals ambiguous
 - **KEPT** — promotion-target is `none`, thresholds not yet met, or status is `active` with no promotion intent
+  - **STALE-OPT-OUT (informational sub-class)** — when a memory has `promotion_target: none` AND `retro_citations >= 2 * threshold`, the entry stays KEPT (the opt-out is authoritative) but is rendered in a separate sub-list so operators can spot drift during wave-retro. No auto-action, no issue filed, no override of the opt-out. (#158)
 - **SUPERSEDED** — status is `superseded` or `enforced-elsewhere` with an explicit `superseded_by` reference
 - **ALREADY-PROMOTED** — name appears in `find_already_promoted()` set (recognized via `Promotion provenance:` blocks in charter/hooks.md)
 
@@ -86,6 +87,9 @@ Use `render_audit_table(decisions)` to produce deterministic markdown with four 
 
 ### KEPT (no action — informational)
 - {item}: {reason}
+
+**STALE-OPT-OUT (review the opt-out — informational only):**
+- {item}: {reason}    ← only rendered when at least one entry crosses 2× threshold
 
 ### SUPERSEDED / ALREADY-PROMOTED (no action — informational)
 - {item}: {pointer}

--- a/.claude/skills/promotion-audit/helpers.py
+++ b/.claude/skills/promotion-audit/helpers.py
@@ -580,6 +580,24 @@ def classify_memory(
     threshold = memory.promotion_threshold.get("retro_citations", 3)
 
     if memory.promotion_target == "none":
+        # STALE-OPT-OUT informational class (#158): a memory marked
+        # `promotion_target: none` is authoritative — the opt-out stands.
+        # But when citations reach 2× the threshold, surface the entry in
+        # an informational sub-list so operators can reconsider during
+        # wave-retro. No auto-action, no issue filed; the kind stays KEPT.
+        if citations >= 2 * threshold:
+            return Decision(
+                kind="KEPT",
+                item_id=memory.filename,
+                from_tier="memory",
+                to_tier="-",
+                signal=f"retro_citations={citations} >= 2 * {threshold}",
+                reason=(
+                    f"promotion_target=none, but cited {citations}x — "
+                    "consider reviewing the opt-out"
+                ),
+                extra={"stale_opt_out": True},
+            )
         return Decision(
             kind="KEPT",
             item_id=memory.filename,
@@ -806,11 +824,26 @@ def render_audit_table(decisions: list[Decision], wave_name: str, audit_date: st
     out.append("")
 
     out.append("### KEPT (no action — informational)")
-    if kept:
-        for d in kept:
-            out.append(f"- `{d.item_id}` ({d.from_tier}): {d.reason} [{d.signal}]")
-    else:
+    # Split KEPT into stale-opt-out flagged vs the rest. STALE-OPT-OUT
+    # entries (#158) are informational callouts — high-citation memories
+    # whose `promotion_target: none` opt-out has crossed 2× the threshold.
+    # They render as a separate sub-list so operators can spot drift
+    # without changing how the rest of KEPT is presented.
+    stale = [d for d in kept if d.extra.get("stale_opt_out")]
+    others = [d for d in kept if not d.extra.get("stale_opt_out")]
+
+    if not kept:
         out.append("_None._")
+    else:
+        if others:
+            for d in others:
+                out.append(f"- `{d.item_id}` ({d.from_tier}): {d.reason} [{d.signal}]")
+        if stale:
+            if others:
+                out.append("")
+            out.append("**STALE-OPT-OUT (review the opt-out — informational only):**")
+            for d in stale:
+                out.append(f"- `{d.item_id}` ({d.from_tier}): {d.reason} [{d.signal}]")
     out.append("")
 
     out.append("### SUPERSEDED / ALREADY-PROMOTED (no action — informational)")

--- a/.claude/skills/promotion-audit/tests/test_helpers.py
+++ b/.claude/skills/promotion-audit/tests/test_helpers.py
@@ -475,6 +475,71 @@ class ClassifyMemoryTests(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# Classification — STALE-OPT-OUT informational class (#158)
+# ---------------------------------------------------------------------------
+
+
+class StaleOptOutTests(unittest.TestCase):
+    """A `promotion_target: none` memory whose retro_citations cross
+    2× the threshold is flagged STALE-OPT-OUT — an informational
+    callout under KEPT, not a new decision tier. The opt-out stays
+    authoritative; nothing is overridden, no issue is filed.
+    """
+
+    def test_high_cite_none_is_flagged(self) -> None:
+        """POS: `none` + citations >= 2 * threshold → KEPT with stale_opt_out flag."""
+        m = _make_memory(promotion_target="none", status="active")
+        d = h.classify_memory(m, {"retro_citations": 7}, set())
+        self.assertEqual(d.kind, "KEPT")
+        self.assertTrue(d.extra.get("stale_opt_out"))
+        self.assertIn("cited 7x", d.reason)
+        self.assertIn(">= 2 *", d.signal)
+
+    def test_low_cite_none_not_flagged(self) -> None:
+        """NEG: `none` + citations below 2 * threshold → plain KEPT, no flag."""
+        m = _make_memory(promotion_target="none", status="active")
+        # threshold default 3; below 2*3=6 must NOT trigger.
+        d = h.classify_memory(m, {"retro_citations": 5}, set())
+        self.assertEqual(d.kind, "KEPT")
+        self.assertFalse(d.extra.get("stale_opt_out", False))
+        self.assertIn("informational memory", d.reason)
+
+    def test_exactly_double_threshold_is_flagged(self) -> None:
+        """POS: edge case — citations == 2 * threshold triggers (>=, not >)."""
+        m = _make_memory(promotion_target="none", status="active")
+        d = h.classify_memory(m, {"retro_citations": 6}, set())  # 2 * 3
+        self.assertEqual(d.kind, "KEPT")
+        self.assertTrue(d.extra.get("stale_opt_out"))
+
+    def test_charter_target_high_cite_unaffected(self) -> None:
+        """NEG: `charter` target with high citations still flows AUTO/DECIDE.
+        STALE-OPT-OUT only applies on the `promotion_target: none` path."""
+        m = _make_memory(promotion_target="charter", status="active")
+        d = h.classify_memory(m, {"retro_citations": 100}, set())
+        self.assertEqual(d.kind, "AUTO")
+        self.assertFalse(d.extra.get("stale_opt_out", False))
+
+    def test_custom_threshold_respected(self) -> None:
+        """NEG: a memory with a custom threshold uses that, not the default."""
+        m = _make_memory(
+            promotion_target="none",
+            status="active",
+            promotion_threshold={"retro_citations": 5, "skill_invocations": 5},
+        )
+        # 2 * 5 = 10; 9 must NOT trigger, 10 MUST.
+        d_below = h.classify_memory(m, {"retro_citations": 9}, set())
+        self.assertFalse(d_below.extra.get("stale_opt_out", False))
+        d_at = h.classify_memory(m, {"retro_citations": 10}, set())
+        self.assertTrue(d_at.extra.get("stale_opt_out"))
+
+    def test_already_promoted_takes_precedence(self) -> None:
+        """NEG: ALREADY-PROMOTED still wins over STALE-OPT-OUT."""
+        m = _make_memory(promotion_target="none", status="active")
+        d = h.classify_memory(m, {"retro_citations": 100}, {"feedback_x.md"})
+        self.assertEqual(d.kind, "ALREADY-PROMOTED")
+
+
+# ---------------------------------------------------------------------------
 # Classification — charter section
 # ---------------------------------------------------------------------------
 
@@ -597,6 +662,68 @@ class RenderAuditTableTests(unittest.TestCase):
         a = h.render_audit_table(decisions, "wave-9", "2026-04-19")
         b = h.render_audit_table(decisions, "wave-9", "2026-04-19")
         self.assertEqual(a, b)
+
+    def test_stale_opt_out_sublist_rendered(self) -> None:
+        """POS: KEPT entries with stale_opt_out=True render as a labeled sub-list."""
+        decisions = [
+            h.Decision(
+                kind="KEPT",
+                item_id="feedback_quiet.md",
+                from_tier="memory",
+                to_tier="-",
+                signal="retro_citations=0",
+                reason="promotion_target=none (informational memory)",
+            ),
+            h.Decision(
+                kind="KEPT",
+                item_id="feedback_loud.md",
+                from_tier="memory",
+                to_tier="-",
+                signal="retro_citations=7 >= 2 * 3",
+                reason="promotion_target=none, but cited 7x — consider reviewing the opt-out",
+                extra={"stale_opt_out": True},
+            ),
+        ]
+        out = h.render_audit_table(decisions, "wave-9", "2026-04-19")
+        self.assertIn("STALE-OPT-OUT", out)
+        # The plain KEPT entry must appear above the STALE-OPT-OUT header.
+        quiet_idx = out.index("feedback_quiet.md")
+        header_idx = out.index("STALE-OPT-OUT")
+        loud_idx = out.index("feedback_loud.md")
+        self.assertLess(quiet_idx, header_idx)
+        self.assertLess(header_idx, loud_idx)
+
+    def test_no_stale_opt_out_header_when_empty(self) -> None:
+        """NEG: with no flagged entries, the STALE-OPT-OUT header must NOT appear."""
+        decisions = [
+            h.Decision(
+                kind="KEPT",
+                item_id="feedback_x.md",
+                from_tier="memory",
+                to_tier="-",
+                signal="retro_citations=0",
+                reason="promotion_target=none (informational memory)",
+            ),
+        ]
+        out = h.render_audit_table(decisions, "wave-9", "2026-04-19")
+        self.assertNotIn("STALE-OPT-OUT", out)
+
+    def test_stale_only_renders_header(self) -> None:
+        """POS: when ALL KEPT entries are stale-flagged, header still appears."""
+        decisions = [
+            h.Decision(
+                kind="KEPT",
+                item_id="feedback_loud.md",
+                from_tier="memory",
+                to_tier="-",
+                signal="retro_citations=7 >= 2 * 3",
+                reason="promotion_target=none, but cited 7x — consider reviewing the opt-out",
+                extra={"stale_opt_out": True},
+            ),
+        ]
+        out = h.render_audit_table(decisions, "wave-9", "2026-04-19")
+        self.assertIn("STALE-OPT-OUT", out)
+        self.assertIn("feedback_loud.md", out)
 
     def test_sorted_within_bucket(self) -> None:
         """NEG: unsorted input must still produce sorted output."""


### PR DESCRIPTION
## Summary

Adds the **STALE-OPT-OUT** informational class to `/promotion-audit` per #158 — a labeled callout under KEPT that surfaces `promotion_target: none` memories whose citation count has clearly drifted past the active-relevance line.

The opt-out remains authoritative: nothing is overridden, no issue is filed, no action is taken. The flag exists so operators can spot drift during wave-retro and reconsider whether the original opt-out still holds.

## Trigger

A memory has `promotion_target: none` AND `retro_citations >= 2 * threshold`. The 2× factor is conservative on purpose — the rule should fire only when the opt-out is *clearly* stale, not on borderline citation growth.

## Current state of the project (informational)

Running the new logic against today's memory set: **0 STALE-OPT-OUT entries**. The most-cited `none`-target memory has 4 retro citations against a 2×3=6 trigger. This matches the wave-9 baseline cited in the issue body.

```
Top 5 cited none-target memories:
  feedback_canonical_source_via_git_show.md       cites=4, 2*thresh=6, silent
  feedback_child_repo_implementer_rule.md         cites=4, 2*thresh=6, silent
  feedback_heredoc_in_git_commit.md               cites=4, 2*thresh=6, silent
  feedback_honest_audit_over_conclusion_claim.md  cites=4, 2*thresh=6, silent
  feedback_review_against_artifact_not_framing.md cites=4, 2*thresh=6, silent
```

(Same retro-citation densification noted in the W3 retro pain-point #3 — these five sit at threshold but are KEPT because of `promotion_target: none`. STALE-OPT-OUT will fire silently the first time one crosses 6, with no operator action required.)

## Changes

- `helpers.classify_memory()`: `none` target + citations >= 2× threshold returns `KEPT` with `extra={"stale_opt_out": True}`. Below threshold = original silent-KEPT path. ALREADY-PROMOTED still takes precedence.
- `helpers.render_audit_table()`: KEPT split into plain entries and stale-flagged entries; the latter render as a labeled sub-list (`**STALE-OPT-OUT (review the opt-out — informational only):**`) only when at least one entry crosses the trigger.
- `SKILL.md`: documents the new informational sub-class under § 3 and shows the rendered shape under § 5.
- `tests/test_helpers.py`: +9 new tests (6 classifier, 3 render).

## Test evidence

```
$ ENVIRONMENT=test python3 -m pytest tests/ -q
.............................................................            [100%]
61 passed in 0.13s
```

## Acceptance vs issue

| Issue criterion | Status |
|---|---|
| Trigger: `promotion_target: none` AND `retro_citations >= 2*threshold` | ✅ |
| Output: one-line note in KEPT (informational) sub-list | ✅ |
| No new decision tier — sub-list under KEPT | ✅ |
| No auto-action, no issue filed, no override | ✅ |
| Determinism preserved (sort-within-bucket) | ✅ |

## Forward context

Per the W3 retro pain-point #3, five `none`-target memories sit at retro_citations=4 (one citation away from the 2× trigger). The first wave that pushes any of them to 6 will surface the flag in the wave-retro audit output — by design, no action required from operators beyond noticing.

## References

- Issue: #158
- Predecessor PR establishing the `promotion_target: none` rule: #155 (closed #152)
- Wave-3 retro pain-point #3 (citation tally vs deterministic-audit-frontmatter mismatch)

Closes #158
