### PR TITLE
skill(/file-bug): aggregate telemetry JSONL + reporting recipes (closes #357)

### DIFF
--- a/.claude/skills/file-bug/SKILL.md
+++ b/.claude/skills/file-bug/SKILL.md
@@ -197,6 +197,55 @@ Per `CLAUDE.md § Bug Report Workflow`:
 2. **Add to project board** — `gh project item-add 2 --owner noorinalabs --url <issue-url>`.
 3. **If multi-layer:** repeat steps 5-6 for each sibling issue, then update each issue's `## Layer siblings` section with the actual issue numbers (since they only become known after creation).
 
+### 7. Telemetry append (every invocation)
+
+Append a single JSONL line per `/file-bug` invocation to `.claude/.file-bug-log.jsonl` (gitignored). Captures the Pass A/B/C outcome and the disposition (filed-new, commented-existing, etc.) so aggregate signal is queryable without re-deriving from issue-body prose.
+
+```bash
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+LOG="$REPO_ROOT/.claude/.file-bug-log.jsonl"
+
+# Build the record from your in-skill state. Pass values come from each Pass's
+# outcome (the prose summary in Step 8 already encodes them).
+TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+REPO_FULL="noorinalabs/<repo>"
+PASS_A="<STRONG_DUP|WEAK_DUP|NO_MATCH>"       # Step 2 outcome
+PASS_B="<COMMENTED_ON|NO_MATCH|SKIPPED>"      # Step 3 outcome (SKIPPED if A intercepted)
+PASS_C="<SINGLE_LAYER|MULTI_LAYER_N|SKIPPED>" # Step 4 outcome (SKIPPED if A/B intercepted)
+DISPOSITION="<FILED_NEW|FILED_MULTIPLE|COMMENTED_EXISTING|NOT_FILED>"
+# Issue numbers as a JSON array: the new issue(s) filed, OR the existing issue
+# you commented on, OR empty array if nothing was created/touched.
+ISSUE_NUMBERS_JSON='[362]'   # or '[]' or '[362,363,364]' for multi-layer
+
+jq -c -n \
+  --arg ts "$TS" \
+  --arg repo "$REPO_FULL" \
+  --arg a "$PASS_A" \
+  --arg b "$PASS_B" \
+  --arg c "$PASS_C" \
+  --arg d "$DISPOSITION" \
+  --argjson nums "$ISSUE_NUMBERS_JSON" \
+  '{ts:$ts, repo:$repo, pass_a:$a, pass_b:$b, pass_c:$c, disposition:$d, issue_numbers:$nums}' \
+  >> "$LOG"
+```
+
+The record is append-only — no rewrites, no per-issue back-references. Each invocation produces exactly one line, regardless of whether 0 / 1 / N issues were created.
+
+Required state values (closed enums — keep stable so retro queries don't drift):
+
+| Field | Values |
+|---|---|
+| `pass_a` | `STRONG_DUP`, `WEAK_DUP`, `NO_MATCH` |
+| `pass_b` | `COMMENTED_ON`, `NO_MATCH`, `SKIPPED` |
+| `pass_c` | `SINGLE_LAYER`, `MULTI_LAYER_2`, `MULTI_LAYER_3`, …, `SKIPPED` |
+| `disposition` | `FILED_NEW`, `FILED_MULTIPLE`, `COMMENTED_EXISTING`, `NOT_FILED` |
+
+If you EXIT at Pass A on STRONG dup: `pass_a=STRONG_DUP`, `pass_b=SKIPPED`, `pass_c=SKIPPED`, `disposition=COMMENTED_EXISTING`, `issue_numbers=[<the existing one>]`.
+
+If you comment evidence on a rationalization issue at Pass B: `pass_a=NO_MATCH`, `pass_b=COMMENTED_ON`, `pass_c=SKIPPED`, `disposition=COMMENTED_EXISTING`.
+
+If you file N siblings at Pass C: `disposition=FILED_MULTIPLE`, `pass_c=MULTI_LAYER_N`, `issue_numbers=[<all N>]`.
+
 ## Output to user
 
 Present a structured summary:
@@ -223,3 +272,45 @@ If Pass A or B intercepted the file (no new issue created), state that clearly s
 - **Acceptance criteria authorship** — domain-specific, operator-authored.
 
 The skill encodes the discipline; it does not replace the judgment.
+
+## Reporting
+
+Aggregate signal lives in `.claude/.file-bug-log.jsonl` (gitignored, append-only). Query directly with `jq -s` — no separate reporting skill is required.
+
+```bash
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+LOG="$REPO_ROOT/.claude/.file-bug-log.jsonl"
+
+# Total invocations this wave (or all-time if no time filter)
+jq -s 'length' "$LOG"
+
+# Pass A intercept rate — would-have-duped saves
+jq -s '[.[] | select(.pass_a == "STRONG_DUP")] | length' "$LOG"
+
+# Pass B intercept rate — drift-evidence-on-existing
+jq -s '[.[] | select(.pass_b == "COMMENTED_ON")] | length' "$LOG"
+
+# Pass C multi-layer preservation — issues that would have been collapsed
+# by Pass-A-alone but were correctly split by Pass C
+jq -s '[.[] | select(.pass_c | startswith("MULTI_LAYER_"))] | length' "$LOG"
+
+# Per-repo dup-attempt rate
+jq -s 'group_by(.repo) | map({
+  repo: .[0].repo,
+  total: length,
+  strong_dup: ([.[] | select(.pass_a == "STRONG_DUP")] | length),
+  multi_layer: ([.[] | select(.pass_c | startswith("MULTI_LAYER_"))] | length)
+})' "$LOG"
+
+# This-wave only (filter by ISO date range)
+WAVE_START="2026-05-10T17:55:00Z"
+jq -s --arg s "$WAVE_START" '[.[] | select(.ts >= $s)] | {total: length,
+  strong_dup: ([.[] | select(.pass_a == "STRONG_DUP")] | length),
+  pass_b_commented: ([.[] | select(.pass_b == "COMMENTED_ON")] | length),
+  multi_layer: ([.[] | select(.pass_c | startswith("MULTI_LAYER_"))] | length),
+  filed_new: ([.[] | select(.disposition == "FILED_NEW")] | length),
+  filed_multiple: ([.[] | select(.disposition == "FILED_MULTIPLE")] | length)
+}' "$LOG"
+```
+
+`/wave-retro` Step 7.7 (memory-to-automation audit) should cite the wave-scoped totals from the last recipe in its skill-effectiveness summary, starting with the first retro after this PR lands.

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ temp/
 # Scratch — ephemeral working drafts (issue bodies, audit scripts, etc.)
 .claude/scratch/
 
+# /file-bug skill telemetry log (#357 — append-only, local-only, queried by /wave-retro)
+.claude/.file-bug-log.jsonl
+
 # Python lockfile for the virtual parent project (no real deps; auto-regen)
 /uv.lock
 

--- a/ontology/checksums.json
+++ b/ontology/checksums.json
@@ -170,10 +170,10 @@
       "resolved_at": "2026-05-06T00:59:20.040752+00:00"
     },
     ".gitignore": {
-      "last_tracked": "190721c8bc9b74b883f33f6daba0ad4432bed3ede48a119788884b0b188ee9ee",
-      "last_resolved": "190721c8bc9b74b883f33f6daba0ad4432bed3ede48a119788884b0b188ee9ee",
-      "tracked_at": "2026-05-08T20:53:45.852247+00:00",
-      "resolved_at": "2026-05-08T20:54:11.368739Z"
+      "last_resolved": "99a48dfddef755ee0af95d7c44b8cc62d5b74a8cda39be8977e236538a4f1b35",
+      "last_tracked": "99a48dfddef755ee0af95d7c44b8cc62d5b74a8cda39be8977e236538a4f1b35",
+      "resolved_at": "2026-05-11T01:24:19.842478+00:00",
+      "tracked_at": "2026-05-11T01:24:19.842478+00:00"
     },
     ".pre-commit-config.yaml": {
       "last_resolved": "e5cb514b9a22f37b80adb4d74896cef8e9d2768f0f42ae3f3a29001efd3ae615",
@@ -1056,6 +1056,12 @@
       "last_resolved": "",
       "tracked_at": "2026-05-10T14:40:22.639809+00:00",
       "resolved_at": ""
+    },
+    ".claude/skills/file-bug/SKILL.md": {
+      "last_resolved": "0e8e6660e3a6691aa4835428e39d39f00432effdfd6e39fb5f11205ffbbe391f",
+      "last_tracked": "0e8e6660e3a6691aa4835428e39d39f00432effdfd6e39fb5f11205ffbbe391f",
+      "resolved_at": "2026-05-11T01:24:19.842478+00:00",
+      "tracked_at": "2026-05-11T01:24:19.842478+00:00"
     }
   },
   "last_cleanup": {


### PR DESCRIPTION
## Summary

Closes #357 — `/file-bug` skill now emits append-only JSONL telemetry to `.claude/.file-bug-log.jsonl` (gitignored), with closed-enum state values for each Pass × disposition combination. Reporting recipes inline in SKILL.md `## Reporting` section. No separate `/file-bug-stats` skill — `jq -s` directly against the log is the reporting interface.

## What changed

Three files:

1. **`.claude/skills/file-bug/SKILL.md`** — adds:
   - **Step 7. Telemetry append** (between Step 6 Post-file follow-up and Output to user): JSONL record build via `jq -c -n --argjson`, with closed-enum state values for each Pass × disposition.
   - **`## Reporting` section** at end: 6 `jq -s` recipes (total invocations, Pass A intercept, Pass B intercept, Pass C multi-layer preservation, per-repo dup-attempt rate, wave-scoped totals).

2. **`.gitignore`** — one new line: `.claude/.file-bug-log.jsonl` (follows existing local-only patterns).

3. **`ontology/checksums.json`** — bumped for SKILL.md + .gitignore edits.

## Record shape

```json
{
  "ts": "2026-05-11T01:30:00Z",
  "repo": "noorinalabs/noorinalabs-main",
  "pass_a": "STRONG_DUP | WEAK_DUP | NO_MATCH",
  "pass_b": "COMMENTED_ON | NO_MATCH | SKIPPED",
  "pass_c": "SINGLE_LAYER | MULTI_LAYER_N | SKIPPED",
  "disposition": "FILED_NEW | FILED_MULTIPLE | COMMENTED_EXISTING | NOT_FILED",
  "issue_numbers": [362]
}
```

One line per invocation. Append-only — no rewrites, no per-issue back-references. Stable closed-enum values so retro queries don't drift.

## Why JSONL over structured-issue-field

The issue's "Proposed shape" offered two options: gitignored JSONL log OR structured `telemetry:` field on the issue itself. JSONL wins on:
- **Single source of truth** — no risk of issue-body and skill drifting on telemetry shape.
- **Queryability** — `jq -s` against one file vs. crawling all issues via gh api.
- **Privacy** — log stays local; per-team aggregates can be shared without exposing every individual filing decision.
- **Replay-safety** — append-only is robust against partial-failure mid-skill (we don't rewrite an existing issue's body, which would invalidate previous reviewers' approvals).

## Live-trace verification

Built 2 sample records via the SKILL.md `jq -c -n --argjson` recipe; queried both via the Reporting recipes. `STRONG_DUP` count = 1, `MULTI_LAYER_*` count = 1. ✅

Raw output included in commit body for traceability.

## Charter / memory provenance

- Per `feedback_enforcement_hierarchy.md` (hook > skill > charter): telemetry is observation, not enforcement — skill-tier is the right rung. No new hook needed.
- Per charter `pull-requests.md § Live-Trace Evidence > Synthetic-Test Acceptance`: live `jq` round-trip verifies the recipes work end-to-end, not just that the SKILL.md syntax is plausible.

## Acceptance per #357

- [x] `/file-bug` emits a structured per-invocation record (JSONL @ `.claude/.file-bug-log.jsonl`)
- [x] A reporting path exists (`## Reporting` section + 6 jq -s recipes)
- [ ] First /wave-retro after merge cites the new metric — annotated in SKILL.md `## Reporting`; retro skill not modified by this PR per scope discipline (downstream pickup)

## Out of scope (deliberate)

- Per-issue audit-trail body section (already working — this is additive)
- Cross-skill telemetry (this is /file-bug-specific)
- `/wave-retro` skill modification (downstream — separate PR if pursued)
- `/file-bug-stats` reporting wrapper (issue suggested as optional; replaced by inline jq recipes in SKILL.md — simpler, no new skill to maintain)

## Test plan

- [x] `jq -c -n --argjson` recipe builds a valid JSONL record
- [x] `jq -s` recipes correctly aggregate against multi-record log
- [x] `.gitignore` entry prevents accidental check-in
- [x] Ontology checksums bumped
- [ ] Reviewer 1 — charter-format Approved
- [ ] Reviewer 2 — charter-format Approved
- [ ] Merges into `deployments/phase-3/wave-9`
