### PR TITLE
tech-debt(/wave-kickoff): fix Step 1 EXISTING_SHA 404 body capture + parser fixtures (#285)

### DIFF
--- a/.claude/skills/wave-kickoff/SKILL.md
+++ b/.claude/skills/wave-kickoff/SKILL.md
@@ -107,8 +107,11 @@ for R in $WAVE_REPOS_IN_SCOPE; do
     BRANCH_STATUS[$R]="error:cannot-read-main"; continue;
   }
 
-  # Probe existing branch
+  # Probe existing branch. gh api returns the raw 404 JSON body when the ref is absent,
+  # which --jq passes through unchanged (non-40-hex). Guard with shape validator so a
+  # missing branch yields EXISTING_SHA="" rather than the error body. (live-trigger: e906e135)
   EXISTING_SHA=$(gh api "repos/noorinalabs/$R/git/refs/heads/$BRANCH" --jq '.object.sha' 2>/dev/null || true)
+  [[ "$EXISTING_SHA" =~ ^[0-9a-f]{40}$ ]] || EXISTING_SHA=""
 
   if [ -n "$EXISTING_SHA" ]; then
     BRANCH_SHA[$R]="$EXISTING_SHA"

--- a/.claude/skills/wave-kickoff/fixtures/README.md
+++ b/.claude/skills/wave-kickoff/fixtures/README.md
@@ -1,0 +1,21 @@
+# wave-kickoff parser fixtures
+
+Covers the EXISTING_SHA capture in Step 1 (branch existence probe via `gh api .../git/refs/heads/<branch>`).
+
+| File | Shape | Expected EXISTING_SHA after validator |
+|------|-------|--------------------------------------|
+| `existing_sha_404.json` | 404 error body (live-trigger: e906e135) | `""` (empty) |
+| `existing_sha_happy.json` | Valid commit ref response | 40-hex SHA |
+| `existing_sha_null_jq.json` | Response where `.object.sha` is JSON null (jq yields string "null") | `""` (empty) |
+| `existing_sha_tag_ref.json` | Tag ref (annotated tag SHA — valid 40-hex, different object type) | 40-hex SHA |
+
+## Validator invariant
+
+After `EXISTING_SHA=$(gh api ... --jq '.object.sha' 2>/dev/null || true)`:
+
+```bash
+[[ "$EXISTING_SHA" =~ ^[0-9a-f]{40}$ ]] || EXISTING_SHA=""
+```
+
+- Any non-40-hex value (JSON error body, "null" string, empty) → `EXISTING_SHA=""`
+- Valid commit or tag SHA → preserved as-is

--- a/.claude/skills/wave-kickoff/fixtures/existing_sha_404.json
+++ b/.claude/skills/wave-kickoff/fixtures/existing_sha_404.json
@@ -1,0 +1,1 @@
+{"message":"Not Found","documentation_url":"https://docs.github.com/rest/git/refs#get-all-references-in-a-namespace","status":"404"}

--- a/.claude/skills/wave-kickoff/fixtures/existing_sha_happy.json
+++ b/.claude/skills/wave-kickoff/fixtures/existing_sha_happy.json
@@ -1,0 +1,1 @@
+{"ref":"refs/heads/deployments/phase-3/wave-7","node_id":"REF_example","url":"https://api.github.com/repos/noorinalabs/noorinalabs-main/git/refs/heads/deployments/phase-3/wave-7","object":{"sha":"05f18753441147bb92d4b502738ae8235475b3f0","type":"commit","url":"https://api.github.com/repos/noorinalabs/noorinalabs-main/git/commits/05f18753441147bb92d4b502738ae8235475b3f0"}}

--- a/.claude/skills/wave-kickoff/fixtures/existing_sha_null_jq.json
+++ b/.claude/skills/wave-kickoff/fixtures/existing_sha_null_jq.json
@@ -1,0 +1,1 @@
+{"ref":"refs/heads/deployments/phase-3/wave-7","node_id":"REF_example","url":"https://api.github.com/repos/noorinalabs/noorinalabs-main/git/refs/heads/deployments/phase-3/wave-7","object":{"sha":null,"type":"commit","url":"https://api.github.com/repos/noorinalabs/noorinalabs-main/git/commits/null"}}

