### PR TITLE
ontology(conventions): codify ADR numbering convention org-wide — 4-digit zero-pad (closes #342)

### DIFF
--- a/ontology/checksums.json
+++ b/ontology/checksums.json
@@ -464,10 +464,10 @@
       "tracked_at": "2026-04-16T21:36:05.052302+00:00"
     },
     "ontology/conventions.md": {
-      "last_tracked": "b204a757947bbd62430a599908ad342294625438d23b5bcc1ea4fcc9bd48c291",
-      "last_resolved": "b204a757947bbd62430a599908ad342294625438d23b5bcc1ea4fcc9bd48c291",
-      "tracked_at": "2026-05-03T16:59:38.573672+00:00",
-      "resolved_at": "2026-05-03T16:59:38.573672+00:00"
+      "last_resolved": "1aa2056252eca54b37e5186cf688f616800e933336a12c1f7349e59bda0371a5",
+      "last_tracked": "1aa2056252eca54b37e5186cf688f616800e933336a12c1f7349e59bda0371a5",
+      "resolved_at": "2026-05-11T01:13:02.983312+00:00",
+      "tracked_at": "2026-05-11T01:13:02.983312+00:00"
     },
     "ontology/domain.yaml": {
       "last_resolved": "6fedad509f80b9570d0385fb5759e861d8b6f7b219ecc425b8dd472173ca536c",

--- a/ontology/conventions.md
+++ b/ontology/conventions.md
@@ -70,6 +70,35 @@ Updated by `/ontology-rebuild`. Manual edits require `checksums.json` update.
 - Internal Docker networks for backend services (not exposed)
 - Resource limits on all containers (memory + CPU)
 
+## Architecture Decision Records (ADRs)
+
+Cross-repo convention for filename, location, and format. Per-repo content remains repo-scoped; this section governs only the shape so an ADR is identifiable and sortable the same way across the org.
+
+- **Location:** `docs/adr/` at each repo root. Index file: `docs/adr/README.md` (chronological list with title + link + date + status).
+- **Filename pattern:** `<NNNN>-<kebab-title>.md` — **4-digit zero-padded** sequential number, hyphen-kebab title. Example: `0001-tf-hetzner-per-env-state-strategy.md`.
+- **Format:** Michael Nygard's ADR template (Title / Status / Context / Decision / Consequences). The dominant `adr-tools` ecosystem and most external reference material assume this shape; newcomers reading an ADR will already know it.
+- **Numbering:** strictly monotonic within a repo. Numbers are not reused on supersede — a superseded ADR keeps its number and the superseding ADR gets the next free number; both reference each other.
+- **Status values:** `Proposed`, `Accepted`, `Deprecated`, `Superseded by NNNN`. No `Rejected` (closed PRs serve that role).
+
+### Why 4-digit zero-padded
+
+Three considerations:
+
+1. **Headroom.** `0001-` supports >999 ADRs without renumbering. `001-` does not. Cheap insurance for a long-lived org.
+2. **Alphasort.** Directory listings sort numerically when zero-padded; otherwise `10-...` sorts before `2-...`. 4 digits matches the headroom decision.
+3. **External convention alignment.** Nygard's own examples and `adr-tools` zero-pad to 4 digits (`docs/adr/0001-record-architecture-decisions.md`).
+
+### Cross-repo state (2026-05-11)
+
+| Repo | Current ADRs | Convention | Action |
+|---|---|---|---|
+| `noorinalabs-deploy` | `0001-tf-hetzner-per-env-state-strategy.md` | 4-digit ✓ | None — already canonical |
+| `noorinalabs-landing-page` | `0001-astro-build-output-hook-coverage.md` (PR #89) | 4-digit ✓ | None — already canonical |
+| `noorinalabs-data-acquisition` | `001-local-hook-policy-dispatcher-style.md` (PR #48) | 3-digit | Follow-up rename PR to `0001-` |
+| `noorinalabs-isnad-graph` | `001-` … `004-` (4 ADRs merged) | 3-digit | Out of scope here — track as separate bulk-rename cleanup if pursued |
+
+Existing 3-digit ADRs are not merge-blockers; renames are mechanical and reversible.
+
 ## Team & process conventions
 
 ### Commit identity


### PR DESCRIPTION
## Summary

Closes #342 — codifies ADR numbering convention org-wide in `ontology/conventions.md`. Canonical: **4-digit zero-padded** (`<NNNN>-<kebab-title>.md`), Michael Nygard format, under `docs/adr/`.

## Why this PR exists

P3W8 surfaced cross-repo divergence between two ADR PRs:

- `noorinalabs-data-acquisition#48` → `001-` (3-digit, following isnad-graph's existing 001-004 series)
- `noorinalabs-landing-page#89` → `0001-` (4-digit, following deploy's existing 0001-)

Both authors followed an existing repo precedent — there was no canonical org-level rule, so the divergence was not "wrong" by anyone, just absent guidance.

## What changed

`ontology/conventions.md` — adds a new top-level section "Architecture Decision Records (ADRs)" between "Architectural patterns" (specific patterns) and "Team & process conventions" (workflow). Separates decision-record convention from architecture-pattern catalog.

The section covers:
- **Location:** `docs/adr/` with `README.md` index
- **Filename:** `<NNNN>-<kebab-title>.md`, 4-digit zero-padded
- **Format:** Michael Nygard's template
- **Numbering:** strictly monotonic, no reuse on supersede
- **Status values:** Proposed / Accepted / Deprecated / Superseded by NNNN

Plus a cross-repo state table making follow-up decisions explicit per repo.

## Why 4-digit zero-padded

Three considerations from #342:

1. **Headroom.** `0001-` supports >999 ADRs without renumbering. `001-` does not.
2. **Alphasort.** Zero-pad keeps directory listings numerically sorted (else `10-...` sorts before `2-...`).
3. **External convention.** Nygard examples and `adr-tools` ecosystem zero-pad to 4 digits.

## Cross-repo state and follow-ups

| Repo | Current | Convention | Action |
|---|---|---|---|
| deploy | `0001-` | ✓ canonical | None |
| landing-page | `0001-` (PR #89) | ✓ canonical | None |
| data-acquisition | `001-` (PR #48) | non-canonical | **Follow-up rename PR needed** |
| isnad-graph | `001-` … `004-` (4 ADRs) | non-canonical | **Out of scope here** — separate bulk-rename if pursued |

Follow-ups are tracked in the section table itself, not as separate issues (single-layer convention adoption — per `feedback_multi_layer_gap_filing.md` not applicable here).

## Acceptance per #342

- [x] `ontology/conventions.md` has an "ADRs" section
- [x] Section names the canonical filename pattern
- [x] Section names the canonical location (`docs/adr/` with `README.md` index)
- [x] Section names the format (Michael Nygard)
- [x] Cross-repo follow-up surface explicit in the section table

## Out of scope (deliberate)

- Rename PRs in data-acquisition / isnad-graph (mechanical, separate)
- `adr-tools` adoption (separate decision)
- Linting/CI gate enforcing the convention (could be filed as follow-up hook if drift recurs)

## Test plan

- [x] Section reads coherently and is internally consistent
- [x] Commit identity via `-c` flags (Aino)
- [x] Hook gates green
- [ ] Reviewer 1 — Approved with Requestor/Requestee/RoR/TechDebt
- [ ] Reviewer 2 — Approved
- [ ] Merges into `deployments/phase-3/wave-9`
