### PR TITLE
feat(/wave-retro): Steps 7.6 (Annunaki-attack) + 7.7 (memory audit) (closes #344)

### DIFF
--- a/.claude/skills/annunaki-attack/SKILL.md
+++ b/.claude/skills/annunaki-attack/SKILL.md
@@ -9,7 +9,8 @@ Process the Annunaki error log, deduplicate errors, propose preventative automat
 
 ## When to run
 
-- Before `/wave-wrapup` hands off to retro (integrated into wave-wrapup step 11.5)
+- **Preferred:** during `/wave-retro` Step 7.6 — findings feed the retro's charter-change proposals (added P3W9 #344, 2026-05-11)
+- Fallback: during `/wave-wrapup` Step 13 — same run-marker (`wave_${M}_annunaki_attack_ran_at`) prevents double-execution; whichever surface runs first wins
 - Manually when the error log has accumulated enough entries to be worth processing
 - Before planning the next wave — ensures error-driven improvements are captured as issues
 
@@ -158,12 +159,15 @@ After all issues are created and fixes implemented, clear the processed errors:
 **Next step:** Issues are labeled for {wave_label} and added to the project board.
 ```
 
-## Integration with wave-wrapup
+## Integration with wave-retro / wave-wrapup
 
-This skill is called automatically as step 11.5 in `/wave-wrapup`, after the memory-to-automation audit and before the final wave report. When called from wave-wrapup:
-- Use the current wave label (already known from wrapup context)
-- If no errors to process, report "Annunaki: No errors captured this wave" and continue
-- Fixes created here are included in the wave report totals
+This skill is called from **`/wave-retro` Step 7.6** (preferred surface, added P3W9 #344) or **`/wave-wrapup` Step 13** (fallback for retro-delayed cases). Both surfaces guard the call with a `wave_${M}_annunaki_attack_ran_at` run-marker in `cross-repo-status.json` so the attack runs at most once per wave.
+
+When called from either surface:
+- Use the current wave label (already known from context)
+- If no errors to process, report "Annunaki: No errors captured this wave", **still write the run-marker**, and continue
+- Fixes created here are included in the wave report totals (wrapup) and feed Step 7 charter-change proposals (retro)
+- On completion, write `wave_${M}_annunaki_attack_ran_at = <ISO-8601 UTC timestamp>` to `cross-repo-status.json`
 
 ## What remains manual
 

--- a/.claude/skills/wave-retro/SKILL.md
+++ b/.claude/skills/wave-retro/SKILL.md
@@ -151,6 +151,61 @@ Invoke `/promotion-audit` to deterministically check whether any memories, chart
 
 The audit appends its table to this retro's feedback_log entry **and** writes a standalone log at `.claude/team/promotion_audit_log/{wave-name}.md`. On unchanged repo state, the audit is byte-deterministic — re-running produces identical output. See issue #152 for the full pipeline spec and PR #153 / Hook 15 for the worked example.
 
+### 7.6. Annunaki-attack (added P3W9 #344 — 2026-05-11)
+
+Invoke `/annunaki-attack` to process errors captured by the Annunaki monitor during this wave. Any hooks/skills/charter changes that emerge feed back into Step 7 (charter changes) retroactively — review the new artifacts in this retro's charter-changes proposal block.
+
+This step is **co-located** with `/wave-wrapup` Step 13. The run-marker check below prevents double-execution; whichever surface runs first wins, and the other surface skips.
+
+```bash
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+ALREADY_RAN=$(jq -r ".wave_${M}_annunaki_attack_ran_at // empty" "$REPO_ROOT/cross-repo-status.json")
+
+if [ -n "$ALREADY_RAN" ]; then
+  echo "Annunaki-attack: already ran at $ALREADY_RAN (likely via /wave-wrapup Step 13). Skipping."
+else
+  # Invoke /annunaki-attack with the current wave context.
+  # On successful completion, the skill (or this step's post-invoke wrapper) writes:
+  #   wave_${M}_annunaki_attack_ran_at = <ISO-8601 UTC timestamp>
+  # to cross-repo-status.json — the marker /wave-wrapup Step 13 reads.
+fi
+```
+
+If `.claude/annunaki/errors.jsonl` is empty or missing, report "Annunaki: No errors captured this wave" and still write the marker (so wrapup's Step 13 doesn't re-check). Include any Annunaki-created issues + PRs in the wave-shape table and per-engineer assessments (Step 4) before presenting the retro at Step 8.
+
+This step runs **before** Step 7.7 (memory-to-automation audit) so that new hooks/skills/charter from error analysis are visible to the memory audit — a memory file matching a just-created hook can be retired in the same retro instead of re-surfacing as a separate audit candidate.
+
+### 7.7. Memory-to-automation audit (added P3W9 #344 — 2026-05-11)
+
+Examine all memory files in the project memory directory for entries that describe behaviors, rules, or patterns that could be codified as a **hook**, **skill**, or **charter update** instead of remaining as soft memory. Findings feed Step 7 (charter changes) retroactively.
+
+This step is **co-located** with `/wave-wrapup` Step 14. Run-marker check is the same pattern as 7.6:
+
+```bash
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+ALREADY_RAN=$(jq -r ".wave_${M}_memory_audit_ran_at // empty" "$REPO_ROOT/cross-repo-status.json")
+
+if [ -n "$ALREADY_RAN" ]; then
+  echo "Memory-to-automation audit: already ran at $ALREADY_RAN (likely via /wave-wrapup Step 14). Skipping."
+else
+  # Run the audit per the recipe in /wave-wrapup Step 14 (kept canonical there to avoid duplication):
+  #   1. Read all memory files: ls ~/.claude/projects/*/memory/*.md
+  #   2. Classify each: Hook candidate | Skill candidate | Charter update | Keep as memory
+  #   3. For each non-keep classification: file an issue, spawn/message best-fit owner, verify, delete/update memory
+  #   4. Report the conversion table
+  # On completion, write wave_${M}_memory_audit_ran_at = <ISO-8601 UTC timestamp> to cross-repo-status.json.
+fi
+```
+
+**Designated owner:** Aino Virtanen handles most conversions (hooks, charter, standards). The orchestrator spawns her with the audit list and she reports back when done — same convention as `/wave-wrapup` Step 14.
+
+**Why retro is the preferred surface (P3W9 #344 rationale):** wave-wrapup is already long, and the audits routinely get deferred at wrapup time, pushing them days or weeks into the next wave-wrapup cycle. Retro is the natural moment because:
+- The retro narrative already discusses charter-change proposals (Step 7); promotion candidates discovered in Step 7.7 land in the same proposal block.
+- Trust matrix updates (Step 5) and feedback_log entries (Step 6) are already in flight; new Aino-assigned audit-conversion issues count toward her wave engagement in the same retro pass.
+- Carry-forward to next wave (Step 9 `/wave-scope`) immediately follows; any audit-conversion issues filed here are visible to scope reconciliation.
+
+P3W8 surfaced the gap (2026-05-10): user explicitly noted "these should be a part of the wave-retro for next time." This step is that next time.
+
 ### 8. Present full retro summary to the user
 
 **Output the complete retro summary directly in the conversation.** Do not just write to files — the user must see the retro without having to open `feedback_log.md`. Include:

--- a/.claude/skills/wave-wrapup/SKILL.md
+++ b/.claude/skills/wave-wrapup/SKILL.md
@@ -238,16 +238,45 @@ Run `/ontology-rebuild` to process any files that changed during this wave. This
 
 ### 13. Annunaki error attack
 
+> **Preferred surface is `/wave-retro` Step 7.6 (P3W9 #344).** Retro is the natural moment for this audit — findings feed the retro's charter-change proposals. Wrapup retains this step as a fallback for cases where retro is delayed or skipped. The run-marker below prevents double-execution.
+
+```bash
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+ALREADY_RAN=$(jq -r ".wave_${M}_annunaki_attack_ran_at // empty" "$REPO_ROOT/cross-repo-status.json")
+
+if [ -n "$ALREADY_RAN" ]; then
+  echo "Annunaki-attack: already ran at $ALREADY_RAN (via /wave-retro Step 7.6). Skipping."
+  # Continue to Step 14.
+else
+  # Proceed with the attack below; on completion write the marker.
+fi
+```
+
 Run `/annunaki-attack` to process any errors captured by the Annunaki monitor during this wave. This converts observed errors into preventative automation (hooks, skills, charter updates) before the wave closes.
 
-- If `.claude/annunaki/errors.jsonl` is empty or missing, report "Annunaki: No errors captured this wave" and skip
+- If `.claude/annunaki/errors.jsonl` is empty or missing, report "Annunaki: No errors captured this wave" and skip the attack — but still write the run-marker so retro's 7.6 doesn't re-check
 - Use the current wave label for any issues created
 - Include Annunaki-created issues and PRs in the final wave report totals
 - This step runs **before** the memory-to-automation audit so that new hooks/skills from error analysis are visible to the memory audit
+- On completion, write `wave_${M}_annunaki_attack_ran_at = <ISO-8601 UTC timestamp>` to `cross-repo-status.json`
 
 ### 14. Memory-to-automation audit
 
-Examine all memory files in the project memory directory for entries that describe behaviors, rules, or patterns that could be codified as a **hook**, **skill**, or **charter update** instead of remaining as soft memory.
+> **Preferred surface is `/wave-retro` Step 7.7 (P3W9 #344).** Retro is the natural moment for this audit — findings feed the retro's charter-change proposals and the Aino-spawned conversion issues count toward the same retro's per-engineer assessment + trust update pass. Wrapup retains this step as the canonical procedure body (referenced by retro's 7.7) and as a fallback for retro-delayed cases. The run-marker below prevents double-execution.
+
+```bash
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+ALREADY_RAN=$(jq -r ".wave_${M}_memory_audit_ran_at // empty" "$REPO_ROOT/cross-repo-status.json")
+
+if [ -n "$ALREADY_RAN" ]; then
+  echo "Memory-to-automation audit: already ran at $ALREADY_RAN (via /wave-retro Step 7.7). Skipping."
+  # Continue to the rest of the wrapup.
+else
+  # Proceed with the audit below; on completion write the marker.
+fi
+```
+
+Examine all memory files in the project memory directory for entries that describe behaviors, rules, or patterns that could be codified as a **hook**, **skill**, or **charter update** instead of remaining as soft memory. On completion, write `wave_${M}_memory_audit_ran_at = <ISO-8601 UTC timestamp>` to `cross-repo-status.json`.
 
 **Process:**
 


### PR DESCRIPTION
## Summary

Adds two new steps to `/wave-retro` between existing Step 7.5 (Promotion audit) and Step 8 (Present retro), making **retro the preferred surface** for the Annunaki-attack + memory-to-automation audit pair. Both surfaces retain `/wave-wrapup` Steps 13 + 14 as fallback for retro-delayed cases. Closes #344.

## What this adds

| Surface | Step | What runs | Skip-check |
|---------|------|-----------|------------|
| `/wave-retro` | **7.6 (new)** | `/annunaki-attack` | `wave_${M}_annunaki_attack_ran_at` |
| `/wave-retro` | **7.7 (new)** | Memory-to-automation audit (recipe canonical in wrapup Step 14) | `wave_${M}_memory_audit_ran_at` |
| `/wave-wrapup` | 13 (updated) | `/annunaki-attack` (fallback) | same marker as 7.6 |
| `/wave-wrapup` | 14 (updated) | Memory audit (fallback; canonical procedure body) | same marker as 7.7 |

## Coordination mechanism

Picked option **(b) state file / run-marker** from the issue body over option (a) cross-reference text alone. Both surfaces read/write timestamps in `cross-repo-status.json`:

```bash
ALREADY_RAN=$(jq -r ".wave_${M}_annunaki_attack_ran_at // empty" "$REPO_ROOT/cross-repo-status.json")
if [ -n "$ALREADY_RAN" ]; then
  echo "Annunaki-attack: already ran at $ALREADY_RAN. Skipping."
fi
```

Consistent with the existing `wave_*_*_at` idiom in `cross-repo-status.json` (`wave_*_scope_reconciled_at` in wave-retro Step 9, `wave_*_counter_corrections` in Step 2.5). Whichever surface runs first writes the marker; the other surface skips with a one-line note. Machine-verifiable, unambiguous, matches existing precedent. Cross-reference text is also retained in both surfaces for human readers.

## Why retro is the preferred surface

- Retro narrative already discusses charter-change proposals (Step 7); promotion candidates discovered in 7.7 land in the same proposal block.
- Trust matrix updates (Step 5) and feedback_log entries (Step 6) are already in flight; new Aino-assigned audit-conversion issues count toward her wave engagement in the same retro pass.
- `/wave-scope` (Step 9) immediately follows; audit-conversion issues filed here are visible to next-wave scope reconciliation.

P3W8 surfaced the gap (2026-05-10): user explicitly noted "these should be a part of the wave-retro for next time." This PR is that next time. W9 retro tests the new flow per the issue acceptance.

## Drive-by fix: `/annunaki-attack` § Integration

While editing the skill chain, fixed a stale cross-ref in `annunaki-attack/SKILL.md` that claimed integration as `/wave-wrapup` "step 11.5". Actual position is Step 13 (has been since the wrapup skill was renumbered). Updated to point to both `/wave-retro` Step 7.6 (preferred) and `/wave-wrapup` Step 13 (fallback) with the run-marker mechanism explained.

## Acceptance criteria (from #344)

- [x] `/wave-retro` SKILL.md gains Steps 7.6 + 7.7
- [x] Step descriptions reference `/annunaki-attack` skill + the memory-audit recipe currently in `/wave-wrapup` Step 14 (kept canonical there to avoid procedure-body duplication)
- [x] `/wave-wrapup` Steps 13 + 14 retained but cross-reference `/wave-retro` as the preferred surface
- [x] Coordination mechanism prevents re-execution — run-marker in `cross-repo-status.json`
- [ ] W9 retro tests the new flow — pending wave wrapup/retro execution

## Diff shape

`+96 / -8`, 3 files:

| File | + / - | Change |
|------|-------|--------|
| `.claude/skills/wave-retro/SKILL.md` | +55 / -0 | New Steps 7.6 + 7.7 |
| `.claude/skills/wave-wrapup/SKILL.md` | +29 / -4 | Skip-check prepended to Steps 13 + 14 |
| `.claude/skills/annunaki-attack/SKILL.md` | +12 / -4 | Stale step-11.5 reference fixed; retro-as-preferred added |

## Test plan

- [x] `git diff --stat` confirms +96 / -8 across 3 files
- [x] Section structure verified:
  - `wave-retro/SKILL.md`: Step 7.5 (line 144) → new Step 7.6 (line 154) → new Step 7.7 (line 178) → Step 8 (line 209). Steps 8 + 9 still present and well-formed.
  - `wave-wrapup/SKILL.md`: Step 13 + 14 retained at lines 239 + 263; canonical procedure body for memory audit untouched (referenced by retro's 7.7).
  - `annunaki-attack/SKILL.md`: § When to run + § Integration with wave-retro / wave-wrapup updated; instruction steps 1-7 untouched.
- [x] Skip-check semantics: marker check fires on a stored `wave_${M}_*_ran_at` value (empty-string default); follows `jq -r ... // empty` pattern used elsewhere in retro Step 9.
- [x] Run-marker key naming consistent with existing `cross-repo-status.json` idioms.
- [x] No charter changes; no hook changes; pure skill-flow restructure.
- [ ] Reviewer pass — Aino Virtanen + Wanjiku Mwangi (Aino owns memory-audit recipe + Standards Lead role; Wanjiku owns wave-orchestration coordination)

Closes #344
