### PR TITLE
tech-debt(/wave-scope): upsert_status_keys.py multi-line sibling fix + final-key comma fix (closes #332)

### DIFF
--- a/.claude/skills/wave-scope/tests/test_upsert_status_keys.py
+++ b/.claude/skills/wave-scope/tests/test_upsert_status_keys.py
@@ -1,0 +1,204 @@
+"""Tests for upsert_status_keys.upsert_top_level_key.
+
+Covers the main#332 fix: insertion point must skip past multi-line array /
+object sibling values, not insert inside them.
+
+Each test builds a small cross-repo-status.json-shaped fixture, calls
+upsert_top_level_key, validates that the result:
+  1. Parses as JSON.
+  2. Contains the new key with the expected value.
+  3. Preserves the sibling values unchanged (no truncation, no reorder).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from upsert_status_keys import upsert_top_level_key  # noqa: E402
+
+
+class UpsertSinglelineSiblingTests(unittest.TestCase):
+    """Baseline — single-line sibling values (the case that always worked)."""
+
+    def test_inserts_after_singleline_sibling(self):
+        text = (
+            "{\n"
+            '  "phase": "phase-3",\n'
+            '  "wave_8_active": true,\n'
+            '  "wave_8_kicked_off_at": "2026-05-08T00:00:00Z"\n'
+            "}\n"
+        )
+        out = upsert_top_level_key(text, "wave_8_scope", '"narrow"')
+        parsed = json.loads(out)
+        self.assertEqual(parsed["wave_8_scope"], "narrow")
+        # Sibling values intact
+        self.assertTrue(parsed["wave_8_active"])
+        self.assertEqual(parsed["wave_8_kicked_off_at"], "2026-05-08T00:00:00Z")
+
+
+class UpsertMultilineArraySiblingTests(unittest.TestCase):
+    """main#332 reproducer — multi-line array sibling (wave_8_carry_forward)."""
+
+    def test_inserts_after_multiline_array(self):
+        text = (
+            "{\n"
+            '  "phase": "phase-3",\n'
+            '  "wave_8_active": true,\n'
+            '  "wave_8_carry_forward": [\n'
+            '    "#341",\n'
+            '    "#342"\n'
+            "  ]\n"
+            "}\n"
+        )
+        out = upsert_top_level_key(text, "wave_8_scope", '"narrow"')
+        parsed = json.loads(out)
+        self.assertEqual(parsed["wave_8_scope"], "narrow")
+        # The array sibling is intact and not truncated/reordered
+        self.assertEqual(parsed["wave_8_carry_forward"], ["#341", "#342"])
+        # New key appears AFTER the array close in source text
+        scope_pos = out.find('"wave_8_scope"')
+        array_close_pos = out.find("  ]")
+        self.assertGreater(scope_pos, array_close_pos)
+
+
+class UpsertMultilineObjectSiblingTests(unittest.TestCase):
+    """main#332 reproducer — multi-line object sibling (wave_8_work)."""
+
+    def test_inserts_after_multiline_object(self):
+        text = (
+            "{\n"
+            '  "phase": "phase-3",\n'
+            '  "wave_8_work": {\n'
+            '    "isnad-graph": ["#868", "#869"],\n'
+            '    "deploy": ["#280"]\n'
+            "  }\n"
+            "}\n"
+        )
+        out = upsert_top_level_key(text, "wave_8_scope", '"narrow"')
+        parsed = json.loads(out)
+        self.assertEqual(parsed["wave_8_scope"], "narrow")
+        # Object sibling is intact (both nested keys present, both arrays preserved)
+        self.assertEqual(parsed["wave_8_work"]["isnad-graph"], ["#868", "#869"])
+        self.assertEqual(parsed["wave_8_work"]["deploy"], ["#280"])
+
+
+class UpsertNestedStructuresTests(unittest.TestCase):
+    """Sibling has deeply nested object/array — depth tracking is correct."""
+
+    def test_inserts_after_deeply_nested_sibling(self):
+        text = (
+            "{\n"
+            '  "wave_8_work": {\n'
+            '    "tiers": {\n'
+            '      "tier_1": ["#86", "#88"],\n'
+            '      "tier_2": {\n'
+            '        "isnad-graph": ["#90"],\n'
+            '        "deploy": ["#92", "#94"]\n'
+            "      }\n"
+            "    },\n"
+            '    "meta": "ok"\n'
+            "  }\n"
+            "}\n"
+        )
+        out = upsert_top_level_key(text, "wave_8_scope", '"narrow"')
+        parsed = json.loads(out)
+        self.assertEqual(parsed["wave_8_scope"], "narrow")
+        # The deeply nested structure round-trips intact
+        self.assertEqual(parsed["wave_8_work"]["tiers"]["tier_2"]["deploy"], ["#92", "#94"])
+        self.assertEqual(parsed["wave_8_work"]["meta"], "ok")
+
+
+class UpsertStringsContainingBracketsTests(unittest.TestCase):
+    """Sibling string values containing `[`, `]`, `{`, `}` must not confuse
+    bracket-depth tracking. JSON string-escape state must be honored."""
+
+    def test_bracket_chars_inside_strings(self):
+        text = (
+            "{\n"
+            '  "wave_8_note": "scope is {tight, narrow} and [bounded]",\n'
+            '  "wave_8_work": {\n'
+            '    "label": "with {literal} braces and [brackets]",\n'
+            '    "deploy": ["#280"]\n'
+            "  }\n"
+            "}\n"
+        )
+        out = upsert_top_level_key(text, "wave_8_scope", '"narrow"')
+        parsed = json.loads(out)
+        self.assertEqual(parsed["wave_8_scope"], "narrow")
+        # String values with bracket chars are unchanged
+        self.assertEqual(parsed["wave_8_note"], "scope is {tight, narrow} and [bounded]")
+        self.assertEqual(parsed["wave_8_work"]["label"], "with {literal} braces and [brackets]")
+
+
+class UpsertEscapedQuotesTests(unittest.TestCase):
+    """Strings with escaped quotes inside multi-line values must not flip
+    bracket-depth tracking's in_string state incorrectly."""
+
+    def test_escaped_quotes_in_string_value(self):
+        text = (
+            "{\n"
+            '  "wave_8_work": {\n'
+            '    "note": "He said \\"yes\\" and {then}",\n'
+            '    "deploy": ["#280"]\n'
+            "  }\n"
+            "}\n"
+        )
+        out = upsert_top_level_key(text, "wave_8_scope", '"narrow"')
+        parsed = json.loads(out)
+        self.assertEqual(parsed["wave_8_scope"], "narrow")
+        self.assertEqual(parsed["wave_8_work"]["note"], 'He said "yes" and {then}')
+
+
+class UpsertIdempotenceTests(unittest.TestCase):
+    """Re-running upsert on a file that already has the new key should
+    replace in place (single-line) — not append, not corrupt."""
+
+    def test_rerun_replaces_in_place(self):
+        text = (
+            "{\n"
+            '  "wave_8_active": true,\n'
+            '  "wave_8_carry_forward": [\n'
+            '    "#341"\n'
+            "  ],\n"
+            '  "wave_8_scope": "narrow"\n'
+            "}\n"
+        )
+        out = upsert_top_level_key(text, "wave_8_scope", '"broad"')
+        parsed = json.loads(out)
+        self.assertEqual(parsed["wave_8_scope"], "broad")
+        self.assertEqual(parsed["wave_8_carry_forward"], ["#341"])
+        # File should NOT have duplicated the key
+        self.assertEqual(out.count('"wave_8_scope"'), 1)
+
+
+class UpsertFinalKeyNoTrailingCommaTests(unittest.TestCase):
+    """When inserting after the LAST top-level key (no trailing comma on
+    the sibling), the result must still be valid JSON."""
+
+    def test_final_key_handling(self):
+        text = '{\n  "phase": "phase-3",\n  "wave_8_active": true\n}\n'
+        out = upsert_top_level_key(text, "wave_8_scope", '"narrow"')
+        parsed = json.loads(out)
+        self.assertEqual(parsed["wave_8_scope"], "narrow")
+        self.assertTrue(parsed["wave_8_active"])
+
+
+class UpsertMultiLineFinalKeyTests(unittest.TestCase):
+    """Sibling is multi-line AND is the final top-level key (no trailing
+    comma after the closing `]` or `}`)."""
+
+    def test_multiline_final_array(self):
+        text = '{\n  "phase": "phase-3",\n  "wave_8_carry_forward": [\n    "#341"\n  ]\n}\n'
+        out = upsert_top_level_key(text, "wave_8_scope", '"narrow"')
+        parsed = json.loads(out)
+        self.assertEqual(parsed["wave_8_scope"], "narrow")
+        self.assertEqual(parsed["wave_8_carry_forward"], ["#341"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/skills/wave-scope/upsert_status_keys.py
+++ b/.claude/skills/wave-scope/upsert_status_keys.py
@@ -32,12 +32,65 @@ import sys
 from pathlib import Path
 
 
+def _find_value_end(text: str, opener_match_end: int) -> int:
+    """Given the regex-match end of a top-level key:value opener line,
+    return the position immediately AFTER that key's value terminates
+    (including trailing `,` if present).
+
+    For a single-line value (line ends with `,` or `]` or `}` inline),
+    `opener_match_end` is already past the value — returned as-is.
+
+    For a multi-line value (line ends with `{` or `[`), scans forward
+    tracking bracket depth and JSON string-escape state until depth
+    returns to 0, then optionally consumes a trailing `,`.
+
+    This is the fix for main#332: the prior implementation treated
+    every wave_N_* sibling-finder match as the value's end position,
+    which inserted INSIDE multi-line arrays/objects (e.g., wave_8_work
+    or wave_8_carry_forward in the P3W8 reproducer).
+    """
+    line_start = text.rfind("\n", 0, opener_match_end) + 1
+    line_text = text[line_start:opener_match_end].rstrip()
+    if not line_text.endswith(("[", "{")):
+        return opener_match_end
+
+    depth = 1
+    in_string = False
+    escape = False
+    pos = opener_match_end
+    while pos < len(text):
+        c = text[pos]
+        if escape:
+            escape = False
+        elif c == "\\" and in_string:
+            escape = True
+        elif c == '"':
+            in_string = not in_string
+        elif not in_string:
+            if c in "{[":
+                depth += 1
+            elif c in "}]":
+                depth -= 1
+                if depth == 0:
+                    end = pos + 1
+                    if end < len(text) and text[end] == ",":
+                        end += 1
+                    return end
+        pos += 1
+    raise ValueError(f"unterminated multi-line value starting at position {opener_match_end}")
+
+
 def upsert_top_level_key(text: str, key: str, json_value: str) -> str:
     """Replace `"<key>": ...,` line in place, or insert a new line if absent.
 
-    Insertion point: after the last existing line whose top-level key matches
+    Insertion point: after the last existing key whose top-level name matches
     `wave_<N>_*` for the same wave number embedded in `key` (best-effort sibling
-    grouping). Falls back to inserting right after the opening `{` line.
+    grouping). Handles multi-line array/object siblings correctly — insertion
+    is placed AFTER the sibling's structural close, not after the opening
+    line (main#332 fix).
+
+    Falls back to inserting right after the opening `{` line if no sibling
+    exists.
     """
     line_re = re.compile(r'^(  )"' + re.escape(key) + r'":\s.*?,?\s*$', re.MULTILINE)
     new_line = f'  "{key}": {json_value},'
@@ -60,7 +113,17 @@ def upsert_top_level_key(text: str, key: str, json_value: str) -> str:
         siblings = list(sibling_re.finditer(text))
         if siblings:
             last = siblings[-1]
-            return text[: last.end()] + "\n" + new_line + text[last.end() :]
+            value_end = _find_value_end(text, last.end())
+            # If the previous sibling was the JSON-final key (no trailing
+            # comma after its value), we must add a comma to it AND drop
+            # the trailing comma from our new line so the new key becomes
+            # the new last. Otherwise we'd emit `prev_key: prev_value\n
+            # new_key: new_value,\n}` which is missing the comma between
+            # the two existing pairs.
+            prev_has_trailing_comma = value_end > 0 and text[value_end - 1] == ","
+            if prev_has_trailing_comma:
+                return text[:value_end] + "\n" + new_line + text[value_end:]
+            return text[:value_end] + "," + "\n" + new_line.rstrip(",") + text[value_end:]
 
     open_brace = text.find("{\n")
     if open_brace < 0:
@@ -95,7 +158,19 @@ def main(argv: list[str]) -> int:
         text = upsert_top_level_key(text, key, json_value)
         parsed[key] = decoded
 
-    reparsed = json.loads(text)
+    try:
+        reparsed = json.loads(text)
+    except json.JSONDecodeError as exc:
+        print(
+            f"ERROR: text-level upsert produced invalid JSON: {exc}\n"
+            "  This usually means the helper's sibling-finder mis-located\n"
+            "  the insertion point inside a multi-line array/object value\n"
+            "  (main#332 reproducer). File the failing input as an issue\n"
+            "  with the offending key=value upsert command.",
+            file=sys.stderr,
+        )
+        return 1
+
     if reparsed != parsed:
         print(
             "ERROR: text-level upsert diverged from logical upsert; aborting write",

--- a/ontology/checksums.json
+++ b/ontology/checksums.json
@@ -1062,6 +1062,12 @@
       "last_tracked": "0e8e6660e3a6691aa4835428e39d39f00432effdfd6e39fb5f11205ffbbe391f",
       "resolved_at": "2026-05-11T01:24:19.842478+00:00",
       "tracked_at": "2026-05-11T01:24:19.842478+00:00"
+    },
+    ".claude/skills/wave-scope/upsert_status_keys.py": {
+      "last_resolved": "5c72e04f279df916c5257fb5c884ad50127b908cebbb8b280b0d0f990da3c7dd",
+      "last_tracked": "5c72e04f279df916c5257fb5c884ad50127b908cebbb8b280b0d0f990da3c7dd",
+      "resolved_at": "2026-05-11T01:29:58.147825+00:00",
+      "tracked_at": "2026-05-11T01:29:58.147825+00:00"
     }
   },
   "last_cleanup": {


### PR DESCRIPTION
## Summary

Closes #332 — `upsert_status_keys.py` sibling-finder now correctly skips past multi-line array / object values via a new `_find_value_end()` JSON bracket-depth scanner. Secondary final-key-comma bug also fixed. 9 new tests cover all acceptance fixtures.

## Bugs fixed

**Primary (main#332):** `siblings[-1].end()` regex pointer landed INSIDE multi-line array/object values, inserting the new key inside the still-open structure → invalid JSON.

P3W8 reproducer (2026-05-08):
- File had `wave_8_work: { ... multi-line ... }` and `wave_8_carry_forward: [ ... multi-line ... ]`
- Sibling regex matched the OPENER line of `wave_8_carry_forward`
- `last.end()` was just past the `[` — inside the array
- Insertion: `[<new_key>:<value>, ... ]` ← invalid JSON

**Secondary (caught by the new tests):** When inserting AFTER the JSON-final top-level key (no trailing comma), the prior code appended the new comma-terminated line — producing `prev: val\n  new: val,\n}` which is missing the comma between the two existing pairs.

## Fix shape

`_find_value_end(text, opener_match_end) -> int`:
- Single-line value (line doesn't end with `[` or `{`): return `opener_match_end` unchanged
- Multi-line value: scan forward tracking JSON bracket depth + string-escape state until depth → 0, then consume optional trailing `,`

`upsert_top_level_key` insertion path:
- Call `_find_value_end()` to get the true end position of the sibling
- If `text[value_end - 1] == ','`: standard case, insert with `new_line` comma-terminated
- If not (previous was JSON-final): add `,` to previous, drop `,` from new_line — new key becomes new last

Plus a clearer error message in `main()` when post-write JSON parse fails — names main#332 reproducer shape and asks the operator to file the failing input.

## Tests (9 cases — `tests/test_upsert_status_keys.py`)

| Test | What it covers |
|---|---|
| `test_inserts_after_singleline_sibling` | Baseline — single-line sibling (the working case) |
| `test_inserts_after_multiline_array` | main#332 reproducer — `wave_8_carry_forward: [ ... ]` |
| `test_inserts_after_multiline_object` | main#332 reproducer — `wave_8_work: { ... }` |
| `test_inserts_after_deeply_nested_sibling` | Object → tiers → tier_2 → keys+arrays deep |
| `test_bracket_chars_inside_strings` | String values containing `[`, `]`, `{`, `}` |
| `test_escaped_quotes_in_string_value` | `\"` inside string doesn't flip in_string state |
| `test_rerun_replaces_in_place` | Idempotence — no duplication on re-run |
| `test_final_key_handling` | Secondary bug — inserting after JSON-final key |
| `test_multiline_final_array` | Combined — multi-line value as JSON-final key |

All 9 pass. Ruff + format + mypy clean.

## Live-trace

Ran the patched helper against the actual `cross-repo-status.json`:
```
$ python upsert_status_keys.py /tmp/status-test.json wave_8_test_marker='"test-2026-05-11"'
  upserted: wave_8_test_marker
$ diff cross-repo-status.json /tmp/status-test.json
1922a1923
>   "wave_8_test_marker": "test-2026-05-11",
$ jq '.wave_8_test_marker' /tmp/status-test.json
"test-2026-05-11"
```

Single-line diff (compact-inline shape preserved), valid JSON, correct value. ✅

## Acceptance per #332

- [x] Helper handles multi-line `wave_<M>_*` sibling values correctly
- [x] Test fixture covering single-line / multi-line array / multi-line object / nested objects
- [x] Re-running on a file with multi-line `wave_<M>_*` values doesn't break (idempotence test)
- [x] Fail-fast with meaningful error on invalid JSON (main#332 reproducer named in error message)

## Out of scope

- Refactoring the regex-based approach into a full JSON-position-tracking parser (separate concern; current approach is correct + minimal)
- `/wave-scope` SKILL.md changes — handled separately in #333

## Test plan

- [x] `pytest tests/test_upsert_status_keys.py -v` — 9/9 pass
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] Live-trace against real `cross-repo-status.json` — valid JSON, single-line diff
- [x] Pre-commit hooks green
- [ ] Reviewer 1 — charter-format Approved
- [ ] Reviewer 2 — charter-format Approved
- [ ] Merges into `deployments/phase-3/wave-9`
