### PR TITLE
skill(/wave-scope): Step 13 cross-check repos_in_scope vs meta-issue body (closes #333)

### DIFF
--- a/.claude/skills/wave-scope/SKILL.md
+++ b/.claude/skills/wave-scope/SKILL.md
@@ -347,6 +347,59 @@ else
   REPOS_IN_SCOPE_JSON=$(printf '%s\n' "${REPOS[@]}" | jq -Rnc '[inputs]')
 fi
 
+# Cross-check against meta-issue body (main#333 fix). The meta-issue's body
+# is the canonical declared scope (see Step 11 framing). Without this check
+# the JSON could ship with a different set than the meta-issue declares, and
+# /wave-kickoff Step 0.5 pre-flight would fail on the divergence — exactly
+# the P3W8 kickoff failure (canonical 8 repos, meta-issue body 7 repos,
+# ingest-platform pre-flight failed missing branch + missing label).
+META_BODY=$(gh issue view "$META_ISSUE" --repo noorinalabs/noorinalabs-main --json body --jq '.body')
+# Two reference shapes observed in real meta-issue bodies:
+#   1. Explicit cross-repo issue refs: `noorinalabs-isnad-graph#866`
+#   2. Section-header bullets: `- noorinalabs-isnad-graph: #866, #867, ...`
+# Both indicate the repo is in scope. The regex matches either suffix
+# (`#N` for the explicit form OR `:` for the section-header form) and
+# strips the suffix. Leading `(^|[^a-z])` prevents partial-word matches
+# (e.g., `non-noorinalabs-X` won't match). main#333 fix.
+ACTUAL_CHILDREN=$(echo "$META_BODY" \
+  | grep -oE '(^|[^a-z])noorinalabs-[a-z][a-z0-9-]*(#[0-9]+|:)' \
+  | sed -E 's/^[^a-z]*//; s/(#[0-9]+|:)$//' \
+  | sort -u \
+  | grep -v '^noorinalabs-main$' || true)
+# Canonical = repos_in_scope minus main (the meta-issue lives in main and
+# self-refs use `main#N` or bare `#N`; main is always implicitly in scope)
+CANONICAL_CHILDREN=$(echo "$REPOS_IN_SCOPE_JSON" \
+  | jq -r '.[] | select(. != "noorinalabs-main")' | sort)
+
+EXTRA_IN_BODY=$(comm -23 \
+  <(printf '%s\n' "$ACTUAL_CHILDREN") \
+  <(printf '%s\n' "$CANONICAL_CHILDREN") | grep -v '^$' || true)
+MISSING_FROM_BODY=$(comm -13 \
+  <(printf '%s\n' "$ACTUAL_CHILDREN") \
+  <(printf '%s\n' "$CANONICAL_CHILDREN") | grep -v '^$' || true)
+
+if [ -n "$EXTRA_IN_BODY" ]; then
+  echo "ERROR: meta-issue $META_ISSUE body references repo(s) NOT in canonical/override:"
+  echo "$EXTRA_IN_BODY" | sed 's/^/  /'
+  echo ""
+  echo "Either (a) add the repo to WAVE_SCOPE_REPOS env var and re-run, or"
+  echo "(b) remove the repo's references from the meta-issue body."
+  echo "/wave-scope aborts so cross-repo-status.json does not ship with an"
+  echo "inconsistent canonical truth — /wave-kickoff Step 0.5 would fail on it."
+  exit 1
+fi
+
+if [ -n "$MISSING_FROM_BODY" ]; then
+  # Body declares FEWER repos than canonical/override — deliberate scope reduction
+  echo "INFO: meta-issue $META_ISSUE deliberately excludes child repo(s):"
+  echo "$MISSING_FROM_BODY" | sed 's/^/  /'
+  echo "Using meta-issue-derived scope (noorinalabs-main + body-referenced children)"
+  echo "instead of the canonical/override array. This is the descope-from-meta path."
+  # Rebuild REPOS_IN_SCOPE_JSON: main + body-derived children
+  REPOS_IN_SCOPE_JSON=$(printf '%s\n' "noorinalabs-main" $ACTUAL_CHILDREN \
+    | jq -Rnc '[inputs | select(. != "")]')
+fi
+
 # wave_{M}_scope: WAVE_SCOPE_STRUCTURED if owner pre-built it, else minimal derived shape
 if [ -n "${WAVE_SCOPE_STRUCTURED:-}" ]; then
   # Validate it is a JSON object before passing through

--- a/ontology/checksums.json
+++ b/ontology/checksums.json
@@ -680,10 +680,10 @@
       "resolved_at": "2026-05-08T23:19:16.069020+00:00"
     },
     ".claude/skills/wave-scope/SKILL.md": {
-      "last_tracked": "b48e229d3c756a9cf829ce9e8cf1c663c3e2c59c31aa7f596345b2f2d1b1f90d",
-      "last_resolved": "b48e229d3c756a9cf829ce9e8cf1c663c3e2c59c31aa7f596345b2f2d1b1f90d",
-      "tracked_at": "2026-05-08T21:34:20.919250+00:00",
-      "resolved_at": "2026-05-08T23:19:16.069020+00:00"
+      "last_resolved": "e5fb212a4dbf3811c68c0796eee339066130852323a140d490af4f5c5b51c21e",
+      "last_tracked": "e5fb212a4dbf3811c68c0796eee339066130852323a140d490af4f5c5b51c21e",
+      "resolved_at": "2026-05-11T01:33:49.621938+00:00",
+      "tracked_at": "2026-05-11T01:33:49.621938+00:00"
     },
     ".claude/scratch/w8-kickoff-866.md": {
       "last_tracked": "5c407cebd5195c5423e6cbd413d09a53a6e01993d5d273acbfbced0af735d3b8",


### PR DESCRIPTION
## Summary

Closes #333 — `/wave-scope` Step 13 now cross-checks the built `REPOS_IN_SCOPE_JSON` against the reconciled meta-issue body. If body declares FEWER repos (deliberate descope), use body-derived set. If body declares EXTRA repos (operator forgot to update `WAVE_SCOPE_REPOS`), STOP with operator-guidance error.

## Origin (P3W8 kickoff failure)

- Meta-issue #331 body: "Scope (36 items, 3 tiers, **7 repos**)" — Tier 3 listed 6 child repos, no ingest-platform
- `/wave-start` correctly created branches in **7 repos** (inferred from body)
- `cross-repo-status.json` `wave_8_repos_in_scope`: 8 repos (canonical default, ingest-platform included)
- `/wave-kickoff` Step 0 read the 8-repo list; Step 0.5 pre-flight failed on ingest-platform (missing branch + missing label)
- Resolved by manual edit dropping ingest-platform from JSON

This PR closes the JSON-vs-meta drift before `/wave-kickoff` can hit it.

## Decision tree

| Body vs canonical | Action |
|---|---|
| `body ⊊ canonical` | Deliberate descope. Use body-derived set. |
| `body ⊋ canonical` | Operator forgot to update `WAVE_SCOPE_REPOS`. **STOP** with error. |
| `body = canonical` | No change. |

## What changed

`.claude/skills/wave-scope/SKILL.md` — adds a cross-check block between `REPOS_IN_SCOPE_JSON` construction (canonical / override) and the `wave_{M}_scope` building. Plus checksum bump.

Reference-extraction regex catches **both** observed shapes in real meta-issue bodies:

```
(1) Explicit cross-repo: `noorinalabs-isnad-graph#866`
(2) Section-header:      `- noorinalabs-isnad-graph: #866, #867, …`
```

Pattern: `(^|[^a-z])noorinalabs-[a-z][a-z0-9-]*(#[0-9]+|:)` — strips the suffix (`#N` or `:`) and `^[^a-z]*` prefix. Leading `(^|[^a-z])` prevents partial-word matches.

`noorinalabs-main` is always implicitly in scope (meta-issue lives there; self-refs use `main#N` or bare `#N`). Comparison set is the child-repos subset.

## Live-trace verification (against W8 #331)

```bash
$ META_BODY=$(gh issue view 331 --repo noorinalabs/noorinalabs-main --json body --jq '.body')
$ echo "$META_BODY" | grep -oE '(^|[^a-z])noorinalabs-[a-z][a-z0-9-]*(#[0-9]+|:)' \
    | sed -E 's/^[^a-z]*//; s/(#[0-9]+|:)$//' \
    | sort -u | grep -v '^noorinalabs-main$'
noorinalabs-data-acquisition
noorinalabs-deploy
noorinalabs-design-system
noorinalabs-isnad-graph
noorinalabs-landing-page
noorinalabs-user-service
```

→ 7 child repos. **Correctly EXCLUDES `noorinalabs-isnad-ingest-platform`** — matches what /wave-start actually inferred (and what the W8 manual fix resolved to). ✅

If this PR had landed before P3W8 kickoff, the gate would have caught the divergence at /wave-scope time and either descoped automatically OR surfaced the missing `WAVE_SCOPE_REPOS` env var.

## Charter / memory provenance

- Per `feedback_enforcement_hierarchy.md`: skill-tier check is the right rung for inter-skill canonical-truth divergence. Hook-tier would be too broad; charter-tier alone left the W8 gap.
- Per charter `pull-requests.md § Live-Trace Evidence > Synthetic-Test Acceptance`: live-trace verified against real W8 meta-issue.

## Acceptance per #333

- [x] Cross-check between built `REPOS_IN_SCOPE_JSON` and meta-issue body
- [x] `actual ⊊ canonical` → use actual (descope-from-meta path)
- [x] `actual ⊋ canonical` → STOP with operator-guidance error
- [x] `actual = canonical` → no change

## Out of scope

- Roster validation — `noorinalabs-main#319` already filed
- Refactoring the regex into a dedicated helper script — live-trace is the test surface here; standalone helper would be marginal value at a maintenance cost
- Backporting the cross-check to /wave-start (Step 0.5 pre-flight is the catching surface there already)

## Test plan

- [x] Live-trace against W8 #331 — correctly extracts 7 child repos (excludes ingest-platform)
- [x] Regex tested against both reference shapes (explicit `#N` AND section-header `:`)
- [x] `main`-suffix repo correctly always-implicitly-in-scope (filtered via `grep -v`)
- [x] Pre-commit hooks green
- [ ] Reviewer 1 — charter-format Approved
- [ ] Reviewer 2 — charter-format Approved
- [ ] Merges into `deployments/phase-3/wave-9`
