### PR TITLE
test(block_no_verify): pin git stash --no-commit shape (#336)

### DIFF
--- a/.claude/hooks/tests/test_block_no_verify.py
+++ b/.claude/hooks/tests/test_block_no_verify.py
@@ -88,6 +88,13 @@ class NegativeMatchTests(unittest.TestCase):
     def test_no_git_at_all(self):
         self.assertIsNone(hook.check(_input("ls --no-verify-flag")))
 
+    def test_git_stash_no_commit_not_blocked(self):
+        # isnad-graph#868: regex-based child copy false-positive on `\bcommit\b`
+        # matching "commit" inside "--no-commit". Parent's shlex tokenization
+        # via _shell_parse rejects this shape (subcommand is `stash`, not
+        # `commit`). Fixture pin so a future non-shlex refactor regresses here.
+        self.assertIsNone(hook.check(_input("git stash --no-commit")))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Adds the single fixture pin called out in #336 — `test_git_stash_no_commit_not_blocked` — to `NegativeMatchTests` in `.claude/hooks/tests/test_block_no_verify.py`.

## Why this is the right shape

isnad-graph#868 explicitly identified `git stash --no-commit` as a false-positive for the regex-based child copy: `\bcommit\b` matches the "commit" inside "--no-commit", causing the stale child copy to incorrectly block.

Parent's `block_no_verify.py` uses shlex tokenization via `_shell_parse.find_git_subcommand` and correctly classifies the subcommand as `stash` (not `commit`) — verified by running `hook.check({"tool_name": "Bash", "tool_input": {"command": "git stash --no-commit"}})` against the parent impl: returns `None` (allow). Behavior is correct in production today.

What was missing is the explicit fixture pin. If `block_no_verify.py` is later refactored away from shlex, the regression would not surface in CI. This adds the pin.

## Mutation verified

Confirmed `\bcommit\b` matches inside `--no-commit` — i.e. the exact regex shape from isnad-graph#868. If a future refactor re-introduced a `\bcommit\b`-style subcommand classifier in place of shlex, this test would fail (assert `result is None` would see `decision == "block"`).

## No behavior change

Test-only change. `block_no_verify.py` is untouched (verified via `git status` — only the test file is in the diff). All existing 12 tests still pass; new test brings the count to 13/13 PASSED.

## Acceptance

- [x] `test_git_stash_no_commit_not_blocked` added to `NegativeMatchTests`
- [x] Test invokes `hook.check(...)` and asserts `result is None`
- [x] All existing tests pass (13/13 PASSED in `pytest .claude/hooks/tests/test_block_no_verify.py -v`)
- [x] `uvx ruff format --check .claude/hooks/tests/test_block_no_verify.py` clean
- [x] No behavior change to `block_no_verify.py`

## Cross-links

- Closes #336
- Source bug: isnad-graph#868 (closed-as-resolved 2026-05-09)
- Charter rule: `.claude/team/charter/hooks.md § 5 Parser-Fixture Coverage Requirements`
