### PR TITLE
test(hooks): block_gh_pr_review fixtures + alembic-heredoc commit-identity coverage (#98, #99)

### DIFF
--- a/.claude/hooks/tests/test_block_gh_pr_review.py
+++ b/.claude/hooks/tests/test_block_gh_pr_review.py
@@ -1,12 +1,16 @@
 #!/usr/bin/env python3
-"""Tests for block_gh_pr_review — basic behavioral fixtures.
+"""Behavioral test fixtures for block_gh_pr_review hook.
 
-This is NOT parser-fixture coverage per the W7 audit
-(`.claude/hooks/audit/parser_fixture_coverage.md` line 61), which classifies
-`block_gh_pr_review` as non-parser-class (simple regex match + shell-separator
-split, no structured parsing). This file closes a smaller gap: the hook had
-zero test coverage at all. These fixtures pin the hook's documented behavior
-and the regex's interaction with the `&&`, `||`, `|`, `;` segment-splitter.
+The hook is parser-class — it parses `tool_input.command` via `re.split` on
+shell separators (`&&`, `||`, `|`, `;`) and `re.match` for `gh pr review`
+detection on each segment. This file closes the empirical fixture gap
+surfaced by user-service#98: the hook had zero test coverage at all
+(verified at origin: `.claude/hooks/tests/test_block_gh_pr_review.py`
+returned HTTP 404 against `noorinalabs-main` `main` pre-PR).
+
+Fixtures pin documented behavior — `gh pr review` blocked, `gh pr comment`
+passes, `gh pr edit` passes — and the segment-splitter's interaction with
+each shell separator class.
 
 Run: ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/test_block_gh_pr_review.py -v
 """

--- a/.claude/hooks/tests/test_block_gh_pr_review.py
+++ b/.claude/hooks/tests/test_block_gh_pr_review.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Tests for block_gh_pr_review — basic behavioral fixtures.
+
+This is NOT parser-fixture coverage per the W7 audit
+(`.claude/hooks/audit/parser_fixture_coverage.md` line 61), which classifies
+`block_gh_pr_review` as non-parser-class (simple regex match + shell-separator
+split, no structured parsing). This file closes a smaller gap: the hook had
+zero test coverage at all. These fixtures pin the hook's documented behavior
+and the regex's interaction with the `&&`, `||`, `|`, `;` segment-splitter.
+
+Run: ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/test_block_gh_pr_review.py -v
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_HOOKS_DIR = _HERE.parent
+sys.path.insert(0, str(_HOOKS_DIR))
+
+import block_gh_pr_review as hook  # noqa: E402
+
+
+def _input(command: str) -> dict:
+    return {"tool_name": "Bash", "tool_input": {"command": command}}
+
+
+class PositiveMatchTests(unittest.TestCase):
+    """Real `gh pr review` invocations MUST be blocked."""
+
+    def test_bare_form(self):
+        result = hook.check(_input("gh pr review 42"))
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+
+    def test_with_approve_flag(self):
+        result = hook.check(_input("gh pr review 42 --approve"))
+        self.assertIsNotNone(result)
+
+    def test_with_body_flag(self):
+        result = hook.check(_input('gh pr review 42 --body "lgtm"'))
+        self.assertIsNotNone(result)
+
+    def test_chained_after_and_and(self):
+        """Segment-split on `&&` must still flag a later `gh pr review`."""
+        result = hook.check(_input("gh pr view 42 && gh pr review 42 --approve"))
+        self.assertIsNotNone(result)
+
+    def test_chained_after_semicolon(self):
+        result = hook.check(_input("echo ready ; gh pr review 42"))
+        self.assertIsNotNone(result)
+
+    def test_chained_after_pipe(self):
+        result = hook.check(_input("true | gh pr review 42"))
+        self.assertIsNotNone(result)
+
+    def test_chained_after_double_pipe(self):
+        result = hook.check(_input("false || gh pr review 42"))
+        self.assertIsNotNone(result)
+
+    def test_block_reason_cites_charter(self):
+        """Block message must redirect to `gh pr comment` (charter § Pull Requests)."""
+        result = hook.check(_input("gh pr review 42"))
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertIn("gh pr comment", result["reason"])
+
+
+class NegativeMatchTests(unittest.TestCase):
+    """Other `gh pr <subcommand>` shapes MUST NOT be blocked."""
+
+    def test_gh_pr_comment(self):
+        """Charter-required review path — explicit allow."""
+        cmd = 'gh pr comment 42 --body "Requestor: A\nRequestee: B\nRequestOrReplied: Approved"'
+        self.assertIsNone(hook.check(_input(cmd)))
+
+    def test_gh_pr_edit(self):
+        self.assertIsNone(hook.check(_input("gh pr edit 42 --body-file .claude/scratch/x.md")))
+
+    def test_gh_pr_list(self):
+        self.assertIsNone(hook.check(_input("gh pr list --state open")))
+
+    def test_gh_pr_view(self):
+        self.assertIsNone(hook.check(_input("gh pr view 42 --json state,mergedAt")))
+
+    def test_gh_pr_create(self):
+        self.assertIsNone(hook.check(_input("gh pr create --body-file .claude/scratch/x.md")))
+
+    def test_gh_pr_ready(self):
+        self.assertIsNone(hook.check(_input("gh pr ready 42")))
+
+    def test_gh_issue_with_review_substring_in_body(self):
+        """A `--body` literal mentioning the words is not a real invocation."""
+        cmd = 'gh issue create --title x --body "see policy on gh pr review"'
+        self.assertIsNone(hook.check(_input(cmd)))
+
+    def test_non_bash_tool_passes(self):
+        self.assertIsNone(
+            hook.check(
+                {
+                    "tool_name": "Edit",
+                    "tool_input": {"command": "gh pr review 42"},
+                }
+            )
+        )
+
+    def test_empty_command(self):
+        self.assertIsNone(hook.check(_input("")))
+
+    def test_unrelated_command(self):
+        self.assertIsNone(hook.check(_input("ls -la")))
+
+    def test_grep_for_phrase_does_not_match(self):
+        """`grep 'gh pr review' file` is not an invocation — first token is grep."""
+        self.assertIsNone(hook.check(_input("grep 'gh pr review' /tmp/log")))
+
+
+class HeredocBoundaryTests(unittest.TestCase):
+    """Document hook behavior on heredoc bodies.
+
+    The hook splits on `&&`, `||`, `|`, `;` without heredoc-awareness. A
+    heredoc body containing any of those separators will be split and each
+    fragment treated as its own segment. This pins current behavior so any
+    future change is intentional.
+    """
+
+    def test_heredoc_body_starting_with_phrase_no_separator(self):
+        """No shell-separator inside the body → whole heredoc is one segment.
+
+        First non-whitespace token is `cat`, so the regex does not match.
+        """
+        cmd = (
+            "cat > /tmp/x.md <<'EOF'\n"
+            "gh pr review is blocked by hook policy\n"
+            "use gh pr comment instead\n"
+            "EOF"
+        )
+        self.assertIsNone(hook.check(_input(cmd)))
+
+    def test_heredoc_body_with_semicolon_splits_segments(self):
+        """KNOWN LIMITATION: `;` inside a heredoc body splits the segment.
+
+        If a literal `gh pr review` appears as the start of a segment after a
+        `;`, even inside a heredoc body, the hook DOES block. This is
+        intentional fail-closed: the hook errs on the side of blocking when
+        shell-separator semantics are ambiguous. Documented for future tuning;
+        no production occurrence to date.
+        """
+        cmd = "cat <<'EOF'\nstep 1; gh pr review is bad; step 2\nEOF"
+        # Documents current behavior. If this changes, update the comment.
+        result = hook.check(_input(cmd))
+        self.assertIsNotNone(result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/hooks/tests/test_validate_commit_identity.py
+++ b/.claude/hooks/tests/test_validate_commit_identity.py
@@ -305,6 +305,41 @@ class MatcherRobustnessTests(unittest.TestCase):
         # Not a real commit invocation — should not require identity.
         self.assertIsNone(hook.check(self._input(cmd)))
 
+    def test_alembic_heredoc_body_via_command_substitution(self):
+        """user-service#99 claim 1: alembic-shape heredoc body via `-m "$(cat <<EOF...)"`.
+
+        Defensive coverage on top of `test_nested_heredoc_in_command_substitution`
+        (#188): the existing test pins the SHAPE; this test pins an alembic-
+        specific BODY containing the literal strings the user-service `make
+        migrate-new` workflow emits — `heads`, `head`, `revision = '<sha>'`,
+        `down_revision`. None of those substrings are hook tokens, but the
+        fixture exists so any future tightening of the parser cannot
+        accidentally treat alembic-emitted strings as identity-flag keywords.
+
+        Memory ref: `project_w10_user_service_alembic.md` (P2W10 #63 alembic
+        heads→head discipline).
+        """
+        valid_name = next(iter(hook.ROSTER), None)
+        if not valid_name:
+            self.skipTest("local roster is empty")
+        valid_email = hook.ROSTER[valid_name]
+        # Alembic-emitted strings inside a heredoc body inside command-sub.
+        cmd = (
+            f'git -c user.name="{valid_name}" -c user.email="{valid_email}" '
+            "commit -m \"$(cat <<'EOF'\n"
+            "migrate(P3W8 user-service#63): merge alembic heads -> head\n"
+            "\n"
+            "revision = 'a1b2c3d4e5f6'\n"
+            "down_revision = ('aaaa1111', 'bbbb2222')\n"
+            "branch_labels = None\n"
+            "depends_on = None\n"
+            'EOF\n)"'
+        )
+        self.assertIsNone(
+            hook.check(self._input(cmd)),
+            "us#99 claim 1: alembic-shape heredoc body should not false-block",
+        )
+
     def test_label_validator_filename_no_longer_blocks(self):
         """#226 meta-instance: --body-file path inside --label list.
 


### PR DESCRIPTION
## Summary

Two file changes closing two cross-repo issues with empirical-state-at-origin justification:

1. **NEW** `.claude/hooks/tests/test_block_gh_pr_review.py` — 21 fixtures. The hook had zero test coverage at all (test file 404 at origin main). Closes user-service#98.
2. **MODIFY** `.claude/hooks/tests/test_validate_commit_identity.py` — +1 alembic-heredoc fixture in `MatcherRobustnessTests`. Closes user-service#99 claim 1.

## Why this PR exists (load-bearing arguments)

### For #98: empirical 404 at origin

```
gh api 'repos/noorinalabs/noorinalabs-main/contents/.claude/hooks/tests/test_block_gh_pr_review.py?ref=main'
# HTTP 404 — Not Found
```

`block_gh_pr_review.py` is canonical at parent and registered via dispatcher `settings.json` in every child repo, but parent's test suite had no fixture file for it. The hook is parser-class (regex/structural parsing on `tool_input.command`: `re.split` on `&&`/`||`/`|`/`;` plus `re.match` for `gh pr review` detection). The fixtures here pin documented behavior — `gh pr review` blocked, `gh pr comment` passes, `gh pr edit` passes — and the segment-splitter's interaction with each shell separator class. The empirical 404 at origin is the load-bearing rationale for this PR's existence; the parser-class classification is justified by the hook's source.

### For #99 claim 1: defensive coverage on alembic shape

The new `test_alembic_heredoc_body_via_command_substitution` fixture pins the alembic-emitted body shape (literal `heads`, `head`, `revision = '<sha>'`, `down_revision`, `branch_labels`, `depends_on`) inside a `-m "$(cat <<'EOF'...EOF)"` form. Existing `test_nested_heredoc_in_command_substitution` (#188) covers the SHAPE; this fixture covers an alembic-specific BODY so any future parser tightening cannot accidentally treat alembic strings as identity-flag keywords. Memory ref: P2W10 user-service#63 alembic heads→head discipline.

## Scope

### `test_block_gh_pr_review.py` (NEW, 21 fixtures across 3 classes)

**`PositiveMatchTests` (8) — `gh pr review` MUST be blocked.**
- Bare form, `--approve`, `--body` flags
- Chained after `&&`, `||`, `|`, `;` (each separator class)
- Block reason cites `gh pr comment` (charter § Pull Requests)

**`NegativeMatchTests` (11) — adjacent shapes MUST pass.**
- `gh pr comment` (charter-required path), `gh pr edit`, `gh pr list`, `gh pr view`, `gh pr create`, `gh pr ready`
- `gh issue create --body "...gh pr review..."` (literal substring in body)
- Non-Bash tool, empty/unrelated commands, `grep 'gh pr review' /tmp/log`

**`HeredocBoundaryTests` (2) — pin current fail-closed behavior.**
- Heredoc body, no shell-separator: passes (first segment token is `cat`).
- Heredoc body with `;` inside: blocks. Documents known limitation that the segment-splitter is heredoc-unaware. No production occurrence to date; tuning deferred.

### `test_validate_commit_identity.py` (MODIFY, +1 fixture)

- `MatcherRobustnessTests.test_alembic_heredoc_body_via_command_substitution`: alembic-emitted strings inside heredoc body inside `-m "$(cat <<'EOF'...EOF)"` form. Asserts `assertIsNone(hook.check(...))` — defensive coverage.

## Test plan

- [x] `pytest .claude/hooks/tests/test_block_gh_pr_review.py` — 21/21 pass
- [x] `pytest .claude/hooks/tests/test_validate_commit_identity.py` — 20/20 pass (was 19, +1 alembic)
- [x] Full hook suite — 488/488 pass (was 487 before this PR)
- [x] `uvx ruff check .claude/hooks/` — clean
- [x] `uvx ruff format --check .claude/hooks/` — 49 files formatted
- [ ] CI green (parent `ci.yml`)
- [ ] Reviewer R1 sign-off
- [ ] Reviewer R2 sign-off

## Reviewers requested

- R1: Anya Kowalczyk (user-service domain)
- R2: Idris Yusuf (user-service domain)
- Aino Virtanen covers organically via parent S&Q reviewer-class queue (informal, not formal R3).

## Cross-links

- Closes `noorinalabs/noorinalabs-user-service#98` — `block_gh_pr_review` fixtures (manual close on merge; `Closes` keyword does not fire across repositories).
- Closes `noorinalabs/noorinalabs-user-service#99` — disposition below.

### user-service#99 per-claim disposition

| Claim | Disposition |
|---|---|
| 1. Alembic heredoc body | **Covered by this PR** — `test_alembic_heredoc_body_via_command_substitution` |
| 2. Backslash line-continuation | **Deferred to `noorinalabs-main#339`** — PR#305 fix exists on `origin/deployments/phase-3/wave-7` (merge `eef6dc0`, 2026-05-08T02:49Z) but is stranded; verified via `git branch -r --contains eef6dc0` returning only wave-7. Bug still live on wave-8 (verified empirically by direct hook probe — `hook.check({...backslash-cont commit...})` returns `block`). Cannot bundle a regression test here because it would CI-red without the corresponding hook fix from #305. Wave-7→main propagation tracked at `noorinalabs-main#339`. |
| 3. Wave-branch ref shape | **Premise incorrect** — issue body cites parent#294 as regression class, but #294 is about `validate_pr_review.py` (PR-merge-gate, ref-aware). Different hook from `validate_commit_identity.py` (command-parser, ref-unaware). Wave-branch ref is not an input to validate_commit_identity. No fixture needed. |

## Out of scope (intentional)

- **Backslash-line-continuation regression test** — see `noorinalabs-main#339`. The fix and its 12 fixture files exist on stranded wave-7; cherry-picking is a separate workstream.
- **`block_git_config` and `block_no_verify` fixture additions** — `test_block_git_config.py` and `test_block_no_verify.py` already exist at parent (verified). Only `block_gh_pr_review` had the 404.

## Charter references

- `charter/hooks.md` § 5 Parser-Fixture Coverage Requirements — this PR is *adjacent to but not under* this section
- `charter/hooks.md` § Hook Audit Protocol — verified ownership via `gh api` committed-tree inspection (per #313)
- W5 `#96` user-service migration to dispatcher style (commit `2191b1af`)
- W7 audit meta-issue: `#300` (audit deliverable PRs `#308` and `#310` are part of the wave-7 stranding tracked at `#339`; charter-rule PR `#314` did propagate to main)

## TechDebt

none
