### PR TITLE
merge(wave-7→main): propagate stranded W7 work — 10 commits, no conflicts (closes #339)

### DIFF
--- a/.claude/hooks/_shell_parse.py
+++ b/.claude/hooks/_shell_parse.py
@@ -138,11 +138,23 @@ _GIT_BOOL_GLOBALS = {
     "--no-optional-locks",
 }
 
+# Backslash + newline = POSIX line continuation. The Claude Code harness passes
+# the raw bash command string including these sequences. shlex.split(posix=True)
+# does NOT consume them as line continuations — instead it emits the trailing
+# newline as a standalone token (issue #287), breaking command-position detection.
+_LINE_CONTINUATION_RE = re.compile(r"\\\n[ \t]*")
+
 
 def tokenize(cmd: str) -> list[str] | None:
-    """shlex.split the command. Return None on parse error (unbalanced quote)."""
+    """shlex.split the command. Return None on parse error (unbalanced quote).
+
+    Normalizes POSIX line-continuation sequences (backslash + newline) to a
+    single space before tokenizing. Without this, shlex.split(posix=True)
+    emits the trailing newline as a stray token that breaks command-position
+    detection (issue #287).
+    """
     try:
-        return shlex.split(cmd, posix=True)
+        return shlex.split(_LINE_CONTINUATION_RE.sub(" ", cmd), posix=True)
     except ValueError:
         return None
 

--- a/.claude/hooks/audit/parser_fixture_coverage.md
+++ b/.claude/hooks/audit/parser_fixture_coverage.md
@@ -1,0 +1,545 @@
+# Parser-Fixture Coverage Audit — noorinalabs-main
+
+**Audit date:** 2026-05-07
+**Auditor:** Wanjiku Mwangi (Technical Program Manager, Staff)
+**Wave:** P3W7
+**Meta-issue:** noorinalabs/noorinalabs-main#300
+**Charter ref:** `.claude/team/charter/hooks.md` § Parser-Fixture Coverage Requirements
+
+---
+
+## Summary
+
+| Metric | Count |
+|--------|-------|
+| Hook files at top level (`.claude/hooks/*.py`) | 31 |
+| Parser-class hooks | 14 |
+| Non-parser hooks | 17 |
+| Parser-class hooks WITH fixture coverage | 9 |
+| Parser-class hooks WITH GAPS | 5 |
+| Gap count (distinct uncovered shapes) | 17 |
+| In-wave Pattern G fixes | 0 |
+| Backport issues filed | 5 |
+
+**Coverage rate (parser-class hooks):** 9/14 = 64% have at least some coverage
+**Gap rate:** 5/14 = 36% of parser-class hooks have fixture gaps
+
+> **Note on hook count reconciliation:** Meta-issue #300 cites 48 hooks for noorinalabs-main. This audit finds 31 hooks under `.claude/hooks/*.py`. The discrepancy is likely the meta-issue counting all hooks across child repos accessible from the orchestrator (7 repos × ~6-7 hooks average ≈ 48) rather than the noorinalabs-main top-level count only. This Tier-1 scope is per-repo; 31 is the correct noorinalabs-main count.
+
+---
+
+## Parser-Class Definition (charter hooks.md)
+
+A hook is **parser-class** if it performs input parsing of any of:
+- Shell argv / shlex tokenization
+- Git output / ref names / commit messages
+- GitHub Actions YAML (`on.pull_request.paths:` etc.)
+- PR body markdown (Requestor/Requestee/TechDebt fields)
+- JSON API responses from gh api / gh pr view
+- Transcript JSONL (session transcript parsing)
+- Carry-forward marker patterns in skill args
+
+A hook is **non-parser** if it performs only:
+- Simple config/env-var checks
+- Regex allowlist matching on a single known-shape input
+- File hash computation
+- Time/staleness checks
+- Network calls to external APIs (Cloudflare, GHCR) without parsing structured input
+
+---
+
+## Hook Classification
+
+### Non-Parser Hooks (17)
+
+| Hook | Reason |
+|------|--------|
+| `_shell_parse.py` | Shared library (tested via consumers); not a hook itself |
+| `annunaki_log.py` | Shared utility — appends JSONL records, no input parsing |
+| `annunaki_monitor.py` | Pattern matching on stdout/stderr text; regex patterns, not structured parsing |
+| `auto_add_issue_to_board.py` | Regex URL extraction from `gh issue create` stdout; single known shape |
+| `block_gh_pr_review.py` | Simple regex match for `gh pr review` command; no structured parsing |
+| `block_shutdown_without_retro.py` | Uses `_shell_parse.is_shutdown_request_message`; has full test coverage |
+| `dispatcher.py` | Routing/orchestration only; no input parsing |
+| `enforce_ontology_context.py` | String marker scan on Agent prompt text; no structured parsing |
+| `no_worktree_self_delete.py` | Uses `_shell_parse` tokenizer; full test coverage |
+| `ontology_tracker.py` | SHA256 hash computation; path filtering via prefix/substring match |
+| `session_handoff.py` | Collects git/gh state via subprocess; no structured input parsing |
+| `session_start.py` | Reads JSON status files; emits directives; no command-shape parsing |
+| `suggest_generic_prompt.py` | File path string matching; no input parsing |
+| `validate_lockfile_paths.py` | Regex scan for `/tmp/` and `file:/` in file contents; simple pattern |
+| `validate_vps_host.py` | IP range lookup; no command-structure parsing |
+| `validate_wave_context.py` | Reads JSON status file; no command-shape parsing |
+| `warn_ghcr_image.py` | Regex match for `gh workflow run`; simple string extraction |
+
+---
+
+### Parser-Class Hooks (14)
+
+---
+
+#### 1. `_shell_parse.py` — Core Shell Parser Library
+
+| Attribute | Value |
+|-----------|-------|
+| **Input kind** | Shell argv (shlex tokenization), heredoc stripping, git subcommand extraction, gh subcommand extraction |
+| **Fixtures present** | `tests/test_shell_parse.py` |
+| **Test count** | 41 tests |
+| **Priority** | HIGH — foundation for 7+ hooks; parser bugs here propagate everywhere |
+
+**Input shapes known:**
+- Simple single-command (`git commit -m "msg"`)
+- Quoted argument values (`-c user.name="Firstname Lastname"`)
+- Heredoc bodies (`$(cat <<'EOF' ... EOF)`)
+- Compound commands with `&&`, `||`, `|`, `;`
+- Leading env-var assignments (`FOO=bar git commit`)
+- `-c=key=value` equals-form git globals
+- Unbalanced quotes (shlex parse failure → `None`)
+
+**Gaps:**
+- Nested command substitutions (`$(cmd1 $(cmd2))`) — only top-level heredocs stripped
+- Windows-style CRLF line endings in heredoc bodies
+- Tab-indented heredoc (`<<-EOF`) with mixed-indent content
+
+**Gap priority:** MEDIUM — edge cases not observed in production; no filed bugs yet.
+
+---
+
+#### 2. `validate_commit_identity.py` — Git Commit Identity Validation
+
+| Attribute | Value |
+|-----------|-------|
+| **Input kind** | git argv (shlex), `-c user.name=` / `-c user.email=` flag extraction, roster JSON, cross-repo `cd` path detection |
+| **Fixtures present** | `tests/test_validate_commit_identity.py` |
+| **Test count** | 19 tests |
+| **Priority** | HIGH — security-relevant; W6 sibling bug #287 |
+
+**Input shapes known:**
+- `git -c user.name="Name" -c user.email="email" commit -m "msg"`
+- Cross-repo: `cd /path && git ... commit`
+- Heredoc body containing `git commit` (should NOT match)
+- Parse failure with commit-looking text (fail-closed)
+- Repeated `-c user.name=` (last-wins semantics)
+
+**Gaps (production-discovered shapes):**
+- `#287` — backslash line continuation in commit command (e.g., `git \\\n -c user.name="Name" \\\n commit`). Filed as backport issue — **OPEN** (Tier-2 work item).
+- Multi-line `git commit -F /tmp/msg.txt` where identity flags span compound command (roster loaded from wrong repo)
+- `git -c user.name='Name With Apostrophe' commit` — single-quoted name with shlex interactions
+
+**Gap priority:** HIGH — `#287` is a known production bug. Single-quote variant is medium.
+
+---
+
+#### 3. `block_no_verify.py` — Block --no-verify Flag
+
+| Attribute | Value |
+|-----------|-------|
+| **Input kind** | git argv (shlex), `--no-verify` / `-n` flag detection in commit/push segments |
+| **Fixtures present** | `tests/test_block_no_verify.py` |
+| **Test count** | 12 tests |
+| **Priority** | MEDIUM |
+
+**Input shapes known:**
+- `git commit --no-verify` (long form)
+- `git commit -n` (short form, commit-only)
+- `git push --no-verify` (long form)
+- Command with `-c` globals before commit
+- Heredoc body mentioning `--no-verify` (should NOT match)
+- `gh issue` body mentioning `--no-verify` (should NOT match)
+- `echo "..."` mentioning phrase (should NOT match)
+
+**Gaps:**
+- `git commit --no-verify` with `=` form (if ever used)
+- Chained command where `--no-verify` appears in a later segment after a non-git command
+
+**Gap priority:** LOW — all observed production shapes covered; gaps are purely theoretical.
+
+---
+
+#### 4. `block_git_config.py` — Block git config Writes
+
+| Attribute | Value |
+|-----------|-------|
+| **Input kind** | git argv (shlex), `git config` subcommand detection, read-only flag checking |
+| **Fixtures present** | `tests/test_block_git_config.py` |
+| **Test count** | 14 tests |
+| **Priority** | MEDIUM |
+
+**Input shapes known:**
+- `git config user.name "Name"` (write)
+- `git config --global user.email "..."` (write)
+- `git -C /path config ...` (with `-C` global)
+- `git -c user.name=X commit` (per-commit flag — NOT a config write)
+- `--get`, `--list`, `-l` read-only flags (allowed)
+- Heredoc body mentioning `git config` (should NOT match)
+- `grep "git config" /tmp/x` (should NOT match)
+- `echo "..."` mentioning phrase (should NOT match)
+
+**Gaps:**
+- `git config --add` form (additive config; currently likely blocked, but not explicitly tested)
+- `git config --unset` form (deletion, should be blocked)
+- `git config --edit` form (launches editor; should be blocked but currently not specifically tested)
+
+**Gap priority:** LOW — `--add`/`--unset`/`--edit` are not observed in production; all common write patterns covered.
+
+---
+
+#### 5. `block_stale_tmp_message_file.py` — Block Stale /tmp Body Files
+
+| Attribute | Value |
+|-----------|-------|
+| **Input kind** | Shell command segment detection (`git commit`, `gh pr/issue create/comment/edit`), `-F`/`--file`/`--body-file` flag + path extraction |
+| **Fixtures present** | `tests/test_block_stale_tmp_message_file.py` |
+| **Test count** | 21 tests |
+| **Priority** | MEDIUM — surfaced in production (2026-05-03 ontology-rebuild incident) |
+
+**Input shapes known:**
+- `git commit -F /tmp/msg.txt` (fresh → allow; stale → block)
+- `git commit --file /tmp/msg.txt`
+- `gh pr create --body-file /tmp/body.md`
+- `gh issue create --body-file /tmp/body.md`
+- `gh pr comment N --body-file /tmp/body.md`
+- `gh issue comment N --body-file /tmp/body.md`
+- `gh pr create --body-file /tmp/body.md` (edit form)
+- Non-/tmp paths (should NOT match)
+- Inline `--body "..."` / `--message` (should NOT match)
+
+**Gaps:**
+- `git commit --body-file /tmp/...` (not a real git flag; probably fine to not cover)
+- `gh pr edit N --body-file /tmp/...` — `gh pr edit` variant; not in current test corpus
+- Multi-segment command where the `commit -F` is after a `&&` with a quoted multi-word path
+
+**Gap priority:** LOW — primary production shapes covered; gaps are theoretical edge cases.
+
+---
+
+#### 6. `validate_labels.py` — Validate gh issue create Labels
+
+| Attribute | Value |
+|-----------|-------|
+| **Input kind** | Shell argv (shlex), `--label`/`-l` flag extraction, `--repo`/`-R` flag extraction, comma-separated label values |
+| **Fixtures present** | `tests/test_validate_labels.py` |
+| **Test count** | 29 tests |
+| **Priority** | MEDIUM |
+
+**Input shapes known:**
+- `gh issue create --label tech-debt`
+- `gh issue create -l tech-debt`
+- `gh issue create --label "tech-debt,phase-3"` (comma-separated)
+- `--repo OWNER/REPO` flag
+- `-R OWNER/REPO` flag
+- Body content containing example label flags (should NOT extract as labels)
+- Code blocks inside body mentioning labels (should NOT extract)
+
+**Gaps:**
+- `gh issue create --label=tech-debt` (equals-form; shlex produces `--label=tech-debt` as one token; label extraction may not handle this)
+- Multiple repos in the same command (chained `gh issue create`)
+
+**Gap priority:** MEDIUM — `--label=` equals form is plausible and may silently skip validation.
+
+---
+
+#### 7. `validate_branch_freshness.py` — Branch Freshness Before PR
+
+| Attribute | Value |
+|-----------|-------|
+| **Input kind** | Shell argv (shlex), `--repo`/`-R`, `--base`/`-B`, `--head`/`-H` flag extraction, OWNER:branch cross-fork prefix stripping |
+| **Fixtures present** | `tests/test_validate_branch_freshness.py` |
+| **Test count** | 40 tests |
+| **Priority** | MEDIUM |
+
+**Input shapes known:**
+- `gh pr create --base main --head feature-branch`
+- `--repo OWNER/REPO` flag (long and short)
+- `--head OWNER:branch` cross-fork form (OWNER: prefix stripped)
+- `--base`/`--head` with equals form
+- Implicit repo resolution from cwd remote URL
+- `--base/-B`, `--head/-H` short forms
+
+**Gaps:**
+- `gh pr create` with no flags (all defaults; uses cwd — tested but API path may have edge cases)
+- Quoted flag values with spaces inside (e.g., `--head "feature branch with spaces"`)
+- `gh pr ready N` triggering the branch freshness check
+
+**Gap priority:** LOW — core flag shapes well covered; edge cases are low-probability.
+
+---
+
+#### 8. `validate_pr_review.py` — Two-Reviewer Enforcement
+
+| Attribute | Value |
+|-----------|-------|
+| **Input kind** | Shell command shape (regex), `gh pr merge` detection, PR number extraction, `--repo` extraction, charter-format PR body parsing (Requestor/Requestee/RequestOrReplied/TechDebt fields), branch head ref parsing for author lastname, JSON API responses |
+| **Fixtures present** | `tests/test_validate_pr_review.py` |
+| **Test count** | 55 tests |
+| **Priority** | HIGH — W6 production bug #294 (wave-branch head_ref misparse) |
+
+**Input shapes known:**
+- `gh pr merge N` (direct number)
+- `gh pr merge` (current branch)
+- `gh pr merge --repo OWNER/REPO N`
+- `--admin` override (short-circuit allow)
+- Charter comment body: `Requestor:`, `Requestee:`, `RequestOrReplied:`, `TechDebt:`
+- Markdown bold form: `**Requestor:**`, `**TechDebt:**`
+- `Approved`, `ChangesRequested`, `Changes Requested`, `Changes` verdict values
+- `Request`, `Reply`, `Replied` non-verdict values
+- `deployments/phase-{N}/wave-{M}` wave-branch head ref (W6 bug #294 — fixed)
+- `wave-bootstrap` label → Single-Reviewer Exception
+- TechDebt issue numbers (`TechDebt: #15, #16`)
+
+**Gaps:**
+- **Reviewer dedup key collision:** Two reviewers with same lastname but different first initials (e.g., `A.Smith` and `B.Smith`) — `_name_lastname` returns identical lastname; both still count as distinct reviewers IF full names differ (correct), but the lowercase full-name dedup key may produce unexpected behavior with very similar names
+- **Non-standard branch formats:** `deployments/phase-{N}/wave-{M}` is now covered (#294), but branches named directly without `{Initial}.{Lastname}` separator (e.g., hotfix branches `hotfix/some-fix`) → `branch_author_lastname` returns `None` → `check_comment_reviews` called with empty sentinel; behavior is to admit any reviewer — not explicitly tested
+- **Paginated comments:** Hook fetches `per_page=100` but does not paginate; PRs with >100 comments may miss later reviews
+- **Requestee field with parenthetical:** `Requestee: Nadia Khoury (Program Director)` — parenthetical stripping tested, but multi-word parentheticals with unicode or nested parens not covered
+
+**Gap priority:** HIGH for pagination gap (production-scale PRs can exceed 100 comments); MEDIUM for others.
+
+---
+
+#### 9. `validate_pr_ci_status.py` — CI Status Before Merge
+
+| Attribute | Value |
+|-----------|-------|
+| **Input kind** | Shell command shape (regex), `gh pr merge` detection, PR number extraction, `--repo` extraction, GitHub API `statusCheckRollup` JSON parsing |
+| **Fixtures present** | `tests/test_validate_pr_ci_status.py` |
+| **Test count** | 28 tests |
+| **Priority** | MEDIUM |
+
+**Input shapes known:**
+- `gh pr merge N`, `gh pr merge --repo OWNER/REPO`
+- `--admin` override, `--auto` flag (pending → warn-allow)
+- `FAILURE`, `CANCELLED`, `TIMED_OUT`, `ACTION_REQUIRED` conclusions → block
+- `SUCCESS`, `SKIPPED`, `NEUTRAL` conclusions → allow
+- Chromatic `NEUTRAL` → pending (allowlist)
+- `IN_PROGRESS`, `QUEUED`, `WAITING`, `REQUESTED`, `PENDING` statuses → pending
+
+**Gaps:**
+- `statusCheckRollup` with empty array `[]` — "no checks" state looks clean to this hook but may indicate uncovered workflow (root cause of deploy#153); currently a documented known gap
+- Check names with unicode or very long names that may trip `check_name()` truncation
+
+**Gap priority:** MEDIUM — empty rollup gap is documented; no fixture pinning the `[]` behavior.
+
+---
+
+#### 10. `validate_workflow_paths_coverage.py` — Workflow Paths Orphan Detection
+
+| Attribute | Value |
+|-----------|-------|
+| **Input kind** | Shell command shape (regex), `gh pr create`/`gh pr ready` detection, `--repo`/`--base`/`--head` extraction, GitHub Actions YAML parsing (`on.pull_request.paths:` via regex state machine), fnmatch glob matching |
+| **Fixtures present** | `tests/test_validate_workflow_paths_coverage.py` |
+| **Test count** | 45 tests |
+| **Priority** | HIGH — W6 production bug #289 (bare `on.pull_request:` misparse) |
+
+**Input shapes known:**
+- `gh pr create [--repo R] [--base B] [--head H]`
+- `gh pr ready N`
+- Chained commands with env-var prefixes
+- Workflow YAML forms: `on: [push, pull_request]` (inline)
+- `on: pull_request:` (block, no paths filter) → covers all
+- `on: pull_request: paths: [...]` (inline list form)
+- `on: pull_request: paths:` (block list form)
+- `on: pull_request: paths-ignore:` (ignore form)
+- `on:` at non-zero indent
+- `pull_request:` as last child of `on:` without paths key (W6 bug #289 — fixed)
+- fnmatch glob `**.github/workflows/**`
+
+**Gaps:**
+- **YAML anchor/alias forms** (`&anchor`, `*alias`) — not handled; parser returns `(set(), False)` = no coverage signal = fail-open. No fixture for anchored paths.
+- **Flow-mapping form** (`on: {pull_request: {paths: [...]}}`) — not handled by current line-by-line parser
+- **Multi-document YAML** (rare in workflows but possible) — parser starts from line 0 only
+- **`paths:` filter with only negative patterns** (all entries are `!glob`) — currently treated as having paths but no positive globs; coverage check may over-block
+
+**Gap priority:** MEDIUM — anchors/flow-maps are rare in this org's workflow style; the current parser handles all observed shapes. File as tech-debt for hardening.
+
+---
+
+#### 11. `validate_review_comment_format.py` — Requestor/Requestee Swap Detection
+
+| Attribute | Value |
+|-----------|-------|
+| **Input kind** | Shell command segment detection (`gh pr comment`), PR body extraction (heredoc, single-quoted, double-quoted string forms), `Requestor:`/`Requestee:`/`RequestOrReplied:` field detection, branch name parsing for author lastname |
+| **Fixtures present** | **NONE** |
+| **Test count** | 0 |
+| **Priority** | HIGH — parser-class hook with NO tests; branch name parsing is a known failure-prone pattern |
+
+**Input shapes known (from code analysis):**
+- `gh pr comment N --body "..."` (double-quoted)
+- `gh pr comment N --body '...'` (single-quoted)
+- `gh pr comment N --body "$(cat <<'EOF'\n...\nEOF)"` (heredoc)
+- Branch name format `{Initial}.{Lastname}/...` → extract lastname
+
+**Gaps (ALL gaps — no tests exist):**
+- Heredoc delimiter variations (`<<EOF`, `<<-EOF`, `<<"EOF"`)
+- `--body-file /tmp/...` (body from file; hook may not inspect file contents)
+- Branch name with dash separator `{Initial}.{Lastname}-{number}-{name}` (vs slash)
+- Env-var prefixed `gh pr comment` command
+- `gh pr comment` with `--repo OWNER/REPO` flag (cross-repo PR comment)
+- PR number from URL form (`https://github.com/.../pull/123`)
+- Requestee field with parenthetical role: `Requestee: Nadia Khoury (Program Director)`
+
+**Gap priority:** **HIGH** — zero coverage on a parser-class hook that controls merge traffic.
+
+---
+
+#### 12. `validate_wave_audit.py` — Wave Lifecycle Skill Gate
+
+| Attribute | Value |
+|-----------|-------|
+| **Input kind** | `tool_input.skill` exact matching, `tool_input.args` carry-forward marker parsing (regex), `cross-repo-status.json` JSON parsing for wave label, `wave-<N>` / `phase-<N>` ref name parsing |
+| **Fixtures present** | `tests/test_validate_wave_audit.py` |
+| **Test count** | 26 tests |
+| **Priority** | MEDIUM |
+
+**Input shapes known:**
+- `wave-wrapup`, `wave-retro`, `handoff` skill names
+- Other skill names (should NOT match)
+- Bash tool with wave-skill substrings (should NOT match)
+- Carry-forward markers: `carry-forward:`, `carry forward:`, `## Carry-forward`, `## Carry forward`, `#N → dest`, `#N -> dest`
+- No active wave (cross-repo-status.json `wave_active: false`) → allow with warning
+- `current_wave: "wave-10"` → label `p2-wave-10`
+- `current_wave: "wave-7"` with `phase: "phase-3"` → label `p3-wave-7`
+
+**Gaps:**
+- `current_wave` as integer rather than string (e.g., `"current_wave": 10`) — `re.fullmatch(r"wave-(\d+)", str(current))` handles via `str()` but the resulting label `wave-10` without phase prefix may not match actual labels
+- Carry-forward args containing the marker in a code block (backtick-fenced) — hook may treat code block content as carry-forward intent
+- `cross-repo-status.json` with `current_wave` as `null` — `str(None)` = `"None"` which won't match wave-N pattern → correct behavior but not explicitly tested
+
+**Gap priority:** LOW — current shapes well covered; edge cases are not production-observed.
+
+---
+
+#### 13. `enforce_librarian_consulted.py` — Ontology Librarian Gate
+
+| Attribute | Value |
+|-----------|-------|
+| **Input kind** | Transcript JSONL parsing (line-by-line JSON objects), `message.content` parsing (str or `list[dict]` block forms), `tool_use` block extraction for `Skill` tool calls, sentinel file hash computation |
+| **Fixtures present** | `tests/test_enforce_librarian_consulted.py` |
+| **Test count** | 29 tests |
+| **Priority** | MEDIUM |
+
+**Input shapes known:**
+- Transcript JSONL with `type: "user"` / `type: "assistant"` objects
+- Content as plain string with librarian markers
+- Content as list with `type: "text"` blocks
+- Content as list with `type: "tool_use"` blocks (`name: "Skill"`, `input.skill: "ontology-librarian"`)
+- Sentinel file (`cwd | sha1sum | cut -c1-16`) attesting librarian consultation
+- Allow-listed paths: `/tmp/**`, `**/memory/*.md`, `**/MEMORY.md`, `~/.claude/**`, `.claude/annunaki/*`
+
+**Gaps:**
+- Transcript JSONL with non-standard `type` values (e.g., `"system"`, `"tool_result"`) — should skip gracefully; not explicitly tested
+- Content list with nested blocks (e.g., `tool_result` containing `text` blocks with librarian markers)
+- Sentinel file with stale mtime (does the sentinel expire? Code shows no expiry check — potential false acceptance after long sessions)
+- `file_path` with symlinks resolving to allow-listed paths but not matching string prefix
+
+**Gap priority:** LOW — primary shapes covered; edge cases are theoretical.
+
+---
+
+#### 14. `validate_edit_completion.py` — Edit Error Sentinel
+
+| Attribute | Value |
+|-----------|-------|
+| **Input kind** | Tool response `is_error` field (top-level and in `content` list), transcript JSONL parsing for acknowledgment detection (Read/Bash cat/head/tail/grep/less/ls), sentinel JSONL file format |
+| **Fixtures present** | `tests/test_validate_edit_completion.py` |
+| **Test count** | 39 tests |
+| **Priority** | MEDIUM |
+
+**Input shapes known:**
+- `tool_response` with `is_error: true` at top level
+- `tool_response` with `content: [{is_error: true, ...}]` list form
+- `tool_response` with non-zero Bash exit code
+- Bash acknowledgment: `cat /path`, `head /path`, `tail /path`, `grep ... /path`, `less /path`, `ls /path`
+- `Read` tool_use on the errored file path
+- `SendMessage` with body containing `"edit-error acknowledged" + file_path`
+- Multi-error sentinel (multiple unacknowledged edits)
+- Session-ID-keyed sentinel files
+
+**Gaps:**
+- Sentinel JSONL with malformed lines (partial writes from concurrent hook invocations)
+- Bash acknowledgment with quoted path containing spaces (`cat "/path with spaces/file"`)
+- Acknowledgment via `grep -r pattern /dir/` (directory path, not exact file path)
+- `Write` tool_use on the errored file as acknowledgment (currently only `Read` counts)
+
+**Gap priority:** LOW — primary shapes well covered; edge cases are theoretical.
+
+---
+
+## Coverage Table Summary
+
+| Hook | Input Kind | Shapes Known | Fixture | Gaps | Priority |
+|------|-----------|-------------|---------|------|----------|
+| `_shell_parse.py` | Shell argv, heredoc | 7 shapes | ✓ (41 tests) | Nested subst, CRLF, tab-indent heredoc | MEDIUM |
+| `validate_commit_identity.py` | git argv, roster JSON, cd-path | 5 shapes | ✓ (19 tests) | #287 backslash-cont, single-quote name | HIGH |
+| `block_no_verify.py` | git argv | 8 shapes | ✓ (12 tests) | `=` form, late-segment position | LOW |
+| `block_git_config.py` | git argv | 8 shapes | ✓ (14 tests) | `--add`, `--unset`, `--edit` forms | LOW |
+| `block_stale_tmp_message_file.py` | Shell segment, `-F`/`--body-file` | 9 shapes | ✓ (21 tests) | `gh pr edit`, multi-segment quoted path | LOW |
+| `validate_labels.py` | Shell argv (shlex) | 7 shapes | ✓ (29 tests) | `--label=` equals form | MEDIUM |
+| `validate_branch_freshness.py` | Shell argv (shlex), gh flags | 6 shapes | ✓ (40 tests) | No-flag defaults, quoted-space values | LOW |
+| `validate_pr_review.py` | Shell cmd, PR body markdown, JSON | 12 shapes | ✓ (55 tests) | Pagination >100 comments, non-std branches | HIGH |
+| `validate_pr_ci_status.py` | Shell cmd, GitHub API JSON | 8 shapes | ✓ (28 tests) | Empty `statusCheckRollup: []` | MEDIUM |
+| `validate_workflow_paths_coverage.py` | Shell cmd, GitHub Actions YAML | 10 shapes | ✓ (45 tests) | Anchors, flow-maps, multi-doc YAML | MEDIUM |
+| `validate_review_comment_format.py` | Shell cmd, PR body (3 quote forms) | 7 shapes | **NONE** | ALL GAPS — zero coverage | **HIGH** |
+| `validate_wave_audit.py` | Skill args, cross-repo-status JSON | 7 shapes | ✓ (26 tests) | Integer `current_wave`, null handling | LOW |
+| `enforce_librarian_consulted.py` | Transcript JSONL, content blocks | 6 shapes | ✓ (29 tests) | Tool_result content, sentinel expiry | LOW |
+| `validate_edit_completion.py` | Tool response JSON, transcript JSONL | 8 shapes | ✓ (39 tests) | Quoted-space paths, Write acknowledgment | LOW |
+
+---
+
+## Prioritized Gap List
+
+### HIGH priority — file backport issues
+
+1. **`validate_review_comment_format.py` — ZERO coverage** (backport issue filed: #[see below])
+   - All 7 input shapes uncover
+   - Branch name dash-separator variant uncover
+   - `--body-file` form uncovered
+
+2. **`validate_pr_review.py` — pagination gap** (backport issue filed: #[see below])
+   - `per_page=100` limit not paginated; PRs with >100 comments may miss reviews
+   - `statusCheckRollup: []` not a validate_pr_review gap (belongs to validate_pr_ci_status)
+
+3. **`validate_commit_identity.py` — #287 backslash-continuation** (Tier-2 open work item)
+   - Already tracked as main#287; no new issue needed
+
+### MEDIUM priority — file backport issues
+
+4. **`validate_labels.py` — `--label=` equals form** (backport issue filed: #[see below])
+   - `gh issue create --label=tech-debt` may silently skip validation
+
+5. **`validate_workflow_paths_coverage.py` — YAML anchor/flow-map forms** (backport issue filed: #[see below])
+   - Workflow files using anchors or flow-mapping syntax would fail-open silently
+
+6. **`validate_pr_ci_status.py` — empty statusCheckRollup** (backport issue filed: #[see below])
+   - `[]` array = no checks = looks clean; documented gap but no pinning fixture
+
+### LOW priority — not filing issues (carry to regular backlog)
+
+- `_shell_parse.py`: nested subst, CRLF, tab-indent heredoc
+- `block_no_verify.py`: equals form, late-segment position
+- `block_git_config.py`: `--add`, `--unset`, `--edit` forms
+- `block_stale_tmp_message_file.py`: `gh pr edit` variant
+- `validate_branch_freshness.py`: no-flag defaults, quoted-space values
+- `validate_wave_audit.py`: integer `current_wave`
+- `enforce_librarian_consulted.py`: tool_result content, sentinel expiry
+- `validate_edit_completion.py`: quoted-space paths, Write acknowledgment
+
+---
+
+## Pattern G Observations (in-wave bugs)
+
+**None found during this audit pass.** All parser logic reviewed appeared correct for observed production input shapes. The high-priority gaps are absence-of-tests rather than incorrect behavior.
+
+The `validate_review_comment_format.py` zero-coverage finding is the most concerning — it has no tests at all, meaning any parser bug would be invisible until production discovery.
+
+---
+
+## Backport Issues Filed
+
+| # | Hook | Gap | Issue |
+|---|------|-----|-------|
+| 1 | `validate_review_comment_format.py` | Zero fixture coverage — all 7 input shapes | #302 |
+| 2 | `validate_pr_review.py` | Comment pagination >100 not covered | #303 |
+| 3 | `validate_labels.py` | `--label=` equals-form silently skips validation | #304 |
+| 4 | `validate_workflow_paths_coverage.py` | YAML anchor and flow-mapping forms | #306 |
+| 5 | `validate_pr_ci_status.py` | Empty `statusCheckRollup: []` not pinned | #307 |

--- a/.claude/hooks/fixtures/validate_commit_identity/adjacent_commit_amend.json
+++ b/.claude/hooks/fixtures/validate_commit_identity/adjacent_commit_amend.json
@@ -1,0 +1,5 @@
+{
+  "description": "Adjacent shape: git commit --amend (amending last commit)",
+  "command": "git -c user.name=\"Aino Virtanen\" -c user.email=\"parametrization+Aino.Virtanen@gmail.com\" commit --amend --no-edit",
+  "expect": "allow"
+}

--- a/.claude/hooks/fixtures/validate_commit_identity/adjacent_heredoc_minus_m.json
+++ b/.claude/hooks/fixtures/validate_commit_identity/adjacent_heredoc_minus_m.json
@@ -1,0 +1,5 @@
+{
+  "description": "Adjacent shape: -m with $(cat <<'EOF' ... EOF) command substitution (feedback_heredoc_in_git_commit)",
+  "command": "git -c user.name=\"Aino Virtanen\" -c user.email=\"parametrization+Aino.Virtanen@gmail.com\" commit -m \"$(cat <<'EOF'\nmulti\nline\nmessage\nEOF\n)\"",
+  "expect": "allow"
+}

--- a/.claude/hooks/fixtures/validate_commit_identity/adjacent_multi_dash_c.json
+++ b/.claude/hooks/fixtures/validate_commit_identity/adjacent_multi_dash_c.json
@@ -1,0 +1,5 @@
+{
+  "description": "Adjacent shape: git -c gpg.format=ssh plus identity flags (multi -c flags beyond identity)",
+  "command": "git -c gpg.format=ssh -c user.name=\"Aino Virtanen\" -c user.email=\"parametrization+Aino.Virtanen@gmail.com\" commit -m \"chore: signed commit with extra -c flags\"",
+  "expect": "allow"
+}

--- a/.claude/hooks/fixtures/validate_commit_identity/adjacent_worktree_add_commit_in_branch.json
+++ b/.claude/hooks/fixtures/validate_commit_identity/adjacent_worktree_add_commit_in_branch.json
@@ -1,0 +1,5 @@
+{
+  "description": "Adjacent shape: git worktree add with 'commit' appearing in branch name — must NOT be blocked",
+  "command": "git worktree add /tmp/wt-a-virtanen-287 -b A.Virtanen/0287-fix-validate-commit-identity-backslash origin/deployments/phase-3/wave-7",
+  "expect": "allow"
+}

--- a/.claude/hooks/fixtures/validate_commit_identity/bug_backslash_line_continuation.json
+++ b/.claude/hooks/fixtures/validate_commit_identity/bug_backslash_line_continuation.json
@@ -1,0 +1,5 @@
+{
+  "description": "Bug #287: backslash-line-continuation in git commit command — must be allowed, not false-blocked",
+  "command": "git -c user.name=\"Aino Virtanen\" \\\n    -c user.email=\"parametrization+Aino.Virtanen@gmail.com\" \\\n    commit -m \"fix: apply parser fix (#287)\"",
+  "expect": "allow"
+}

--- a/.claude/hooks/fixtures/validate_commit_identity/happy_commit_file.json
+++ b/.claude/hooks/fixtures/validate_commit_identity/happy_commit_file.json
@@ -1,0 +1,5 @@
+{
+  "description": "Happy path: git commit -F /tmp/msg.txt (file-based message per feedback_heredoc_in_git_commit)",
+  "command": "git -c user.name=\"Aino Virtanen\" -c user.email=\"parametrization+Aino.Virtanen@gmail.com\" commit -F /tmp/287-commit-msg.txt",
+  "expect": "allow"
+}

--- a/.claude/hooks/fixtures/validate_commit_identity/happy_single_line.json
+++ b/.claude/hooks/fixtures/validate_commit_identity/happy_single_line.json
@@ -1,0 +1,5 @@
+{
+  "description": "Happy path: single-line git commit with quoted -c flags",
+  "command": "git -c user.name=\"Aino Virtanen\" -c user.email=\"parametrization+Aino.Virtanen@gmail.com\" commit -m \"fix: straightforward single-line commit\"",
+  "expect": "allow"
+}

--- a/.claude/hooks/fixtures/validate_commit_identity/negative_mismatched_email.json
+++ b/.claude/hooks/fixtures/validate_commit_identity/negative_mismatched_email.json
@@ -1,0 +1,5 @@
+{
+  "description": "Negative: user.email does not match roster entry for user.name — must be blocked",
+  "command": "git -c user.name=\"Aino Virtanen\" -c user.email=\"wrong.email@example.com\" commit -m \"wrong email\"",
+  "expect": "block:email mismatch"
+}

--- a/.claude/hooks/fixtures/validate_commit_identity/negative_missing_user_email.json
+++ b/.claude/hooks/fixtures/validate_commit_identity/negative_missing_user_email.json
@@ -1,0 +1,5 @@
+{
+  "description": "Negative: missing -c user.email= flag — must be blocked",
+  "command": "git -c user.name=\"Aino Virtanen\" commit -m \"missing email flag\"",
+  "expect": "block:missing user.email"
+}

--- a/.claude/hooks/fixtures/validate_commit_identity/negative_missing_user_name.json
+++ b/.claude/hooks/fixtures/validate_commit_identity/negative_missing_user_name.json
@@ -1,0 +1,5 @@
+{
+  "description": "Negative: missing -c user.name= flag — must be blocked",
+  "command": "git -c user.email=\"parametrization+Aino.Virtanen@gmail.com\" commit -m \"missing name flag\"",
+  "expect": "block:missing user.name"
+}

--- a/.claude/hooks/fixtures/validate_commit_identity/negative_no_identity_at_all.json
+++ b/.claude/hooks/fixtures/validate_commit_identity/negative_no_identity_at_all.json
@@ -1,0 +1,5 @@
+{
+  "description": "Negative: bare git commit with no -c flags — must be blocked",
+  "command": "git commit -m \"no identity flags at all\"",
+  "expect": "block:missing user.name"
+}

--- a/.claude/hooks/fixtures/validate_commit_identity/negative_unrecognized_name.json
+++ b/.claude/hooks/fixtures/validate_commit_identity/negative_unrecognized_name.json
@@ -1,0 +1,5 @@
+{
+  "description": "Negative: user.name not in roster — must be blocked",
+  "command": "git -c user.name=\"Totally Fake Person\" -c user.email=\"fake@example.com\" commit -m \"not in roster\"",
+  "expect": "block:unrecognized name"
+}

--- a/.claude/hooks/tests/test_validate_commit_identity.py
+++ b/.claude/hooks/tests/test_validate_commit_identity.py
@@ -341,7 +341,9 @@ class ParseFailureFailClosedTests(unittest.TestCase):
         )
         assert result is not None
         self.assertEqual(result["decision"], "block")
-        self.assertIn("shlex parsing", result["reason"])
+        # Reason must indicate parse failure and actionable guidance
+        # (message updated in #287 to be more precise than "shlex parsing").
+        self.assertIn("unbalanced quotes", result["reason"])
 
     def test_unbalanced_quote_without_commit_allows(self):
         """Parse failure on a non-commit command → allow (no commit to validate)."""

--- a/.claude/hooks/tests/test_validate_commit_identity_parser.py
+++ b/.claude/hooks/tests/test_validate_commit_identity_parser.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Fixture-driven parser tests for validate_commit_identity hook.
+
+Each JSON file in fixtures/validate_commit_identity/ is one test case:
+
+    {
+        "description": "<human label>",
+        "command": "<raw bash command string>",
+        "expect": "allow" | "block:<reason-keyword>"
+    }
+
+The `expect` field:
+  - "allow"         → check() must return None
+  - "block:<kw>"    → check() must return a block decision; <kw> is a
+                      substring of the reason (case-insensitive) for
+                      self-documenting test output, not strict matching.
+
+Run:  python3 -m pytest .claude/hooks/tests/test_validate_commit_identity_parser.py -v
+      (or the full suite: python3 -m pytest .claude/hooks/tests/ -v)
+
+Covers:
+  Bug shape  — backslash-line-continuation (#287)
+  Happy path — single-line, -F file, multi -c, --amend
+  Adjacent   — heredoc -m, gpg -c, worktree add with 'commit' in branch name
+  Negative   — missing name, missing email, mismatched email, unrecognized name
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_HOOKS_DIR = _HERE.parent
+_FIXTURES_DIR = _HOOKS_DIR / "fixtures" / "validate_commit_identity"
+
+sys.path.insert(0, str(_HOOKS_DIR))
+
+import validate_commit_identity as hook  # noqa: E402
+
+
+def _load_fixtures() -> list[tuple[str, dict]]:
+    """Return (fixture_name, fixture_data) pairs for every JSON in the fixture dir."""
+    fixtures = []
+    for path in sorted(_FIXTURES_DIR.glob("*.json")):
+        data = json.loads(path.read_text(encoding="utf-8"))
+        fixtures.append((path.stem, data))
+    return fixtures
+
+
+def _make_input(command: str) -> dict:
+    return {"tool_name": "Bash", "tool_input": {"command": command}}
+
+
+class FixtureDrivenParserTests(unittest.TestCase):
+    """One test method per fixture file — generated dynamically."""
+
+
+def _add_fixture_test(name: str, fixture: dict) -> None:
+    """Attach a test method to FixtureDrivenParserTests for `fixture`."""
+    description = fixture.get("description", name)
+    command = fixture["command"]
+    expect = fixture["expect"]
+
+    def test_method(self: unittest.TestCase) -> None:
+        result = hook.check(_make_input(command))
+        if expect == "allow":
+            self.assertIsNone(
+                result,
+                f"{description!r}: expected allow (None) but got block: {result}",
+            )
+        elif expect.startswith("block:"):
+            self.assertIsNotNone(
+                result,
+                f"{description!r}: expected block but got allow (None)",
+            )
+            assert result is not None  # for mypy
+            self.assertEqual(
+                result.get("decision"),
+                "block",
+                f"{description!r}: result decision is not 'block': {result}",
+            )
+        else:
+            raise ValueError(f"Unknown expect value {expect!r} in fixture {name!r}")
+
+    test_method.__name__ = f"test_{name}"
+    test_method.__doc__ = description
+    setattr(FixtureDrivenParserTests, test_method.__name__, test_method)
+
+
+for _fixture_name, _fixture_data in _load_fixtures():
+    _add_fixture_test(_fixture_name, _fixture_data)
+
+
+class LineContinuationNormalizationTests(unittest.TestCase):
+    """Unit tests for the backslash-newline normalization in _shell_parse.tokenize."""
+
+    def test_backslash_newline_not_in_tokens(self):
+        """After normalization, no newline char token appears in the output."""
+        import _shell_parse as sp
+
+        cmd = 'git -c user.name="X" \\\n    -c user.email="y@z.com" commit -m "m"'
+        tokens = sp.tokenize(cmd)
+        self.assertIsNotNone(tokens)
+        self.assertNotIn("\n", tokens, "Newline char must not appear as a standalone token")
+        self.assertNotIn("n", tokens, "Stray 'n' token must not appear after normalization")
+
+    def test_commit_subcommand_found_after_continuation(self):
+        """find_git_subcommand resolves to 'commit' even with backslash-continuation."""
+        import _shell_parse as sp
+
+        cmd = 'git -c user.name="X" \\\n    -c user.email="y@z.com" \\\n    commit -m "m"'
+        tokens = sp.tokenize(cmd)
+        self.assertIsNotNone(tokens)
+        for seg in sp.iter_command_segments(tokens):
+            decoded = sp.find_git_subcommand(seg)
+            if decoded is not None:
+                _globals, rest = decoded
+                if rest and rest[0] == "commit":
+                    return  # found it
+        self.fail(
+            "commit subcommand not found in tokens after backslash-continuation normalization"
+        )
+
+    def test_normalization_does_not_break_quoted_values(self):
+        """Quoted values containing literal spaces survive normalization correctly."""
+        import _shell_parse as sp
+
+        cmd = 'git -c user.name="Aino Virtanen" \\\n    commit -m "multi word message"'
+        tokens = sp.tokenize(cmd)
+        self.assertIsNotNone(tokens)
+        self.assertIn("user.name=Aino Virtanen", tokens)
+        self.assertIn("multi word message", tokens)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/hooks/tests/test_validate_workflow_paths_coverage.py
+++ b/.claude/hooks/tests/test_validate_workflow_paths_coverage.py
@@ -70,6 +70,64 @@ class IsGhPrGateCommandTests(unittest.TestCase):
         """grep with the phrase in pattern position — should NOT match."""
         self.assertFalse(hook._is_gh_pr_gate_command("grep 'gh pr create' /tmp/file"))
 
+    def test_line_continuation_pr_create_matches(self):
+        """Backslash-newline line continuation in gh pr create — transitive #305 fix.
+
+        _shell_parse.tokenize() normalizes '\\\\\\n' to ' ' before shlex.split,
+        so a multi-line gh pr create still lands at command position and matches.
+        """
+        cmd = "gh pr create \\\n  --title 'fix: thing' \\\n  --base main"
+        self.assertTrue(hook._is_gh_pr_gate_command(cmd))
+
+    def test_line_continuation_pr_ready_matches(self):
+        """gh pr ready with line continuation — transitive #305 fix."""
+        cmd = "gh pr ready \\\n  123"
+        self.assertTrue(hook._is_gh_pr_gate_command(cmd))
+
+    def test_heredoc_containing_gh_pr_create_does_not_match(self):
+        """gh pr create text INSIDE a heredoc body must NOT trigger the gate.
+
+        strip_heredocs() removes the body before tokenization, so `gh pr create`
+        appearing as document content is never seen as a command token.
+        """
+        cmd = "cat <<EOF\ngh pr create --base main\nEOF\necho done"
+        self.assertFalse(hook._is_gh_pr_gate_command(cmd))
+
+    def test_chained_with_line_continuation_matches(self):
+        """git push && gh pr create across a line continuation — #305 transitive."""
+        cmd = "git push origin feature \\\n  && gh pr create --base main"
+        self.assertTrue(hook._is_gh_pr_gate_command(cmd))
+
+
+class WalkFlagValueTests(unittest.TestCase):
+    """_walk_flag_value: token-based flag extraction."""
+
+    def test_space_separated_form(self):
+        tokens = ["gh", "pr", "create", "--base", "main"]
+        self.assertEqual(hook._walk_flag_value(tokens, "base"), "main")
+
+    def test_equals_form(self):
+        tokens = ["gh", "pr", "create", "--base=develop"]
+        self.assertEqual(hook._walk_flag_value(tokens, "base"), "develop")
+
+    def test_absent_returns_none(self):
+        tokens = ["gh", "pr", "create"]
+        self.assertIsNone(hook._walk_flag_value(tokens, "base"))
+
+    def test_flag_value_inside_body_not_extracted(self):
+        """Flag value inside --body is a single token; won't match as --repo value.
+
+        shlex collapses quoted body to one token, so '--repo' inside the body
+        string is never a separate token in flag position.
+        """
+        tokens = ["gh", "pr", "create", "--body", "use --repo x/y here"]
+        self.assertIsNone(hook._walk_flag_value(tokens, "repo"))
+
+    def test_flag_at_end_with_no_value_returns_none(self):
+        """Flag token at end of list with no following value."""
+        tokens = ["gh", "pr", "create", "--base"]
+        self.assertIsNone(hook._walk_flag_value(tokens, "base"))
+
 
 class ExtractFlagTests(unittest.TestCase):
     """_extract_flag covers --flag value, --flag=value, --flag "quoted"."""
@@ -94,6 +152,25 @@ class ExtractFlagTests(unittest.TestCase):
 
     def test_absent_flag_returns_none(self):
         self.assertIsNone(hook._extract_flag("gh pr create", "base"))
+
+    def test_repo_value_in_quoted_body_not_extracted(self):
+        """--repo value inside --body quoted string must NOT be extracted as --repo.
+
+        shlex collapses the quoted body to one token, so the --repo substring
+        inside it is never seen as a flag token by _walk_flag_value.
+        """
+        cmd = 'gh pr create --body "link: --repo x/y here" --repo noorinalabs/test'
+        self.assertEqual(hook._extract_flag(cmd, "repo"), "noorinalabs/test")
+
+    def test_flag_extracted_after_line_continuation(self):
+        """--repo flag value after a backslash-newline continuation — #305 transitive."""
+        cmd = "gh pr create \\\n  --repo noorinalabs/test \\\n  --base main"
+        self.assertEqual(hook._extract_flag(cmd, "repo"), "noorinalabs/test")
+
+    def test_base_extracted_after_line_continuation(self):
+        """--base after line continuation tokenizes correctly."""
+        cmd = "gh pr create \\\n  --base deployments/phase-3/wave-7"
+        self.assertEqual(hook._extract_flag(cmd, "base"), "deployments/phase-3/wave-7")
 
 
 class ParseWorkflowPathsTests(unittest.TestCase):

--- a/.claude/hooks/validate_commit_identity.py
+++ b/.claude/hooks/validate_commit_identity.py
@@ -127,24 +127,25 @@ def _detect_target_roster(command: str) -> dict[str, str] | None:
     return merged or None
 
 
-def _find_commit_segment(command: str) -> list[str] | None:
-    """Find the `git ... commit ...` segment in `command`. None if absent.
+_PARSE_FAILURE = object()  # sentinel: tokenize returned None
+
+
+def _find_commit_segment(command: str) -> list[str] | None | object:
+    """Find the `git ... commit ...` segment in `command`.
+
+    Returns:
+      - list[str]      — the commit segment tokens (allow identity validation)
+      - None           — tokenize succeeded but no commit subcommand found
+      - _PARSE_FAILURE — tokenize failed (unbalanced quotes); caller must use
+                         regex fallback
 
     Strips heredocs first so a heredoc body containing the literal phrase
-    "git commit" cannot be confused with a real invocation. Tokenizes the
-    cleaned command with shlex, walks each pipeline segment, and returns
-    the first segment whose `find_git_subcommand` resolves to subcommand
-    `commit`.
-
-    Returns None on parse failure OR when there is no commit. The caller
-    distinguishes the two via `_looks_like_git_commit` so a malformed-but-
-    suspicious command falls through to a fail-closed regex path instead
-    of being silently allowed (per `_shell_parse.tokenize` contract).
+    "git commit" cannot be confused with a real invocation.
     """
     cleaned = strip_heredocs(command)
     tokens = tokenize(cleaned)
     if tokens is None:
-        return None
+        return _PARSE_FAILURE
     for segment in iter_command_segments(tokens):
         decoded = find_git_subcommand(segment)
         if decoded is None:
@@ -156,11 +157,12 @@ def _find_commit_segment(command: str) -> list[str] | None:
 
 
 # Regex-only heuristic for the parse-failure fallback: did the command,
-# after stripping heredocs, contain `git ... commit` at command position?
-# Anchored at start-of-line or after a shell operator. Liberal on purpose
-# — when shlex fails we want to err on the side of validating identity.
+# after stripping heredocs, contain `git commit` as a standalone subcommand
+# (not embedded in a path/branch-name)?  Anchored at start-of-line or after a
+# shell operator. Requires `commit` to appear as a word-boundary token
+# separated from options by whitespace (not inside a slash-separated path).
 _COMMIT_FALLBACK_RE = re.compile(
-    r"(?:^|[;&|]\s*|&&\s*|\|\|\s*)\s*git\b[^;&|]*?\bcommit\b",
+    r"(?:^|[;&|]\s*|&&\s*|\|\|\s*)\s*git\b[^;&|]*?(?<!\S)\bcommit\b(?!\S*/)",
     re.MULTILINE,
 )
 
@@ -187,25 +189,29 @@ def check(input_data: dict) -> dict | None:
     command = input_data.get("tool_input", {}).get("command", "")
 
     commit_segment = _find_commit_segment(command)
-    if commit_segment is None:
-        # Parse-failure fail-closed path: shlex couldn't tokenize, but the
-        # command LOOKS like it contains a `git commit`. Block with a
-        # parse-failure-specific message so the operator can fix the quoting
-        # and retry. Allowing here would create a hole — paste a malformed
-        # `git commit` and bypass identity validation.
+    if commit_segment is _PARSE_FAILURE:
+        # tokenize() returned None — shlex could not parse the command. Use
+        # the regex fallback: if it looks like a git commit, block (fail-closed);
+        # otherwise allow (fail-open for non-commit commands).
         if not _looks_like_git_commit(command):
             return None
         result = {
             "decision": "block",
             "reason": (
-                "BLOCKED: git commit detected but command failed shlex parsing "
-                "(likely unbalanced quotes). Cannot validate `-c user.name=` / "
-                "`-c user.email=` flags from a malformed command. Fix the "
-                "quoting and retry."
+                "BLOCKED: git commit detected but the command contains unbalanced "
+                "quotes or other syntax shlex cannot parse. Cannot safely validate "
+                "`-c user.name=` / `-c user.email=` identity flags. Fix the quoting "
+                "(e.g. use -F /tmp/msg.txt instead of inline -m with unbalanced "
+                "quotes) and retry."
             ),
         }
         log_pretooluse_block("validate_commit_identity", command, result["reason"])
         return result
+    if commit_segment is None:
+        # Tokenize succeeded but no git commit subcommand was found.
+        return None
+
+    assert isinstance(commit_segment, list)  # _PARSE_FAILURE and None already handled above
 
     # Cross-repo support: if the command `cd`s into another repo, load that
     # repo's roster instead of the local one.

--- a/.claude/hooks/validate_workflow_paths_coverage.py
+++ b/.claude/hooks/validate_workflow_paths_coverage.py
@@ -97,13 +97,21 @@ import subprocess
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _shell_parse import (  # noqa: E402
+    find_gh_subcommand,
+    iter_command_segments,
+    strip_heredocs,
+    tokenize,
+)
 from annunaki_log import log_pretooluse_block  # noqa: E402
 
 # --- Command-shape matchers -------------------------------------------------
 
-# Match `gh pr create` / `gh pr ready` at command position. Liberal pattern
-# (chained command via &&/||/|/; is fine; leading env-var assignments are
-# handled by stripping them before matching).
+_GH_PR_GATE_ACTIONS = {"create", "ready"}
+
+# Regex fallback used only when shlex tokenization fails (unbalanced quotes,
+# malformed input). Intentionally kept so the hook degrades to the old
+# substring-match path rather than silently allowing on parse failure.
 _GH_PR_GATE_RE = re.compile(
     r"(?:^|[;&|]\s*|&&\s*|\|\|\s*)\s*"
     r"(?:[A-Za-z_][A-Za-z0-9_]*=\S+\s+)*"
@@ -111,29 +119,69 @@ _GH_PR_GATE_RE = re.compile(
     re.MULTILINE,
 )
 
-# Flag extraction (single shlex-aware pass via simple regex; matches
-# `--flag value` and `--flag=value`). Conservative — false negatives just
-# mean we fall back to defaults (cwd repo / main / current branch).
-_FLAG_VALUE_RE = re.compile(
-    r"--{flag}(?:=|\s+)([^\s'\"]+)|--{flag}\s+\"([^\"]+)\"|--{flag}\s+'([^']+)'"
-)
+
+def _is_gh_pr_gate_command(command: str) -> bool:
+    """True if any segment of `command` is a `gh pr create` or `gh pr ready` call.
+
+    Uses _shell_parse.tokenize + find_gh_subcommand for command-position detection.
+    Falls back to regex on shlex parse failure (fail-open for the gate check:
+    a false negative just means we proceed to the coverage check).
+    Inherits _shell_parse.tokenize() line-continuation normalization from #305.
+    """
+    cleaned = strip_heredocs(command)
+    tokens = tokenize(cleaned)
+    if tokens is None:
+        return bool(_GH_PR_GATE_RE.search(command))
+    for segment in iter_command_segments(tokens):
+        result = find_gh_subcommand(segment)
+        if result is None:
+            continue
+        _globals, rest = result
+        if len(rest) >= 2 and rest[0] == "pr" and rest[1] in _GH_PR_GATE_ACTIONS:
+            return True
+    return False
 
 
-def _extract_flag(command: str, flag: str) -> str | None:
-    """Return the value of --flag from `command`, or None if absent."""
-    pat = _FLAG_VALUE_RE.pattern.replace("{flag}", re.escape(flag))
-    m = re.search(pat, command)
-    if not m:
-        return None
-    for grp in m.groups():
-        if grp:
-            return grp
+def _walk_flag_value(tokens: list[str], flag: str) -> str | None:
+    """Return the first value of `--flag` found in `tokens`, or None.
+
+    Handles `--flag value` (two tokens) and `--flag=value` (one token).
+    Only matches tokens in flag position — never inside quoted values of
+    other flags (shlex has already collapsed those to single tokens).
+    """
+    for i, tok in enumerate(tokens):
+        if tok == f"--{flag}" and i + 1 < len(tokens):
+            return tokens[i + 1]
+        if tok.startswith(f"--{flag}="):
+            return tok[len(flag) + 3 :]
     return None
 
 
-def _is_gh_pr_gate_command(command: str) -> bool:
-    """True if the command contains a `gh pr create` or `gh pr ready` at command position."""
-    return bool(_GH_PR_GATE_RE.search(command))
+def _extract_flag(command: str, flag: str) -> str | None:
+    """Return the value of --flag from `command`, or None if absent.
+
+    Tokenizes with _shell_parse.tokenize() so flag values inside quoted
+    --body strings or heredocs cannot masquerade as --repo/--base/--head.
+    Falls back to a regex scan on shlex parse failure (fail-open: a false
+    negative means we fall back to the default value in callers).
+    """
+    cleaned = strip_heredocs(command)
+    tokens = tokenize(cleaned)
+    if tokens is None:
+        f = re.escape(flag)
+        pat = (
+            rf"--{f}(?:=|\s+)([^\s'\"]+)"
+            rf"|--{f}\s+\"([^\"]+)\""
+            rf"|--{f}\s+'([^']+)'"
+        )
+        m = re.search(pat, command)
+        if not m:
+            return None
+        for grp in m.groups():
+            if grp:
+                return grp
+        return None
+    return _walk_flag_value(tokens, flag)
 
 
 # --- Workflow paths filter parsing ------------------------------------------

--- a/.claude/skills/wave-kickoff/SKILL.md
+++ b/.claude/skills/wave-kickoff/SKILL.md
@@ -107,8 +107,11 @@ for R in $WAVE_REPOS_IN_SCOPE; do
     BRANCH_STATUS[$R]="error:cannot-read-main"; continue;
   }
 
-  # Probe existing branch
+  # Probe existing branch. gh api returns the raw 404 JSON body when the ref is absent,
+  # which --jq passes through unchanged (non-40-hex). Guard with shape validator so a
+  # missing branch yields EXISTING_SHA="" rather than the error body. (live-trigger: e906e135)
   EXISTING_SHA=$(gh api "repos/noorinalabs/$R/git/refs/heads/$BRANCH" --jq '.object.sha' 2>/dev/null || true)
+  [[ "$EXISTING_SHA" =~ ^[0-9a-f]{40}$ ]] || EXISTING_SHA=""
 
   if [ -n "$EXISTING_SHA" ]; then
     BRANCH_SHA[$R]="$EXISTING_SHA"

--- a/.claude/skills/wave-kickoff/fixtures/README.md
+++ b/.claude/skills/wave-kickoff/fixtures/README.md
@@ -1,0 +1,21 @@
+# wave-kickoff parser fixtures
+
+Covers the EXISTING_SHA capture in Step 1 (branch existence probe via `gh api .../git/refs/heads/<branch>`).
+
+| File | Shape | Expected EXISTING_SHA after validator |
+|------|-------|--------------------------------------|
+| `existing_sha_404.json` | 404 error body (live-trigger: e906e135) | `""` (empty) |
+| `existing_sha_happy.json` | Valid commit ref response | 40-hex SHA |
+| `existing_sha_null_jq.json` | Response where `.object.sha` is JSON null (jq yields string "null") | `""` (empty) |
+| `existing_sha_tag_ref.json` | Tag ref (annotated tag SHA — valid 40-hex, different object type) | 40-hex SHA |
+
+## Validator invariant
+
+After `EXISTING_SHA=$(gh api ... --jq '.object.sha' 2>/dev/null || true)`:
+
+```bash
+[[ "$EXISTING_SHA" =~ ^[0-9a-f]{40}$ ]] || EXISTING_SHA=""
+```
+
+- Any non-40-hex value (JSON error body, "null" string, empty) → `EXISTING_SHA=""`
+- Valid commit or tag SHA → preserved as-is

--- a/.claude/skills/wave-kickoff/fixtures/existing_sha_404.json
+++ b/.claude/skills/wave-kickoff/fixtures/existing_sha_404.json
@@ -1,0 +1,1 @@
+{"message":"Not Found","documentation_url":"https://docs.github.com/rest/git/refs#get-all-references-in-a-namespace","status":"404"}

--- a/.claude/skills/wave-kickoff/fixtures/existing_sha_happy.json
+++ b/.claude/skills/wave-kickoff/fixtures/existing_sha_happy.json
@@ -1,0 +1,1 @@
+{"ref":"refs/heads/deployments/phase-3/wave-7","node_id":"REF_example","url":"https://api.github.com/repos/noorinalabs/noorinalabs-main/git/refs/heads/deployments/phase-3/wave-7","object":{"sha":"05f18753441147bb92d4b502738ae8235475b3f0","type":"commit","url":"https://api.github.com/repos/noorinalabs/noorinalabs-main/git/commits/05f18753441147bb92d4b502738ae8235475b3f0"}}

--- a/.claude/skills/wave-kickoff/fixtures/existing_sha_null_jq.json
+++ b/.claude/skills/wave-kickoff/fixtures/existing_sha_null_jq.json
@@ -1,0 +1,1 @@
+{"ref":"refs/heads/deployments/phase-3/wave-7","node_id":"REF_example","url":"https://api.github.com/repos/noorinalabs/noorinalabs-main/git/refs/heads/deployments/phase-3/wave-7","object":{"sha":null,"type":"commit","url":"https://api.github.com/repos/noorinalabs/noorinalabs-main/git/commits/null"}}

--- a/.claude/skills/wave-kickoff/fixtures/existing_sha_tag_ref.json
+++ b/.claude/skills/wave-kickoff/fixtures/existing_sha_tag_ref.json
@@ -1,0 +1,1 @@
+{"ref":"refs/tags/v1.2.3","node_id":"REF_tag_example","url":"https://api.github.com/repos/noorinalabs/noorinalabs-main/git/refs/tags/v1.2.3","object":{"sha":"abc123def456abc123def456abc123def456abc1","type":"tag","url":"https://api.github.com/repos/noorinalabs/noorinalabs-main/git/tags/abc123def456abc123def456abc123def456abc1"}}

--- a/.claude/skills/wave-kickoff/tests/test_existing_sha_validator.py
+++ b/.claude/skills/wave-kickoff/tests/test_existing_sha_validator.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Tests for the EXISTING_SHA shape validator in wave-kickoff Step 1.
+
+The validator guards against gh api returning the raw 404 JSON error body when
+a branch doesn't exist, which was captured live during P3W7 kickoff (e906e135).
+
+Run: ENVIRONMENT=test python3 -m pytest .claude/skills/wave-kickoff/tests/test_existing_sha_validator.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import unittest
+from pathlib import Path
+
+_FIXTURES = Path(__file__).resolve().parent.parent / "fixtures"
+
+SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+
+
+def _apply_validator(raw: str) -> str:
+    """Mirror the bash validator: return raw if valid 40-hex, else empty string."""
+    if SHA_PATTERN.match(raw):
+        return raw
+    return ""
+
+
+def _jq_object_sha(fixture_path: Path) -> str:
+    """Run jq '.object.sha' against fixture, returning raw stdout (mirrors gh api --jq)."""
+    result = subprocess.run(
+        ["jq", "-r", ".object.sha"],
+        input=fixture_path.read_text(encoding="utf-8"),
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+class TestExistingShaValidator(unittest.TestCase):
+
+    def test_404_body_yields_empty(self):
+        """Live-trigger fixture: 404 JSON error body must produce EXISTING_SHA=""."""
+        fixture = _FIXTURES / "existing_sha_404.json"
+        data = json.loads(fixture.read_text())
+        self.assertEqual(data["status"], "404")
+
+        raw_jq = _jq_object_sha(fixture)
+        result = _apply_validator(raw_jq)
+        self.assertEqual(result, "", f"Expected empty, got [{result!r}] from 404 body")
+
+    def test_happy_path_preserves_sha(self):
+        """Valid 40-hex commit SHA must be preserved unchanged."""
+        fixture = _FIXTURES / "existing_sha_happy.json"
+        data = json.loads(fixture.read_text())
+        expected_sha = data["object"]["sha"]
+        self.assertRegex(expected_sha, r"^[0-9a-f]{40}$")
+
+        raw_jq = _jq_object_sha(fixture)
+        result = _apply_validator(raw_jq)
+        self.assertEqual(result, expected_sha)
+
+    def test_null_sha_yields_empty(self):
+        """When jq returns 'null' string (object.sha is JSON null), validator must clear it."""
+        fixture = _FIXTURES / "existing_sha_null_jq.json"
+        raw_jq = _jq_object_sha(fixture)
+        self.assertEqual(raw_jq, "null")
+
+        result = _apply_validator(raw_jq)
+        self.assertEqual(result, "", f"Expected empty for null sha, got [{result!r}]")
+
+    def test_tag_ref_sha_preserved(self):
+        """Tag ref SHA (still 40-hex) must pass through validator unchanged."""
+        fixture = _FIXTURES / "existing_sha_tag_ref.json"
+        data = json.loads(fixture.read_text())
+        expected_sha = data["object"]["sha"]
+        self.assertRegex(expected_sha, r"^[0-9a-f]{40}$")
+
+        raw_jq = _jq_object_sha(fixture)
+        result = _apply_validator(raw_jq)
+        self.assertEqual(result, expected_sha)
+
+    def test_raw_404_string_capture_yields_empty(self):
+        """When EXISTING_SHA holds the raw 404 JSON body string (no jq), validator clears it."""
+        raw = '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/git/refs#get-all-references-in-a-namespace","status":"404"}'
+        result = _apply_validator(raw)
+        self.assertEqual(result, "", f"Expected empty, got [{result!r}]")
+
+    def test_empty_string_yields_empty(self):
+        """Empty string (e.g. api call failed entirely) must stay empty."""
+        self.assertEqual(_apply_validator(""), "")
+
+    def test_short_hex_rejected(self):
+        """A SHA shorter than 40 hex chars must not pass (truncated/corrupt output)."""
+        self.assertEqual(_apply_validator("abc123"), "")
+
+    def test_uppercase_hex_rejected(self):
+        """GitHub SHAs are lowercase; uppercase must be rejected as non-canonical."""
+        self.assertEqual(_apply_validator("E906E135D811CDE" + "a" * 25), "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/team/audit/p3w7-cross-repo-parser-fixture-summary.md
+++ b/.claude/team/audit/p3w7-cross-repo-parser-fixture-summary.md
@@ -1,0 +1,188 @@
+# P3W7 Cross-Repo Parser-Fixture Coverage Audit — Summary
+
+**Wave:** Phase 3, Wave 7  
+**Meta-issue:** noorinalabs-main#300  
+**Authored by:** Nadia Khoury (Program Director)  
+**Date:** 2026-05-08  
+**Status:** All 10 wave PRs merged; 0 admin overrides
+
+---
+
+## 1. Executive Thesis
+
+The wave applied `charter/hooks.md § Parser-Fixture Coverage Requirements` (introduced W6 via PR #299) retroactively across all 8 NoorinALabs repos. The audit's central finding is a gap at the **parent→child update boundary**: fixture-first discipline was enforced in the parent canonical repo (`noorinalabs-main`) but hook-owning child repos that copied hooks in earlier waves did not inherit the fixture discipline. However, the deeper finding from committed-tree inspection (not filesystem enumeration) is that **all 7 child repos have already migrated to dispatcher-style** — they hold 0 committed local `.claude/hooks/` files, delegating entirely to the parent canonical via `settings.json`. The wave's audit work primarily *confirmed* that migration was already complete, while also establishing the first generation of charter reference implementations (PRs #301 and #305) for the new fixture-with-fix rule.
+
+The target state — dispatcher-style children where the parent canonical holds all hook code and all fixtures — is **already realized across the organization**. The backport issues filed this wave address fixture gaps in the parent's own test suite for hooks that were under-tested before the charter rule existed.
+
+---
+
+## 2. Per-Repo State Table
+
+| Repo | Classification | W7 Audit PR | Prior Migration PR | Remaining Work |
+|------|---------------|-------------|-------------------|---------------|
+| `noorinalabs-main` | **Hook-owning** (parent canonical) | #308 (Wanjiku, main parser audit) | — (canonical origin) | Backport issues filed in-wave; W8 carry-forward list below |
+| `noorinalabs-isnad-graph` | **Dispatcher-style** | #871 (Anya Kowalczyk audit) | No committed local files — never had local hooks (worktree artifacts only, per Arjun R2) | Backport issues filed; no local hook maintenance burden |
+| `noorinalabs-user-service` | **Dispatcher-style** | #100 (Mateo audit) | P3W5 #96 (commit 2191b1af) removed stale local copies | None — already dispatcher confirmed by Anya-K R2 |
+| `noorinalabs-deploy` | **Dispatcher-style** | #279 (Bereket deploy audit) | Stale copies are untracked working-directory artifacts only (Weronika R2) | Untracked artifacts may need cleanup; no committed hook burden |
+| `noorinalabs-design-system` | **Dispatcher-style** | #73 (Kofi audit) | W5 #66 removed stale local copies | None — already dispatcher confirmed by Beren R2 |
+| `noorinalabs-data-acquisition` | **Dispatcher-style** | #45 (Sofia audit) | `.claude/hooks/` directory never existed in committed tree (Jeanclaude R2) | None |
+| `noorinalabs-landing-page` | **Dispatcher-style** | #87 (Nazia audit) | W5 #79 removed stale local copies | None — already dispatcher confirmed |
+| `noorinalabs-isnad-ingest-platform` | **No hooks** (placeholder) | — (skip per meta-issue scope) | — | Placeholder slot; no action required |
+
+**Key correction:** Early audit framing used "stale-mirror" language for 3 repos (design-system, user-service, data-acquisition). Committed-tree inspection via `gh api repos/<repo>/git/trees/<sha>?recursive=1` showed no committed local hook files. The "stale-mirror" classification was a methodological error (see § 4 below).
+
+---
+
+## 3. Wave Deliverables Tally
+
+**PRs merged:** 10 total, 0 admin overrides, all at 2026-05-08T02:49–02:50Z
+
+| Tier | Repo | PR | Merge SHA | Authors |
+|------|------|-----|-----------|---------|
+| T2 | main | #305 (main#287 fix+fixtures) | eef6dc0f | Aino Virtanen |
+| T2 | main | #301 (main#285 fix+fixtures) | 3b7b121b | Wanjiku Mwangi |
+| T1 | main | #308 (main parser audit) | a08676aa | Wanjiku Mwangi |
+| T1 | isnad-graph | #871 (Anya Kowalczyk audit) | 843ce62a | Anya Kowalczyk |
+| T1 | user-service | #100 (Mateo audit) | cc54f7e8 | Mateo Salazar |
+| T3 | deploy | #278 (Bereket Alertmanager #274) | 61a803d2 | Bereket Tadesse |
+| T1 | deploy | #279 (Bereket deploy audit) | d6c03ccf | Bereket Tadesse |
+| T1 | design-system | #73 (Kofi audit) | 4ff9f8d9 | Kofi Mensah |
+| T1 | data-acquisition | #45 (Sofia audit) | 07275d8d | Sofia Cardoso |
+| T1 | landing-page | #87 (Nazia audit) | 9302f8e2 | Nazia (landing-page roster) |
+
+**Backport issues filed:** ~20 across repos (in-wave discovered parser gaps, Node 20 deprecation × 5 at wrapup via #309, plus 5 child-repo issues).
+
+**Implementer substitutions recorded in `cross-repo-status.json`:** 2 (`wave_7_decisions` field).
+
+**Charter reference PRs:** #301 + #305 are the first PRs to land under `charter § Parser-Fixture Coverage Requirements` (rule introduced W6 via #299). They are the worked examples future reviewers can cite.
+
+---
+
+## 4. Cross-Cutting Patterns Identified
+
+### 4a. Pattern G — Live-trace acceptance template (canonical: PR #301)
+
+**Shape:** Production trigger commit (e.g., e906e135) surfaces a parser failure → in-band workaround applied → backport PR filed with fixture that pins the exact trigger input shape, plus adjacent shapes discovered during triage.
+
+**Implementation:** PR #301 (Wanjiku, main#285 fix) is the canonical Pattern G reference implementation: fix + fixture in the same commit, fixture named after the trigger commit, workaround documented in PR body. Recommend this as the required template for all future production-discovered parser bugs.
+
+### 4b. Shared-utility hardening pattern (canonical: PR #305)
+
+**Shape:** Parser fix applied at the `_shell_parse.tokenize()` module level rather than at individual call sites. All hooks that import `_shell_parse` benefit automatically, with no per-hook follow-up required.
+
+**Implementation:** PR #305 (Aino, main#287 fix) is the canonical example. The `_shell_parse` module is the emerging centralization point for shell-input parsing across all parent-canonical hooks. Fixes there propagate organization-wide.
+
+### 4c. Charter rule reference implementations (PRs #301 + #305)
+
+Both PRs are the first post-`§ Parser-Fixture Coverage Requirements` merges. They demonstrate: fixture-with-fix in a single commit, coverage of the bug shape plus adjacent shapes, CI passing as acceptance. Future PR reviewers can cite these as the worked examples for the rule's application.
+
+### 4d. Filesystem enumeration ≠ committed tree (methodological finding)
+
+Three of seven child-repo audits initially misclassified repos as "stale-mirror hook-owning" based on filesystem enumeration. All three misclassifications shared a single root cause: the auditor enumerated working-directory files (including worktree artifacts and untracked files) instead of the committed git tree.
+
+**Verified correct method:** `gh api repos/<owner>/<repo>/git/trees/<head_sha>?recursive=1` — queries the committed tree at a specific SHA, excluding untracked files, worktree artifacts, and gitignored content.
+
+This is a charter-promotion candidate (see § 5, Proposal 2).
+
+### 4e. Silent-no-op family of GitHub CLI bugs (3 surfaces this wave)
+
+Three distinct silent-no-op patterns reproduced this wave:
+
+1. **`gh project item-add`** — silently no-ops on cross-repo project boards. Affected: Wanjiku #308 × 5 issues, Sofia #45 × 2, Mateo #100 × 2. Working pattern: GraphQL `addProjectV2ItemById` mutation + PVTI node read-back verify.
+
+2. **`gh project item-list --limit N`** — returns false matches on multi-repo boards because issue numbers collide across repos. Working pattern: PVTI node lookup, never filter by issue number alone.
+
+3. **`gh api -X PATCH -f body=@file`** — silently passes the literal string `@file` as the body value. Affected: Kofi #73 PR body update. Working pattern: `--field "body=$content"` with inline shell expansion.
+
+Existing memory `feedback_gh_pr_edit_silent_noop.md` should be extended to cover this whole family (see § 5, Proposal 3).
+
+---
+
+## 5. Charter Change Proposals
+
+These proposals are NOT applied in this PR. They require separate review per `feedback_enforcement_hierarchy.md` (hook > skill > charter). Each is filed as a separate issue in W8 scope or marked as a charter-change PR candidate.
+
+### Proposal 1 — Dispatcher-children sub-clause (charter `hooks.md § 5`)
+
+**Target:** `charter/hooks.md § 5. Parser-Fixture Coverage Requirements`
+
+**Change:** Add a sub-clause explicitly exempting children with no committed `.claude/hooks/` files from per-child fixture obligations. The existing rule's requirement ("Every hook with input parsing MUST have test fixtures") applies to hook-owning repos; dispatcher-style children satisfy coverage obligations through the parent-canonical test suite.
+
+**Rationale:** The current rule text is silent on dispatcher-style children, creating ambiguity for future auditors. Design-system and landing-page are exemplars of the exempt pattern.
+
+**Proposed language:**
+> **Dispatcher-style children (no committed `.claude/hooks/`):** Children that delegate all hook execution to the parent canonical via `settings.json` are exempt from per-child fixture requirements. Coverage obligations are fulfilled by the parent's test suite. A child is classified as dispatcher-style when `gh api repos/<owner>/<repo>/git/trees/<head_sha>?recursive=1` returns 0 entries under `.claude/hooks/`. Design-system and landing-page (post-W5) are the canonical exemplars.
+
+### Proposal 2 — Audit Protocol section (charter `hooks.md`, new section)
+
+**Target:** `charter/hooks.md` — add `§ Hook Audit Protocol` after existing sections
+
+**Change:** Codify `gh api repos/<repo>/git/trees/<sha>?recursive=1` as the mandatory first verification step in all hook audits. Prohibit classifying a repo's hook status from filesystem enumeration alone.
+
+**Rationale:** Three misclassifications this wave from the same root cause (filesystem vs. committed tree). The correct method is one API call away; codifying it prevents recurrence.
+
+**Proposed section:**
+> **§ Hook Audit Protocol**
+>
+> When auditing a repo's hook ownership status (hook-owning vs. dispatcher-style):
+> 1. Fetch the committed tree: `gh api repos/<owner>/<repo>/git/trees/<head_sha>?recursive=1 --jq '[.tree[].path | select(startswith(".claude/hooks/"))]'`
+> 2. Classification: if the result is empty (`[]`), the repo is dispatcher-style. If non-empty, it is hook-owning.
+> 3. Filesystem enumeration (SSH, ls, find) is NOT a valid substitute — it includes untracked files, worktree artifacts, and gitignored content that are invisible to git.
+
+### Proposal 3 — Memory extension (not a charter change)
+
+**Target:** `feedback_gh_pr_edit_silent_noop.md` in project memory
+
+**Change:** Extend to cover the full silent-no-op family identified this wave (see § 4e above). Current entry covers only `gh pr edit --body-file`. The three new surfaces are `gh project item-add`, `gh project item-list --limit N`, and `gh api -X PATCH -f body=@file`.
+
+**Implementation:** Memory update (no charter PR needed). Team lead or Wanjiku to apply post-merge.
+
+---
+
+## 6. Acceptance Criteria Reconciliation (vs. meta-issue #300)
+
+| Acceptance bullet | Status |
+|------------------|--------|
+| All 8 Tier-1 audit PRs merged | MET — #308 (main), #871 (isnad-graph), #100 (user-service), #279 (deploy), #73 (design-system), #45 (data-acquisition), #87 (landing-page); ingest-platform = 0-hooks skip per scope | 
+| Both Tier-2 fix+fixture PRs merged | MET — #301 (main#285), #305 (main#287) |
+| deploy#274 merged | MET — PR #278 |
+| Cross-repo audit summary PR (★ Nadia) merged | IN PROGRESS — this PR |
+| Audit-discovered parser bugs filed in-wave | MET — ~20 backport issues filed; critical bugs (Pattern G) fixed in-wave via #301, #305 |
+| 0 admin overrides | MET — 0 overrides across all 10 PRs |
+
+**All acceptance bullets met or actively closing.**
+
+---
+
+## 7. W8 Carry-Forward Recommendations
+
+The following items should be folded into W8 scope during `/wave-scope`:
+
+### Backport issues filed this wave (~20 total)
+
+Exact issue list is in child-repo issue trackers and `cross-repo-status.json`. Priority-order recommendation:
+
+1. **main — parser fixture gaps** from #308 audit (high priority — these are in the canonical hook repo)
+2. **deploy — untracked artifact cleanup** — Weronika-flagged stale working-directory hook artifacts; not a registered-hook risk but creates audit noise
+3. **isnad-graph — worktree artifact cleanup** — Arjun-flagged `.claude/worktrees/*/` copies; same category as deploy artifacts
+
+### Charter change proposals (Proposals 1 + 2 above)
+
+Both are P3W8 candidates. Proposal 1 (dispatcher-children sub-clause) is lower scope and should be done early in W8 to prevent auditor confusion. Proposal 2 (Audit Protocol section) is a companion and should ship in the same charter-change PR.
+
+### Node 20 deprecation issues (× 5, filed during wrapup via #309)
+
+Filed in parallel during wave wrapup. Should be labeled for W8 and added to project board.
+
+### 5 child-repo issues filed during wrapup
+
+Same as above — verify they have W8 labels and project board entries.
+
+### Memory update (Proposal 3)
+
+Extend `feedback_gh_pr_edit_silent_noop.md` with the 3 new silent-no-op surfaces. Low-effort; can be done by any team member early in W8 session.
+
+---
+
+*Authored by Nadia Khoury (Program Director) — P3W7 ★ cross-repo audit summary*  
+*Refs: meta-issue #300, PRs #301 #305 #308 #871 #100 #278 #279 #73 #45 #87*


### PR DESCRIPTION
## Summary

Closes #339 — propagation PR for the stranded `noorinalabs-main` `deployments/phase-3/wave-7` branch. Brings 10 commits of legitimate W7 work to `main` via a clean merge commit from a branch off `main`'s current HEAD (no rewrite of `wave-7` itself).

## Origin (#339 — wave-7 stranded)

`deployments/phase-3/wave-7` ended up `ahead_by=10, behind_by=31, status=diverged` from main with **0** wave-7 → main PRs ever opened. The wave was treated as closed because PRs into the wave-branch merged, but the wave-branch itself never reached main. **PR #305 (validate_commit_identity backslash fix)** and 11 hook fixtures sat stranded.

This PR is the propagation. Verified live-trace via the new `/wave-wrapup` Step 11.5 reachability gate (PR #365) — the gate would have caught this had it been in place at W7 wrap.

## What's brought forward (10 commits)

| # | Commit | Work |
|---|---|---|
| 1 | `75c53d0` | tech-debt(/wave-kickoff): EXISTING_SHA 404 body capture fix + 4 fixtures (#285) |
| 2 | `4315af2` | tech-debt(hook): validate_commit_identity backslash-line-continuation parsing + 11 fixtures (#287) |
| 3 | `7b4c0b9` | audit(P3W7): noorinalabs-main parser-fixture coverage (#300) |
| 4 | `eef6dc0` | Merge PR #305 (the #287 fix) |
| 5 | `3b7b121` | Merge PR #301 (the #285 fix) |
| 6 | `a08676a` | Merge PR #308 (the #300 audit) |
| 7 | `d7f16f3` | feat(audit): P3W7 cross-repo parser-fixture coverage summary (#300 ★) |
| 8 | `2d68b63` | tech-debt(hook): validate_workflow_paths_coverage refactor to _shell_parse + fixtures (#260) |
| 9 | `25100c8` | Merge PR #310 (the cross-repo summary) |
| 10 | `093792a` | Merge PR #312 (the workflow refactor) |

## Net file additions

```
+ 14 fixture JSONs (.claude/hooks/fixtures/validate_commit_identity/*)
+ test_validate_commit_identity_parser.py (139 lines)
+ test_validate_workflow_paths_coverage.py modifications (+77)
+ test_validate_commit_identity.py modifications (+3/-1)
+ .claude/hooks/audit/parser_fixture_coverage.md (545 lines)
+ .claude/team/audit/p3w7-cross-repo-parser-fixture-summary.md (188 lines)
+ /wave-kickoff fixtures + test (existing_sha_*, 4 JSONs + 1 test 104 lines)
~ validate_commit_identity.py (+32/-26)
~ validate_workflow_paths_coverage.py (+69/-21)
~ _shell_parse.py (+14/-2)
```

## Merge mechanics

Created `N.Khoury/0339-wave-7-propagation` from `main` HEAD, then `git merge --no-ff origin/deployments/phase-3/wave-7`. **No conflicts** — wave-7's changes are mostly additive (new fixtures, tests, audit docs); the file modifications didn't overlap with the W8/W9 work that landed on main since wave-7 forked.

The `wave-7` branch itself is NOT modified by this PR (no rewrite, no force-push). It remains as historical record.

## Live-trace verification

Post-merge state at origin (expected after this PR lands):
- `gh api .../compare/main...deployments/phase-3/wave-7` → expected `ahead_by=0` (wave-7 fully propagated)
- New `/wave-wrapup` Step 11.5 gate (PR #365) would now pass on wave-7

Test suite at branch HEAD: **515/515 pass**. `ruff check` clean. `ruff format --check` clean.

## Why now and not earlier

W7's PR #305 (the validate_commit_identity backslash fix) was the obvious miss — it's a hook bug fix that was on wave-7 but never reached main. W8/W9 added separate hook improvements (#345 parse-failure msg, #353 Reply-vs-Approved, #364 swap callout) without ever picking up the W7 backslash fix as a base.

Per memory `feedback_wave_branch_issue_close.md`: this stranding pattern is exactly what `/wave-wrapup` Step 11.5 (added by PR #365 this wave) will now prevent in W10+. This PR closes the loop on the W7 instance.

## Closes

- #339 — wave-7 stranded propagation (this PR's primary deliverable)

(Companion isnad-graph half: PR `noorinalabs-isnad-graph#875` — landed earlier this session.)

## Test plan

- [x] `pytest .claude/hooks/tests/` — 515 passed
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] No conflicts in merge (clean integration)
- [x] Commit identity via `-c` flags (Nadia Khoury — orchestration role for cross-wave propagation)
- [ ] Reviewer 1 — charter-format Approved
- [ ] Reviewer 2 — charter-format Approved
- [ ] Merges into `main`
