### PR TITLE
fix(hook #289): consult pr_has_paths_key on on:-block boundary in validate_workflow_paths_coverage

### DIFF
--- a/.claude/hooks/tests/test_validate_workflow_paths_coverage.py
+++ b/.claude/hooks/tests/test_validate_workflow_paths_coverage.py
@@ -120,6 +120,26 @@ class ParseWorkflowPathsTests(unittest.TestCase):
         self.assertEqual(paths, set())
         self.assertTrue(no_paths)
 
+    def test_pr_last_child_of_on_without_paths_filter(self):
+        """Regression for #289: `pull_request:` as LAST child of `on:` with no
+        `paths:` key was misparsed as covering-nothing because the on:-block
+        boundary cleared `in_pr` without consulting `pr_has_paths_key`.
+        """
+        yml = (
+            "name: CI\n"
+            "on:\n"
+            "  push:\n"
+            "    branches: [main]\n"
+            "  pull_request:\n"
+            '    branches: [main, "deployments/**"]\n'
+            "jobs:\n"
+            "  build:\n"
+            "    runs-on: ubuntu-latest\n"
+        )
+        paths, no_paths = hook._parse_workflow_paths(yml)
+        self.assertEqual(paths, set())
+        self.assertTrue(no_paths)
+
     def test_pr_with_inline_paths_list(self):
         yml = 'name: CI\non:\n  pull_request:\n    paths: ["src/**", "tests/**"]\n'
         paths, no_paths = hook._parse_workflow_paths(yml)

--- a/.claude/hooks/validate_workflow_paths_coverage.py
+++ b/.claude/hooks/validate_workflow_paths_coverage.py
@@ -196,6 +196,13 @@ def _parse_workflow_paths(yml_text: str) -> tuple[set[str], bool]:
 
         # Inside `on:` block.
         if indent <= on_indent:
+            # Symmetric with the sibling-boundary case (line 220-227) and the
+            # EOF case (line 256-258): if we exit `on:` while still inside
+            # `pull_request:` with no `paths:` key seen, that's covers-all.
+            # Without this guard, workflows where `pull_request:` is the LAST
+            # child of `on:` are misparsed as covering-nothing (#289).
+            if in_pr and not pr_has_paths_key:
+                return set(), True
             in_on = False
             in_pr = False
             in_pr_paths = False


### PR DESCRIPTION
## Summary

Fixes #289. `validate_workflow_paths_coverage._parse_workflow_paths` misparsed workflows where `pull_request:` was the LAST child of `on:` as covering-nothing instead of covering-all. Discovered at P3W6 wave-kickoff while Kofi Mensah-Williams attempted to open `gh pr create` for the landing-page#77 hotfix — the hook blocked the PR-create against a base branch (`deployments/phase-3/wave-6`) whose `ci.yml` is in exactly this shape.

## Root cause

State-machine parser at line 198–207 cleared `in_pr` and `in_pr_paths` when `indent <= on_indent` (top-level YAML key boundary, e.g., `jobs:` after `on:`) without first consulting `pr_has_paths_key`. The two existing covers-all-recognition paths handle:

- Sibling-boundary case (line 220–227): another sibling under `on:` at `pr_indent` exits `pull_request:` cleanly
- EOF case (line 256–258): file ends still inside `pull_request:`

Missing: the on:-block-boundary case where `pull_request:` is the LAST child of `on:` and the next line is a top-level key (`jobs:`, etc).

GitHub itself runs such workflows on every path (no `paths:` filter = no path filtering), but our parser was reading them as "covers nothing."

## Fix

Make the on:-block-boundary path symmetric with the sibling-boundary and EOF paths:

```python
        # Inside `on:` block.
        if indent <= on_indent:
            # Symmetric with the sibling-boundary case (line 220-227) and the
            # EOF case (line 256-258): if we exit `on:` while still inside
            # `pull_request:` with no `paths:` key seen, that's covers-all.
            # Without this guard, workflows where `pull_request:` is the LAST
            # child of `on:` are misparsed as covering-nothing (#289).
            if in_pr and not pr_has_paths_key:
                return set(), True
            in_on = False
            in_pr = False
            ...
```

5 lines added.

## Test Plan

- [x] New regression test `ParseWorkflowPathsTests.test_pr_last_child_of_on_without_paths_filter` covers the exact failure mode (mirrors landing-page `ci.yml` shape: `push:` first, `pull_request:` last, no `paths:` key, `jobs:` top-level)
- [x] Existing `test_pr_without_paths_filter` (pull_request as ONLY trigger) still passes — regression check
- [x] Existing `test_pr_with_inline_paths_list` (explicit paths) still passes — paths-extraction not affected
- [x] Existing `test_no_pull_request_trigger` (push: only) still passes — non-PR workflows unchanged
- [x] All 45 tests in the suite pass (`ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/test_validate_workflow_paths_coverage.py -v`)
- [x] Local repro of #289's failure mode now correctly returns `(set(), True)` instead of `(set(), False)`

## Discovery context (Pattern G primitive)

This is the third hook/skill parser bug surfaced during P3W6 alone:
- `#285` — `/wave-kickoff` Step 1 EXISTING_SHA captures 404 body (in-scope, p3-wave-6)
- `#287` — `validate_commit_identity` false-blocks backslash-line-continuation (tracking only)
- `#289` — this PR (tracking only originally; pulling in-wave because it blocks landing-page#77)

Plus charter/skill codifications surfaced:
- `#286` — hookify `/wave-kickoff` Steps 7+8
- `#290` — default `isolation: "worktree"` for implementer spawns

Pattern G ("in-wave skill self-improvement") W6 tally: **5 surfaced**, vs W4=1 + W5=1. The "lower-the-noise-floor" wave theme is producing visible meta-tooling clarity worth flagging at retro.

## Reviewers

- R1: **Aino Virtanen** (Standards & Quality Lead — natural owner per W4/W5/W6 hook canonicalization track record)
- R2: **Nadia Khoury** (Program Director — hub-and-spoke endorsement)

Per charter `pull-requests.md`, comment-only reviews. Each comment ends with `TechDebt: <none|#N>` line.

## Acceptance after merge

1. `gh pr create` for landing-page workflow-touching PRs succeeds against any base whose `ci.yml` has `pull_request:` as last child of `on:` — no precursor-PR workaround needed.
2. Kofi's hotfix #77 PR opens cleanly without the chicken-and-egg.
3. `noorinalabs-main#289` closes when this PR merges.

## Out of scope (deliberately)

- Kofi's hotfix #77 itself (separate PR, lands after this).
- Broader audit of other state-machine parsers in `.claude/hooks/` for similar boundary-clearing bugs (could be retro action item; this PR is surgical).
- Refactoring the parser to use a YAML library (charter convention is regex-based for hooks; this fix preserves that).

TechDebt: <none>
