### PR TITLE
tech-debt(hook): fix validate_commit_identity backslash-line-continuation parsing + fixtures (#287)

### DIFF
--- a/.claude/hooks/_shell_parse.py
+++ b/.claude/hooks/_shell_parse.py
@@ -138,11 +138,23 @@ _GIT_BOOL_GLOBALS = {
     "--no-optional-locks",
 }
 
+# Backslash + newline = POSIX line continuation. The Claude Code harness passes
+# the raw bash command string including these sequences. shlex.split(posix=True)
+# does NOT consume them as line continuations — instead it emits the trailing
+# newline as a standalone token (issue #287), breaking command-position detection.
+_LINE_CONTINUATION_RE = re.compile(r"\\\n[ \t]*")
+
 
 def tokenize(cmd: str) -> list[str] | None:
-    """shlex.split the command. Return None on parse error (unbalanced quote)."""
+    """shlex.split the command. Return None on parse error (unbalanced quote).
+
+    Normalizes POSIX line-continuation sequences (backslash + newline) to a
+    single space before tokenizing. Without this, shlex.split(posix=True)
+    emits the trailing newline as a stray token that breaks command-position
+    detection (issue #287).
+    """
     try:
-        return shlex.split(cmd, posix=True)
+        return shlex.split(_LINE_CONTINUATION_RE.sub(" ", cmd), posix=True)
     except ValueError:
         return None
 

--- a/.claude/hooks/fixtures/validate_commit_identity/adjacent_commit_amend.json
+++ b/.claude/hooks/fixtures/validate_commit_identity/adjacent_commit_amend.json
@@ -1,0 +1,5 @@
+{
+  "description": "Adjacent shape: git commit --amend (amending last commit)",
+  "command": "git -c user.name=\"Aino Virtanen\" -c user.email=\"parametrization+Aino.Virtanen@gmail.com\" commit --amend --no-edit",
+  "expect": "allow"
+}

--- a/.claude/hooks/fixtures/validate_commit_identity/adjacent_heredoc_minus_m.json
+++ b/.claude/hooks/fixtures/validate_commit_identity/adjacent_heredoc_minus_m.json
@@ -1,0 +1,5 @@
+{
+  "description": "Adjacent shape: -m with $(cat <<'EOF' ... EOF) command substitution (feedback_heredoc_in_git_commit)",
+  "command": "git -c user.name=\"Aino Virtanen\" -c user.email=\"parametrization+Aino.Virtanen@gmail.com\" commit -m \"$(cat <<'EOF'\nmulti\nline\nmessage\nEOF\n)\"",
+  "expect": "allow"
+}

--- a/.claude/hooks/fixtures/validate_commit_identity/adjacent_multi_dash_c.json
+++ b/.claude/hooks/fixtures/validate_commit_identity/adjacent_multi_dash_c.json
@@ -1,0 +1,5 @@
+{
+  "description": "Adjacent shape: git -c gpg.format=ssh plus identity flags (multi -c flags beyond identity)",
+  "command": "git -c gpg.format=ssh -c user.name=\"Aino Virtanen\" -c user.email=\"parametrization+Aino.Virtanen@gmail.com\" commit -m \"chore: signed commit with extra -c flags\"",
+  "expect": "allow"
+}

--- a/.claude/hooks/fixtures/validate_commit_identity/adjacent_worktree_add_commit_in_branch.json
+++ b/.claude/hooks/fixtures/validate_commit_identity/adjacent_worktree_add_commit_in_branch.json
@@ -1,0 +1,5 @@
+{
+  "description": "Adjacent shape: git worktree add with 'commit' appearing in branch name — must NOT be blocked",
+  "command": "git worktree add /tmp/wt-a-virtanen-287 -b A.Virtanen/0287-fix-validate-commit-identity-backslash origin/deployments/phase-3/wave-7",
+  "expect": "allow"
+}

--- a/.claude/hooks/fixtures/validate_commit_identity/bug_backslash_line_continuation.json
+++ b/.claude/hooks/fixtures/validate_commit_identity/bug_backslash_line_continuation.json
@@ -1,0 +1,5 @@
+{
+  "description": "Bug #287: backslash-line-continuation in git commit command — must be allowed, not false-blocked",
+  "command": "git -c user.name=\"Aino Virtanen\" \\\n    -c user.email=\"parametrization+Aino.Virtanen@gmail.com\" \\\n    commit -m \"fix: apply parser fix (#287)\"",
+  "expect": "allow"
+}

--- a/.claude/hooks/fixtures/validate_commit_identity/happy_commit_file.json
+++ b/.claude/hooks/fixtures/validate_commit_identity/happy_commit_file.json
@@ -1,0 +1,5 @@
+{
+  "description": "Happy path: git commit -F /tmp/msg.txt (file-based message per feedback_heredoc_in_git_commit)",
+  "command": "git -c user.name=\"Aino Virtanen\" -c user.email=\"parametrization+Aino.Virtanen@gmail.com\" commit -F /tmp/287-commit-msg.txt",
+  "expect": "allow"
+}

--- a/.claude/hooks/fixtures/validate_commit_identity/happy_single_line.json
+++ b/.claude/hooks/fixtures/validate_commit_identity/happy_single_line.json
@@ -1,0 +1,5 @@
+{
+  "description": "Happy path: single-line git commit with quoted -c flags",
+  "command": "git -c user.name=\"Aino Virtanen\" -c user.email=\"parametrization+Aino.Virtanen@gmail.com\" commit -m \"fix: straightforward single-line commit\"",
+  "expect": "allow"
+}

--- a/.claude/hooks/fixtures/validate_commit_identity/negative_mismatched_email.json
+++ b/.claude/hooks/fixtures/validate_commit_identity/negative_mismatched_email.json
@@ -1,0 +1,5 @@
+{
+  "description": "Negative: user.email does not match roster entry for user.name — must be blocked",
+  "command": "git -c user.name=\"Aino Virtanen\" -c user.email=\"wrong.email@example.com\" commit -m \"wrong email\"",
+  "expect": "block:email mismatch"
+}

--- a/.claude/hooks/fixtures/validate_commit_identity/negative_missing_user_email.json
+++ b/.claude/hooks/fixtures/validate_commit_identity/negative_missing_user_email.json
@@ -1,0 +1,5 @@
+{
+  "description": "Negative: missing -c user.email= flag — must be blocked",
+  "command": "git -c user.name=\"Aino Virtanen\" commit -m \"missing email flag\"",
+  "expect": "block:missing user.email"
+}

--- a/.claude/hooks/fixtures/validate_commit_identity/negative_missing_user_name.json
+++ b/.claude/hooks/fixtures/validate_commit_identity/negative_missing_user_name.json
@@ -1,0 +1,5 @@
+{
+  "description": "Negative: missing -c user.name= flag — must be blocked",
+  "command": "git -c user.email=\"parametrization+Aino.Virtanen@gmail.com\" commit -m \"missing name flag\"",
+  "expect": "block:missing user.name"
+}

--- a/.claude/hooks/fixtures/validate_commit_identity/negative_no_identity_at_all.json
+++ b/.claude/hooks/fixtures/validate_commit_identity/negative_no_identity_at_all.json
@@ -1,0 +1,5 @@
+{
+  "description": "Negative: bare git commit with no -c flags — must be blocked",
+  "command": "git commit -m \"no identity flags at all\"",
+  "expect": "block:missing user.name"
+}

--- a/.claude/hooks/fixtures/validate_commit_identity/negative_unrecognized_name.json
+++ b/.claude/hooks/fixtures/validate_commit_identity/negative_unrecognized_name.json
@@ -1,0 +1,5 @@
+{
+  "description": "Negative: user.name not in roster — must be blocked",
+  "command": "git -c user.name=\"Totally Fake Person\" -c user.email=\"fake@example.com\" commit -m \"not in roster\"",
+  "expect": "block:unrecognized name"
+}

--- a/.claude/hooks/tests/test_validate_commit_identity.py
+++ b/.claude/hooks/tests/test_validate_commit_identity.py
@@ -341,7 +341,9 @@ class ParseFailureFailClosedTests(unittest.TestCase):
         )
         assert result is not None
         self.assertEqual(result["decision"], "block")
