### PR TITLE
hooks(validate_commit_identity): improve parse-failure block message — point at -F file fix (#345)

### DIFF
--- a/.claude/hooks/tests/test_validate_commit_identity.py
+++ b/.claude/hooks/tests/test_validate_commit_identity.py
@@ -378,6 +378,26 @@ class ParseFailureFailClosedTests(unittest.TestCase):
         self.assertEqual(result["decision"], "block")
         self.assertIn("shlex parsing", result["reason"])
 
+    def test_block_message_points_at_F_file_fix(self):
+        """Parse-failure block message MUST cite the -F file fix and the
+        heredoc-as-cause framing. Codified by #345 after 8 occurrences in
+        P3W7-W8 of agents repeating the heredoc pattern despite the memory
+        pointer existing — the message itself must surface the fix.
+        """
+        cmd = 'git -c user.name="Aino Virtanen -c user.email="a@b.c" commit -m "x"'
+        result = hook.check(self._input(cmd))
+        assert result is not None
+        reason = result["reason"]
+        # Cause framing: the heredoc-inside--m pattern is named.
+        self.assertIn("heredoc", reason.lower())
+        self.assertIn('-m "$(cat <<EOF', reason)
+        # Fix: -F file pattern is shown.
+        self.assertIn("-F /path/to/msg.txt", reason)
+        self.assertIn("/tmp/msg-issue-N.txt", reason)
+        # Memory pointer: the canonical reference is named so the operator
+        # can read full context after applying the fix.
+        self.assertIn("feedback_heredoc_in_git_commit.md", reason)
+
     def test_unbalanced_quote_without_commit_allows(self):
         """Parse failure on a non-commit command → allow (no commit to validate)."""
         cmd = 'echo "unterminated'

--- a/.claude/hooks/validate_commit_identity.py
+++ b/.claude/hooks/validate_commit_identity.py
@@ -199,9 +199,15 @@ def check(input_data: dict) -> dict | None:
             "decision": "block",
             "reason": (
                 "BLOCKED: git commit detected but command failed shlex parsing "
-                "(likely unbalanced quotes). Cannot validate `-c user.name=` / "
-                "`-c user.email=` flags from a malformed command. Fix the "
-                "quoting and retry."
+                "(likely unbalanced quotes — common when embedding heredocs "
+                'inside `-m "$(cat <<EOF...EOF)"` next to `-c user.name=` flags). '
+                "Cannot validate identity flags from a malformed command.\n\n"
+                "Fix: write the message to a file and use `-F /path/to/msg.txt`:\n"
+                "  printf '%s\\n' \"your commit message\" > /tmp/msg-issue-N.txt\n"
+                '  git -c user.name="Foo Bar" -c user.email="..." \\\n'
+                "      commit -F /tmp/msg-issue-N.txt\n"
+                "(Or for multi-line: heredoc into the file FIRST, then -F.)\n\n"
+                "See memory feedback_heredoc_in_git_commit.md for full context."
             ),
         }
         log_pretooluse_block("validate_commit_identity", command, result["reason"])


### PR DESCRIPTION
## Summary

Fixes #345 — improves the `validate_commit_identity` parse-failure BLOCKED message to surface the `-F file` fix instead of relying on agents recalling memory `feedback_heredoc_in_git_commit.md`.

Annunaki captured **8 occurrences** in 37-error log spanning 2026-05-08 → 2026-05-10 of agents tripping the parse-failure block by embedding heredocs inside `-m "$(cat <<EOF...EOF)"` next to `-c user.name=...` flags. The memory exists, but the block message itself didn't surface the fix — so agents kept repeating the pattern.

### Changes

`.claude/hooks/validate_commit_identity.py` — updates the BLOCKED message at lines 200-205 to:

1. Name the heredoc-inside-`-m` pattern as the common cause.
2. Show the canonical `-F file` fix as a copy-paste recipe.
3. Reference `feedback_heredoc_in_git_commit.md` for full context.

`.claude/hooks/tests/test_validate_commit_identity.py` — adds `test_block_message_points_at_F_file_fix` to lock in the new message contents. A future tightening of the message must explicitly update the test, preventing regressions.

### No behavior change

Still blocks on parse failure — just with better operator guidance. All 21 existing tests pass.

## Phase C alignment

This is PR1 of 2 for Phase C (hook-message improvements) of #346:

- **PR1 (this)** — #345 `validate_commit_identity` (8 occurrences captured by Annunaki)
- **PR2 (next)** — `validate_pr_review` Approved-vs-Reply error message clarification (per `feedback_validate_pr_review_approved_not_reply.md`)

## Related Issues

Closes #345
Refs #346

## Review Checklist

- [ ] Reviewed by another team member
- [ ] Must-fix items resolved
- [ ] Tech debt items filed as GitHub Issues (if any)

## Test Plan

### Pre-merge validation

- All 21 tests pass: `ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/test_validate_commit_identity.py -v` → `21 passed in 0.07s`.
- New test (`test_block_message_points_at_F_file_fix`) verifies the message contains: heredoc-as-cause framing, `-F /path/to/msg.txt` fix recipe, `/tmp/msg-issue-N.txt` example, memory file pointer.
- ruff-format clean: `uvx ruff@0.13.0 format --check` → `2 files already formatted`.
- ruff-lint clean: `uvx ruff@0.13.0 check` → `All checks passed!`.

### Post-merge validation

- Next agent that trips the parse-failure path will see the new guidance — no need to recall the memory.
- Annunaki monitor should show occurrence count tail off in subsequent waves.

Co-Authored-By: Aino Virtanen <parametrization+Aino.Virtanen@gmail.com>
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
