### PR TITLE
tech-debt(hook): fix block_gh_pr_review direction (#372)

### DIFF
--- a/.claude/hooks/block_gh_pr_review.py
+++ b/.claude/hooks/block_gh_pr_review.py
@@ -35,11 +35,20 @@ def check(input_data: dict) -> dict | None:
                 "reason": (
                     "BLOCKED: `gh pr review` is not supported — all agents share one "
                     "GitHub user, so API-based approvals always fail.\n"
-                    "Charter § Pull Requests requires comment-based reviews instead.\n\n"
+                    "Charter § Pull Requests / § Comment-Based Reviews requires "
+                    "comment-based reviews instead.\n\n"
                     "Use `gh pr comment <PR#> --body '...'` with this format:\n"
-                    "  Requestor: <branch author name>\n"
-                    "  Requestee: <reviewer name>\n"
-                    "  RequestOrReplied: Approved | Changes Requested\n"
+                    "  Requestor: <reviewer name>      # team member POSTING the comment\n"
+                    "  Requestee: <PR author name>     # team member ADDRESSED by it\n"
+                    "  RequestOrReplied: Approved | ChangesRequested\n"
+                    "  TechDebt: none | #issue, ...\n\n"
+                    "Direction reminder (charter § Comment-Based Reviews Direction table):\n"
+                    "  Approved / ChangesRequested verdicts → Requestor=reviewer, "
+                    "Requestee=PR author.\n"
+                    "  Swapping these reproduces the W9 PR#349 cascade — "
+                    "`validate_pr_review` counts distinct Requestor values across "
+                    "Approved comments, so two reviewers both writing the PR author's "
+                    "name as Requestor collapse to 1/2.\n"
                 ),
             }
             log_pretooluse_block("block_gh_pr_review", command, result["reason"])

--- a/.claude/hooks/tests/test_block_gh_pr_review.py
+++ b/.claude/hooks/tests/test_block_gh_pr_review.py
@@ -74,6 +74,68 @@ class PositiveMatchTests(unittest.TestCase):
         self.assertIn("gh pr comment", result["reason"])
 
 
+class BlockedMessageDirectionTests(unittest.TestCase):
+    """Regression for #372: BLOCKED message example must NOT invert Requestor/Requestee.
+
+    Pre-fix the example said `Requestor: <branch author name>` and
+    `Requestee: <reviewer name>` — the opposite of the charter § Comment-Based
+    Reviews Direction table for Approved/ChangesRequested verdicts. An operator
+    copying the example literally reproduced the W9 PR#349 cascade
+    (validate_pr_review counts distinct Requestor values; two reviewers both
+    posting the PR author's name as Requestor → 1/2 distinct).
+    """
+
+    def _reason(self) -> str:
+        result = hook.check(_input("gh pr review 42 --approve"))
+        self.assertIsNotNone(result)
+        assert result is not None
+        return result["reason"]
+
+    def test_requestor_example_is_reviewer_not_branch_author(self):
+        reason = self._reason()
+        self.assertIn("Requestor: <reviewer name>", reason)
+        self.assertNotIn("Requestor: <branch author name>", reason)
+        self.assertNotIn("Requestor: <branch author>", reason)
+        self.assertNotIn("Requestor: <PR author", reason)
+
+    def test_requestee_example_is_pr_author_not_reviewer(self):
+        reason = self._reason()
+        self.assertIn("Requestee: <PR author name>", reason)
+        self.assertNotIn("Requestee: <reviewer name>", reason)
+        self.assertNotIn("Requestee: <reviewer>", reason)
+
+    def test_requestor_precedes_requestee_in_example(self):
+        reason = self._reason()
+        idx_r1 = reason.find("Requestor: <reviewer name>")
+        idx_r2 = reason.find("Requestee: <PR author name>")
+        self.assertGreaterEqual(idx_r1, 0)
+        self.assertGreaterEqual(idx_r2, 0)
+        self.assertLess(idx_r1, idx_r2)
+
+    def test_block_message_cites_direction_table(self):
+        """Message must reference the charter Direction table (per #372 acceptance #4)."""
+        reason = self._reason()
+        self.assertIn("Comment-Based Reviews", reason)
+        self.assertIn("Direction", reason)
+
+    def test_block_message_explains_swap_failure_mode(self):
+        """Message must include a callout naming the W9 PR#349 cascade failure mode."""
+        reason = self._reason()
+        self.assertIn("W9 PR#349", reason)
+        self.assertIn("distinct Requestor", reason)
+
+    def test_block_message_uses_canonical_verdict_strings(self):
+        """Verdict tokens prefer the canonical `ChangesRequested` (no space).
+
+        validate_pr_review.py accepts both forms (`ChangesRequested` per
+        charter line 14 and the spaced `Changes Requested` per the parser's
+        tolerance shim), but the operator-facing example should use the
+        canonical form to avoid teaching the spaced variant.
+        """
+        reason = self._reason()
+        self.assertIn("Approved | ChangesRequested", reason)
+
+
 class NegativeMatchTests(unittest.TestCase):
     """Other `gh pr <subcommand>` shapes MUST NOT be blocked."""
 


