### PR TITLE
skill(P3W5 T2 #273): thread /wave-scope into /wave-retro Step 9 + /wave-kickoff Step 0

### DIFF
--- a/.claude/skills/wave-kickoff/SKILL.md
+++ b/.claude/skills/wave-kickoff/SKILL.md
@@ -10,6 +10,32 @@ Automate the wave kickoff process for the `{team_name}` team.
 
 ## Instructions
 
+### 0a. Verify next-wave scope is reconciled (Mandatory precondition — added P3W5 #273)
+
+`cross-repo-status.json` MUST carry a `wave_{M}_scope_reconciled_at` ISO timestamp written by `/wave-scope {P} {M}`, and that timestamp MUST post-date the previous wave's retro completion timestamp. If absent or stale, STOP and require the user to run `/wave-scope {P} {M}` first.
+
+```bash
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+SCOPE_TS=$(jq -r '.wave_{M}_scope_reconciled_at // empty' "$REPO_ROOT/cross-repo-status.json")
+PRIOR_RETRO_TS=$(jq -r '.wave_$(({M} - 1))_retro_completed_at // .wave_$(({M} - 1))_completed_at // empty' "$REPO_ROOT/cross-repo-status.json")
+
+if [ -z "$SCOPE_TS" ]; then
+  echo "ERROR: wave_{M}_scope_reconciled_at missing in cross-repo-status.json."
+  echo "  Run /wave-scope {P} {M} before /wave-kickoff."
+  exit 1
+fi
+
+if [ -n "$PRIOR_RETRO_TS" ] && [ "$SCOPE_TS" \< "$PRIOR_RETRO_TS" ]; then
+  echo "ERROR: wave_{M}_scope_reconciled_at ($SCOPE_TS) predates last retro ($PRIOR_RETRO_TS)."
+  echo "  Re-run /wave-scope {P} {M} so the reconciliation reflects the current carry-forward + memory-must-include state."
+  exit 1
+fi
+
+echo "  Scope reconciled at: $SCOPE_TS (post-dates last retro: $PRIOR_RETRO_TS)"
+```
+
+This check is a deterministic JSON read — no GitHub API calls, no side effects. It catches the off-path case where `/wave-kickoff` is invoked without a recent `/wave-scope` (drift signal: meta-issue out of sync with labels). The common path is covered by `/wave-retro` Step 9, which auto-invokes `/wave-scope {P} {M+1}` at end-of-wave.
+
 ### 0. Derive wave repos in scope (Mandatory first step)
 
 The canonical source for the wave's repo list is `cross-repo-status.json` key `wave_{M}_repos_in_scope` (array of `noorinalabs-*` strings). All subsequent steps iterate this list.

--- a/.claude/skills/wave-kickoff/SKILL.md
+++ b/.claude/skills/wave-kickoff/SKILL.md
@@ -12,9 +12,13 @@ Automate the wave kickoff process for the `{team_name}` team.
 
 ### 0a. Verify next-wave scope is reconciled (Mandatory precondition — added P3W5 #273)
 
-`cross-repo-status.json` MUST carry a `wave_{M}_scope_reconciled_at` ISO timestamp written by `/wave-scope {P} {M}`, and that timestamp MUST post-date the previous wave's retro completion timestamp. If absent or stale, STOP and require the user to run `/wave-scope {P} {M}` first.
+`cross-repo-status.json` MUST carry a `wave_{M}_scope_reconciled_at` ISO timestamp written by `/wave-scope {P} {M}`. If a prior-wave retro/completion timestamp is also present, the scope timestamp MUST post-date it. If `wave_{M}_scope_reconciled_at` is absent the kickoff STOPs unconditionally; the staleness check is permissive (no-op) when the prior-wave timestamp is also absent — see "Permissive fallback" below.
 
 ```bash
+# Note: `{P}` and `{M}` are skill-template placeholders the orchestrator
+# string-substitutes BEFORE the bash block runs. After substitution
+# `$(({M} - 1))` becomes a literal arithmetic expansion like `$((5 - 1))` —
+# they are not bash variables.
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 SCOPE_TS=$(jq -r '.wave_{M}_scope_reconciled_at // empty' "$REPO_ROOT/cross-repo-status.json")
 PRIOR_RETRO_TS=$(jq -r '.wave_$(({M} - 1))_retro_completed_at // .wave_$(({M} - 1))_completed_at // empty' "$REPO_ROOT/cross-repo-status.json")
@@ -31,10 +35,16 @@ if [ -n "$PRIOR_RETRO_TS" ] && [ "$SCOPE_TS" \< "$PRIOR_RETRO_TS" ]; then
   exit 1
 fi
 
-echo "  Scope reconciled at: $SCOPE_TS (post-dates last retro: $PRIOR_RETRO_TS)"
+if [ -z "$PRIOR_RETRO_TS" ]; then
+  echo "  Scope reconciled at: $SCOPE_TS (no prior-wave timestamp — first wave of phase or fresh project; staleness check skipped)"
+else
+  echo "  Scope reconciled at: $SCOPE_TS (post-dates last retro: $PRIOR_RETRO_TS)"
+fi
 ```
 
 This check is a deterministic JSON read — no GitHub API calls, no side effects. It catches the off-path case where `/wave-kickoff` is invoked without a recent `/wave-scope` (drift signal: meta-issue out of sync with labels). The common path is covered by `/wave-retro` Step 9, which auto-invokes `/wave-scope {P} {M+1}` at end-of-wave.
+
+**Permissive fallback (intentional).** When neither `wave_{M-1}_retro_completed_at` nor `wave_{M-1}_completed_at` exists in `cross-repo-status.json` — e.g., the first wave of a phase, or a fresh project — the staleness comparison is silently skipped and only the absent-scope check fires. This keeps the precondition usable for Phase-N-Wave-1 cases without requiring a synthetic zero-timestamp. The trade-off: a `wave_{M}_scope_reconciled_at` written years ago with no surrounding context will pass. If that becomes a real failure mode, tighten to fail-closed and require an explicit `WAVE_KICKOFF_ALLOW_NO_PRIOR_RETRO=1` override.
 
 ### 0. Derive wave repos in scope (Mandatory first step)
 

--- a/.claude/skills/wave-retro/SKILL.md
+++ b/.claude/skills/wave-retro/SKILL.md
@@ -140,13 +140,26 @@ Carry-forward and memory-must-include state is freshest immediately after retro,
 ```bash
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 NEXT_WAVE=$(({M} + 1))
-NEXT_META_ISSUE=$(gh issue list --repo noorinalabs/noorinalabs-main \
-    --search "Phase {N} Wave $NEXT_WAVE in:title" \
-    --json number,title --jq '.[0].number')
 
-if [ -z "$NEXT_META_ISSUE" ] || [ "$NEXT_META_ISSUE" = "null" ]; then
+# Anchored title pattern + open-state filter. Meta-issue title format is
+# "Phase {N} Wave {M+1} — <theme>" — the dash-space tail prevents bleed into
+# retro tracking issues like "Phase 3 Wave 5 retro tracking" that some teams
+# file separately. Asserting exactly-one-hit surfaces ambiguity as a blocker
+# instead of silently picking whichever issue GitHub orders first.
+META_HITS=$(gh issue list --repo noorinalabs/noorinalabs-main --state open \
+    --search "\"Phase {N} Wave $NEXT_WAVE —\" in:title" \
+    --json number,title)
+HIT_COUNT=$(echo "$META_HITS" | jq 'length')
+NEXT_META_ISSUE=$(echo "$META_HITS" | jq -r '.[0].number // empty')
+
+if [ "$HIT_COUNT" -eq 0 ]; then
   echo "BLOCKER for /wave-kickoff p{N} w$NEXT_WAVE:"
-  echo "  Next-wave meta-issue not yet drafted. Create the meta-issue, then run /wave-scope {N} $NEXT_WAVE before /wave-kickoff."
+  echo "  Next-wave meta-issue not yet drafted. Create one titled 'Phase {N} Wave $NEXT_WAVE — <theme>' and run /wave-scope {N} $NEXT_WAVE before /wave-kickoff."
+elif [ "$HIT_COUNT" -gt 1 ]; then
+  echo "BLOCKER for /wave-kickoff p{N} w$NEXT_WAVE:"
+  echo "  Multiple open issues match 'Phase {N} Wave $NEXT_WAVE —' in title — meta-issue is ambiguous:"
+  echo "$META_HITS" | jq -r '.[] | "    - #\(.number): \(.title)"'
+  echo "  Resolve before running /wave-scope."
 else
   echo "Auto-invoking /wave-scope {N} $NEXT_WAVE (next-wave meta-issue: noorinalabs-main#$NEXT_META_ISSUE)"
   # Invoke the skill — it will write wave_${NEXT_WAVE}_scope_reconciled_at to cross-repo-status.json on success.

--- a/.claude/skills/wave-retro/SKILL.md
+++ b/.claude/skills/wave-retro/SKILL.md
@@ -133,6 +133,34 @@ The audit appends its table to this retro's feedback_log entry **and** writes a 
 
 **Do NOT apply any charter changes without explicit user approval.** The user decides which proposals to adopt, modify, or reject.
 
+### 9. Reconcile next-wave scope (`/wave-scope`) — added P3W5 #273
+
+Carry-forward and memory-must-include state is freshest immediately after retro, so this is the highest-value moment to run `/wave-scope`. Auto-invoke if the next-wave meta-issue exists; otherwise surface as a kickoff blocker.
+
+```bash
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+NEXT_WAVE=$(({M} + 1))
+NEXT_META_ISSUE=$(gh issue list --repo noorinalabs/noorinalabs-main \
+    --search "Phase {N} Wave $NEXT_WAVE in:title" \
+    --json number,title --jq '.[0].number')
+
+if [ -z "$NEXT_META_ISSUE" ] || [ "$NEXT_META_ISSUE" = "null" ]; then
+  echo "BLOCKER for /wave-kickoff p{N} w$NEXT_WAVE:"
+  echo "  Next-wave meta-issue not yet drafted. Create the meta-issue, then run /wave-scope {N} $NEXT_WAVE before /wave-kickoff."
+else
+  echo "Auto-invoking /wave-scope {N} $NEXT_WAVE (next-wave meta-issue: noorinalabs-main#$NEXT_META_ISSUE)"
+  # Invoke the skill — it will write wave_${NEXT_WAVE}_scope_reconciled_at to cross-repo-status.json on success.
+fi
+```
+
+Then invoke the `/wave-scope` skill with the next phase + wave numbers. The skill is responsible for:
+- Reading carry-forward (just-written by step 6) and memory must-includes
+- Reconciling declared (meta-issue) vs labeled scope across all repos
+- Refreshing the next-wave meta-issue body
+- Writing `wave_$NEXT_WAVE_scope_reconciled_at` so `/wave-kickoff` Step 0a passes
+
+This step closes the retro→kickoff handoff loop: every retro produces a reconciled next-wave scope, and every kickoff verifies it. If the meta-issue doesn't exist yet (early-stage phase planning), surface explicitly so the gap is owned before the next kickoff.
+
 ## What remains manual
 
 - User must approve all charter changes before they are applied

--- a/.claude/skills/wave-scope/SKILL.md
+++ b/.claude/skills/wave-scope/SKILL.md
@@ -298,6 +298,31 @@ Do NOT delete the original body — copy it (or post the pre-update version as a
 
 If any step surfaced a process gap (stale memory, missing meta-issue, vague reference), include a `**Process gaps surfaced**` section so the next retro can address them.
 
+### 13. Write reconciliation timestamp to `cross-repo-status.json` (added P3W5 #273)
+
+This is what `/wave-kickoff` Step 0a reads to confirm the wave's scope was reconciled before kickoff. Write only on full success — if the run aborted at step 7 (no dispositions) or step 10 (label-churn confirmation declined), do NOT write.
+
+```bash
+TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+NOTE_ARGS=()
+if [ -n "${SCOPE_RECONCILIATION_NOTE:-}" ]; then
+  NOTE_ARGS+=(--arg note "$SCOPE_RECONCILIATION_NOTE")
+fi
+
+jq --arg ts "$TS" "${NOTE_ARGS[@]}" \
+   '.wave_{M}_scope_reconciled_at = $ts
+    | (if $ENV.SCOPE_RECONCILIATION_NOTE then .wave_{M}_scope_reconciliation_note = $note else . end)' \
+   "$REPO_ROOT/cross-repo-status.json" \
+   > "$REPO_ROOT/cross-repo-status.json.tmp" \
+   && mv "$REPO_ROOT/cross-repo-status.json.tmp" "$REPO_ROOT/cross-repo-status.json"
+
+echo "  wave_{M}_scope_reconciled_at = $TS written to cross-repo-status.json"
+```
+
+The optional `wave_{M}_scope_reconciliation_note` is for capturing edge cases (e.g., "no drift; no memory must-includes; manual run because skill not yet built"). Set `SCOPE_RECONCILIATION_NOTE` in the environment before invoking the jq command if there is a non-trivial summary worth preserving for the next retro.
+
+The companion read-side check is `/wave-kickoff` SKILL.md § 0a — it stops kickoff if this timestamp is missing or predates the prior wave's retro.
+
 ## Relationship to other wave skills
 
 | Skill | Timing | Output |

--- a/.claude/skills/wave-scope/SKILL.md
+++ b/.claude/skills/wave-scope/SKILL.md
@@ -302,24 +302,26 @@ If any step surfaced a process gap (stale memory, missing meta-issue, vague refe
 
 This is what `/wave-kickoff` Step 0a reads to confirm the wave's scope was reconciled before kickoff. Write only on full success — if the run aborted at step 7 (no dispositions) or step 10 (label-churn confirmation declined), do NOT write.
 
+**Why not raw jq:** `jq ... > tmp && mv` round-trips reformat the entire file from compact-inline (the deliberate shape used by `/wave-kickoff` and `/wave-start` for `wave_{N}_*` keys) to jq's default pretty form, doubling line count and producing a 500+ line cosmetic diff per run. P3W5 PR #276 review flagged this as load-bearing. The targeted upsert helper below preserves the existing shape — replace-in-place when the key exists (zero churn), insert-near-sibling when it doesn't (delta = 1 line per new key).
+
 ```bash
 TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-NOTE_ARGS=()
+UPSERT_ARGS=("wave_{M}_scope_reconciled_at=$(jq -nc --arg t "$TS" '$t')")
+
 if [ -n "${SCOPE_RECONCILIATION_NOTE:-}" ]; then
-  NOTE_ARGS+=(--arg note "$SCOPE_RECONCILIATION_NOTE")
+  UPSERT_ARGS+=("wave_{M}_scope_reconciliation_note=$(jq -nc --arg n "$SCOPE_RECONCILIATION_NOTE" '$n')")
 fi
 
-jq --arg ts "$TS" "${NOTE_ARGS[@]}" \
-   '.wave_{M}_scope_reconciled_at = $ts
-    | (if $ENV.SCOPE_RECONCILIATION_NOTE then .wave_{M}_scope_reconciliation_note = $note else . end)' \
-   "$REPO_ROOT/cross-repo-status.json" \
-   > "$REPO_ROOT/cross-repo-status.json.tmp" \
-   && mv "$REPO_ROOT/cross-repo-status.json.tmp" "$REPO_ROOT/cross-repo-status.json"
+python3 "$REPO_ROOT/.claude/skills/wave-scope/upsert_status_keys.py" \
+  "$REPO_ROOT/cross-repo-status.json" \
+  "${UPSERT_ARGS[@]}"
 
 echo "  wave_{M}_scope_reconciled_at = $TS written to cross-repo-status.json"
 ```
 
-The optional `wave_{M}_scope_reconciliation_note` is for capturing edge cases (e.g., "no drift; no memory must-includes; manual run because skill not yet built"). Set `SCOPE_RECONCILIATION_NOTE` in the environment before invoking the jq command if there is a non-trivial summary worth preserving for the next retro.
+The helper validates JSON pre- and post-write, replaces top-level keys in place when they already exist, and inserts new keys after the most-recent `wave_{N}_*` sibling line. Idempotent — re-running with identical values produces zero diff.
+
+The optional `wave_{M}_scope_reconciliation_note` is for capturing edge cases (e.g., "no drift; no memory must-includes; manual run because skill not yet built"). Set `SCOPE_RECONCILIATION_NOTE` in the environment before invoking the helper if there is a non-trivial summary worth preserving for the next retro.
 
 The companion read-side check is `/wave-kickoff` SKILL.md § 0a — it stops kickoff if this timestamp is missing or predates the prior wave's retro.
 

--- a/.claude/skills/wave-scope/upsert_status_keys.py
+++ b/.claude/skills/wave-scope/upsert_status_keys.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Upsert top-level keys in cross-repo-status.json preserving compact-inline shape.
+
+The skill ecosystem (/wave-kickoff, /wave-start) writes that file with deliberate
+mixed style: top-level wave_{N}_* keys are compact single-liners, older
+wave_*_scope blocks are pretty-indented. A naive `jq ... > tmp && mv` round-trip
+reformats every compact line to jq's default pretty form, doubling the file
+length and producing a 500+ line cosmetic diff per wave.
+
+This helper does targeted text-level upsert:
+  - If the key exists at top level → replace its line in place.
+  - If the key does not exist → insert a new compact-inline line right after
+    the most-recent wave_{N}_* sibling (or before the closing `}`).
+
+Validates JSON before AND after the rewrite so a malformed write is caught.
+
+Invocation:
+  upsert_status_keys.py <path> <key>=<json-encoded-value> [<key>=<json-encoded-value> ...]
+
+Example:
+  upsert_status_keys.py cross-repo-status.json \
+    wave_5_scope_reconciled_at='"2026-05-05T22:31:00Z"' \
+    wave_5_scope_reconciliation_note='"manual run"'
+
+Each VALUE must be a self-contained JSON literal (string/number/bool/array/object).
+Strings include their quotes — pass `'"foo"'` from the shell.
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+
+def upsert_top_level_key(text: str, key: str, json_value: str) -> str:
+    """Replace `"<key>": ...,` line in place, or insert a new line if absent.
+
+    Insertion point: after the last existing line whose top-level key matches
+    `wave_<N>_*` for the same wave number embedded in `key` (best-effort sibling
+    grouping). Falls back to inserting right after the opening `{` line.
+    """
+    line_re = re.compile(r'^(  )"' + re.escape(key) + r'":\s.*?,?\s*$', re.MULTILINE)
+    new_line = f'  "{key}": {json_value},'
+    m = line_re.search(text)
+    if m:
+        existing = m.group(0)
+        last_existing = existing.rstrip()
+        if last_existing.endswith(","):
+            replacement = new_line
+        else:
+            replacement = new_line.rstrip(",")
+        return text[: m.start()] + replacement + text[m.end() :]
+
+    wave_num_match = re.match(r"wave_(\d+)_", key)
+    if wave_num_match:
+        sibling_re = re.compile(
+            r'^(  )"wave_' + re.escape(wave_num_match.group(1)) + r'_[^"]+":.*$',
+            re.MULTILINE,
+        )
+        siblings = list(sibling_re.finditer(text))
+        if siblings:
+            last = siblings[-1]
+            return text[: last.end()] + "\n" + new_line + text[last.end() :]
+
+    open_brace = text.find("{\n")
+    if open_brace < 0:
+        raise ValueError("could not locate opening `{` line for insertion")
+    insertion_point = open_brace + 2
+    return text[:insertion_point] + new_line + "\n" + text[insertion_point:]
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 3:
+        print(__doc__, file=sys.stderr)
+        return 2
+
+    path = Path(argv[1])
+    pairs = []
+    for arg in argv[2:]:
+        if "=" not in arg:
+            print(f"ERROR: argument {arg!r} is not key=value", file=sys.stderr)
+            return 2
+        k, _, raw = arg.partition("=")
+        try:
+            decoded = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            print(f"ERROR: value for {k} is not valid JSON: {exc}", file=sys.stderr)
+            return 2
+        pairs.append((k, raw, decoded))
+
+    text = path.read_text()
+    parsed = json.loads(text)
+
+    for key, json_value, decoded in pairs:
+        text = upsert_top_level_key(text, key, json_value)
+        parsed[key] = decoded
+
+    reparsed = json.loads(text)
+    if reparsed != parsed:
+        print(
+            "ERROR: text-level upsert diverged from logical upsert; aborting write",
+            file=sys.stderr,
+        )
+        return 1
+
+    path.write_text(text)
+    for key, _, _ in pairs:
+        print(f"  upserted: {key}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
Closes #273.

## Sweep

| File | Δ |
|---|---|
| `.claude/skills/wave-kickoff/SKILL.md` | +26 / new Step 0a precondition above existing Step 0 |
| `.claude/skills/wave-retro/SKILL.md` | +28 / new Step 9 after Step 8 summary |
| `.claude/skills/wave-scope/SKILL.md` | +25 / new Step 13 after Step 12 emit summary |

Total: +79 lines, 0 deletions, 3 files.

## Scope

Thread `/wave-scope` into the retro→kickoff handoff so reconciliation is no longer a separately-remembered ritual. P3W4 surfaced one consequence of the gap: `wave_4_repos_in_scope` listed ingest-platform with no tier item targeting it (#272 audit) — exactly the class of mismatch `/wave-scope` is designed to catch, but the skill never ran because nothing invoked it.

**A. `/wave-kickoff` Step 0a — read-side precondition (off-path catch)**

New step above the existing "Derive wave repos in scope" block. Reads `wave_{M}_scope_reconciled_at` from `cross-repo-status.json`; STOPs if absent or if it predates the prior wave's retro completion. Pure JSON read — no GitHub API calls, no side effects. Closes the case where someone invokes kickoff directly without running scope.

**B. `/wave-retro` Step 9 — auto-invoke (common-path catch)**

New step after Step 8 (present summary). Looks up next-wave meta-issue; if it exists, invokes `/wave-scope {P} {M+1}` automatically. If it doesn't, surfaces as a kickoff blocker. Carry-forward + memory-must-include state is freshest right after retro, so this is the highest-value reconciliation moment.

**C. `/wave-scope` Step 13 — write-side timestamp (the value 0a reads)**

New step after Step 12 (emit summary). Writes `wave_{M}_scope_reconciled_at` and optional `wave_{M}_scope_reconciliation_note` to `cross-repo-status.json` via `jq` tmp-file pattern (matches Step 1's idiom in `/wave-kickoff`).

**Hook deliberately omitted this round** per memory `feedback_enforcement_hierarchy.md` — hooks come *after* observed breakage, not preemptively. A+B together cover both paths; if drift is observed in production use, file a follow-up to add Hook-class enforcement.

## Acceptance (from #273)

- [x] `/wave-kickoff` Step 0a verifies `wave_{M}_scope_reconciled_at`
- [x] `/wave-retro` Step 9 auto-invokes `/wave-scope {P} {M+1}` (with surface-as-blocker fallback)
- [x] `/wave-scope` writes `wave_{M}_scope_reconciled_at` to `cross-repo-status.json` on success
- [x] Round-trip dry run W5→W6 confirms both edits hold (see Test plan)

## Test plan

Round-trip dry run executed locally against a scratch copy of `cross-repo-status.json` (parent canonical state untouched throughout):

| Phase | Expected | Observed |
|---|---|---|
| A: stale W5 timestamp predating W4 retro (`2025-01-01` vs `2026-05-05T22:00:00Z`) | Step 0a STOP fires | STOP fired: `scope 2025-01-01T00:00:00Z predates retro 2026-05-05T22:00:00Z` |
| B: invoke wave-scope Step 13 with fresh timestamp + note | timestamp + note written | `wave_5_scope_reconciled_at = 2026-05-05T23:36:16Z` + note persisted |
| C: rerun Step 0a after fresh write | precondition passes, kickoff proceeds | `Step 0a (fresh): PASSED — scope post-dates retro` |
| Cleanup | parent `cross-repo-status.json` untouched | confirmed via `git status` (no diff on parent file) |

Skill bash blocks were validated under `/bin/bash` (zsh treats `\<` differently in interactive mode, but skill execution context is bash — checked).

Charter-mandated reviewer pattern: PR-body reviewers each post their charter-format review comment via `gh pr comment` (not `gh pr review` per memory `feedback_pr_review_comment_only.md`). Each comment includes a `TechDebt: <none|#N>` line per memory `feedback_reviewer_techdebt_line_required.md`.

## Reviewers (Pattern B order — reviewer-class established before implementer-class)

- **First reviewer:** Wanjiku Mwangi (TPM, org-level)
- **Second reviewer:** Nadia Khoury (PD, org-level)
