### PR TITLE
charter(P3W6 retro #298): apply 3 process changes — parser-fixture, kickoff PUT contents, spawn /tmp reminder

### DIFF
--- a/.claude/skills/wave-kickoff/SKILL.md
+++ b/.claude/skills/wave-kickoff/SKILL.md
@@ -183,6 +183,23 @@ fi
 
 **Verify step 0.1 holds for every repo before moving on** — every entry in the status table must be `created`, `exists-clean`, `exists-ancestor`, or (with explicit user sign-off) `exists-drift`. A missing or errored wave branch in any child repo is a stop-the-line condition.
 
+### 1a. Status commits — use `gh api` PUT contents (atomic, no local orphan)
+
+**Status commit pattern (added P3W6 retro 2026-05-08, supersedes local-then-push):**
+
+Wave-status commits (kickoff active state, reconciliation timestamps, completion state) MUST use `gh api -X PUT repos/.../contents/cross-repo-status.json` instead of local checkout + local commit + push. The PUT-contents flow is atomic — no local-orphan-possible (the P3W6 e235b0b orphan was a local kickoff status commit that never reached origin and only surfaced at wrapup).
+
+Recipe:
+1. Fetch current sha + content via `gh api .../contents/cross-repo-status.json?ref=main --jq .sha` and `--jq .content | base64 -d`
+2. Build new content via `jq` (e.g., `jq '. + {wave_N_kicked_off_at: $now, wave_N_active: true, ...}'`)
+3. base64-encode the new content
+4. Build PUT payload JSON with `message`, `content` (base64), `sha` (current), `branch: "main"`, `author: {name, email}`, `committer: {name, email}`
+5. `gh api -X PUT repos/.../contents/cross-repo-status.json --input <payload>.json`
+
+Attribution: kickoff status commits use Wanjiku Mwangi (TPM); reconciliation/wrapup commits use the role-running implementer.
+
+The local-then-push `jq | mv | git commit | git push` pattern at the end of Step 1 above pre-dates this guidance — it remains acceptable for the `wave_{M}_branches` write (which is wave-branch-scoped, not main) but MUST NOT be used for any commit landing on `main`. Status writes that target `main` (kickoff active, reconciliation, wrapup completion) use the PUT-contents recipe.
+
 ### 2. Create wave label
 
 Check if label `p{N}-wave-{M}` exists:

--- a/.claude/team/charter/agents.md
+++ b/.claude/team/charter/agents.md
@@ -238,6 +238,7 @@ Every implementer spawn prompt MUST include, **in order**:
 6. **Cross-Contract rule** reference if the PR is part of a cross-contract cluster (charter `pull-requests.md`).
 7. **Charter enforcement reminders** (2 reviewers, CI green before merge, no `--no-verify`, no global/repo git config, `/ontology-librarian` per agent).
 8. **Reporting pattern** — who they report to (usually their manager) and when (draft open, CI green, blocker, merge).
+9. **/tmp file-race discipline:** When using `--body-file` with `gh issue/pr comment` or `git commit -F`, write the file to an issue#-keyed path (e.g., `/tmp/{issue#}-{purpose}.md`) IMMEDIATELY before the gh/git call — no other tool calls between the Write and the consuming Bash. Hook `block_stale_tmp_message_file` blocks files older than 30s. P3W6 surfaced 3 such blocks in spawned-agent gh-comment flows; this discipline prevents them.
 
 ### Origin
 

--- a/.claude/team/charter/hooks.md
+++ b/.claude/team/charter/hooks.md
@@ -289,4 +289,12 @@ The hook's test suite (or docstring-embedded manual verification) must include a
 
 New Bash hooks must register in `dispatcher.py`'s `_BASH_HOOKS` list, not as a separate `settings.json` entry. See `charter/hooks.md` § Hook Dispatcher Consolidation (Hook 7 pattern).
 
-**Enforcement:** The Standards & Quality Lead (Aino) verifies these requirements during hook PR review. A hook missing any of the four requirements must not be approved.
+### 5. Parser-Fixture Coverage Requirements
+
+Every hook with input parsing MUST have test fixtures covering all known input shapes. New input shapes discovered in production (e.g., a `head_ref` shape the parser doesn't recognize, a quoting style that trips shlex, a YAML edge case) require fixture-add backport BEFORE the bug-fix PR can merge — the fixture pinning the new shape lands together with the parser fix in the same commit.
+
+**Rationale:** P3W6 surfaced 4 hook parser bugs in a single wave (#285 /wave-kickoff Step 1 EXISTING_SHA captures 404 body; #287 validate_commit_identity false-blocks backslash-line-continuation; #289 validate_workflow_paths_coverage misparses bare `on.pull_request:`; #294 validate_pr_review skips reviewer counting on `deployments/*/wave-*` heads). All four are parser bugs in production hooks discovered AT runtime when an unanticipated input shape arrives. Fixture-with-fix discipline pins the new shape so future regressions surface in CI.
+
+**Acceptance:** PR introducing a parser-bug fix MUST include the new fixture in the same commit. CI (or hook authors during review) flags PRs that change parser logic without an accompanying fixture addition.
+
+**Enforcement:** The Standards & Quality Lead (Aino) verifies these requirements during hook PR review. A hook missing any of the five requirements must not be approved.


### PR DESCRIPTION
Closes #298.

## Summary

Implements the 3 charter changes proposed and approved during P3W6 retro PR #297 (merged at `09b3a4e`). All edits are docs/skill text; no Python touched.

## Changes

| # | File | Insertion | Lines |
|---|------|-----------|-------|
| 1 | `.claude/team/charter/hooks.md` | NEW `### 5. Parser-Fixture Coverage Requirements` under § Hook Authorship Requirements; updated trailing Enforcement bullet count from "four" → "five" | +9 / −1 |
| 2 | `.claude/skills/wave-kickoff/SKILL.md` | NEW `### 1a. Status commits — use gh api PUT contents (atomic, no local orphan)` between Step 1 and Step 2; recipe + attribution + scope-clarification line | +17 |
| 3 | `.claude/team/charter/agents.md` | NEW bullet #9 (`/tmp file-race discipline`) at the end of `### Orchestrator checklist when spawning an implementer` | +1 |

Total: **27 insertions, 1 deletion** across 3 files.

## Why each change matters

1. **Parser-fixture coverage** — P3W6 surfaced 4 hook parser bugs at runtime (#285, #287, #289, #294). Each was a hook that parsed an input shape its tests didn't cover. The discipline pins new shapes in CI so regressions surface there, not in production wave runs.

2. **PUT-contents status commits** — P3W6 had a kickoff-status orphan commit (`e235b0b`) that was committed locally but never reached origin, surfacing only at wrapup audit. The atomic `gh api -X PUT` pattern eliminates the local-orphan failure mode for any commit landing on `main`. Pre-existing local-then-push for wave-branch-scoped writes is preserved (it's not a `main` write).

3. **/tmp file-race reminder** — `block_stale_tmp_message_file` blocks `--body-file` and `git commit -F` files older than 30s, which P3W6 hit 3 times in spawned-agent gh-comment flows. One-line bullet in the implementer-spawn checklist makes the discipline architectural rather than memorial (same shape as P2W10's reviewer-slate first-line move).

## Verification

- `git diff --stat` matches the table above (3 files, +27 -1)
- Pre-commit hooks (ruff-format / ruff-lint / mypy) all skipped — no .py files touched (expected)
- Branch is up-to-date with origin/main at `580d296`
- Commit message follows repo convention (charter-class scope tag, retro+issue refs, structured bullet list)

## Reviewers

- **R1**: Wanjiku Mwangi (TPM) — orchestrator discipline + spawn-template ownership
- **R2**: Nadia Khoury (PD, charter-enforcer) — charter-class authorship rules

Both have charter format `Requestor: <reviewer>  Requestee: Aino Virtanen  RequestOrReplied: Approved  TechDebt: <none|#N>` per memory `feedback_reviewer_techdebt_line_required.md`.

## Test plan

- [x] `git diff --stat` reflects exactly 3 files / 27 +1 (no scope creep)
- [x] hooks.md `Enforcement` line correctly updated from "four" → "five"
- [x] wave-kickoff Step 1a placement is between Step 1 and Step 2 (not inside either)
- [x] agents.md spawn-checklist bullet #9 follows existing 8-bullet pattern (terminal period, present-tense imperative)
- [ ] R1 + R2 post Approved with charter format including TechDebt line
- [ ] Hook validates merge gate cleanly (implementer-pattern head — uses existing `if branch_author_lastname:` path)
- [ ] Merge to main
