### PR TITLE
tech-debt(hook): refactor validate_workflow_paths_coverage to use _shell_parse + fixtures (#260)

### DIFF
--- a/.claude/hooks/tests/test_validate_workflow_paths_coverage.py
+++ b/.claude/hooks/tests/test_validate_workflow_paths_coverage.py
@@ -70,6 +70,64 @@ class IsGhPrGateCommandTests(unittest.TestCase):
         """grep with the phrase in pattern position — should NOT match."""
         self.assertFalse(hook._is_gh_pr_gate_command("grep 'gh pr create' /tmp/file"))
 
+    def test_line_continuation_pr_create_matches(self):
+        """Backslash-newline line continuation in gh pr create — transitive #305 fix.
+
+        _shell_parse.tokenize() normalizes '\\\\\\n' to ' ' before shlex.split,
+        so a multi-line gh pr create still lands at command position and matches.
+        """
+        cmd = "gh pr create \\\n  --title 'fix: thing' \\\n  --base main"
+        self.assertTrue(hook._is_gh_pr_gate_command(cmd))
+
+    def test_line_continuation_pr_ready_matches(self):
+        """gh pr ready with line continuation — transitive #305 fix."""
+        cmd = "gh pr ready \\\n  123"
+        self.assertTrue(hook._is_gh_pr_gate_command(cmd))
+
+    def test_heredoc_containing_gh_pr_create_does_not_match(self):
+        """gh pr create text INSIDE a heredoc body must NOT trigger the gate.
+
+        strip_heredocs() removes the body before tokenization, so `gh pr create`
+        appearing as document content is never seen as a command token.
+        """
+        cmd = "cat <<EOF\ngh pr create --base main\nEOF\necho done"
+        self.assertFalse(hook._is_gh_pr_gate_command(cmd))
+
+    def test_chained_with_line_continuation_matches(self):
+        """git push && gh pr create across a line continuation — #305 transitive."""
+        cmd = "git push origin feature \\\n  && gh pr create --base main"
+        self.assertTrue(hook._is_gh_pr_gate_command(cmd))
+
+
+class WalkFlagValueTests(unittest.TestCase):
+    """_walk_flag_value: token-based flag extraction."""
+
+    def test_space_separated_form(self):
+        tokens = ["gh", "pr", "create", "--base", "main"]
+        self.assertEqual(hook._walk_flag_value(tokens, "base"), "main")
+
+    def test_equals_form(self):
+        tokens = ["gh", "pr", "create", "--base=develop"]
+        self.assertEqual(hook._walk_flag_value(tokens, "base"), "develop")
+
+    def test_absent_returns_none(self):
+        tokens = ["gh", "pr", "create"]
+        self.assertIsNone(hook._walk_flag_value(tokens, "base"))
+
+    def test_flag_value_inside_body_not_extracted(self):
+        """Flag value inside --body is a single token; won't match as --repo value.
+
+        shlex collapses quoted body to one token, so '--repo' inside the body
+        string is never a separate token in flag position.
+        """
+        tokens = ["gh", "pr", "create", "--body", "use --repo x/y here"]
+        self.assertIsNone(hook._walk_flag_value(tokens, "repo"))
+
+    def test_flag_at_end_with_no_value_returns_none(self):
+        """Flag token at end of list with no following value."""
+        tokens = ["gh", "pr", "create", "--base"]
+        self.assertIsNone(hook._walk_flag_value(tokens, "base"))
+
 
 class ExtractFlagTests(unittest.TestCase):
     """_extract_flag covers --flag value, --flag=value, --flag "quoted"."""
@@ -94,6 +152,25 @@ class ExtractFlagTests(unittest.TestCase):
 
     def test_absent_flag_returns_none(self):
         self.assertIsNone(hook._extract_flag("gh pr create", "base"))
+
+    def test_repo_value_in_quoted_body_not_extracted(self):
+        """--repo value inside --body quoted string must NOT be extracted as --repo.
+
+        shlex collapses the quoted body to one token, so the --repo substring
+        inside it is never seen as a flag token by _walk_flag_value.
+        """
+        cmd = 'gh pr create --body "link: --repo x/y here" --repo noorinalabs/test'
+        self.assertEqual(hook._extract_flag(cmd, "repo"), "noorinalabs/test")
+
+    def test_flag_extracted_after_line_continuation(self):
+        """--repo flag value after a backslash-newline continuation — #305 transitive."""
+        cmd = "gh pr create \\\n  --repo noorinalabs/test \\\n  --base main"
+        self.assertEqual(hook._extract_flag(cmd, "repo"), "noorinalabs/test")
+
+    def test_base_extracted_after_line_continuation(self):
+        """--base after line continuation tokenizes correctly."""
+        cmd = "gh pr create \\\n  --base deployments/phase-3/wave-7"
+        self.assertEqual(hook._extract_flag(cmd, "base"), "deployments/phase-3/wave-7")
 
 
 class ParseWorkflowPathsTests(unittest.TestCase):

--- a/.claude/hooks/validate_workflow_paths_coverage.py
+++ b/.claude/hooks/validate_workflow_paths_coverage.py
@@ -97,13 +97,21 @@ import subprocess
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _shell_parse import (  # noqa: E402
+    find_gh_subcommand,
+    iter_command_segments,
+    strip_heredocs,
+    tokenize,
+)
 from annunaki_log import log_pretooluse_block  # noqa: E402
 
 # --- Command-shape matchers -------------------------------------------------
 
-# Match `gh pr create` / `gh pr ready` at command position. Liberal pattern
-# (chained command via &&/||/|/; is fine; leading env-var assignments are
-# handled by stripping them before matching).
+_GH_PR_GATE_ACTIONS = {"create", "ready"}
+
+# Regex fallback used only when shlex tokenization fails (unbalanced quotes,
+# malformed input). Intentionally kept so the hook degrades to the old
+# substring-match path rather than silently allowing on parse failure.
 _GH_PR_GATE_RE = re.compile(
     r"(?:^|[;&|]\s*|&&\s*|\|\|\s*)\s*"
     r"(?:[A-Za-z_][A-Za-z0-9_]*=\S+\s+)*"
@@ -111,29 +119,69 @@ _GH_PR_GATE_RE = re.compile(
     re.MULTILINE,
 )
 
-# Flag extraction (single shlex-aware pass via simple regex; matches
-# `--flag value` and `--flag=value`). Conservative — false negatives just
-# mean we fall back to defaults (cwd repo / main / current branch).
-_FLAG_VALUE_RE = re.compile(
-    r"--{flag}(?:=|\s+)([^\s'\"]+)|--{flag}\s+\"([^\"]+)\"|--{flag}\s+'([^']+)'"
-)
+
+def _is_gh_pr_gate_command(command: str) -> bool:
+    """True if any segment of `command` is a `gh pr create` or `gh pr ready` call.
+
+    Uses _shell_parse.tokenize + find_gh_subcommand for command-position detection.
+    Falls back to regex on shlex parse failure (fail-open for the gate check:
+    a false negative just means we proceed to the coverage check).
+    Inherits _shell_parse.tokenize() line-continuation normalization from #305.
+    """
+    cleaned = strip_heredocs(command)
+    tokens = tokenize(cleaned)
+    if tokens is None:
+        return bool(_GH_PR_GATE_RE.search(command))
+    for segment in iter_command_segments(tokens):
+        result = find_gh_subcommand(segment)
+        if result is None:
+            continue
+        _globals, rest = result
+        if len(rest) >= 2 and rest[0] == "pr" and rest[1] in _GH_PR_GATE_ACTIONS:
+            return True
+    return False
 
 
-def _extract_flag(command: str, flag: str) -> str | None:
-    """Return the value of --flag from `command`, or None if absent."""
-    pat = _FLAG_VALUE_RE.pattern.replace("{flag}", re.escape(flag))
-    m = re.search(pat, command)
-    if not m:
-        return None
-    for grp in m.groups():
-        if grp:
-            return grp
+def _walk_flag_value(tokens: list[str], flag: str) -> str | None:
+    """Return the first value of `--flag` found in `tokens`, or None.
+
+    Handles `--flag value` (two tokens) and `--flag=value` (one token).
+    Only matches tokens in flag position — never inside quoted values of
+    other flags (shlex has already collapsed those to single tokens).
+    """
+    for i, tok in enumerate(tokens):
+        if tok == f"--{flag}" and i + 1 < len(tokens):
+            return tokens[i + 1]
+        if tok.startswith(f"--{flag}="):
+            return tok[len(flag) + 3 :]
     return None
 
 
-def _is_gh_pr_gate_command(command: str) -> bool:
-    """True if the command contains a `gh pr create` or `gh pr ready` at command position."""
-    return bool(_GH_PR_GATE_RE.search(command))
+def _extract_flag(command: str, flag: str) -> str | None:
+    """Return the value of --flag from `command`, or None if absent.
+
+    Tokenizes with _shell_parse.tokenize() so flag values inside quoted
+    --body strings or heredocs cannot masquerade as --repo/--base/--head.
+    Falls back to a regex scan on shlex parse failure (fail-open: a false
+    negative means we fall back to the default value in callers).
+    """
+    cleaned = strip_heredocs(command)
+    tokens = tokenize(cleaned)
+    if tokens is None:
+        f = re.escape(flag)
+        pat = (
+            rf"--{f}(?:=|\s+)([^\s'\"]+)"
+            rf"|--{f}\s+\"([^\"]+)\""
+            rf"|--{f}\s+'([^']+)'"
+        )
+        m = re.search(pat, command)
+        if not m:
+            return None
+        for grp in m.groups():
+            if grp:
+                return grp
+        return None
+    return _walk_flag_value(tokens, flag)
 
 
 # --- Workflow paths filter parsing ------------------------------------------


### PR DESCRIPTION
**Closes #260**

## Summary

- **2 regex matchers replaced** with `_shell_parse` token-based detection: `_GH_PR_GATE_RE` + `_is_gh_pr_gate_command()` now use `tokenize()` + `iter_command_segments()` + `find_gh_subcommand()` for command-position detection; `_FLAG_VALUE_RE` + `_extract_flag()` now use `tokenize()` + new `_walk_flag_value()` token-walker (regex retained only as shlex-failure fallback path).
- **1 new `_shell_parse` helper surface used**: `strip_heredocs()` applied before tokenization eliminates the heredoc-body false-positive class for both gate detection and flag extraction.
- **12 new fixture tests** covering: line-continuation gate match (transitive #305 fix verified), heredoc-body negative gate match, `_walk_flag_value` direct cases (5 shapes), `_extract_flag` quoted-body isolation + line-continuation extraction. 45 pre-existing tests still green (57 total).

**Transitive dependency note:** Inherits `_shell_parse.tokenize()` line-continuation fix from #305 (merged eef6dc0f). All shapes that fix unblocks are now usable here — confirmed via `test_line_continuation_pr_create_matches` and `test_flag_extracted_after_line_continuation`.

**Charter compliance:** Per `charter/hooks.md` § Parser-Fixture Coverage Requirements — fix + fixtures + tests in same PR (Nadia called PRs #301 and #305 the reference implementations; this is the third).

## Test plan

- [x] 45 pre-existing `test_validate_workflow_paths_coverage.py` tests pass
- [x] 12 new fixture tests pass (57 total)
- [x] Full hooks test suite: 492 pass, 1 pre-existing environment-specific failure in `test_block_stale_tmp_message_file.py::NonMatchingTests::test_non_tmp_path_not_matched` (worktree tmpdir path artifact, not related to this PR — passes from main repo cwd)
- [x] `uvx ruff@latest format --check .claude/hooks/` — clean
- [x] `uvx ruff@latest check .claude/hooks/` — clean
- [x] mypy pre-commit hook — passed
