### PR TITLE
charter(hooks.md): dispatcher-children sub-clause + § Hook Audit Protocol (#311, #313)

### DIFF
--- a/.claude/team/charter/hooks.md
+++ b/.claude/team/charter/hooks.md
@@ -297,4 +297,22 @@ Every hook with input parsing MUST have test fixtures covering all known input s
 
 **Acceptance:** PR introducing a parser-bug fix MUST include the new fixture in the same commit. CI (or hook authors during review) flags PRs that change parser logic without an accompanying fixture addition.
 
+**Dispatcher-style children (no committed `.claude/hooks/`):** Children that delegate all hook execution to the parent canonical via `settings.json` are exempt from per-child fixture requirements. Coverage obligations are fulfilled by the parent's test suite. A child is classified as dispatcher-style when `gh api repos/<owner>/<repo>/git/trees/<head_sha>?recursive=1` returns 0 entries under `.claude/hooks/`. Design-system and landing-page (post-W5) are the canonical exemplars.
+
 **Enforcement:** The Standards & Quality Lead (Aino) verifies these requirements during hook PR review. A hook missing any of the five requirements must not be approved.
+
+## Hook Audit Protocol
+
+When auditing a repo's hook ownership status (hook-owning vs. dispatcher-style):
+
+1. Fetch the committed tree:
+   ```
+   gh api repos/<owner>/<repo>/git/trees/<head_sha>?recursive=1 \
+     --jq '[.tree[].path | select(startswith(".claude/hooks/"))]'
+   ```
+2. Classification: if the result is empty (`[]`), the repo is dispatcher-style. If non-empty, it is hook-owning.
+3. Filesystem enumeration (SSH, `ls`, `find`) is NOT a valid substitute — it includes untracked files, worktree artifacts, and gitignored content that are invisible to git.
+
+**Rationale:** P3W7 produced 3 repo misclassifications from a single root cause: auditors enumerated working-directory files instead of querying the committed git tree. Misclassified repos: design-system, user-service, data-acquisition — all initially called "stale-mirror hook-owning" but confirmed dispatcher-style via committed-tree inspection. The correct method is one API call away.
+
+**Enforcement:** Any audit-finding comment that asserts a repo's classification must cite the `gh api .../git/trees` invocation it ran (or the equivalent `gh api .../contents/.claude/hooks?ref=<sha>` form). Reviewers reject classification claims sourced from `ls`, `find`, SSH, or local checkout.


### PR DESCRIPTION
## Summary

Two W7-retro-promoted charter changes to `.claude/team/charter/hooks.md`, bundled per #313's directive ("Should ship alongside #311 in a single charter-change PR").

### #311 — Dispatcher-style-children sub-clause inside § 5 Parser-Fixture Coverage Requirements

Adds explicit exemption for children with 0 committed `.claude/hooks/` files. Closes auditor ambiguity that produced false fixture-gap findings during W7 audits across all 7 child repos (all confirmed dispatcher-style post-W5 migrations).

Classification rule baked in:

```
gh api repos/<owner>/<repo>/git/trees/<head_sha>?recursive=1 \
  --jq '[.tree[].path | select(startswith(".claude/hooks/"))]'
```

Returns `[]` → dispatcher-style, exempt. Non-empty → hook-owning, fixture requirements apply.

### #313 — New § Hook Audit Protocol after § 5

Mandates committed-tree inspection over filesystem enumeration (SSH, `ls`, `find`) for hook-ownership classification. P3W7 produced 3 misclassifications (design-system, user-service, data-acquisition) from local-checkout-based audits; all 3 confirmed dispatcher-style via committed-tree inspection. Reviewer-enforced: classification claims must cite the `gh api` invocation.

## Diff scope

`.claude/team/charter/hooks.md` only. 18 insertions, 0 deletions, 0 other files touched.

## Why bundle

Both edits target adjacent locations in `charter/hooks.md`. Splitting into two PRs would double review overhead with no isolation gain — the changes ship together per #313's explicit directive and are the W7-retro-promoted ★ charter pair (PR #310 summary).

## Test plan

- [ ] Reviewers verify text matches issue-body specs at #311 and #313
- [ ] Reviewers verify the classification command is correct (`gh api .../git/trees/<sha>?recursive=1` with `--jq` filter)
- [ ] Reviewers verify enforcement language is operationally testable (the cite-the-`gh api`-call rule is observable in PR comments)
- [ ] No automated tests — doc-only change to charter

## Refs

- Closes #311
- Closes #313
- Refs #310 (★ summary PR)
- Refs #300 (W7 meta)
- P3W8 wave: noorinalabs/noorinalabs-main#331

## Reviewers

- Nadia Khoury (process owner — Program Director)
- Santiago Ferreira (release-affected — RC reviewer)