### PR DESCRIPTION
## Summary

Closes the sibling-hook gap to #356 / PR #364. `validate_pr_review.py` had its inverted Requestor/Requestee example fixed by #356, but `block_gh_pr_review.py` carried the **same inversion** and was not touched in the same scope.

**Operator-facing impact:** an agent that hits `gh pr review` and copies the BLOCKED message's example literally reproduces the W9 PR#349 cascade — two reviewers write the PR author's name as `Requestor:`, `validate_pr_review` counts 1 distinct Requestor across the Approved comments, BLOCKED at 1/2.

## Changes

### `.claude/hooks/block_gh_pr_review.py` (lines 36-53)

- **Swap Requestor / Requestee** to match charter § Comment-Based Reviews Direction table:
  - `Requestor: <reviewer name>` (POSTING the comment)
  - `Requestee: <PR author name>` (ADDRESSED by it)
- **Canonicalize** `ChangesRequested` (no space, matches validate_pr_review.py line 27) — was previously `Changes Requested` (spaced).
- **Add** `TechDebt: none | #issue, ...` line — required by the 2-reviewer attestation gate added by #356.
- **Add Direction-reminder callout** naming the W9 PR#349 cascade root cause and what `validate_pr_review` actually counts.
- **Cite charter § Comment-Based Reviews** (not just § Pull Requests).

### `.claude/hooks/tests/test_block_gh_pr_review.py` (new `BlockedMessageDirectionTests` class, 6 tests)

- `test_requestor_example_is_reviewer_not_branch_author` — pins the swap (asserts present + absent forms)
- `test_requestee_example_is_pr_author_not_reviewer`
- `test_requestor_precedes_requestee_in_example` — ordering invariant
- `test_block_message_cites_direction_table` — acceptance criterion #4 from #372
- `test_block_message_explains_swap_failure_mode` — W9 PR#349 callout present
- `test_block_message_uses_canonical_verdict_strings` — `ChangesRequested` no-space

## Validation

- `python3 -m unittest discover -s .claude/hooks/tests -p "test_block_gh_pr_review.py"` → **27/27 OK** (21 pre-existing + 6 new)
- `uvx ruff@0.7.4 format --check .claude/hooks/` → `52 files already formatted`
- `uvx ruff@0.7.4 check .claude/hooks/block_gh_pr_review.py .claude/hooks/tests/test_block_gh_pr_review.py` → All checks passed
- Pre-commit hooks (ruff-format, ruff-lint, mypy) all passed on commit
- Hook still blocks all 7 `gh pr review` shapes (bare, `--approve`, `--body`, chained after `&&` / `;` / `|` / `||`) — pre-existing PositiveMatchTests all green
- Hook still passes-through `gh pr comment`, `gh pr edit`, `gh pr list`, `gh pr view`, `gh pr create`, `gh pr ready` — pre-existing NegativeMatchTests all green

## Acceptance criteria (from #372)

- [x] BLOCKED message shows `Requestor: <reviewer name>` and `Requestee: <PR author name>` (matching `validate_pr_review.py` line 522 and the Direction table)
- [x] BLOCKED message includes a brief callout (3 lines) referencing the swap failure mode that `validate_pr_review.py` documents
- [x] No regression on the `gh pr review` block itself — block still fires for all `gh pr review` invocations (verified by pre-existing PositiveMatchTests)
- [x] Message cites `pull-requests.md § Comment-Based Reviews`

## Test plan

- [ ] CI green
- [ ] Two reviewers approve with `RequestOrReplied: Approved` + `TechDebt:` line
- [ ] After merge to wave-9, `gh issue view 372` confirms auto-close note (wave-branch merges don't auto-close per memory `feedback_wave_branch_issue_close` — explicit `gh issue close 372` after wave-9 → main propagation, or close directly on this PR's merge)
- [ ] Next session that hits `gh pr review` sees the corrected example

## Relates to

- Closes #372
- Sibling closed: #356 (PR #364, commit `e1d14fc`) — `validate_pr_review.py` fix
- Sibling closed: #233 — charter directionality settlement
- Memory: `feedback_spawn_brief_requestor_field_semantics.md`, `feedback_validate_pr_review_approved_not_reply.md`
- Surfaced live in PR #371 review by Aino Virtanen and Wanjiku Mwangi (https://github.com/noorinalabs/noorinalabs-main/pull/371)
