### PR TITLE
hooks(validate_pr_review): explain Reply-vs-Approved in BLOCKED message (#352)

### DIFF
--- a/.claude/hooks/tests/test_validate_pr_review.py
+++ b/.claude/hooks/tests/test_validate_pr_review.py
@@ -629,6 +629,37 @@ class CheckEndToEndTests(unittest.TestCase):
         self.assertEqual(result["decision"], "block")
         self.assertIn("1/2", result["reason"])
 
+    def test_block_message_explains_reply_vs_approved(self):
+        """BLOCKED message MUST surface the Reply-vs-Approved distinction and
+        the diagnostic recipe. Codified by #352 after a P3W8 17-addendum
+        cascade across 11 PRs where spawn briefs initially specified
+        `RequestOrReplied: Reply` and the prior message didn't explain why
+        Reply doesn't count.
+        """
+        review_result = hook.CommentReviewResult()
+        review_result.reviewers = {"anya kowalczyk"}  # 1/2
+        with (
+            mock.patch.object(hook, "get_pr_data", return_value=self._patch_pr_data()),
+            mock.patch.object(hook, "check_comment_reviews", return_value=review_result),
+        ):
+            result = hook.check(self._input("gh pr merge 100 --squash"))
+        assert result is not None
+        reason = result["reason"]
+        # Failure-mode framing: Reply-vs-Approved distinction is named.
+        self.assertIn("Reply vs Approved", reason)
+        self.assertIn(
+            "Reply / Replied / Request / ChangesRequested do NOT",
+            reason,
+        )
+        # Body-prose-not-inspected framing (so operator doesn't think
+        # "looks good" or "Approved." in the body fixes it).
+        self.assertIn("body prose is not inspected", reason)
+        # Diagnostic recipe: gh api jq one-liner is shown.
+        self.assertIn("gh api repos/<owner>/<repo>/issues/<PR>/comments", reason)
+        self.assertIn('contains("RequestOrReplied: Approved")', reason)
+        # Memory pointer: canonical reference for full context.
+        self.assertIn("feedback_validate_pr_review_approved_not_reply.md", reason)
+
     def test_one_reviewer_with_wave_bootstrap_and_enforcer_allows(self):
         """Single-Reviewer Exception (#228): wave-bootstrap + charter enforcer → allow.
 

--- a/.claude/hooks/validate_pr_review.py
+++ b/.claude/hooks/validate_pr_review.py
@@ -520,11 +520,24 @@ def check(input_data: dict) -> dict | None:
                 "Approved comments (resolves main#244).\n"
                 "Use `gh pr comment <PR#> --body '...'` with charter format:\n"
                 "  Requestor: <reviewer>  Requestee: <PR author>  "
-                "RequestOrReplied: Approved  TechDebt: none | #issue, ...\n"
+                "RequestOrReplied: Approved  TechDebt: none | #issue, ...\n\n"
+                "Common failure mode — Reply vs Approved:\n"
+                "  RequestOrReplied: Reply / Replied / Request / ChangesRequested do NOT\n"
+                "  count toward the 2-reviewer threshold, EVEN IF the body prose says\n"
+                '  "Approved" or "looks good." The hook parses the RequestOrReplied:\n'
+                "  field directly — body prose is not inspected for verdict signals.\n"
+                "  If a reviewer's intent was to approve, they must post a NEW comment\n"
+                "  with `RequestOrReplied: Approved` (Reply comments cannot be edited\n"
+                "  in-place to change the field).\n\n"
+                "Diagnose the count yourself before retrying merge:\n"
+                "  gh api repos/<owner>/<repo>/issues/<PR>/comments \\\n"
+                "    --jq '[.[] | select(.body | "
+                'contains("RequestOrReplied: Approved"))] | length\'\n\n'
                 "Single-Reviewer Exception (charter § Single-Reviewer Exception (Wave-Bootstrap "
                 "Only)): label PR `wave-bootstrap` AND have a charter-enforcer review (Standards "
                 "Lead, Manager, Tech Lead, Project Lead, or Program Director).\n"
-                "Pass `--admin` for emergency overrides only."
+                "Pass `--admin` for emergency overrides only.\n"
+                "See memory feedback_validate_pr_review_approved_not_reply.md for full context."
             ),
         }
         log_pretooluse_block("validate_pr_review", command, result["reason"])


### PR DESCRIPTION
## Summary

Closes #352 — improves the `validate_pr_review` BLOCKED message to explicitly call out the Reply-vs-Approved distinction.

P3W8 wave 2026-05-09 surfaced a **17-addendum cascade across 11 PRs** because orchestrator spawn briefs initially specified `RequestOrReplied: Reply` for approval comments. The hook gates on distinct Requestor across `Approved` comments **only** — Reply / Replied / Request / ChangesRequested do NOT count, even when the body prose says "Approved" or "looks good." The prior message mentioned Approved comments but didn't explain why Reply doesn't count.

### Changes

`.claude/hooks/validate_pr_review.py` — extends the BLOCKED message at the `total_distinct < 2` branch with:

- An explicit "Common failure mode — Reply vs Approved:" section naming the mistake.
- A note that body prose is not inspected — the hook parses `RequestOrReplied:` directly.
- The diagnostic `gh api ... | jq` one-liner from the memory so managers can self-diagnose at the pre-merge checkpoint.
- Reference to `feedback_validate_pr_review_approved_not_reply.md`.

`.claude/hooks/tests/test_validate_pr_review.py` — adds `test_block_message_explains_reply_vs_approved` to lock in the new message contents (Reply-vs-Approved framing, body-prose-not-inspected note, diagnostic recipe, memory pointer).

### No behavior change

Still blocks when distinct-Approved-Requestor count < 2. All 56 existing tests pass.

## Phase C alignment

This is PR2 of 2 for Phase C (hook-message improvements) of #346:

- **PR1** — #345 `validate_commit_identity` heredoc → -F file fix (PR #351, opened earlier)
- **PR2 (this)** — #352 `validate_pr_review` Reply-vs-Approved clarification

## Related Issues

Closes #352
Refs #346

## Review Checklist

- [ ] Reviewed by another team member
- [ ] Must-fix items resolved
- [ ] Tech debt items filed as GitHub Issues (if any)

## Test Plan

### Pre-merge validation

- All 56 tests pass: `ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/test_validate_pr_review.py -v` → `56 passed in 0.10s`.
- New test `test_block_message_explains_reply_vs_approved` verifies the message contains: "Reply vs Approved" framing, "Reply / Replied / Request / ChangesRequested do NOT" enumeration, "body prose is not inspected" note, `gh api ... | jq` diagnostic recipe (with `contains("RequestOrReplied: Approved")`), memory file pointer.
- ruff format clean, ruff lint clean.

### Post-merge validation

- Next agent that hits the 0/2 or 1/2 reviewer block will see the explicit Reply-vs-Approved explanation, reducing addendum-cascade churn.
- Annunaki-monitored cascades from spawn-brief-language-mismatch should taper off in subsequent waves.

Co-Authored-By: Aino Virtanen <parametrization+Aino.Virtanen@gmail.com>
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
