### PR TITLE
skill(/file-bug): consolidate 3 bug-filing-discipline memories (#346 Phase D)

### DIFF
--- a/.claude/skills/file-bug/SKILL.md
+++ b/.claude/skills/file-bug/SKILL.md
@@ -1,0 +1,221 @@
+---
+name: file-bug
+description: File a GitHub issue with built-in dup-search, drift-evidence-on-existing-issue, and multi-layer-gap discrimination. Consolidates 3 charter-promotion-target memories into a single command.
+args: optional — keyword(s) describing the bug; if omitted, the skill prompts for them
+---
+
+Files a GitHub issue against the appropriate repo, but FIRST runs three discriminator passes that catch:
+
+1. **Duplicates** — same root cause, different framing
+2. **Drift evidence** — single-instance drift covered by an open rationalization workstream
+3. **Multi-layer gaps** — distinct layers (detection / strategy / docs) that share a root cause but are NOT duplicates
+
+This skill consolidates three feedback memories that have hit the charter-promotion threshold but are skill-shaped, not charter-shaped:
+
+- `feedback_search_before_filing.md` — duplicate detection
+- `feedback_drift_evidence_to_existing_rationalization_issue.md` — single-instance-of-pattern detection
+- `feedback_multi_layer_gap_filing.md` — distinct-layer counter-rule
+
+> **Note:** all repo paths in bash blocks below are rooted at `$REPO_ROOT` to avoid cwd drift when the skill is invoked from a worktree or child-repo subdirectory.
+
+## When to use
+
+- The user reports a bug or surfaces a gap in conversation.
+- A code review surfaces a finding that needs tracking.
+- The orchestrator's `/wave-wrapup` audit identifies a rationalization opportunity.
+
+Invoke as `/file-bug <keywords>` (e.g., `/file-bug CSP theme-flash`) OR with no args (the skill will prompt).
+
+## Instructions
+
+### 1. Gather inputs
+
+Identify:
+
+- **Symptom keywords** — 2-4 words from the surface symptom (e.g., `theme flash`, `notify-deploy`, `OAuth /token`).
+- **Suspected root cause keywords** — 2-4 words describing the underlying mechanism (e.g., `CSP inline script`, `repository_dispatch event-type`, `URL override prod-gate`).
+- **Layer classification** (preliminary) — is this:
+  - **detection** (CI / hook / validator / monitor)
+  - **strategy / architectural** (ADR, IaC pattern, ownership)
+  - **docs / runbook** (operator procedure, escalation path)
+  - **bug** (single concrete defect at one layer)
+- **Affected repo** — which repo's tracker should the issue land in?
+- **Layer-sibling candidates** — does this incident also surface gaps at OTHER layers? (Pre-flag for the multi-layer-gap pass below.)
+
+### 2. Pass A — search-before-filing (duplicate detection)
+
+Search the relevant repo for existing issues that may cover the same root cause:
+
+```bash
+gh issue list --repo "noorinalabs/<repo>" --state all --search "<symptom keywords>" --json number,title,state --limit 10
+gh issue list --repo "noorinalabs/<repo>" --state all --search "<root-cause keywords>" --json number,title,state --limit 10
+```
+
+For cross-repo bugs (deploy chain, CSP, auth, ontology), search BOTH the symptom-side repo AND the cause-side repo. Examples:
+
+- notify-deploy bugs may be filed in `noorinalabs-deploy` OR `noorinalabs-isnad-graph`.
+- CSP issues may be filed in `noorinalabs-isnad-graph` OR `noorinalabs-design-system`.
+- Hook drift may be filed in `noorinalabs-main` OR the affected child repo.
+
+Read the matches. Score each as:
+
+| Score | Meaning | Action |
+|---|---|---|
+| **STRONG dup** | Same root cause, same proposed fix; titles share core keywords | Comment new diagnosis on existing issue, exit |
+| **WEAK dup** | Adjacent symptom, may share root cause but unclear | Comment on existing AND consider continuing — confirm with user |
+| **No match** | No existing issue covers this | Continue to Pass B |
+
+If STRONG dup: comment your diagnosis (with `gh api` head_sha verification per `state-claims.md § Refresh State Before Claim`), then EXIT. Do not file a new issue.
+
+### 3. Pass B — drift-evidence-on-existing (single-instance pattern detection)
+
+Even if Pass A found no symptom dup, search for open **rationalization / cleanup** issues whose execution would eliminate this entire class of bug:
+
+```bash
+gh issue list --repo "noorinalabs/<repo>" --state open \
+  --search "rationalize OR consolidate OR standardize OR cleanup OR canonical" \
+  --json number,title,labels --limit 20
+```
+
+Also search for issue titles matching `tech-debt:`, `rationalize:`, `consolidate:`, `cleanup:`, `standardize:`.
+
+If your incident is a **single concrete instance** of a pattern that one of these issues would eliminate (typical examples: copy-resident drift, duplicated config, divergent paths after rename), the right action is to **comment evidence on the existing rationalization issue**, NOT file a new single-instance ticket.
+
+Decision rule:
+
+| Pattern | Open rationalization issue exists? | Action |
+|---|---|---|
+| Single-instance drift | Yes — would eliminate this class | Comment evidence on existing; do NOT file |
+| Single-instance drift | No | Continue to Pass C |
+| Multi-instance / new class | (irrelevant) | Continue to Pass C |
+
+Comment shape on the existing rationalization issue:
+
+```markdown
+## Concrete drift example surfaced 2026-MM-DD
+
+**Surface:** <file path or component>
+**Drift observed:** <specific divergence — sha refs, line numbers>
+**Source:** <where this surfaced — code review of PR #N, /wave-wrapup audit, etc.>
+
+This strengthens the case for #<this-issue> rationalization (concrete > abstract).
+Not filed as a separate issue per `feedback_drift_evidence_to_existing_rationalization_issue.md`.
+```
+
+Surface the observation in the originating review comment as well (so the author sees it inline). Both, not either.
+
+### 4. Pass C — multi-layer-gap discrimination
+
+If the incident has surfaced gaps at MORE THAN ONE layer (detection AND strategy, or strategy AND docs, etc.), **file separately at each layer with cross-references** rather than collapsing into one comprehensive issue.
+
+Distinct-layer issues that share a root cause are NOT duplicates. The `search-before-filing` rule (Pass A) catches symptom-dup; this rule catches the inverse — false-collapse of distinct layers.
+
+Worked example (B2 cred rotation, 2026-04-28):
+
+| Layer | Issue | Concern |
+|---|---|---|
+| Detection | `noorinalabs-deploy#158` | CI validate-creds drift check (automation) |
+| Strategy | `noorinalabs-deploy#180` | ADR / bucket IaC management, rotation cadence (architectural decision) |
+| Docs | `noorinalabs-deploy#182` | Operator runbook for rotation loop (documentation) |
+
+Each was filed separately, all three cross-referenced in their bodies. Bereket initially proposed dedup at retro; Lucas-Rev-177's three-layer separation overrode.
+
+For each distinct-layer issue, draft a body that:
+
+- Names the layer in the title prefix (e.g., `detection:`, `strategy:`, `docs:`)
+- Cross-references all sibling issues in a `## Layer siblings` section
+- Notes the shared root cause but the layer-specific scope
+
+### 5. File the issue (single layer, or one of N)
+
+After Passes A + B + C, file the new issue (or batch of layer-issues):
+
+```bash
+gh issue create --repo "noorinalabs/<repo>" \
+  --title "<discoverable title — symptom + root-cause guess>" \
+  --body-file /tmp/issue-body-<descriptive-slug>.txt \
+  --label "<bug|tech-debt>" \
+  --label "<assignee-label, if known>" \
+  --label "<wave-label, if applicable>"
+```
+
+Title discipline (per `feedback_search_before_filing.md`): include both the symptom AND a guess at the root cause. The next person who hits this should find your issue via either keyword.
+
+Issue body skeleton:
+
+```markdown
+## Symptom
+
+<observable behavior, with file/line references where possible>
+
+## Suspected root cause
+
+<mechanism — what's broken, why>
+
+## Reproduction (if applicable)
+
+<minimal repro steps>
+
+## Layer siblings (if multi-layer)
+
+- detection: #N
+- strategy: #M
+- docs: #K
+
+## Pre-filing dup-search performed
+
+- `gh issue list --search "<symptom>"` → no matches OR matches considered: #X (different scope), #Y (different scope)
+- `gh issue list --search "<root-cause>"` → no matches OR matches considered: #Z (resolved 2026-MM-DD)
+- Rationalization scan (Pass B) → no eliminating issue found OR found #W (this is multi-instance / new class, not single-instance covered by #W)
+
+## Acceptance Criteria
+
+- [ ] <specific, testable>
+- [ ] <specific, testable>
+
+## Out of scope
+
+<what this issue does NOT cover, with cross-refs to where it does>
+```
+
+Per `feedback_tmp_msg_file_stale.md`: write the body to `/tmp/issue-body-<descriptive-slug>.txt` (NOT `/tmp/msg.txt` — the issue#-keyed slug avoids the stale-tmp-file race), then `gh issue create --body-file`. Read-back-verify within 30s of creation per `feedback_gh_pr_edit_silent_noop.md`:
+
+```bash
+NEW_ISSUE_NUM=<from gh issue create output>
+gh issue view "$NEW_ISSUE_NUM" --repo "noorinalabs/<repo>" --json number,title,labels --jq '{n:.number, t:.title, l:[.labels[].name]}'
+```
+
+### 6. Post-file follow-up
+
+Per `CLAUDE.md § Bug Report Workflow`:
+
+1. **Label for current wave** — check `cross-repo-status.json` for `wave_<N>_active=true`, apply that wave label.
+2. **Add to project board** — `gh project item-add 2 --owner noorinalabs --url <issue-url>`.
+3. **If multi-layer:** repeat steps 5-6 for each sibling issue, then update each issue's `## Layer siblings` section with the actual issue numbers (since they only become known after creation).
+
+## Output to user
+
+Present a structured summary:
+
+```
+**File-bug result**
+
+| Pass | Result |
+|---|---|
+| A — search-before-filing | <STRONG dup #N | WEAK dup #M | no match> |
+| B — drift-evidence-on-existing | <commented on #K | no rationalization match> |
+| C — multi-layer | <single layer | N siblings: #X #Y #Z> |
+
+**Action taken:** <filed #N | commented on #K | filed N siblings: #X #Y #Z>
+**Follow-up:** <wave-labeled, project-board-added, all sibling cross-refs updated>
+```
+
+If Pass A or B intercepted the file (no new issue created), state that clearly so the operator knows the bug is tracked even though no new issue exists.
+
+## What remains manual
+
+- **Score interpretation** — STRONG vs WEAK dup is judgment; the skill surfaces matches, the operator decides.
+- **Layer classification at incident time** — the skill prompts for it but does not infer it.
+- **Acceptance criteria authorship** — domain-specific, operator-authored.
+
+The skill encodes the discipline; it does not replace the judgment.


### PR DESCRIPTION
## Summary

Phase D of #346 — adds `.claude/skills/file-bug/SKILL.md`, a structured bug-filing skill that consolidates three feedback memories that have hit the charter-promotion threshold but are skill-shaped (operational, not rule-shaped):

- **Pass A** — search-before-filing (duplicate detection) — promotes `feedback_search_before_filing.md`
- **Pass B** — drift-evidence-on-existing (single-instance-of-pattern detection) — promotes `feedback_drift_evidence_to_existing_rationalization_issue.md`
- **Pass C** — multi-layer-gap discrimination (distinct-layer issues are NOT dups) — promotes `feedback_multi_layer_gap_filing.md`

### Why one skill, not three

These three memories converge on a single skill because they all operate at the same lifecycle position (pre-file triage) and produce **counter-rules to each other**:

- A says "search for dups, comment on dup if found"
- B says "even if no symptom dup, look for rationalization-class issue that would eliminate the entire pattern"
- C says "even if you find a sibling at another layer, distinct layers are NOT dups — file separately with cross-refs"

Encoding them as one skill with sequenced passes lets the operator apply the full discipline in one invocation without remembering which memory governs which case. Each pass cites its source memory + the canonical worked example.

### Output discipline

The skill produces a structured summary table (per-pass result + final action statement) so operators can audit that the discipline was applied. Per-pass cross-references inline with the canonical worked examples (#162/#838 for Pass A, main#214 for Pass B, deploy#158/#180/#182 for Pass C).

### Memory state

The 3 promoted memory files have been updated to `status: superseded` with `superseded_by: skill:/file-bug Pass <X>` and `superseded_at: 2026-05-10`. MEMORY.md index entries marked SUPERSEDED.

## Related Issues

Refs #346

## Review Checklist

- [ ] Reviewed by another team member
- [ ] Must-fix items resolved
- [ ] Tech debt items filed as GitHub Issues (if any)

## Test Plan

### Pre-merge validation

- Skill file follows the convention of existing skills (close-stale-issues, ontology-librarian) — frontmatter with `name`/`description`/`args`, instruction sections, repo-rooted bash blocks via `$REPO_ROOT`.
- Each Pass cites its source memory file by path + canonical worked example.
- Skill body explicitly preserves what remains manual (judgment, layer classification, acceptance criteria authorship) so operators understand the skill encodes discipline, not replaces it.
- Cross-references to companion skills (`/wave-wrapup`, `state-claims.md § Refresh State Before Claim`) and memories (`feedback_tmp_msg_file_stale.md`, `feedback_gh_pr_edit_silent_noop.md`) are accurate.

### Post-merge validation

- Next time a bug is reported in conversation, agent invokes `/file-bug <keywords>` instead of going straight to `gh issue create`.
- `/promotion-audit` should mark the 3 source memories as ALREADY-PROMOTED on next run.
- Spot-check observable: a bug filed via `/file-bug` should produce a structured Pass A/B/C summary visible in the operator's transcript.

Co-Authored-By: Aino Virtanen <parametrization+Aino.Virtanen@gmail.com>
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
