### PR TITLE
fix(hook #294): recognize deployments/*/wave-* head refs in validate_pr_review

### DIFF
--- a/.claude/hooks/tests/test_validate_pr_review.py
+++ b/.claude/hooks/tests/test_validate_pr_review.py
@@ -678,6 +678,66 @@ class CheckEndToEndTests(unittest.TestCase):
         self.assertIsNone(result)
         get_mock.assert_not_called()
 
+    def test_wave_merge_head_ref_runs_comment_review(self):
+        """Issue #294: wave-merge PRs (head = deployments/phase-{N}/wave-{M}) must
+        invoke check_comment_reviews with an empty-string author-lastname sentinel
+        rather than silently skipping it.
+
+        Before the fix, extract_branch_author_lastname() returned None for the
+        wave-branch shape and the inner `if branch_author_lastname:` short-circuited,
+        leaving comment_review_result empty — the 2-reviewer gate blocked legitimate
+        wave-merge PRs even when 2 charter-format Approved comments were present.
+
+        With the fix, the new `elif` clause detects deployments/.../wave-... heads
+        and calls check_comment_reviews(number, "", repo=repo) so existing
+        reviewer-vs-author lastname comparison admits any non-empty reviewer name.
+        """
+        review_result = hook.CommentReviewResult()
+        review_result.reviewers = {"aino virtanen", "nadia khoury"}
+        with (
+            mock.patch.object(
+                hook,
+                "get_pr_data",
+                return_value=self._patch_pr_data(headRefName="deployments/phase-3/wave-6"),
+            ),
+            mock.patch.object(
+                hook, "check_comment_reviews", return_value=review_result
+            ) as ccr_mock,
+        ):
+            result = hook.check(self._input("gh pr merge 100 --squash"))
+        self.assertIsNone(
+            result,
+            "wave-merge PR with 2 charter-format Approveds should allow merge",
+        )
+        ccr_mock.assert_called_once()
+        # Empty-string sentinel is what permits any non-empty reviewer name.
+        call_args = ccr_mock.call_args
+        self.assertEqual(call_args.args[0], 100)
+        self.assertEqual(call_args.args[1], "")
+
+    def test_wave_merge_head_ref_blocks_with_one_reviewer(self):
+        """Issue #294: wave-merge PRs still subject to the 2-reviewer threshold.
+
+        The fix only routes the comment-review check; it does NOT relax the
+        reviewer count requirement. A wave-merge PR with a single Approved
+        comment must still block (no wave-bootstrap exception applies here).
+        """
+        review_result = hook.CommentReviewResult()
+        review_result.reviewers = {"aino virtanen"}
+        with (
+            mock.patch.object(
+                hook,
+                "get_pr_data",
+                return_value=self._patch_pr_data(headRefName="deployments/phase-3/wave-6"),
+            ),
+            mock.patch.object(hook, "check_comment_reviews", return_value=review_result),
+        ):
+            result = hook.check(self._input("gh pr merge 100 --squash"))
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+        self.assertIn("1/2", result["reason"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.claude/hooks/validate_pr_review.py
+++ b/.claude/hooks/validate_pr_review.py
@@ -492,6 +492,11 @@ def check(input_data: dict) -> dict | None:
         branch_author_lastname = extract_branch_author_lastname(head_ref)
         if branch_author_lastname:
             comment_review_result = check_comment_reviews(number, branch_author_lastname, repo=repo)
+        elif head_ref.startswith("deployments/") and "/wave-" in head_ref:
+            # Wave-merge PR (head = deployments/phase-{N}/wave-{M}); no implementer-branch
+            # author. Pass empty sentinel so the reviewer-vs-author lastname comparison
+            # admits any non-empty reviewer name. See main#294.
+            comment_review_result = check_comment_reviews(number, "", repo=repo)
 
     distinct_reviewers = formal_reviewers | comment_review_result.reviewers
     total_distinct = len(distinct_reviewers)


### PR DESCRIPTION
Closes #294.

## Summary

`validate_pr_review` previously silently bypassed the 2-reviewer gate on wave-merge PRs because `extract_branch_author_lastname()` returns `None` for the `deployments/phase-{N}/wave-{M}` head-ref shape. The inner `if branch_author_lastname:` then short-circuited, leaving `comment_review_result` empty — so `total_distinct == 0` and the only way to land the wave-merge was `--admin` (which the hook does NOT count, leaving `cross-repo-status.json`'s `wave_N_admin_overrides: 0` counter inaccurate for W3–W5).

## Fix

5-line addition after `validate_pr_review.py:494`: a new `elif` clause that detects `deployments/.../wave-...` heads and calls `check_comment_reviews(number, "", repo=repo)`. The empty-string sentinel travels through `check_comment_reviews` line 345 (`reviewer_lastname.lower() != branch_author_lastname.lower()`) — `"".lower() == ""`, so any non-empty reviewer name passes the self-review filter.

Backwards-compatible: implementer-branch heads (e.g., `A.Virtanen/0179-...`) continue to use lastname-based self-review filtering — that path is untouched.

## Tests

Two new fixtures in `CheckEndToEndTests`:

- `test_wave_merge_head_ref_runs_comment_review` — happy path, `headRefName="deployments/phase-3/wave-6"`, two Approved comments from "aino virtanen" + "nadia khoury" → hook returns `None` (allow). Asserts `check_comment_reviews` was called with `("", repo=...)`-style empty sentinel.
- `test_wave_merge_head_ref_blocks_with_one_reviewer` — confirms the fix only routes the comment-review path; it does NOT relax the 2-reviewer threshold. Single Approved on a wave-merge head still blocks.

All 55 tests pass locally.

## Discovery

P3W6 wrapup blocked all 7 wave-6 → main PRs despite valid 2-reviewer Approveds (Aino + Nadia). Local in-band patch was applied to land the wave; this PR is the canonical fix on `main`.

The 7 P3W6 wrapup PRs that exercised this gap:
- noorinalabs-main #293
- noorinalabs-isnad-graph #865
- noorinalabs-deploy #275
- noorinalabs-design-system #71
- noorinalabs-data-acquisition #42
- noorinalabs-isnad-ingest-platform #29
- noorinalabs-landing-page #83

## Test plan

- [x] `ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/test_validate_pr_review.py -v` → 55/55 pass
- [x] `uvx ruff format --check .claude/hooks/` → 48 files already formatted
- [x] `uvx ruff check .claude/hooks/` → All checks passed
- [x] Pre-commit hooks (ruff-format / ruff-lint / mypy) → all Passed
- [ ] Hook validates THIS PR cleanly (meta-symmetric: implementer-branch head → existing `if branch_author_lastname:` path)
- [ ] 2 charter-enforcer reviewers (Wanjiku Mwangi R1 + Nadia Khoury R2) post Approved
- [ ] Merge to main
