### PR TITLE
Phase 3 Wave 8 → main (noorinalabs-main)

### DIFF
--- a/.claude/hooks/tests/test_block_gh_pr_review.py
+++ b/.claude/hooks/tests/test_block_gh_pr_review.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Behavioral test fixtures for block_gh_pr_review hook.
+
+The hook is parser-class — it parses `tool_input.command` via `re.split` on
+shell separators (`&&`, `||`, `|`, `;`) and `re.match` for `gh pr review`
+detection on each segment. This file closes the empirical fixture gap
+surfaced by user-service#98: the hook had zero test coverage at all
+(verified at origin: `.claude/hooks/tests/test_block_gh_pr_review.py`
+returned HTTP 404 against `noorinalabs-main` `main` pre-PR).
+
+Fixtures pin documented behavior — `gh pr review` blocked, `gh pr comment`
+passes, `gh pr edit` passes — and the segment-splitter's interaction with
+each shell separator class.
+
+Run: ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/test_block_gh_pr_review.py -v
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_HOOKS_DIR = _HERE.parent
+sys.path.insert(0, str(_HOOKS_DIR))
+
+import block_gh_pr_review as hook  # noqa: E402
+
+
+def _input(command: str) -> dict:
+    return {"tool_name": "Bash", "tool_input": {"command": command}}
+
+
+class PositiveMatchTests(unittest.TestCase):
+    """Real `gh pr review` invocations MUST be blocked."""
+
+    def test_bare_form(self):
+        result = hook.check(_input("gh pr review 42"))
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+
+    def test_with_approve_flag(self):
+        result = hook.check(_input("gh pr review 42 --approve"))
+        self.assertIsNotNone(result)
+
+    def test_with_body_flag(self):
+        result = hook.check(_input('gh pr review 42 --body "lgtm"'))
+        self.assertIsNotNone(result)
+
+    def test_chained_after_and_and(self):
+        """Segment-split on `&&` must still flag a later `gh pr review`."""
+        result = hook.check(_input("gh pr view 42 && gh pr review 42 --approve"))
+        self.assertIsNotNone(result)
+
+    def test_chained_after_semicolon(self):
+        result = hook.check(_input("echo ready ; gh pr review 42"))
+        self.assertIsNotNone(result)
+
+    def test_chained_after_pipe(self):
+        result = hook.check(_input("true | gh pr review 42"))
+        self.assertIsNotNone(result)
+
+    def test_chained_after_double_pipe(self):
+        result = hook.check(_input("false || gh pr review 42"))
+        self.assertIsNotNone(result)
+
+    def test_block_reason_cites_charter(self):
+        """Block message must redirect to `gh pr comment` (charter § Pull Requests)."""
+        result = hook.check(_input("gh pr review 42"))
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertIn("gh pr comment", result["reason"])
+
+
+class NegativeMatchTests(unittest.TestCase):
+    """Other `gh pr <subcommand>` shapes MUST NOT be blocked."""
+
+    def test_gh_pr_comment(self):
+        """Charter-required review path — explicit allow."""
+        cmd = 'gh pr comment 42 --body "Requestor: A\nRequestee: B\nRequestOrReplied: Approved"'
+        self.assertIsNone(hook.check(_input(cmd)))
+
+    def test_gh_pr_edit(self):
+        self.assertIsNone(hook.check(_input("gh pr edit 42 --body-file .claude/scratch/x.md")))
+
+    def test_gh_pr_list(self):
+        self.assertIsNone(hook.check(_input("gh pr list --state open")))
+
+    def test_gh_pr_view(self):
+        self.assertIsNone(hook.check(_input("gh pr view 42 --json state,mergedAt")))
+
+    def test_gh_pr_create(self):
+        self.assertIsNone(hook.check(_input("gh pr create --body-file .claude/scratch/x.md")))
+
+    def test_gh_pr_ready(self):
+        self.assertIsNone(hook.check(_input("gh pr ready 42")))
+
+    def test_gh_issue_with_review_substring_in_body(self):
+        """A `--body` literal mentioning the words is not a real invocation."""
+        cmd = 'gh issue create --title x --body "see policy on gh pr review"'
+        self.assertIsNone(hook.check(_input(cmd)))
+
+    def test_non_bash_tool_passes(self):
+        self.assertIsNone(
+            hook.check(
+                {
+                    "tool_name": "Edit",
+                    "tool_input": {"command": "gh pr review 42"},
+                }
+            )
+        )
+
+    def test_empty_command(self):
+        self.assertIsNone(hook.check(_input("")))
+
+    def test_unrelated_command(self):
+        self.assertIsNone(hook.check(_input("ls -la")))
+
+    def test_grep_for_phrase_does_not_match(self):
+        """`grep 'gh pr review' file` is not an invocation — first token is grep."""
+        self.assertIsNone(hook.check(_input("grep 'gh pr review' /tmp/log")))
+
+
+class HeredocBoundaryTests(unittest.TestCase):
+    """Document hook behavior on heredoc bodies.
+
+    The hook splits on `&&`, `||`, `|`, `;` without heredoc-awareness. A
+    heredoc body containing any of those separators will be split and each
+    fragment treated as its own segment. This pins current behavior so any
+    future change is intentional.
+    """
+
+    def test_heredoc_body_starting_with_phrase_no_separator(self):
+        """No shell-separator inside the body → whole heredoc is one segment.
+
+        First non-whitespace token is `cat`, so the regex does not match.
+        """
+        cmd = (
+            "cat > /tmp/x.md <<'EOF'\n"
+            "gh pr review is blocked by hook policy\n"
+            "use gh pr comment instead\n"
+            "EOF"
+        )
+        self.assertIsNone(hook.check(_input(cmd)))
+
+    def test_heredoc_body_with_semicolon_splits_segments(self):
+        """KNOWN LIMITATION: `;` inside a heredoc body splits the segment.
+
+        If a literal `gh pr review` appears as the start of a segment after a
+        `;`, even inside a heredoc body, the hook DOES block. This is
+        intentional fail-closed: the hook errs on the side of blocking when
+        shell-separator semantics are ambiguous. Documented for future tuning;
+        no production occurrence to date.
+        """
+        cmd = "cat <<'EOF'\nstep 1; gh pr review is bad; step 2\nEOF"
+        # Documents current behavior. If this changes, update the comment.
+        result = hook.check(_input(cmd))
+        self.assertIsNotNone(result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/hooks/tests/test_validate_commit_identity.py
+++ b/.claude/hooks/tests/test_validate_commit_identity.py
@@ -305,6 +305,41 @@ class MatcherRobustnessTests(unittest.TestCase):
         # Not a real commit invocation — should not require identity.
         self.assertIsNone(hook.check(self._input(cmd)))
 
+    def test_alembic_heredoc_body_via_command_substitution(self):
+        """user-service#99 claim 1: alembic-shape heredoc body via `-m "$(cat <<EOF...)"`.
+
+        Defensive coverage on top of `test_nested_heredoc_in_command_substitution`
+        (#188): the existing test pins the SHAPE; this test pins an alembic-
+        specific BODY containing the literal strings the user-service `make
+        migrate-new` workflow emits — `heads`, `head`, `revision = '<sha>'`,
+        `down_revision`. None of those substrings are hook tokens, but the
+        fixture exists so any future tightening of the parser cannot
+        accidentally treat alembic-emitted strings as identity-flag keywords.
+
+        Memory ref: `project_w10_user_service_alembic.md` (P2W10 #63 alembic
+        heads→head discipline).
+        """
+        valid_name = next(iter(hook.ROSTER), None)
+        if not valid_name:
+            self.skipTest("local roster is empty")
+        valid_email = hook.ROSTER[valid_name]
+        # Alembic-emitted strings inside a heredoc body inside command-sub.
+        cmd = (
+            f'git -c user.name="{valid_name}" -c user.email="{valid_email}" '
+            "commit -m \"$(cat <<'EOF'\n"
+            "migrate(P3W8 user-service#63): merge alembic heads -> head\n"
+            "\n"
+            "revision = 'a1b2c3d4e5f6'\n"
+            "down_revision = ('aaaa1111', 'bbbb2222')\n"
+            "branch_labels = None\n"
+            "depends_on = None\n"
+            'EOF\n)"'
+        )
+        self.assertIsNone(
+            hook.check(self._input(cmd)),
+            "us#99 claim 1: alembic-shape heredoc body should not false-block",
+        )
+
     def test_label_validator_filename_no_longer_blocks(self):
         """#226 meta-instance: --body-file path inside --label list.
 

--- a/.claude/skills/wave-kickoff/SKILL.md
+++ b/.claude/skills/wave-kickoff/SKILL.md
@@ -357,6 +357,7 @@ Per charter `agents.md` § Hub-and-Spoke Orchestration Model + § Single-Leader 
 - **Single team per session** — one `TeamCreate` per orchestrator session; additional TeamCreates fail with "Already leading team." Use `team_name: "noorinalabs"` for cross-repo waves.
 - **Managers request implementer spawns** via `SendMessage` to the team lead with full context (name, roster file, issue, branch, reviewers, Contract ownership if applicable).
 - **Team lead spawns each implementer** following step 9 above (both bakes).
+- **Isolation: every implementer spawn MUST set `isolation: "worktree"`,** even when the parent-side worktree is cosmetic (child-repo work). Per charter `agents.md` § Spawn Isolation Default. The cost is a temporary parent-repo worktree per agent (auto-cleaned if no changes); the benefit is correct workspace-presentation in the harness UI (the operator sees agents under team membership rather than as anonymous background tasks) and consistent Hook 14 (`enforce_ontology_context`) enforcement.
 
 When composing spawn prompts for implementers, pull the manager's specified reviewer pairings, branch names, and Contract expectations into the prompt so the implementer starts with full context.
 

--- a/.claude/team/charter/agents.md
+++ b/.claude/team/charter/agents.md
@@ -147,6 +147,22 @@ The orchestrator is the **single point that can create agents**. The Program Dir
 
 Failing to honor a spawn request within the same response is a **minor feedback event** for the orchestrator.
 
+### Spawn Isolation Default
+
+**All implementer-class spawns from the orchestrator MUST be invoked with `isolation: "worktree"`,** even when the parent-side worktree is cosmetic (e.g., the agent's actual code work lives in a child-repo clone).
+
+**Rationale:** the harness uses worktree-isolation as the signal for workspace-presented team-member surfaces. Non-isolated subagents render as generic "background tasks" — incorrect for implementer-class agents that the operator needs to monitor as team members.
+
+**Cost:** a temporary parent-repo worktree per agent (auto-cleaned if no changes — see Agent tool docs).
+
+**Benefit:** correct workspace presentation; Hook 14 (`enforce_ontology_context`) fires consistently across all implementer spawns; manager-class agents (per-repo PD/manager) and implementer-class agents (per-repo engineers) both render under their team membership rather than as anonymous background tasks.
+
+**Exception:** research-only forks (e.g., `Agent` calls that omit `subagent_type` to inherit context) need NOT use isolation, since they're explicitly context-inheriting forks rather than fresh implementer workspaces.
+
+**Origin:** owner-named at P3W6 wave-kickoff (2026-05-06) after observing 18 implementer spawns rendered as "background tasks" in the harness UI rather than as workspace-presented team members. The orchestrator weighed the trade-off explicitly during spawn ("17 of 18 implementers do code work in child repos which are `.gitignore`d from the parent — orchestrator-side worktree is cosmetic") and picked "no parent worktree" — that turned out to be the wrong call because the UI presentation cost wasn't surfaced in the trade-off analysis. Codified by noorinalabs-main#290.
+
+Failing to set `isolation: "worktree"` on an implementer spawn is a **minor feedback event** for the orchestrator.
+
 ### No Direct-to-Engineer Spawns
 
 **The orchestrator MUST NOT spawn engineers directly without first spawning the Program Director.** Even for "simple" or "mechanical" fixes, the team hierarchy must be followed:

--- a/.claude/team/charter/hooks.md
+++ b/.claude/team/charter/hooks.md
@@ -297,4 +297,22 @@ Every hook with input parsing MUST have test fixtures covering all known input s
 
 **Acceptance:** PR introducing a parser-bug fix MUST include the new fixture in the same commit. CI (or hook authors during review) flags PRs that change parser logic without an accompanying fixture addition.
 
+**Dispatcher-style children (no committed `.claude/hooks/`):** Children that delegate all hook execution to the parent canonical via `settings.json` are exempt from per-child fixture requirements. Coverage obligations are fulfilled by the parent's test suite. A child is classified as dispatcher-style when `gh api repos/<owner>/<repo>/git/trees/<head_sha>?recursive=1` returns 0 entries under `.claude/hooks/`. Design-system and landing-page (post-W5) are the canonical exemplars.
+
 **Enforcement:** The Standards & Quality Lead (Aino) verifies these requirements during hook PR review. A hook missing any of the five requirements must not be approved.
+
+## Hook Audit Protocol
+
+When auditing a repo's hook ownership status (hook-owning vs. dispatcher-style):
+
+1. Fetch the committed tree:
+   ```
+   gh api repos/<owner>/<repo>/git/trees/<head_sha>?recursive=1 \
+     --jq '[.tree[].path | select(startswith(".claude/hooks/"))]'
+   ```
+2. Classification: if the result is empty (`[]`), the repo is dispatcher-style. If non-empty, it is hook-owning.
+3. Filesystem enumeration (SSH, `ls`, `find`) is NOT a valid substitute — it includes untracked files, worktree artifacts, and gitignored content that are invisible to git.
+
+**Rationale:** P3W7 produced 3 repo misclassifications from a single root cause: auditors enumerated working-directory files instead of querying the committed git tree. Misclassified repos: design-system, user-service, data-acquisition — all initially called "stale-mirror hook-owning" but confirmed dispatcher-style via committed-tree inspection. The correct method is one API call away.
+
+**Enforcement:** Any audit-finding comment that asserts a repo's classification must cite the `gh api .../git/trees` invocation it ran (or the equivalent `gh api .../contents/.claude/hooks?ref=<sha>` form). Reviewers reject classification claims sourced from `ls`, `find`, SSH, or local checkout.


### PR DESCRIPTION
## Wave merge — Phase 3 Wave 8 → main (noorinalabs-main)

Final wave merge of `deployments/phase-3/wave-8` to `main` for the parent repo.

**Wave-branch commits landing:**
- `2c7f5805` feat(charter+skill): codify isolation: worktree default for all implementer spawns (#338) — closes #290
- `c7fd964c` charter(hooks.md): dispatcher-children sub-clause + § Hook Audit Protocol (#311, #313) (#334)
- `b3313958` test(hooks): block_gh_pr_review fixtures + alembic-heredoc commit-identity coverage (#98, #99) (#340)

**Merge type:** non-fast-forward — main carries 3 status commits (wave-kickoff status × 2, ontology rebuild) made directly on main per the PUT-contents pattern (`/wave-kickoff` Step 1a). Wave branch carries the 3 squash-merges. Result is a merge commit reconciling both lineages.

**Reviewers:** N/A — this is a wave-completion merge of already-reviewed-and-merged PRs, not new code.
