### PR TITLE
feat(charter+skill): codify isolation: worktree default for all implementer spawns (#290)

### DIFF
--- a/.claude/skills/wave-kickoff/SKILL.md
+++ b/.claude/skills/wave-kickoff/SKILL.md
@@ -357,6 +357,7 @@ Per charter `agents.md` § Hub-and-Spoke Orchestration Model + § Single-Leader 
 - **Single team per session** — one `TeamCreate` per orchestrator session; additional TeamCreates fail with "Already leading team." Use `team_name: "noorinalabs"` for cross-repo waves.
 - **Managers request implementer spawns** via `SendMessage` to the team lead with full context (name, roster file, issue, branch, reviewers, Contract ownership if applicable).
 - **Team lead spawns each implementer** following step 9 above (both bakes).
+- **Isolation: every implementer spawn MUST set `isolation: "worktree"`,** even when the parent-side worktree is cosmetic (child-repo work). Per charter `agents.md` § Spawn Isolation Default. The cost is a temporary parent-repo worktree per agent (auto-cleaned if no changes); the benefit is correct workspace-presentation in the harness UI (the operator sees agents under team membership rather than as anonymous background tasks) and consistent Hook 14 (`enforce_ontology_context`) enforcement.
 
 When composing spawn prompts for implementers, pull the manager's specified reviewer pairings, branch names, and Contract expectations into the prompt so the implementer starts with full context.
 

--- a/.claude/team/charter/agents.md
+++ b/.claude/team/charter/agents.md
@@ -147,6 +147,22 @@ The orchestrator is the **single point that can create agents**. The Program Dir
 
 Failing to honor a spawn request within the same response is a **minor feedback event** for the orchestrator.
 
+### Spawn Isolation Default
+
+**All implementer-class spawns from the orchestrator MUST be invoked with `isolation: "worktree"`,** even when the parent-side worktree is cosmetic (e.g., the agent's actual code work lives in a child-repo clone).
+
+**Rationale:** the harness uses worktree-isolation as the signal for workspace-presented team-member surfaces. Non-isolated subagents render as generic "background tasks" — incorrect for implementer-class agents that the operator needs to monitor as team members.
+
+**Cost:** a temporary parent-repo worktree per agent (auto-cleaned if no changes — see Agent tool docs).
+
+**Benefit:** correct workspace presentation; Hook 14 (`enforce_ontology_context`) fires consistently across all implementer spawns; manager-class agents (per-repo PD/manager) and implementer-class agents (per-repo engineers) both render under their team membership rather than as anonymous background tasks.
+
+**Exception:** research-only forks (e.g., `Agent` calls that omit `subagent_type` to inherit context) need NOT use isolation, since they're explicitly context-inheriting forks rather than fresh implementer workspaces.
+
+**Origin:** owner-named at P3W6 wave-kickoff (2026-05-06) after observing 18 implementer spawns rendered as "background tasks" in the harness UI rather than as workspace-presented team members. The orchestrator weighed the trade-off explicitly during spawn ("17 of 18 implementers do code work in child repos which are `.gitignore`d from the parent — orchestrator-side worktree is cosmetic") and picked "no parent worktree" — that turned out to be the wrong call because the UI presentation cost wasn't surfaced in the trade-off analysis. Codified by noorinalabs-main#290.
+
+Failing to set `isolation: "worktree"` on an implementer spawn is a **minor feedback event** for the orchestrator.
+
 ### No Direct-to-Engineer Spawns
 
 **The orchestrator MUST NOT spawn engineers directly without first spawning the Program Director.** Even for "simple" or "mechanical" fixes, the team hierarchy must be followed:


### PR DESCRIPTION
## Summary

Codifies `isolation: "worktree"` as the default for all implementer-class spawns from the orchestrator — both as a charter rule (`agents.md`) and a `/wave-kickoff` SKILL.md Step 9a requirement. Closes #290.

Two layers per the issue body:

**Charter `agents.md`** — adds new `### Spawn Isolation Default` sub-section under existing `## Hub-and-Spoke Orchestration Model`, between `### Spawn Request Delegation` and `### No Direct-to-Engineer Spawns`. Documents rationale (harness uses worktree-isolation as the workspace-presented-team-member signal), cost (auto-cleaned cosmetic worktree), benefit (correct UI presentation + Hook 14 consistency), exception (research-only forks), and origin (P3W6 wave-kickoff observation).

**`/wave-kickoff` SKILL.md** — adds an `isolation: "worktree"` bullet to the existing `### 9a. Delegation pattern — orchestrator spawns, managers request` bullet list, cross-referencing the new charter section.

## Reviewers

R1: Nadia Khoury (PD owns process-class changes)
R2: Aino Virtanen (S&Q owns charter convention; co-signed the position-first reviewer-slate discipline that this section sits adjacent to)

## Test plan

- [x] `git diff --stat` shows 2 files modified, 17 insertions, 0 deletions
- [x] charter `agents.md` parses (no broken Markdown headings — verify section nesting)
- [x] `/wave-kickoff` SKILL.md Step 9a is still parseable as a step list
- [ ] CI green on hooks-lint (no .py changes; scoped paths shouldn't trigger)
- [ ] R1 + R2 charter-format reviewer comments with `TechDebt: <none|#N>` line on every comment incl. approval (per `validate_pr_review` hook)
- [ ] Verification at PR head_sha via `gh api repos/noorinalabs/noorinalabs-main/contents/.claude/team/charter/agents.md?ref=<head_sha>` (per memory `feedback_review_against_artifact_not_framing.md` + `feedback_origin_over_local_for_still_has_claims.md`)

## Out of scope (deliberately, per issue body)

- Re-spawning P3W6 implementers with isolation. The 18 spawns are mid-flight or done; PRs are open. Adopt the new default for the next wave (P3W7+, including this current P3W8 — already applied).
- Hook-class enforcement. Charter+skill is the right starting layer per `feedback_enforcement_hierarchy.md`; promote to hook only if the rule decays.

## P3W8 application note

This wave already applies the `isolation: "worktree"` default — every P3W8 implementer spawn (Anya, Idris, Ingrid, Mateo, Astrid, Lucas, Jean-Claude, Kofi, Aisha, Tarek, Wanjiku) was spawned with isolation. The charter+skill changes here ratify the in-flight discipline.

## Cross-link

- Closes noorinalabs-main#290
- Adjacent retro-promotion candidates surfaced in P3W8 (related discipline gaps): #337 (Nadia's `validate_wave_label_evidence` hook proposal), Aino's worktree-base-ref discipline gap (her #334 worktree branched from main carrying status commits — separate W9 candidate)