-        self.assertIn("shlex parsing", result["reason"])
+        # Reason must indicate parse failure and actionable guidance
+        # (message updated in #287 to be more precise than "shlex parsing").
+        self.assertIn("unbalanced quotes", result["reason"])
 
     def test_unbalanced_quote_without_commit_allows(self):
         """Parse failure on a non-commit command → allow (no commit to validate)."""

--- a/.claude/hooks/tests/test_validate_commit_identity_parser.py
+++ b/.claude/hooks/tests/test_validate_commit_identity_parser.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Fixture-driven parser tests for validate_commit_identity hook.
+
+Each JSON file in fixtures/validate_commit_identity/ is one test case:
+
+    {
+        "description": "<human label>",
+        "command": "<raw bash command string>",
+        "expect": "allow" | "block:<reason-keyword>"
+    }
+
+The `expect` field:
+  - "allow"         → check() must return None
+  - "block:<kw>"    → check() must return a block decision; <kw> is a
+                      substring of the reason (case-insensitive) for
+                      self-documenting test output, not strict matching.
+
+Run:  python3 -m pytest .claude/hooks/tests/test_validate_commit_identity_parser.py -v
+      (or the full suite: python3 -m pytest .claude/hooks/tests/ -v)
+
+Covers:
+  Bug shape  — backslash-line-continuation (#287)
+  Happy path — single-line, -F file, multi -c, --amend
+  Adjacent   — heredoc -m, gpg -c, worktree add with 'commit' in branch name
+  Negative   — missing name, missing email, mismatched email, unrecognized name
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_HOOKS_DIR = _HERE.parent
+_FIXTURES_DIR = _HOOKS_DIR / "fixtures" / "validate_commit_identity"
+
+sys.path.insert(0, str(_HOOKS_DIR))
+
+import validate_commit_identity as hook  # noqa: E402
+
+
+def _load_fixtures() -> list[tuple[str, dict]]:
+    """Return (fixture_name, fixture_data) pairs for every JSON in the fixture dir."""
+    fixtures = []
+    for path in sorted(_FIXTURES_DIR.glob("*.json")):
+        data = json.loads(path.read_text(encoding="utf-8"))
+        fixtures.append((path.stem, data))
+    return fixtures
+
+
+def _make_input(command: str) -> dict:
+    return {"tool_name": "Bash", "tool_input": {"command": command}}
+
+
+class FixtureDrivenParserTests(unittest.TestCase):
+    """One test method per fixture file — generated dynamically."""
+
+
+def _add_fixture_test(name: str, fixture: dict) -> None:
+    """Attach a test method to FixtureDrivenParserTests for `fixture`."""
+    description = fixture.get("description", name)
+    command = fixture["command"]
+    expect = fixture["expect"]
+
+    def test_method(self: unittest.TestCase) -> None:
+        result = hook.check(_make_input(command))
+        if expect == "allow":
+            self.assertIsNone(
+                result,
+                f"{description!r}: expected allow (None) but got block: {result}",
+            )
+        elif expect.startswith("block:"):
+            self.assertIsNotNone(
+                result,
+                f"{description!r}: expected block but got allow (None)",
+            )
+            assert result is not None  # for mypy
+            self.assertEqual(
+                result.get("decision"),
+                "block",
+                f"{description!r}: result decision is not 'block': {result}",
+            )
+        else:
+            raise ValueError(f"Unknown expect value {expect!r} in fixture {name!r}")
+
+    test_method.__name__ = f"test_{name}"
+    test_method.__doc__ = description
+    setattr(FixtureDrivenParserTests, test_method.__name__, test_method)
+
+
+for _fixture_name, _fixture_data in _load_fixtures():
+    _add_fixture_test(_fixture_name, _fixture_data)
+
+
+class LineContinuationNormalizationTests(unittest.TestCase):
+    """Unit tests for the backslash-newline normalization in _shell_parse.tokenize."""
+
+    def test_backslash_newline_not_in_tokens(self):
+        """After normalization, no newline char token appears in the output."""
+        import _shell_parse as sp
+
+        cmd = 'git -c user.name="X" \\\n    -c user.email="y@z.com" commit -m "m"'
+        tokens = sp.tokenize(cmd)
+        self.assertIsNotNone(tokens)
+        self.assertNotIn("\n", tokens, "Newline char must not appear as a standalone token")
+        self.assertNotIn("n", tokens, "Stray 'n' token must not appear after normalization")
+
+    def test_commit_subcommand_found_after_continuation(self):
+        """find_git_subcommand resolves to 'commit' even with backslash-continuation."""
+        import _shell_parse as sp
+
+        cmd = 'git -c user.name="X" \\\n    -c user.email="y@z.com" \\\n    commit -m "m"'
+        tokens = sp.tokenize(cmd)
+        self.assertIsNotNone(tokens)
+        for seg in sp.iter_command_segments(tokens):
+            decoded = sp.find_git_subcommand(seg)
+            if decoded is not None:
+                _globals, rest = decoded
+                if rest and rest[0] == "commit":
+                    return  # found it
+        self.fail(
+            "commit subcommand not found in tokens after backslash-continuation normalization"
+        )
+
+    def test_normalization_does_not_break_quoted_values(self):
+        """Quoted values containing literal spaces survive normalization correctly."""
+        import _shell_parse as sp
+
+        cmd = 'git -c user.name="Aino Virtanen" \\\n    commit -m "multi word message"'
+        tokens = sp.tokenize(cmd)
+        self.assertIsNotNone(tokens)
+        self.assertIn("user.name=Aino Virtanen", tokens)
+        self.assertIn("multi word message", tokens)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/hooks/validate_commit_identity.py
+++ b/.claude/hooks/validate_commit_identity.py
@@ -127,24 +127,25 @@ def _detect_target_roster(command: str) -> dict[str, str] | None:
     return merged or None
 
 
-def _find_commit_segment(command: str) -> list[str] | None:
-    """Find the `git ... commit ...` segment in `command`. None if absent.
+_PARSE_FAILURE = object()  # sentinel: tokenize returned None
+
+
+def _find_commit_segment(command: str) -> list[str] | None | object:
+    """Find the `git ... commit ...` segment in `command`.
+
+    Returns:
+      - list[str]      — the commit segment tokens (allow identity validation)
+      - None           — tokenize succeeded but no commit subcommand found
+      - _PARSE_FAILURE — tokenize failed (unbalanced quotes); caller must use
+                         regex fallback
 
     Strips heredocs first so a heredoc body containing the literal phrase
-    "git commit" cannot be confused with a real invocation. Tokenizes the
-    cleaned command with shlex, walks each pipeline segment, and returns
-    the first segment whose `find_git_subcommand` resolves to subcommand
-    `commit`.
-
-    Returns None on parse failure OR when there is no commit. The caller
-    distinguishes the two via `_looks_like_git_commit` so a malformed-but-
-    suspicious command falls through to a fail-closed regex path instead
-    of being silently allowed (per `_shell_parse.tokenize` contract).
+    "git commit" cannot be confused with a real invocation.
     """
     cleaned = strip_heredocs(command)
     tokens = tokenize(cleaned)
     if tokens is None:
-        return None
+        return _PARSE_FAILURE
     for segment in iter_command_segments(tokens):
         decoded = find_git_subcommand(segment)
         if decoded is None:
@@ -156,11 +157,12 @@ def _find_commit_segment(command: str) -> list[str] | None:
 
 
 # Regex-only heuristic for the parse-failure fallback: did the command,
-# after stripping heredocs, contain `git ... commit` at command position?
-# Anchored at start-of-line or after a shell operator. Liberal on purpose
-# — when shlex fails we want to err on the side of validating identity.
+# after stripping heredocs, contain `git commit` as a standalone subcommand
+# (not embedded in a path/branch-name)?  Anchored at start-of-line or after a
+# shell operator. Requires `commit` to appear as a word-boundary token
+# separated from options by whitespace (not inside a slash-separated path).
 _COMMIT_FALLBACK_RE = re.compile(
-    r"(?:^|[;&|]\s*|&&\s*|\|\|\s*)\s*git\b[^;&|]*?\bcommit\b",
+    r"(?:^|[;&|]\s*|&&\s*|\|\|\s*)\s*git\b[^;&|]*?(?<!\S)\bcommit\b(?!\S*/)",
     re.MULTILINE,
 )
 
@@ -187,25 +189,29 @@ def check(input_data: dict) -> dict | None:
     command = input_data.get("tool_input", {}).get("command", "")
 
     commit_segment = _find_commit_segment(command)
-    if commit_segment is None:
-        # Parse-failure fail-closed path: shlex couldn't tokenize, but the
-        # command LOOKS like it contains a `git commit`. Block with a
-        # parse-failure-specific message so the operator can fix the quoting
-        # and retry. Allowing here would create a hole — paste a malformed
-        # `git commit` and bypass identity validation.
+    if commit_segment is _PARSE_FAILURE:
+        # tokenize() returned None — shlex could not parse the command. Use
+        # the regex fallback: if it looks like a git commit, block (fail-closed);
+        # otherwise allow (fail-open for non-commit commands).
         if not _looks_like_git_commit(command):
             return None
         result = {
             "decision": "block",
             "reason": (
-                "BLOCKED: git commit detected but command failed shlex parsing "
-                "(likely unbalanced quotes). Cannot validate `-c user.name=` / "
-                "`-c user.email=` flags from a malformed command. Fix the "
-                "quoting and retry."
+                "BLOCKED: git commit detected but the command contains unbalanced "
+                "quotes or other syntax shlex cannot parse. Cannot safely validate "
+                "`-c user.name=` / `-c user.email=` identity flags. Fix the quoting "
+                "(e.g. use -F /tmp/msg.txt instead of inline -m with unbalanced "
+                "quotes) and retry."
             ),
         }
         log_pretooluse_block("validate_commit_identity", command, result["reason"])
         return result
+    if commit_segment is None:
+        # Tokenize succeeded but no git commit subcommand was found.
+        return None
+
+    assert isinstance(commit_segment, list)  # _PARSE_FAILURE and None already handled above
 
     # Cross-repo support: if the command `cd`s into another repo, load that
     # repo's roster instead of the local one.


### PR DESCRIPTION
Closes #287

## Summary

- **Root cause:** `_shell_parse.tokenize()` called `shlex.split(posix=True)` on raw bash commands containing POSIX line-continuation sequences (`\` + newline). shlex produced the trailing newline as a standalone `\n` token rather than collapsing it, causing `find_git_subcommand` to see `\n` as the git subcommand instead of `commit`. `_find_commit_segment` returned `None`, which fell through to the regex fallback, which fired on the command and emitted the misleading "shlex parsing" block message.
- **Fix:** `_LINE_CONTINUATION_RE = re.compile(r"\\\n[ \t]*")` applied in `tokenize()` before `shlex.split`, collapsing continuation sequences to a single space. One-line change in `_shell_parse.py`.
- **Improvements:** `_find_commit_segment` now returns a `_PARSE_FAILURE` sentinel to distinguish "tokenize failed" from "no commit found"; error message updated to say "unbalanced quotes" (not "shlex parsing") with actionable guidance.

## Bug shape demonstration

```bash
# This command false-blocked with the pre-fix hook:
git -c user.name="Aino Virtanen" \
    -c user.email="parametrization+Aino.Virtanen@gmail.com" \
    commit -m "fix: something"
# Error: "BLOCKED: git commit detected but command failed shlex parsing..."
```

## Fix strategy

Single regex normalization in `_shell_parse.tokenize()` before `shlex.split`. Chose `tokenize()` rather than a call-site patch so all hooks that consume this module benefit automatically. The regex `r"\\\n[ \t]*"` matches exactly one backslash + one newline + optional leading whitespace on the continuation line.

## Fixtures added

| File | Shape | Expect |
|------|-------|--------|
| `bug_backslash_line_continuation.json` | `\`-continuation across 3 lines | allow |
| `happy_single_line.json` | Single-line with quoted -c flags | allow |
| `happy_commit_file.json` | `commit -F /tmp/msg.txt` | allow |
| `adjacent_heredoc_minus_m.json` | `-m "$(cat <<'EOF' ... EOF)"` | allow |
| `adjacent_multi_dash_c.json` | `-c gpg.format=ssh` + identity flags | allow |
| `adjacent_commit_amend.json` | `commit --amend --no-edit` | allow |
| `adjacent_worktree_add_commit_in_branch.json` | `git worktree add` with "commit" in branch name | allow |
| `negative_missing_user_name.json` | No `-c user.name=` | block |
| `negative_missing_user_email.json` | No `-c user.email=` | block |
| `negative_mismatched_email.json` | Wrong email for name | block |
| `negative_unrecognized_name.json` | Name not in roster | block |
| `negative_no_identity_at_all.json` | Bare `git commit -m` | block |

**Charter compliance:** Per `charter/hooks.md` § Parser-Fixture Coverage Requirements

## Test plan

- [x] `ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/test_validate_commit_identity_parser.py -v` → 15 passed
- [x] `ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/test_validate_commit_identity.py -v` → 19 passed (all existing tests green)
- [x] `ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/test_shell_parse.py -v` → 41 passed
- [x] `uvx ruff@0.11.2 format --check .claude/hooks/` → clean
- [x] pre-commit mypy → passed
- [x] All negative block-cases (missing name/email, wrong email, unrecognized name) still block
- [x] `git worktree add` with "commit" in branch name no longer false-blocks