--- a/.claude/skills/wave-kickoff/fixtures/existing_sha_tag_ref.json
+++ b/.claude/skills/wave-kickoff/fixtures/existing_sha_tag_ref.json
@@ -1,0 +1,1 @@
+{"ref":"refs/tags/v1.2.3","node_id":"REF_tag_example","url":"https://api.github.com/repos/noorinalabs/noorinalabs-main/git/refs/tags/v1.2.3","object":{"sha":"abc123def456abc123def456abc123def456abc1","type":"tag","url":"https://api.github.com/repos/noorinalabs/noorinalabs-main/git/tags/abc123def456abc123def456abc123def456abc1"}}

--- a/.claude/skills/wave-kickoff/tests/test_existing_sha_validator.py
+++ b/.claude/skills/wave-kickoff/tests/test_existing_sha_validator.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Tests for the EXISTING_SHA shape validator in wave-kickoff Step 1.
+
+The validator guards against gh api returning the raw 404 JSON error body when
+a branch doesn't exist, which was captured live during P3W7 kickoff (e906e135).
+
+Run: ENVIRONMENT=test python3 -m pytest .claude/skills/wave-kickoff/tests/test_existing_sha_validator.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import unittest
+from pathlib import Path
+
+_FIXTURES = Path(__file__).resolve().parent.parent / "fixtures"
+
+SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+
+
+def _apply_validator(raw: str) -> str:
+    """Mirror the bash validator: return raw if valid 40-hex, else empty string."""
+    if SHA_PATTERN.match(raw):
+        return raw
+    return ""
+
+
+def _jq_object_sha(fixture_path: Path) -> str:
+    """Run jq '.object.sha' against fixture, returning raw stdout (mirrors gh api --jq)."""
+    result = subprocess.run(
+        ["jq", "-r", ".object.sha"],
+        input=fixture_path.read_text(encoding="utf-8"),
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+class TestExistingShaValidator(unittest.TestCase):
+
+    def test_404_body_yields_empty(self):
+        """Live-trigger fixture: 404 JSON error body must produce EXISTING_SHA=""."""
+        fixture = _FIXTURES / "existing_sha_404.json"
+        data = json.loads(fixture.read_text())
+        self.assertEqual(data["status"], "404")
+
+        raw_jq = _jq_object_sha(fixture)
+        result = _apply_validator(raw_jq)
+        self.assertEqual(result, "", f"Expected empty, got [{result!r}] from 404 body")
+
+    def test_happy_path_preserves_sha(self):
+        """Valid 40-hex commit SHA must be preserved unchanged."""
+        fixture = _FIXTURES / "existing_sha_happy.json"
+        data = json.loads(fixture.read_text())
+        expected_sha = data["object"]["sha"]
+        self.assertRegex(expected_sha, r"^[0-9a-f]{40}$")
+
+        raw_jq = _jq_object_sha(fixture)
+        result = _apply_validator(raw_jq)
+        self.assertEqual(result, expected_sha)
+
+    def test_null_sha_yields_empty(self):
+        """When jq returns 'null' string (object.sha is JSON null), validator must clear it."""
+        fixture = _FIXTURES / "existing_sha_null_jq.json"
+        raw_jq = _jq_object_sha(fixture)
+        self.assertEqual(raw_jq, "null")
+
+        result = _apply_validator(raw_jq)
+        self.assertEqual(result, "", f"Expected empty for null sha, got [{result!r}]")
+
+    def test_tag_ref_sha_preserved(self):
+        """Tag ref SHA (still 40-hex) must pass through validator unchanged."""
+        fixture = _FIXTURES / "existing_sha_tag_ref.json"
+        data = json.loads(fixture.read_text())
+        expected_sha = data["object"]["sha"]
+        self.assertRegex(expected_sha, r"^[0-9a-f]{40}$")
+
+        raw_jq = _jq_object_sha(fixture)
+        result = _apply_validator(raw_jq)
+        self.assertEqual(result, expected_sha)
+
+    def test_raw_404_string_capture_yields_empty(self):
+        """When EXISTING_SHA holds the raw 404 JSON body string (no jq), validator clears it."""
+        raw = '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/git/refs#get-all-references-in-a-namespace","status":"404"}'
+        result = _apply_validator(raw)
+        self.assertEqual(result, "", f"Expected empty, got [{result!r}]")
+
+    def test_empty_string_yields_empty(self):
+        """Empty string (e.g. api call failed entirely) must stay empty."""
+        self.assertEqual(_apply_validator(""), "")
+
+    def test_short_hex_rejected(self):
+        """A SHA shorter than 40 hex chars must not pass (truncated/corrupt output)."""
+        self.assertEqual(_apply_validator("abc123"), "")
+
+    def test_uppercase_hex_rejected(self):
+        """GitHub SHAs are lowercase; uppercase must be rejected as non-canonical."""
+        self.assertEqual(_apply_validator("E906E135D811CDE" + "a" * 25), "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #285

## Summary

- `gh api .../git/refs/heads/<branch>` returns a raw 404 JSON error body when the branch doesn't exist; `--jq '.object.sha'` passes this through unchanged (non-40-hex string), so `EXISTING_SHA` was non-empty on every missing branch — triggering spurious `exists-drift` for all 8 repos in P3W7 kickoff
- Fix: one-line SHA-shape regex validator immediately after the capture — any value not matching `^[0-9a-f]{40}$` is cleared to `""`, preserving the idempotency contract
- Fixtures and 8 pytest cases added covering: live 404 shape, happy path, jq-null output, tag ref SHA, raw error string, empty, truncated, and uppercase inputs

## Live-trace acceptance

Bug fired in the wild during P3W7 kickoff branch-creation probe (commit **e906e135**):

> *"Note: bug #285 (gh api 404 EXISTING_SHA capture as JSON error body) actually fired during this kickoff's branch-creation probe step — workaround SHA-shape validator added in-band."*

In-band workaround applied at the time:
```bash
[[ "$EXISTING_SHA" =~ ^[0-9a-f]{40}$ ]] || EXISTING_SHA=""
```

This PR backports that workaround as the canonical fix with full fixture coverage.

## Fix (SKILL.md Step 1 diff)

```bash
# Before (line 111):
EXISTING_SHA=$(gh api "repos/noorinalabs/$R/git/refs/heads/$BRANCH" --jq '.object.sha' 2>/dev/null || true)

# After:
EXISTING_SHA=$(gh api "repos/noorinalabs/$R/git/refs/heads/$BRANCH" --jq '.object.sha' 2>/dev/null || true)
[[ "$EXISTING_SHA" =~ ^[0-9a-f]{40}$ ]] || EXISTING_SHA=""
```

## Fixtures added

| File | Shape covered |
|------|--------------|
| `fixtures/existing_sha_404.json` | **Live-trigger**: actual 404 error body from `gh api .../git/refs/heads/<nonexistent>` |
| `fixtures/existing_sha_happy.json` | Valid commit ref response with 40-hex SHA |
| `fixtures/existing_sha_null_jq.json` | Response where `.object.sha` is JSON null (jq yields string `"null"`) |
| `fixtures/existing_sha_tag_ref.json` | Tag ref (annotated tag SHA — valid 40-hex, different object type) |

## Tests

`tests/test_existing_sha_validator.py` — 8 pytest cases, all passing:

```
test_404_body_yields_empty           PASSED
test_happy_path_preserves_sha        PASSED
test_null_sha_yields_empty           PASSED
test_tag_ref_sha_preserved           PASSED
test_raw_404_string_capture_yields_empty PASSED
test_empty_string_yields_empty       PASSED
test_short_hex_rejected              PASSED
test_uppercase_hex_rejected          PASSED
```

## Charter compliance

Per `charter/hooks.md` § Parser-Fixture Coverage Requirements: every hook/skill with input parsing MUST have fixtures for all known input shapes; production-discovered shapes require fixture-add backport before bug-fix merge. Fix and fixtures land in the same PR.

## Test plan

- [x] `ENVIRONMENT=test python3 -m pytest .claude/skills/wave-kickoff/tests/test_existing_sha_validator.py -v` — 8/8 passed
- [x] Live reproduction: `gh api "repos/noorinalabs/noorinalabs-main/git/refs/heads/nonexistent-branch-for-fixture-capture-285" --jq '.object.sha' 2>/dev/null || true` yields JSON error body; post-validator yields `""`
- [x] Happy path: `gh api "repos/noorinalabs/noorinalabs-main/git/refs/heads/main" --jq '.object.sha'` yields valid 40-hex; validator preserves it unchanged
- [ ] Reviewer approval: Aino Virtanen, Nadia Khoury
