### PR TITLE
skill(/file-bug): Pass A directly cites origin-over-local rule (closes #358)

### DIFF
--- a/.claude/skills/file-bug/SKILL.md
+++ b/.claude/skills/file-bug/SKILL.md
@@ -57,7 +57,11 @@ For cross-repo bugs (deploy chain, CSP, auth, ontology), search BOTH the symptom
 - CSP issues may be filed in `noorinalabs-isnad-graph` OR `noorinalabs-design-system`.
 - Hook drift may be filed in `noorinalabs-main` OR the affected child repo.
 
-Read the matches. Score each as:
+Read the matches.
+
+> **Origin > local clone**: when evaluating file-content claims in a matched issue (e.g., "file X still exists at path Y", "config Z has value W"), fetch via `gh api repos/<owner>/<repo>/contents/<path>?ref=<head_sha>` — NOT the local clone. Local main may lag origin, especially during waves where work lands on a wave branch first. Charter `pull-requests.md § Origin > Local Clone for "Still-Has-X" File-Content Claims` (promoted from `feedback_origin_over_local_for_still_has_claims.md`, Bereket→Lucas-87/PR #181 2026-04-28).
+
+Score each as:
 
 | Score | Meaning | Action |
 |---|---|---|


### PR DESCRIPTION
## Summary

Closes #358 — `/file-bug` Pass A now directly cites the origin-over-local rule at the point of decision (reading matched issues), instead of relying on one-hop indirection through `state-claims.md § Refresh State Before Claim`.

## Change

Single edit to `.claude/skills/file-bug/SKILL.md` line 60 — inserts a callout block immediately after "Read the matches." that:

- Names the rule directly: **Origin > local clone**
- Gives the canonical `gh api repos/<owner>/<repo>/contents/<path>?ref=<head_sha>` invocation
- Cites charter `pull-requests.md § Origin > Local Clone for "Still-Has-X" File-Content Claims` (post-2026-05-10 canonical location)
- Includes the source memory `feedback_origin_over_local_for_still_has_claims.md` per #358 acceptance criterion (memory is SUPERSEDED but retained as historical pointer)

## Acceptance per #358

- [x] Pass A directly references `feedback_origin_over_local_for_still_has_claims.md` (not just via state-claims.md indirection) — callout block names it inline
- [x] Inline reminder at the point of decision (reading matched issues), not in a generic preamble — placed between "Read the matches." and the scoring table

## Why a callout block vs. inline parenthetical

The scoring table is the next thing the operator reads; an inline parenthetical inside the table would be easy to skip during incident pressure. A block-quote callout above the table interrupts attention before scoring begins — same pattern as the existing tmp_msg_file_stale citation at line 181 (per #358 "Out of scope" note: that one is already direct, kept as-is).

## Test plan

- [x] Local file edited and committed via Aino's commit identity (`-c user.name= -c user.email=`)
- [x] Hook pre-commit gate passed (ruff/mypy skipped — no .py files changed)
- [ ] Reviewer 1: charter-format Approved with Requestor=reviewer, Requestee=PR author
- [ ] Reviewer 2: charter-format Approved
- [ ] `validate_pr_review` 2-reviewer gate clears
- [ ] PR merges into `deployments/phase-3/wave-9`

## Out of scope

- Skill structural redesign (Pass A/B/C shape unchanged)
- Other charter-link audits across the skill (#358 explicitly notes tmp_msg_file_stale is fine as-is)
- Memory-supersedure cleanup (separate hygiene item)
