### PR TITLE
promotion(P3W5 retro): codify 5 AUTO memories → charter (3 new sections + 2 provenance markers)

### DIFF
--- a/.claude/team/charter/agents.md
+++ b/.claude/team/charter/agents.md
@@ -286,3 +286,50 @@ Track instance count at each retro. If the count grows materially (e.g., crossed
 ### Why
 
 P3W1 saw ~4 Lucas-side message-ordering races plus ≥1 analogous Aisha-side instance, all professionally handled but each costing ~30s of attention overhead. None caused duplicate work or wrong-direction shipping. The narrow trigger captures the high-consequence variant (spawn duplication) without sacrificing the wave-throughput-positive implementer-anticipates-context discipline.
+
+<!-- Promoted from memory: feedback_child_repo_implementer_rule.md (P3W5 retro 2026-05-06) -->
+
+## Child-Repo Implementer Rule + Spawn-Brief Verification (Mandatory) <!-- promotion-target: hook -->
+
+When spawning an implementer for a PR or feature in a child repo, the implementer's identity (`user.name` + `user.email`) MUST come from **that child repo's** team roster (`<child>/.claude/team/roster/` and `<child>/.claude/team/roster.json`) — NOT from the parent's org-level coordination team and NOT from a sibling repo's roster.
+
+### Why
+
+Hook 5 (`validate_commit_identity`) scans the working repo's `roster.json` and BLOCKS commits whose `user.name` isn't a roster member. Per the enforcement-hierarchy principle (hook > skill > charter), the hook is the binding source of truth — a wrong-roster spawn will fail at first commit, costing a respawn cycle. Each child repo has its own simulated team with its own role fit; cross-roster authorship is a category error the hook catches.
+
+### Orchestrator-side spawn-brief checklist
+
+Before authoring an implementer spawn brief for a child-repo issue:
+
+1. **Determine working repo for the change.** Read the issue body. Note that **issue location ≠ working repo** (e.g., a `noorinalabs-deploy` issue body may say the changes go in `noorinalabs-landing-page`). The repo that hosts the FILES the implementer will edit is the working repo.
+2. **Read that repo's roster.** `cat <working-repo>/.claude/team/roster.json` or list `<working-repo>/.claude/team/roster/`.
+3. **Pick a roster member with role fit** for the change class (frontend Dockerfile → frontend engineer; CI workflow → devops/platform engineer; security/CVE → security engineer; observability config → observability engineer; etc.).
+4. **In the spawn brief, set the implementer's identity to that roster member's `user.name` + `user.email`.**
+5. **Reviewer assignment is a separate decision.** Cross-team reviewer is OK (e.g., parent / sibling-team reviewer reading a child-repo PR). Don't conflate REVIEWER class with IMPLEMENTER class — see § Role-Class-Specific Boundaries elsewhere in charter for the distinction.
+
+### Per-repo implementer pools (verify at spawn time — these snapshots may drift)
+
+- `noorinalabs-deploy`: Lucas Ferreira, Aisha Idrissi, Bereket Tadesse, Weronika Zielinska, Nino Kavtaradze, others
+- `noorinalabs-isnad-graph`: Idris Yusuf, Linh Pham, Anya Kowalczyk, Mateo Salazar, others
+- `noorinalabs-user-service`: Mateo Salazar, Anya Kowalczyk, others
+- `noorinalabs-landing-page`: Anika Diop-Sarr, Cédric Novák, Kofi Mensah-Williams, Marcia Vasquez-Paredes, Nazia Rahman
+- `noorinalabs-main` (parent): Wanjiku Mwangi (TPM), Aino Virtanen (Standards), Santiago Ferreira (RC), Nadia Khoury (PD)
+- `noorinalabs-design-system`, `noorinalabs-data-acquisition`, `noorinalabs-isnad-ingest-platform`: per-repo rosters
+
+The verbatim canonical roster lives in each child repo's `.claude/team/roster.json` — read that at spawn time, not this snapshot.
+
+### Exceptions
+
+- **User explicitly directs otherwise** in a given session ("have Lucas do the landing-page work" overrides). Hook would still block; user would need to register the agent in the target roster first or accept the block.
+- **Child repo has no `.claude/team/` defined yet** — check recent git history for de-facto implementer (`git log --format='%an' -- <path>`) and match, or ask the user before defaulting.
+
+### Severity if violated
+
+Wrong-roster spawn (hook-blocked at first commit, respawn required): minor — auto-corrected by Hook 5; cost is one wasted Aino-spawn. Wrong-roster spawn that bypasses Hook 5 (e.g., committed via a different mechanism that escapes the hook): moderate — the child-repo's role-fit signal is corrupted in git history.
+
+### Failure modes seen and what blocked them
+
+| Date | Surface | What went wrong | What blocked it |
+|---|---|---|---|
+| 2026-04-22 | child-repo#139 prereqs | Deferred-under-misread of user intent | Owner correction next turn |
+| 2026-05-03 | P3W3 deploy#242 spawn brief | Spawned Lucas Ferreira (deploy roster) for landing-page work; conflated reviewer-class permission with implementer-class | Hook 5 blocked Lucas-242's first commit; Lucas-242 surfaced charter Pattern B catch (verify-vs-artifact: roster.json) and recommended Kofi from landing-page roster |

--- a/.claude/team/charter/pull-requests.md
+++ b/.claude/team/charter/pull-requests.md
@@ -322,6 +322,8 @@ Minor — but recurrence is moderate. The discipline is high-leverage for incide
 
 Phase 3 Wave 1 produced 4 corroborating data points (above) where the design-rationale block earned positive reviewer engagement, surfaced design alternatives during review, and provided the canonical retro evidence later. Without it, gate-DAG correctness is invisible to anyone reading the PR after merge.
 
+<!-- Promoted from memory: feedback_review_against_artifact_not_framing.md (P3W5 retro 2026-05-06; reviewer-side). The implementer-side data points (#161, #206 Reality-post-#87) predate the dedicated memory and were the original founding examples; the memory codified the reviewer-side counterpart, which this section now incorporates. -->
+
 ## Trust the Artifact, Not the Framing (Mandatory) <!-- promotion-target: skill -->
 
 Both implementer and reviewer disciplines on the same axis: verify spec assumptions and PR-body framing against ground truth before action.
@@ -375,3 +377,47 @@ A sweep PR uses the same charter-format comments and TechDebt line as standard P
 **Why:** P3W4 ran 4 separate per-repo PRs for an identical 1-line CLAUDE.md slash sync (isnad-graph#857, user-service#94, design-system#63, data-acquisition#34) — 4 review pairs, 4 CI runs, ~12 charter-format comments for a no-decision change. The 2-reviewer requirement is load-bearing for behavior changes; for byte-identical doc sweeps, the verification value is concentrated at the parent tracking issue, not at each child PR.
 
 **Severity if violated:** Invoking the sweep exception on a non-byte-identical change, or skipping the tracking issue, is moderate (review-bypass for changes that needed standard review). The 2nd reviewer is the load-bearing safeguard against silent behavior change.
+
+<!-- Promoted from memory: feedback_security_guard_inline_not_followup.md (P3W5 retro 2026-05-06) -->
+
+## Security Guards Belong Inline, Not in a Followup (Mandatory) <!-- promotion-target: skill -->
+
+When reviewing a PR whose security model depends on a runtime guard — env check, scheme restriction (`{http,https}` whitelist), HTTPS-required-outside-test, startup assertion, URL rewriter, auth bypass flag — the guard MUST ship in the same PR. Filing a TechDebt followup issue is a legitimate review artifact (paper trail in case the guard ever regresses), but it is **not a substitute** for the inline guard.
+
+### Reviewer protocol
+
+When the threat model requires a runtime guard:
+
+1. **Post `Changes Requested`**, even if a followup issue exists for the guard.
+2. **File the followup BEFORE posting the review comment** so the comment can cite `TechDebt: #N` cleanly.
+3. **Frame the ask as:** "Resolve inline; close the followup with the fixup SHA referenced from this PR." The followup is a tracking artifact, not a fix.
+4. **Approve only after** the inline guard lands. Acceptable shapes for the guard: env-gate that refuses-to-boot in prod, scheme whitelist, HTTPS-required-outside-test assertion, startup-time check that fails fast, URL-rewriter input validation.
+
+### What this rule applies to
+
+- Environment gates (prod/staging refuse-to-boot under override paths)
+- Scheme whitelists (`{http,https}` restrictions on user-controlled URLs)
+- HTTPS-required-outside-test assertions
+- Startup-time security assertions (boot fails if config is unsafe)
+- URL rewriters / proxy redirects (input validation)
+- Auth bypass flags (e.g., `OAUTH_PROVIDER_BASE_URL_OVERRIDE`-class knobs)
+
+Docstring warnings, code-comment cautions, and "remember to set X in prod" notes are NEVER sufficient for these.
+
+### What this rule does NOT apply to
+
+- Defense-in-depth hardening that doesn't change the threat surface
+- Log-level tuning, observability additions
+- Doc updates that describe existing behavior
+- Refactors that preserve threat model
+
+These are legitimate followups when the inline change is already safe.
+
+### Severity if violated
+
+- Reviewer Approves a PR with a deferred runtime guard, no inline safeguard: **severe** (silent regression window between merge and followup-fixup).
+- Implementer ships a knob without the guard, even if a followup is filed: **moderate** (the followup is paperwork; the threat surface is open until the guard lands).
+
+### Worked example
+
+`noorinalabs-user-service#77` (`OAUTH_PROVIDER_BASE_URL_OVERRIDE`, 2026-04-21). Reviewer filed followup #78 proposing a prod-environment guard + HTTPS-outside-test requirement, and posted `Changes Requested`. Mateo landed both inline in fixup `1104104`; #78 closed same day. Team-lead's verdict: "shipping the env-gate + HTTPS requirement inline rather than deferring to #78 was the right call." Deferring would have left a window where a prod misconfig could exfil `client_secret` via `/token` POSTs with no backstop.

--- a/.claude/team/charter/skills.md
+++ b/.claude/team/charter/skills.md
@@ -2,6 +2,8 @@
 
 This file defines the charter rules that govern skill invocation, composition, and wave-lifecycle discipline. For skill authorship itself, see individual skill directories under `.claude/skills/`.
 
+<!-- Promoted from memory: feedback_honest_audit_over_conclusion_claim.md (P3W5 retro 2026-05-06). Already enforced via Hook 17 (validate_wave_audit) per hooks.md L169 — the dedicated provenance entry there is now mirrored to the source memory's superseded_by. -->
+
 ## Wave Lifecycle — Open-Item Audit <!-- promotion-target: hook -->
 
 Before any skill or agent claims a wave, workstream, or milestone is **"concluded"**, **"complete"**, or **"done"**, it MUST run a cross-repo open-item count for the active wave scope. The claim is only permitted if one of two conditions holds:

--- a/.claude/team/charter/state-claims.md
+++ b/.claude/team/charter/state-claims.md
@@ -50,3 +50,41 @@ Phase 3 Wave 1 produced 11 distinct instances across 3 people in one wave, despi
 ### Aspiration: post-publish audit (no enforcement)
 
 The proactive variant — self-audit of own previously-published claims absent any external prompt — was demonstrated by no team member in Phase 3 Wave 1. Charter aspires to this discipline but does not mandate it. Easily becomes box-checking; the team's discipline portfolio is honestly named to include this gap.
+
+<!-- Promoted from memory: feedback_canonical_source_via_git_show.md (P3W5 retro 2026-05-06) -->
+
+## Canonical Source via `git show <sha>:<path>` (Mandatory) <!-- promotion-target: skill -->
+
+For any task that says "use the canonical version from commit X" or "sync from parent sha X", the worktree is **convenience**, not truth. Local `main` may not yet include `X` even if `origin/main` does. The git object database is the source of truth.
+
+### How to apply
+
+For any "sync from parent sha X" or "use the canonical version from commit X" task:
+
+1. **Confirm the sha exists locally:**
+   ```bash
+   git log --oneline --all | grep <sha>
+   ```
+2. **Check whether local `main` actually contains it:**
+   ```bash
+   git branch --contains <sha>
+   ```
+3. **Pull the file via `git show` regardless of worktree state:**
+   ```bash
+   git show <sha>:<path> > /tmp/canonical.<filename>
+   ```
+   Copy FROM `/tmp/canonical.<filename>`, not from the worktree.
+
+If steps 1 and 2 disagree (sha exists locally but `main` doesn't contain it), you have a stale local main. Either fetch + fast-forward first, OR use `git show <sha>:<path>` directly — never trust the worktree path for a "from sha X" sync.
+
+### Severity if violated
+
+Silently copying a worktree file when the task said "from sha X" is moderate when the divergence has no behavior change, severe when the divergence is a downgrade through a load-bearing merge (e.g., the noorinalabs-main#112 part-(b) PR-#186 sync that would have downgraded the validate_commit_identity hook past its `_load_merged_roster` design).
+
+### Why
+
+Worktree state can lag origin by arbitrary amounts (un-pulled merges, in-progress branches checked out, paused rebase). The cost of an extra `git show` invocation is negligible; the cost of silently downgrading a child repo past a load-bearing merge is moderate-to-severe. The discipline is asymmetric: never costly to apply, sometimes catastrophic to skip.
+
+### Worked example
+
+`noorinalabs-main#112` part (b): task description said PR #186 at sha `508b6cd` was on main. True for `origin/main`, but the local worktree was on an earlier commit (`615f4c8`) that did NOT include #186. Worktree's `validate_commit_identity.py` was the pre-#186 design (no `_load_merged_roster`); copying it forward to child repos would have silently downgraded them. `git show 508b6cd:.claude/hooks/validate_commit_identity.py` returned the correct 232-line post-#186 version.

--- a/ontology/checksums.json
+++ b/ontology/checksums.json
@@ -134,10 +134,10 @@
       "resolved_at": "2026-05-03T16:59:38.573672+00:00"
     },
     ".claude/team/charter/agents.md": {
-      "last_resolved": "791f49adadd0065103aeb3b808252d2204b61c35b9ca2eb0cb4a5faf93757f89",
-      "last_tracked": "791f49adadd0065103aeb3b808252d2204b61c35b9ca2eb0cb4a5faf93757f89",
-      "resolved_at": "2026-04-23T23:34:47.340707+00:00",
-      "tracked_at": "2026-04-23T03:05:57.195189+00:00"
+      "last_tracked": "e01a0d773db423445cd7eb1a974c00663a325e14d285618beb85f0425e6a6059",
+      "last_resolved": "e01a0d773db423445cd7eb1a974c00663a325e14d285618beb85f0425e6a6059",
+      "tracked_at": "2026-05-06T01:09:30.045935+00:00",
+      "resolved_at": "2026-05-06T01:11:01.420649+00:00"
     },
     ".claude/team/charter/hooks.md": {
       "last_resolved": "518829629de66db1d14abc8d37c32703dfee4bd42ebeb3c651b7afe2946232c7",
@@ -152,16 +152,16 @@
       "tracked_at": "2026-04-23T03:27:45.739038+00:00"
     },
     ".claude/team/charter/pull-requests.md": {
-      "last_resolved": "f38d6f2f26158d2698aae1859d78738ce4f1ad0d015692f85ab2e1c326910d48",
-      "last_tracked": "f38d6f2f26158d2698aae1859d78738ce4f1ad0d015692f85ab2e1c326910d48",
-      "resolved_at": "2026-04-23T00:07:17.600045+00:00",
-      "tracked_at": "2026-04-22T23:02:38.307846+00:00"
+      "last_tracked": "df75d7e64166855e0f12591358e64d06a34c2d782db742caf15e857fff86b872",
+      "last_resolved": "df75d7e64166855e0f12591358e64d06a34c2d782db742caf15e857fff86b872",
+      "tracked_at": "2026-05-06T01:10:00.084070+00:00",
+      "resolved_at": "2026-05-06T01:11:01.420649+00:00"
     },
     ".claude/team/charter/skills.md": {
-      "last_resolved": "3d17f4b3d18d25767976007ec0d79884c5befa66bf9096c52a0c7b2ba9636078",
-      "last_tracked": "3d17f4b3d18d25767976007ec0d79884c5befa66bf9096c52a0c7b2ba9636078",
-      "resolved_at": "2026-04-23T00:07:17.600045+00:00",
-      "tracked_at": "2026-04-22T23:02:59.573817+00:00"
+      "last_tracked": "ebed0f2646c067c3f5fe4c5cd3d15504d51c2bc16a2b9bd9eed550bbfae5a598",
+      "last_resolved": "ebed0f2646c067c3f5fe4c5cd3d15504d51c2bc16a2b9bd9eed550bbfae5a598",
+      "tracked_at": "2026-05-06T01:08:14.927799+00:00",
+      "resolved_at": "2026-05-06T01:11:01.420649+00:00"
     },
     ".claude/team/feedback_log.md": {
       "last_tracked": "bfec458da44732e6fbcddfb0ba042b3448e68be5e9544a2fb447d1342f9af704",
@@ -660,6 +660,12 @@
       "last_resolved": "85263be2a3a83a8d84e4334aac290bed766cc5a2b08e238ffbc5b26563791002",
       "tracked_at": "2026-05-06T00:59:20.040752+00:00",
       "resolved_at": "2026-05-06T00:59:20.040752+00:00"
+    },
+    ".claude/team/charter/state-claims.md": {
+      "last_tracked": "0a27638d2ae460ef1730509b35a97b70cfb64498b5dba0b68897164b4a359f02",
+      "last_resolved": "0a27638d2ae460ef1730509b35a97b70cfb64498b5dba0b68897164b4a359f02",
+      "tracked_at": "2026-05-06T01:08:41.676774+00:00",
+      "resolved_at": "2026-05-06T01:11:01.420649+00:00"
     }
   },
   "last_cleanup": {


### PR DESCRIPTION
## Summary

Codifies the **5 AUTO promotions** surfaced by the P3W5 `/promotion-audit` (see audit log at `.claude/team/promotion_audit_log/wave-5.md` and the running retro PR #281).

This is a **separate PR from the retro** because charter-tier promotions are substantive content additions deserving independent review focus from the retro narrative changes.

## Audit context

P3W4 audit was `0 AUTO / 0 DECIDE` — every memory had `promotion_target: none`. PR #277 (P3W5 T2) systematically classified all 36 feedback memories with `promotion_target` frontmatter, flipping the next audit to surface real candidates. The W5 audit run confirmed `5 AUTO` exactly as predicted in #277's PR body.

## Surprise during execution: parser gap

While preparing the 5 charter sections, 2 of the 5 candidates turned out to **already be in charter**:

- `feedback_review_against_artifact_not_framing` — already at `pull-requests.md` § Trust the Artifact, Not the Framing (L325)
- `feedback_honest_audit_over_conclusion_claim` — already at `skills.md` § Wave Lifecycle — Open-Item Audit (also Hook 17)

The audit's `find_already_promoted()` parser only scans `hooks.md` for `Promotion provenance:` blocks. Charter-tier-only promotions (memory → charter without a corresponding hook) are invisible to the parser. **Follow-up issue queued** (see Action Items).

## Changes

### 3 new charter sections (real promotions)

| Memory | Citations | Charter destination |
|---|---|---|
| `feedback_canonical_source_via_git_show.md` | 4 | `state-claims.md` § Canonical Source via `git show <sha>:<path>` |
| `feedback_child_repo_implementer_rule.md` | 4 | `agents.md` § Child-Repo Implementer Rule + Spawn-Brief Verification |
| `feedback_security_guard_inline_not_followup.md` | 4 | `pull-requests.md` § Security Guards Belong Inline, Not in a Followup |

Each new section preserves the memory's load-bearing content (the rule, the why, the worked example, the severity ladder) plus an HTML-comment provenance marker for parser visibility on future audits.

### 2 provenance markers (already-in-charter, parser miss)

| Memory | Existing charter section | Action |
|---|---|---|
| `feedback_review_against_artifact_not_framing.md` | `pull-requests.md` § Trust the Artifact, Not the Framing | Added `Promoted from memory:` comment marker above the existing section |
| `feedback_honest_audit_over_conclusion_claim.md` | `skills.md` § Wave Lifecycle — Open-Item Audit | Added matching marker (provenance was already in `hooks.md` L169 for the Hook 17 promotion; this mirror makes it visible at the charter-section level too) |

### Memory frontmatter updates (user-level, not in this commit)

All 5 memory files at `~/.claude/projects/.../memory/` had their frontmatter updated:
- `status: superseded` (or `enforced-elsewhere` for the 2 already-in-charter cases)
- `superseded_by: charter:<file> § <section>` (canonical pointer)
- `superseded_at: 2026-05-06`

Re-running `/promotion-audit` after these updates confirms `AUTO: 0` (5 → 0 as expected). Re-audit summary:

```
Re-audit (post-this-PR):
  ALREADY-PROMOTED: 1
  KEPT: 52
  SUPERSEDED: 16   (was 11; +5 from this PR's promotions)
  AUTO: 0          (was 5; correctly flushed)
```

## Test plan

- [x] `/promotion-audit` re-run shows `AUTO: 0` (down from 5)
- [x] 3 new charter sections render cleanly (no markdown errors, fits surrounding section style)
- [x] 2 provenance markers don't break existing section content
- [x] Memory frontmatter updates point to actual charter sections (verified by reading the new section text vs the memory's "How to apply" body)
- [ ] Wanjiku (TPM): Approve the section homing decisions (state-claims for canonical-source, agents for child-repo-implementer, pull-requests for security-guard)
- [ ] Nadia (PD): Approve charter additions in aggregate

## Acceptance per skill spec

The `/promotion-audit` skill (§ 4) says: "For each AUTO decision: memory → charter: apply `templates/charter-section.md` to the memory, append to the appropriate charter file, mark memory `superseded_by: charter:{file} § {section}`. Stage the diff, commit on a new branch as Aino."

Followed verbatim:
- ✅ Branch: `A.Virtanen/promotion-audit-wave-5-20260506` (Aino as author)
- ✅ Reviewers per skill: Wanjiku (TPM, coordination), Nadia (PD, charter additions)
- ✅ All commits as Aino
- ✅ Memory `superseded_by` set on all 5

## Action items (post-merge)

1. **File follow-up issue against `/promotion-audit`** — the `find_already_promoted()` parser should also scan `charter/*.md` for `Promoted from memory:` comment markers, so charter-tier promotions without hook backing are recognized as ALREADY-PROMOTED on subsequent runs (not re-surfaced as AUTO).
2. **W6 promotion-audit will need to verify the parser fix lands** before relying on AUTO/SUPERSEDED counts.

## Reviewers

- **Primary:** Wanjiku Mwangi (TPM)
- **Secondary:** Nadia Khoury (PD)

Each reviewer to post a `gh pr comment` with `Requestor/Requestee/RequestOrReplied` header and `TechDebt: <none|#N>` line.

## Related

- Audit log: `.claude/team/promotion_audit_log/wave-5.md` (committed via PR #281)
- W4 audit baseline: `.claude/team/promotion_audit_log/wave-4.md` (`0 AUTO / 0 DECIDE`)
- Frontmatter classification PR: #277 (P3W5 T2)
- Retro PR (this is the AUTO-promotion sibling): #281
- Skill spec: `.claude/skills/promotion-audit/SKILL.md` § 4 (artifact generation)
- Promotion provenance for honest_audit was already at: `charter/hooks.md` L169 (Hook 17 promotion path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
