### PR TITLE
tech-debt(hook): ruff format vwpc.py (closes #373)

### DIFF
--- a/.claude/hooks/validate_workflow_paths_coverage.py
+++ b/.claude/hooks/validate_workflow_paths_coverage.py
@@ -169,11 +169,7 @@ def _extract_flag(command: str, flag: str) -> str | None:
     tokens = tokenize(cleaned)
     if tokens is None:
         f = re.escape(flag)
-        pat = (
-            rf"--{f}(?:=|\s+)([^\s'\"]+)"
-            rf"|--{f}\s+\"([^\"]+)\""
-            rf"|--{f}\s+'([^']+)'"
-        )
+        pat = rf"--{f}(?:=|\s+)([^\s'\"]+)" rf"|--{f}\s+\"([^\"]+)\"" rf"|--{f}\s+'([^']+)'"
         m = re.search(pat, command)
         if not m:
             return None


### PR DESCRIPTION
## Summary

Applies `uvx ruff@0.7.4 format` to `.claude/hooks/validate_workflow_paths_coverage.py`. The drift is a 4-line `rf"..."` concatenation in `_extract_flag`'s regex-fallback block (lines 169-175) introduced by the #260 refactor (commit `2d68b63`). Ruff prefers the joined single-line form. Regex pattern is semantically identical — only whitespace and source layout change.

## Diff

```
-        pat = (
-            rf"--{f}(?:=|\s+)([^\s'\"]+)"
-            rf"|--{f}\s+\"([^\"]+)\""
-            rf"|--{f}\s+'([^']+)'"
-        )
+        pat = rf"--{f}(?:=|\s+)([^\s'\"]+)" rf"|--{f}\s+\"([^\"]+)\"" rf"|--{f}\s+'([^']+)'"
```

1 insertion, 5 deletions.

## Validation

- **Before:** `uvx ruff@0.7.4 format --check .claude/hooks/` → `51 files already formatted, 1 would be reformatted`
- **After:** `uvx ruff@0.7.4 format --check .claude/hooks/` → `52 files already formatted`
- **Regression:** `python3 -m unittest discover -s .claude/hooks/tests -p "test_validate_workflow_paths_coverage*"` → **57/57 OK**
- **Pre-commit hooks:** ruff-format, ruff-lint, mypy all passed on commit.

## Test plan

- [ ] CI green
- [ ] Two reviewers (charter-required) approve with `RequestOrReplied: Approved` + `TechDebt:` line
- [ ] After merge to wave-9, `gh issue view 373` confirms auto-close (note: wave-branch merges don't auto-close per memory `feedback_wave_branch_issue_close` — explicit `gh issue close 373` required after wave-9 → main propagation, OR close directly on this PR's merge to wave-9 by manual edit if `Closes #373` doesn't fire)
- [ ] `uvx ruff@0.7.4 format --check .claude/hooks/` remains clean on subsequent commits this wave

## Relates to

- Closes #373
- Origin commit: `2d68b63ac7` (#260 refactor that introduced the drift)
- Surfaced in: PR #371 review by reviewers Aino Virtanen and Wanjiku Mwangi (https://github.com/noorinalabs/noorinalabs-main/pull/371#issuecomment-4417076354)
- Memory: `feedback_ruff_format_check_before_push.md`
