### PR TITLE
ci(P3W5 T1 #267): include .claude/skills/** in ci.yml paths filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,12 +5,14 @@ on:
     branches: [main, "deployments/**"]
     paths:
       - ".claude/hooks/**"
+      - ".claude/skills/**"
       - ".github/workflows/ci.yml"
       - "pyproject.toml"
   pull_request:
     branches: [main, "deployments/**"]
     paths:
       - ".claude/hooks/**"
+      - ".claude/skills/**"
       - ".github/workflows/ci.yml"
       - "pyproject.toml"
 


### PR DESCRIPTION
## Summary
- Adds `.claude/skills/**` to `push.paths` and `pull_request.paths` in `.github/workflows/ci.yml` so skill-only PRs trigger the existing lint/format/typecheck/smoke jobs instead of shipping with empty `statusCheckRollup`.
- Minimal scope: 2 lines added (one per filter), no job changes, no new workflows. The richer proposal in #267 (`**/*.py` glob + per-skill pytest discovery job) is left as follow-up so this PR stays the smallest tractable W5 T1 change.
- Surfaced from PR#266 primary review 2026-05-05 — diff was entirely under `.claude/skills/promotion-audit/**` and no CI ran.

## Related Issues
Closes #267

Refs:
- #200 (`pull_request` triggers vs wave branches — sibling workflow-paths gap)
- #203 / Hook 19 (`validate_workflow_paths_coverage` — narrower scope, workflow-file orphan blocker)

## Why minimal-only
- Proves the W5 wave-branch + label flow end-to-end before #273 (skill internals) and #269 (broader workflow shape) ride on top.
- Existing `.claude/hooks/**` CI behavior is unchanged — diff is purely additive on the include list.
- Branch is cut from `deployments/phase-3/wave-5` so this rides the wave merge train, not a direct-to-main path.

## Out of scope (deferred)
- Per-skill pytest discovery job for `.claude/skills/*/tests/` directories. Promotion-audit's 61 unit tests will still run via the existing `pytest` invocation in CI for the smoke-test job only when `pyproject.toml` or `.claude/hooks/**` paths match — this PR does NOT extend test coverage to skill tests, only path-filter coverage so that lint/format/typecheck/hook-smoke do trigger on skill-touching PRs. Test-runner job tracked as a follow-up under #267 v2 or a separate issue.
- Markdown-only skill PRs (e.g., touch-only `SKILL.md` edits) WILL now trigger CI. Acceptable cost — the existing jobs are fast (<60s end-to-end for a clean tree).

## Verification
Local:
- `python3 -c "import yaml; yaml.safe_load(...)"` → parses clean.
- `actionlint .github/workflows/ci.yml` (with shellcheck on PATH per `feedback_actionlint_needs_shellcheck.md`) → exit 0, no findings.
- `git diff` is exactly +2 lines, both inside the existing `paths:` arrays.

Post-merge dry-run plan:
- Touch-only edit to any `.claude/skills/*/SKILL.md` on a feature branch → CI workflow `CI — Hooks & Scripts` should appear in the PR's `statusCheckRollup` (was empty before this PR).

## Review Checklist
- [ ] Reviewed by another team member (Wanjiku — Pattern B primary)
- [ ] Reviewed by another team member (Nadia — Pattern B secondary)
- [ ] Must-fix items resolved
- [ ] Tech debt items filed as GitHub Issues (if any)

Co-Authored-By: Aino Virtanen <parametrization+Aino.Virtanen@gmail.com>
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
