### PR TITLE
feat: wave-skill polish batch (#318/#319/#320)

### DIFF
--- a/.claude/skills/wave-scope/SKILL.md
+++ b/.claude/skills/wave-scope/SKILL.md
@@ -360,6 +360,69 @@ Do NOT delete the original body — copy it (or post the pre-update version as a
 
 If any step surfaced a process gap (stale memory, missing meta-issue, vague reference), include a `**Process gaps surfaced**` section so the next retro can address them.
 
+### 12.5. Validate implementer/reviewer names against per-repo rosters (#319)
+
+If the wave-scope output includes an implementer/reviewer matrix (a per-repo mapping of `implementer` / `reviewer` / `reviewer_2` to team-member names), validate every declared name against the relevant roster BEFORE `/wave-kickoff` fan-out. Pre-#319 a stale alias like "Anya Volkov" (canonical: "Anya Kowalczyk") would propagate through scope and only surface at first-spawn time — P3W7 retro recorded TWO such substitutions in `wave_7_decisions.implementer_substitutions`.
+
+**Resolution rules:**
+- Per-repo entries (`noorinalabs-deploy`, `noorinalabs-isnad-graph`, …) → child-repo roster (`<repo>/.claude/team/roster/*.md`) UNION parent roster. This lets org-level coordinators (Aino, Nadia, Wanjiku, Santiago) fill child-repo slots without duplicating roster entries.
+- Parent entries (`noorinalabs-main` or empty repo key) → parent-only roster (`.claude/team/roster/*.md`).
+- Match is case-insensitive; trailing parenthetical role suffix (`Aino Virtanen (Standards & Quality Lead)`) is stripped before comparison.
+- On miss: fuzzy-match via difflib SequenceMatcher; surface the top-3 closest matches to the operator.
+
+**Invocation:**
+
+```bash
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+VALIDATOR="$REPO_ROOT/.claude/skills/wave-scope/validate_matrix_names.py"
+
+# The matrix JSON shape is {repo: {role: name, ...}, ...}. Build it from
+# the scope file you composed (or extract from cross-repo-status.json's
+# wave_{M}_scope tier_* entries if those have been written).
+cat > /tmp/wave-{M}-matrix.json <<'EOF'
+{
+    "noorinalabs-isnad-graph": {
+        "implementer": "Anya Kowalczyk",
+        "reviewer": "Idris Yusuf",
+        "reviewer_2": "Marisol Vega-Cruz"
+    },
+    "noorinalabs-deploy": {
+        "implementer": "Bereket Tadesse",
+        "reviewer": "Lucas Ferreira",
+        "reviewer_2": "Aino Virtanen"
+    }
+}
+EOF
+
+python3 "$VALIDATOR" /tmp/wave-{M}-matrix.json
+RC=$?
+if [ $RC -ne 0 ]; then
+    echo "STOP: resolve unresolved names before /wave-kickoff fan-out."
+    echo "  If a substitution is intentional, document it in"
+    echo "  cross-repo-status.json wave_{M}_decisions.implementer_substitutions"
+    echo "  with rationale; then update the matrix and re-run /wave-scope."
+    exit 1
+fi
+```
+
+**Acceptance:**
+- Every implementer / reviewer / reviewer_2 name in the scope matrix resolves to a canonical roster entry.
+- Unresolved names are surfaced with suggested matches.
+- Approved overrides are recorded under `wave_{M}_decisions.implementer_substitutions` in `cross-repo-status.json` with this shape:
+
+```json
+{
+    "repo": "<repo-name>",
+    "pr": "<repo>#<N>",
+    "declared": "<matrix name>",
+    "actual": "<canonical roster name>",
+    "swapped_at": "<ISO-8601 UTC>",
+    "rationale": "<why the substitution is correct>"
+}
+```
+
+**Why this lives in `/wave-scope` not `/wave-kickoff`:** Step 0 of kickoff is a pre-flight CHECKLIST that the orchestrator confirms manually. By the time kickoff runs, scope is supposed to be settled. Validating names at scope-time means the matrix shape is already correct when kickoff reads it — the orchestrator never sees a "name not in roster" surface at fan-out time, only at scope-time review.
+
 ### 13. Write reconciliation timestamp + structured bookkeeping keys to `cross-repo-status.json`
 
 This is what `/wave-kickoff` Steps 0a and 0 read to confirm the wave's scope was reconciled before kickoff AND to derive the per-repo iteration list. Write only on full success — if the run aborted at step 7 (no dispositions) or step 10 (label-churn confirmation declined), do NOT write.

--- a/.claude/skills/wave-scope/tests/test_validate_matrix_names.py
+++ b/.claude/skills/wave-scope/tests/test_validate_matrix_names.py
@@ -1,0 +1,216 @@
+"""Tests for /wave-scope validate_matrix_names roster check (#319).
+
+The P3W7 retro surfaced an "Anya Volkov" alias in the scope matrix that
+doesn't exist in any roster (canonical isnad-graph Tech Lead is "Anya
+Kowalczyk"). Substitution worked in-flight but wasn't caught at scope time.
+This test pins that the validator surfaces such aliases with a suggestion.
+
+Tests use isolated tmpdir-based rosters to avoid coupling to the real
+org-dir state (which changes wave-to-wave).
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from validate_matrix_names import validate  # noqa: E402
+
+
+def _write_roster_card(roster_dir: Path, role_slug: str, name: str) -> None:
+    """Mimic the in-repo roster card shape: `**Name:** <name>` field."""
+    roster_dir.mkdir(parents=True, exist_ok=True)
+    (roster_dir / f"{role_slug}.md").write_text(
+        "# Team Member Roster Card\n\n"
+        "## Identity\n"
+        f"- **Name:** {name}\n"
+        "- **Role:** Engineer\n"
+        "- **Status:** Active\n"
+    )
+
+
+def _build_fake_org_dir(tmp: Path) -> Path:
+    """Build a fake org-dir with parent + 2 child rosters for testing."""
+    # Parent roster — org-level coordinators.
+    parent_roster = tmp / ".claude" / "team" / "roster"
+    _write_roster_card(parent_roster, "pd_nadia", "Nadia Khoury")
+    _write_roster_card(parent_roster, "tpm_wanjiku", "Wanjiku Mwangi")
+    _write_roster_card(parent_roster, "sql_aino", "Aino Virtanen")
+    # Child: noorinalabs-deploy
+    deploy_roster = tmp / "noorinalabs-deploy" / ".claude" / "team" / "roster"
+    _write_roster_card(deploy_roster, "lead_bereket", "Bereket Tadesse")
+    _write_roster_card(deploy_roster, "eng_lucas", "Lucas Ferreira")
+    # Child: noorinalabs-isnad-graph
+    graph_roster = tmp / "noorinalabs-isnad-graph" / ".claude" / "team" / "roster"
+    _write_roster_card(graph_roster, "tl_anya", "Anya Kowalczyk")
+    _write_roster_card(graph_roster, "eng_idris", "Idris Yusuf")
+    _write_roster_card(graph_roster, "eng_marisol", "Marisol Vega-Cruz")
+    return tmp
+
+
+class HappyPathTests(unittest.TestCase):
+    """All declared names resolve to canonical roster entries."""
+
+    def test_all_resolved_returns_no_unresolved(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = _build_fake_org_dir(Path(tmpdir))
+            matrix = {
+                "noorinalabs-isnad-graph": {
+                    "implementer": "Anya Kowalczyk",
+                    "reviewer": "Idris Yusuf",
+                },
+            }
+            report = validate(matrix, org)
+            findings = report["noorinalabs-isnad-graph"]
+            self.assertEqual(len(findings), 2)
+            for f in findings:
+                self.assertTrue(f["resolved"], f"{f['declared']} should be resolved")
+
+    def test_org_level_coordinator_resolves_in_child_slot(self):
+        """Parent-roster coordinators (Aino, Nadia, etc.) can fill child-repo slots."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = _build_fake_org_dir(Path(tmpdir))
+            matrix = {
+                "noorinalabs-isnad-graph": {
+                    "implementer": "Anya Kowalczyk",
+                    "reviewer": "Aino Virtanen",  # parent-org-level
+                }
+            }
+            report = validate(matrix, org)
+            findings = report["noorinalabs-isnad-graph"]
+            for f in findings:
+                self.assertTrue(f["resolved"], f"{f['declared']} should be resolved")
+
+    def test_parenthetical_role_stripped_for_match(self):
+        """`Aino Virtanen (Standards Lead)` should resolve to `Aino Virtanen`."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = _build_fake_org_dir(Path(tmpdir))
+            matrix = {
+                "noorinalabs-isnad-graph": {
+                    "reviewer": "Aino Virtanen (Standards & Quality Lead)",
+                }
+            }
+            report = validate(matrix, org)
+            self.assertTrue(report["noorinalabs-isnad-graph"][0]["resolved"])
+
+
+class UnresolvedNameTests(unittest.TestCase):
+    """Names that don't match any roster — must surface + suggest."""
+
+    def test_anya_volkov_alias_surfaces_with_suggestion(self):
+        """P3W7 reproducer: Anya Volkov is a stale alias; canonical = Anya Kowalczyk."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = _build_fake_org_dir(Path(tmpdir))
+            matrix = {
+                "noorinalabs-isnad-graph": {
+                    "implementer": "Anya Volkov",
+                }
+            }
+            report = validate(matrix, org)
+            finding = report["noorinalabs-isnad-graph"][0]
+            self.assertFalse(finding["resolved"])
+            self.assertIn("Anya Kowalczyk", finding["suggestions"])
+
+    def test_completely_unknown_name_surfaces_with_best_guess(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = _build_fake_org_dir(Path(tmpdir))
+            matrix = {
+                "noorinalabs-deploy": {
+                    "implementer": "Nonexistent Person",
+                }
+            }
+            report = validate(matrix, org)
+            finding = report["noorinalabs-deploy"][0]
+            self.assertFalse(finding["resolved"])
+            # Suggestions list may be empty for very-distant names — that's fine.
+            self.assertIn("suggestions", finding)
+
+    def test_case_insensitive_resolution(self):
+        """`anya kowalczyk` (lowercase) must resolve to `Anya Kowalczyk`."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = _build_fake_org_dir(Path(tmpdir))
+            matrix = {
+                "noorinalabs-isnad-graph": {
+                    "implementer": "anya kowalczyk",
+                }
+            }
+            report = validate(matrix, org)
+            self.assertTrue(report["noorinalabs-isnad-graph"][0]["resolved"])
+
+    def test_empty_slot_skipped(self):
+        """An empty string slot is ignored (TBD-pending placeholder)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = _build_fake_org_dir(Path(tmpdir))
+            matrix = {
+                "noorinalabs-deploy": {
+                    "implementer": "Bereket Tadesse",
+                    "reviewer_2": "",
+                }
+            }
+            report = validate(matrix, org)
+            # Only 1 finding (reviewer_2 empty was skipped)
+            self.assertEqual(len(report["noorinalabs-deploy"]), 1)
+
+
+class ParentRosterFallbackTests(unittest.TestCase):
+    """`noorinalabs-main` (parent) repo entries resolve via parent roster only."""
+
+    def test_parent_repo_entry_resolves_against_parent_roster(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = _build_fake_org_dir(Path(tmpdir))
+            matrix = {
+                "noorinalabs-main": {
+                    "implementer": "Nadia Khoury",
+                    "reviewer": "Wanjiku Mwangi",
+                }
+            }
+            report = validate(matrix, org)
+            for f in report["noorinalabs-main"]:
+                self.assertTrue(f["resolved"], f"{f['declared']} should be resolved")
+
+    def test_empty_repo_string_treated_as_parent(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = _build_fake_org_dir(Path(tmpdir))
+            matrix = {
+                "": {
+                    "implementer": "Nadia Khoury",
+                }
+            }
+            report = validate(matrix, org)
+            self.assertTrue(report[""][0]["resolved"])
+
+
+class MissingRosterTests(unittest.TestCase):
+    """Repos with no roster dir → fall back to parent-only lookup."""
+
+    def test_missing_repo_roster_still_resolves_org_level_names(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = _build_fake_org_dir(Path(tmpdir))
+            matrix = {
+                "noorinalabs-design-system": {  # No roster created for this repo.
+                    "reviewer": "Aino Virtanen",  # Parent-org-level — should resolve.
+                }
+            }
+            report = validate(matrix, org)
+            self.assertTrue(report["noorinalabs-design-system"][0]["resolved"])
+
+    def test_missing_repo_roster_with_only_per_repo_name_unresolved(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = _build_fake_org_dir(Path(tmpdir))
+            matrix = {
+                "noorinalabs-design-system": {
+                    "implementer": "Bereket Tadesse",  # Lives in deploy roster, not DS.
+                }
+            }
+            report = validate(matrix, org)
+            # Bereket only exists in deploy roster — design-system lookup
+            # combines parent + design-system rosters, not deploy.
+            self.assertFalse(report["noorinalabs-design-system"][0]["resolved"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/skills/wave-scope/validate_matrix_names.py
+++ b/.claude/skills/wave-scope/validate_matrix_names.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Validate implementer/reviewer names in a wave-scope matrix against rosters.
+
+Pre-#319 `/wave-scope` did not validate names in the matrix — a stale alias
+like "Anya Volkov" (canonical: "Anya Kowalczyk") propagated through scope
+and only surfaced at first-spawn time. P3W7 logged both substitutions in
+`wave_7_decisions.implementer_substitutions`. This script runs at scope
+time and surfaces unknown names BEFORE `/wave-kickoff` fan-out.
+
+Usage:
+    validate_matrix_names.py <scope-json-path>
+
+Where `<scope-json-path>` is a JSON file with the shape:
+
+    {
+        "noorinalabs-isnad-graph": {
+            "implementer": "Anya Kowalczyk",
+            "reviewer": "Idris Diallo",
+            "reviewer_2": "Marcia Vieira"
+        },
+        "noorinalabs-deploy": {
+            "implementer": "Bereket Tesfaye",
+            "reviewer": "Lucas Pham",
+            "reviewer_2": "Aino Virtanen"
+        }
+    }
+
+Exit codes:
+    0 — all names resolve to a canonical roster entry
+    1 — one or more names don't resolve; suggested matches printed to stderr
+    2 — invalid input
+
+Resolution:
+    - For each per-repo entry, read `<parent>/<repo>/.claude/team/roster/*.md`
+      and extract the `**Name:**` field.
+    - For parent-repo entries (repo == "noorinalabs-main" or no repo), fall
+      back to the parent's own `.claude/team/roster/`.
+    - Case-insensitive exact match wins.
+    - On miss: fuzzy-match (difflib SequenceMatcher) and print the top-3
+      closest matches as suggestions.
+
+The script is read-only — it never modifies the matrix or rosters. The
+operator makes the substitution decision and re-runs.
+"""
+
+from __future__ import annotations
+
+import difflib
+import json
+import re
+import sys
+from pathlib import Path
+
+
+def _find_org_dir() -> Path:
+    """Find the directory that contains all `noorinalabs-*` repo checkouts.
+
+    Org layout: `~/code/noorinalabs-main/` contains both the parent repo
+    (itself, called `noorinalabs-main` at the org level) AND sibling-repo
+    checkouts (`noorinalabs-deploy`, `noorinalabs-isnad-graph`, ...). So
+    `noorinalabs-deploy` etc. live at `<org_dir>/noorinalabs-deploy/`, and
+    the parent repo's own roster lives at `<org_dir>/.claude/team/roster/`.
+
+    When invoked from a worktree (`<org_dir>/.claude/worktrees/<name>/`),
+    walk up to the org_dir.
+    """
+    cwd = Path.cwd().resolve()
+    for ancestor in [cwd, *cwd.parents]:
+        if (ancestor / "noorinalabs-deploy").is_dir() and (
+            ancestor / ".claude" / "team" / "roster"
+        ).is_dir():
+            return ancestor
+    return cwd
+
+
+def _load_roster_names(roster_dir: Path) -> set[str]:
+    """Parse `**Name:** Foo Bar` lines from every .md file in roster_dir."""
+    names: set[str] = set()
+    if not roster_dir.is_dir():
+        return names
+    name_re = re.compile(r"\*\*Name:\*\*\s+(.+?)\s*$", re.MULTILINE)
+    for md_file in roster_dir.glob("*.md"):
+        try:
+            text = md_file.read_text()
+        except OSError:
+            continue
+        for match in name_re.finditer(text):
+            name = match.group(1).strip()
+            # Trim role/status parentheticals (`Foo Bar (Tech Lead)`).
+            name = re.sub(r"\s*\(.*?\)\s*$", "", name)
+            if name:
+                names.add(name)
+    return names
+
+
+def _load_repo_roster(org_dir: Path, repo: str) -> set[str]:
+    """Load roster names for a given repo.
+
+    `repo == "noorinalabs-main"` or empty → org_dir's own `.claude/team/roster/`
+    (the parent repo's roster is at org-dir root, not under a sibling subdir).
+    Else `<org_dir>/<repo>/.claude/team/roster/`.
+    """
+    if not repo or repo == "noorinalabs-main":
+        return _load_roster_names(org_dir / ".claude" / "team" / "roster")
+    return _load_roster_names(org_dir / repo / ".claude" / "team" / "roster")
+
+
+def _suggest(name: str, candidates: set[str], top: int = 3) -> list[str]:
+    """Return up to `top` closest matches from candidates via difflib."""
+    if not candidates:
+        return []
+    return difflib.get_close_matches(name, sorted(candidates), n=top, cutoff=0.5)
+
+
+def validate(
+    matrix: dict[str, dict[str, str]],
+    org_dir: Path,
+) -> dict[str, list[dict[str, object]]]:
+    """Return a per-repo report of name → resolution status.
+
+    Result shape:
+        {
+            "noorinalabs-isnad-graph": [
+                {"role": "implementer", "declared": "Anya Volkov",
+                 "resolved": False, "suggestions": ["Anya Kowalczyk"]},
+                ...
+            ],
+            ...
+        }
+    """
+    report: dict[str, list[dict[str, object]]] = {}
+    for repo, slots in matrix.items():
+        # Parent rosters are always loaded — org-level coordinators
+        # (Nadia, Wanjiku, Aino, Santiago) can appear in per-repo matrix
+        # slots when reviewing parent-flavored work.
+        parent_roster = _load_repo_roster(org_dir, "noorinalabs-main")
+        repo_roster = _load_repo_roster(org_dir, repo)
+        combined = parent_roster | repo_roster
+        repo_findings: list[dict[str, object]] = []
+        for role, declared in slots.items():
+            if not declared:
+                continue
+            declared_clean = re.sub(r"\s*\(.*?\)\s*$", "", declared).strip()
+            resolved = any(declared_clean.lower() == known.lower() for known in combined)
+            entry: dict[str, object] = {
+                "role": role,
+                "declared": declared,
+                "resolved": resolved,
+            }
+            if not resolved:
+                entry["suggestions"] = _suggest(declared_clean, combined)
+            repo_findings.append(entry)
+        report[repo] = repo_findings
+    return report
+
+
+def _print_report_to_stderr(report: dict[str, list[dict[str, object]]]) -> int:
+    """Pretty-print the report to stderr; return exit code."""
+    total = 0
+    unresolved = 0
+    for repo, findings in report.items():
+        for f in findings:
+            total += 1
+            if not f["resolved"]:
+                unresolved += 1
+    if unresolved == 0:
+        print(
+            f"validate_matrix_names: all {total} names resolved across {len(report)} repos.",
+            file=sys.stderr,
+        )
+        return 0
+    print(
+        f"validate_matrix_names: {unresolved}/{total} names UNRESOLVED across {len(report)} repos.",
+        file=sys.stderr,
+    )
+    for repo, findings in report.items():
+        bad = [f for f in findings if not f["resolved"]]
+        if not bad:
+            continue
+        print(f"\n  {repo}:", file=sys.stderr)
+        for f in bad:
+            suggestions = f.get("suggestions") or []
+            sug_str = ", ".join(suggestions) if suggestions else "(no close matches)"
+            print(
+                f"    - {f['role']}: {f['declared']!r}  →  suggestions: {sug_str}",
+                file=sys.stderr,
+            )
+    print(
+        "\n  Resolve each unknown name before /wave-kickoff fan-out.\n"
+        "  Approved substitutions: record under wave_{M}_decisions.implementer_substitutions"
+        " in cross-repo-status.json with rationale.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(__doc__, file=sys.stderr)
+        return 2
+    path = Path(argv[1])
+    try:
+        matrix = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"ERROR reading {path}: {exc}", file=sys.stderr)
+        return 2
+    if not isinstance(matrix, dict):
+        print("ERROR: top-level must be an object mapping repo → role-slots", file=sys.stderr)
+        return 2
+    org_dir = _find_org_dir()
+    report = validate(matrix, org_dir)
+    return _print_report_to_stderr(report)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.claude/skills/wave-wrapup/SKILL.md
+++ b/.claude/skills/wave-wrapup/SKILL.md
@@ -197,6 +197,48 @@ Flag any changes to:
 **Next step:** Run `/wave-retro` for full retrospective with assessments and trust updates.
 ```
 
+### 10.5. Write canonical counter keys to `cross-repo-status.json`
+
+Write the **top-level** canonical counter keys that `/wave-retro` Step 2.5 verifies. Pre-#318 these were either missing or buried under `wave_{M}_summary.*`, which forced a manual followup commit at retro (P3W7 `fb459b2`). Post-#318 the skill writes them at wrapup time so retro reads cleanly.
+
+Use the shared `upsert_status_keys.py` helper from `/wave-scope` — it does targeted text-level upsert that preserves the compact-inline shape of `cross-repo-status.json` (a naive `jq … > tmp && mv` reformats every compact line to pretty form, producing a 500-line cosmetic diff per wave — see `main#332`). The helper also validates JSON before AND after the rewrite.
+
+```bash
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+STATUS="$REPO_ROOT/cross-repo-status.json"
+UPSERT="$REPO_ROOT/.claude/skills/wave-scope/upsert_status_keys.py"
+
+# Compute the three canonical counters from the wave-wrapup report numbers.
+FINAL_PR_COUNT={count_of_merged_PRs}            # same as Step 10 "PRs: Merged"
+CHANGES_REQUESTED_CYCLES={cr_cycle_count}       # count of `ChangesRequested` verdict comments across the wave's PRs
+TOP_CONCENTRATION_PCT={highest_repo_pct}        # PRs-in-top-repo / PRs-total * 100, rounded int
+
+# Each value MUST be a self-contained JSON literal (integer here — no quotes).
+python3 "$UPSERT" "$STATUS" \
+    "wave_{M}_final_pr_count=${FINAL_PR_COUNT}" \
+    "wave_{M}_changes_requested_cycles=${CHANGES_REQUESTED_CYCLES}" \
+    "wave_{M}_top_concentration_pct=${TOP_CONCENTRATION_PCT}"
+
+# Read-back verify (memory `feedback_gh_pr_edit_silent_noop` family — any
+# jq/upsert pipeline that silently fails produces zero diff but exit 0).
+jq -r --arg m "{M}" '
+  "wave_" + $m + "_final_pr_count = " + (.["wave_" + $m + "_final_pr_count"] | tostring),
+  "wave_" + $m + "_changes_requested_cycles = " + (.["wave_" + $m + "_changes_requested_cycles"] | tostring),
+  "wave_" + $m + "_top_concentration_pct = " + (.["wave_" + $m + "_top_concentration_pct"] | tostring)
+' "$STATUS"
+```
+
+Optionally also write a richer `wave_{M}_summary` block with wave-shape detail (per-tier PR breakdown, charter-change proposals, thesis text — see P3W7 `cross-repo-status.json` for the canonical shape). Top-level keys above remain **authoritative** for `/wave-retro` Step 2.5; the summary block is a supplementary surface for retro-prose composition.
+
+**Why top-level not nested:** `/wave-retro` Step 2.5 reads via `jq -r ".wave_${M}_final_pr_count"` — a direct top-level lookup. Nesting under `wave_{M}_summary.final_pr_count` would require Step 2.5 changes per wave-counter-key, breaking the canonical-key contract. Top-level keeps the read-side simple.
+
+**Acceptance for /wave-retro Step 2.5:**
+- All three keys exist at top-level after `/wave-wrapup` completes.
+- Values match the rendered Step 10 wave report.
+- A `wave_{M}_summary` block, if also present, must not contradict the top-level values (top-level is authoritative).
+
+If a key cannot be computed (e.g., no PRs merged this wave), write the literal `0` — `/wave-retro` Step 2.5 distinguishes "0 cycles" from "key missing" and only the latter is treated as drift.
+
 ### 11. Merge to main per repo (final wave only)
 
 If this is the final wave of the phase, every repo in `wave_{M}_repos_in_scope` has its OWN `deployments/phase-{P}/wave-{M}` branch (created by `/wave-kickoff` step 1) that needs its own PR to main. This is the symmetric counterpart of the multi-repo branch creation gap (main#238).

--- a/.claude/skills/wave-wrapup/tests/test_canonical_counter_keys.py
+++ b/.claude/skills/wave-wrapup/tests/test_canonical_counter_keys.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Smoke test for /wave-wrapup Step 10.5 canonical counter keys (#318).
+
+Pre-#318 /wave-wrapup did not write the canonical top-level counter keys at
+all — the orchestrator had to manually add them at retro time (P3W7
+`fb459b2`). Step 10.5 of the skill now invokes `upsert_status_keys.py` to
+write three keys: `wave_{M}_final_pr_count`, `wave_{M}_changes_requested_cycles`,
+`wave_{M}_top_concentration_pct`.
+
+These tests verify:
+1. The shared upsert helper handles the three counter keys correctly on a
+   `cross-repo-status.json`-shaped fixture (no existing wave_{M}_* keys).
+2. The keys are written at top level (NOT nested under wave_{M}_summary.*),
+   matching the `/wave-retro` Step 2.5 lookup contract.
+3. Sibling keys are preserved unchanged (no truncation, no reorder).
+4. A subsequent re-run is idempotent (replace-in-place, not duplicate).
+
+Run: python3 -m unittest discover -s .claude/skills/wave-wrapup/tests
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+# Reuse the helper from wave-scope/ — Step 10.5 of /wave-wrapup invokes it.
+_HERE = Path(__file__).resolve().parent
+_WAVE_SCOPE_DIR = _HERE.parent.parent / "wave-scope"
+sys.path.insert(0, str(_WAVE_SCOPE_DIR))
+
+from upsert_status_keys import upsert_top_level_key  # noqa: E402
+
+
+def _apply_three_counter_keys(
+    text: str,
+    wave_number: int,
+    final_pr_count: int,
+    cr_cycles: int,
+    top_concentration_pct: int,
+) -> str:
+    """Mirror what /wave-wrapup Step 10.5 does — three upsert_top_level_key calls."""
+    text = upsert_top_level_key(text, f"wave_{wave_number}_final_pr_count", str(final_pr_count))
+    text = upsert_top_level_key(
+        text, f"wave_{wave_number}_changes_requested_cycles", str(cr_cycles)
+    )
+    text = upsert_top_level_key(
+        text, f"wave_{wave_number}_top_concentration_pct", str(top_concentration_pct)
+    )
+    return text
+
+
+class CounterKeyWriteTests(unittest.TestCase):
+    """Step 10.5 writes 3 top-level keys via upsert_top_level_key."""
+
+    def test_writes_three_keys_at_top_level(self):
+        text = (
+            "{\n"
+            '  "phase": "phase-3",\n'
+            '  "wave_9_active": true,\n'
+            '  "wave_9_kicked_off_at": "2026-05-09T00:00:00Z"\n'
+            "}\n"
+        )
+        out = _apply_three_counter_keys(text, 9, 12, 6, 17)
+        parsed = json.loads(out)
+        self.assertEqual(parsed["wave_9_final_pr_count"], 12)
+        self.assertEqual(parsed["wave_9_changes_requested_cycles"], 6)
+        self.assertEqual(parsed["wave_9_top_concentration_pct"], 17)
+
+    def test_keys_are_top_level_not_nested(self):
+        """/wave-retro Step 2.5 reads `.wave_{M}_final_pr_count` — top-level lookup."""
+        text = '{\n  "phase": "phase-3",\n  "wave_9_active": true\n}\n'
+        out = _apply_three_counter_keys(text, 9, 5, 2, 40)
+        parsed = json.loads(out)
+        # NOT under a wave_9_summary.* nested block.
+        self.assertNotIn("wave_9_summary", parsed)
+        self.assertIn("wave_9_final_pr_count", parsed)
+        self.assertIn("wave_9_changes_requested_cycles", parsed)
+        self.assertIn("wave_9_top_concentration_pct", parsed)
+
+    def test_preserves_existing_siblings(self):
+        text = (
+            "{\n"
+            '  "phase": "phase-3",\n'
+            '  "wave_9_active": true,\n'
+            '  "wave_9_kicked_off_at": "2026-05-09T00:00:00Z",\n'
+            '  "wave_9_repos_in_scope": [\n'
+            '    "noorinalabs-main",\n'
+            '    "noorinalabs-deploy"\n'
+            "  ]\n"
+            "}\n"
+        )
+        out = _apply_three_counter_keys(text, 9, 12, 6, 17)
+        parsed = json.loads(out)
+        # Sibling values intact
+        self.assertTrue(parsed["wave_9_active"])
+        self.assertEqual(parsed["wave_9_kicked_off_at"], "2026-05-09T00:00:00Z")
+        self.assertEqual(
+            parsed["wave_9_repos_in_scope"],
+            ["noorinalabs-main", "noorinalabs-deploy"],
+        )
+        # New keys present
+        self.assertEqual(parsed["wave_9_final_pr_count"], 12)
+
+    def test_is_idempotent_on_rerun(self):
+        """Re-running Step 10.5 (e.g., wrapup re-invocation) replaces in place."""
+        text = '{\n  "phase": "phase-3",\n  "wave_9_active": true\n}\n'
+        out1 = _apply_three_counter_keys(text, 9, 12, 6, 17)
+        out2 = _apply_three_counter_keys(out1, 9, 12, 6, 17)
+        self.assertEqual(out1, out2)
+        parsed = json.loads(out2)
+        # Exactly one of each — not duplicated.
+        self.assertEqual(parsed["wave_9_final_pr_count"], 12)
+        # Count occurrences of the key string at line-start indentation.
+        self.assertEqual(out2.count('"wave_9_final_pr_count"'), 1)
+        self.assertEqual(out2.count('"wave_9_changes_requested_cycles"'), 1)
+        self.assertEqual(out2.count('"wave_9_top_concentration_pct"'), 1)
+
+    def test_replace_in_place_with_new_values(self):
+        """Re-running with new values updates rather than appends."""
+        text = '{\n  "phase": "phase-3",\n  "wave_9_active": true\n}\n'
+        out1 = _apply_three_counter_keys(text, 9, 12, 6, 17)
+        out2 = _apply_three_counter_keys(out1, 9, 15, 8, 22)
+        parsed = json.loads(out2)
+        self.assertEqual(parsed["wave_9_final_pr_count"], 15)
+        self.assertEqual(parsed["wave_9_changes_requested_cycles"], 8)
+        self.assertEqual(parsed["wave_9_top_concentration_pct"], 22)
+        # Still single-occurrence per key.
+        self.assertEqual(out2.count('"wave_9_final_pr_count"'), 1)
+
+    def test_writes_alongside_wave_summary_block(self):
+        """A `wave_{M}_summary` block, if present, coexists at top level.
+
+        Top-level counters remain authoritative; summary block is supplementary.
+        """
+        text = (
+            "{\n"
+            '  "phase": "phase-3",\n'
+            '  "wave_9_active": true,\n'
+            '  "wave_9_summary": {\n'
+            '    "total_prs_merged": 12,\n'
+            '    "thesis": "wave-shape narrative here"\n'
+            "  }\n"
+            "}\n"
+        )
+        out = _apply_three_counter_keys(text, 9, 12, 6, 17)
+        parsed = json.loads(out)
+        # Both forms present; top-level is authoritative for retro Step 2.5.
+        self.assertEqual(parsed["wave_9_final_pr_count"], 12)
+        self.assertIn("wave_9_summary", parsed)
+        self.assertEqual(parsed["wave_9_summary"]["total_prs_merged"], 12)
+        self.assertEqual(parsed["wave_9_summary"]["thesis"], "wave-shape narrative here")
+
+
+class RetroLookupShapeTests(unittest.TestCase):
+    """The keys must be readable via `/wave-retro` Step 2.5's exact jq form."""
+
+    def test_jq_lookup_path_resolves(self):
+        """`/wave-retro` Step 2.5 uses `jq -r ".wave_${M}_final_pr_count"`.
+
+        That's a direct top-level lookup. Anything but a top-level scalar
+        produces "null" or a syntax error in retro — drift signal.
+        """
+        text = '{\n  "phase": "phase-3"\n}\n'
+        out = _apply_three_counter_keys(text, 9, 12, 6, 17)
+        parsed = json.loads(out)
+        # Simulate the retro lookup; these must each resolve to a non-null int.
+        for key in (
+            "wave_9_final_pr_count",
+            "wave_9_changes_requested_cycles",
+            "wave_9_top_concentration_pct",
+        ):
+            value = parsed.get(key)
+            self.assertIsNotNone(value, f"retro Step 2.5 would see null for {key}")
+            self.assertIsInstance(value, int, f"{key} must be int for retro arithmetic")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/team/charter/agents.md
+++ b/.claude/team/charter/agents.md
@@ -242,6 +242,47 @@ The harness enforces **one team per orchestrator session** — `TeamCreate` fail
 >
 > **Why position-first:** P2W10 surfaced four+ instances across three managers' spawn prompts where the manager-as-reviewer anti-pattern slipped through despite charter rule existing. Pattern: reviewer-naming had already happened mentally during the early-drafting pass (scope/branch/sequencing first, reviewers as a back-fill). The charter rule was correctly applied in isolated contexts but missed when embedded in a multi-section spawn prompt. Moving the rule to first-line position makes "who reviews this" a first-order architectural decision the template forces the agent to make before advancing. Discipline becomes architectural, not memorial. Co-signed by Bereket (deploy manager), Nadia Boukhari (isnad-graph + user-service manager), Marcia (landing-page manager) — each had a concrete instance during W10.
 
+### Reviewer spawn brief — throughline-watch (default, #320) <!-- promotion-target: none -->
+
+> **Every reviewer-class spawn brief MUST include a "Throughline-watch" instruction.** Reviewers are PR-scoped by primary task, but they often see cross-PR patterns that only become visible when looking at the wave from a reviewer position. Asking explicitly for throughline observations turns this latent signal into a structured surface for the wave retro's ★ summary.
+>
+> **The section MUST appear in every reviewer-class spawn brief**, regardless of whether the wave is expected to have a wave-level thesis. Single-PR waves can produce "no throughline observed, this is a standalone fix" and that is itself a useful retro signal.
+>
+> **Required template block (copy-paste verbatim into reviewer-class spawn briefs):**
+>
+> ```
+> ## Throughline-watch (in addition to PR-level review)
+>
+> As you review this PR, note any pattern that recurs across multiple PRs in
+> the wave or any wave-level structural finding that emerges from your
+> PR-level review. Surface findings explicitly at the end of your review
+> comment under a `## Throughline observations` section — do NOT bury them
+> inside TechDebt or per-line inline review.
+>
+> Typical throughline shapes (illustrative, not exhaustive):
+> - "Same root cause appears in {N} PRs across {M} repos" — convergent class
+> - "Boundary X (parent→child / hook→skill / detection→strategy) breaks
+>   repeatedly" — boundary-class
+> - "Charter rule Y is technically followed but operationally undermined
+>   by Z" — rule-vs-practice gap
+> - "Memory M would prevent class C but isn't promoted to charter/hook
+>   yet" — promotion candidate
+>
+> If you observe no throughline (single-PR wave, or finding is fully
+> PR-scoped), write: `## Throughline observations\n\nNo wave-level pattern
+> observed — this PR is a standalone fix.` The explicit no-pattern record
+> is useful retro-signal too.
+>
+> The next wave-retro `*` summary pass synthesizes throughline observations
+> across all reviewers into the wave thesis (per P3W7 demonstration:
+> 5 reviewers + 4 implementers independently arrived at the two-tier wave
+> thesis BEFORE the * spawn fired).
+> ```
+>
+> **Why default, not per-wave addition:** P3W7 added the throughline-watch instruction ad-hoc to that wave's reviewer briefs and produced a complete pre-loaded retro thesis (Idris-coined "fixture-first discipline broke at the parent→child update boundary" confirmed by 5 subsequent reviewers; Nadia's ★ spawn synthesized rather than discovered). Making this default — not memorial discipline that the orchestrator must remember to add — propagates the P3W7 win to every wave.
+>
+> **Origin:** P3W7 retro feedback log § Proposed process changes #5 (orchestrator-class). Promoted via #320.
+
 ### Orchestrator checklist when spawning an implementer
 
 Every implementer spawn prompt MUST include, **in order**:
@@ -255,6 +296,20 @@ Every implementer spawn prompt MUST include, **in order**:
 7. **Charter enforcement reminders** (2 reviewers, CI green before merge, no `--no-verify`, no global/repo git config, `/ontology-librarian` per agent).
 8. **Reporting pattern** — who they report to (usually their manager) and when (draft open, CI green, blocker, merge).
 9. **/tmp file-race discipline:** When using `--body-file` with `gh issue/pr comment` or `git commit -F`, write the file to an issue#-keyed path (e.g., `/tmp/{issue#}-{purpose}.md`) IMMEDIATELY before the gh/git call — no other tool calls between the Write and the consuming Bash. Hook `block_stale_tmp_message_file` blocks files older than 30s. P3W6 surfaced 3 such blocks in spawned-agent gh-comment flows; this discipline prevents them.
+
+### Orchestrator checklist when spawning a reviewer
+
+Every reviewer-class spawn prompt MUST include, **in order**:
+
+1. **PR + author identity** — the specific PR# and head-SHA being reviewed, the author's name (NOT the reviewer's), and the angle the reviewer is being asked to take (TPM angle, charter/QA angle, domain angle, release coordinator angle, etc.).
+2. **MANDATORY first-action** instruction to run `/ontology-librarian {topic}` — Hook 15 scans the reviewer's own transcript and blocks Edit/Write otherwise. Reviewer-class spawns don't typically Edit/Write (they post comments), but the librarian is also load-bearing for understanding what the PR touches.
+3. **Throughline-watch block** (per § Reviewer spawn brief — throughline-watch above) — copy-paste the verbatim template block. Default, not per-wave addition (#320).
+4. **`Requestor: <reviewer name>` / `Requestee: <PR author name>` / `RequestOrReplied: Approved | ChangesRequested` / `TechDebt:` format** — explicit reminder using the canonical Direction-table form (per `pull-requests.md` § Comment-Based Reviews, post-#372 / PR #375 fix). The brief should embed the verbatim "Use `gh pr comment <PR#> --body '...'` with this format:" template block to prevent W9 PR#349-style cascades from re-emerging.
+5. **`gh pr review` vs `gh pr comment` discipline** — explicit reminder NOT to use `gh pr review` (`block_gh_pr_review` enforces; spawn-brief mention prevents the trip).
+6. **Read-the-diff-at-HEAD discipline** — `gh api repos/.../contents/<path>?ref=<head_sha>` not local clone (per `pull-requests.md` § Origin > Local Clone for "Still-Has-X" File-Content Claims).
+7. **Pre-enumeration discipline** — `grep -c` per file then sum, never `| head -N` (per memory `feedback_no_head_in_surface_enumeration`).
+8. **Verdict literal-string requirements** — `RequestOrReplied: Approved` (or `ChangesRequested`), NOT `Reply`. `validate_pr_review` counts Approved-verdict comments only; Reply doesn't gate-count (per memory `feedback_validate_pr_review_approved_not_reply`).
+9. **Reporting pattern** — who to report verdict + literal-strings-confirmation to (typically team-lead or the manager who requested the review).
 
 ### Origin
 


### PR DESCRIPTION
## Summary

Batched wave-skill polish PR closing 3 P3W7-retro-promoted issues:

| Issue | Hook/Skill | Type | Surface |
|---|---|---|---|
| #318 | `/wave-wrapup` SKILL.md | new Step 10.5 | writes canonical top-level counter keys to `cross-repo-status.json` at wrapup, eliminating P3W7-style manual followup commits |
| #319 | `/wave-scope` SKILL.md + validator script | new Step 12.5 + new `validate_matrix_names.py` | catches stale matrix aliases (P3W7 "Anya Volkov" reproducer) before `/wave-kickoff` fan-out |
| #320 | `.claude/team/charter/agents.md` | two new sections | bakes throughline-watch + reviewer-class checklist into spawn-brief defaults (P3W7 reviewer-pre-load pattern) |

Total: 4 files changed, +772/-1 lines, +18 tests across two new/extended test suites.

## Per-commit summary

### Commit 1 — `e45f423` — closes #318

`/wave-wrapup` Step 10.5: write canonical counter keys (`wave_{M}_final_pr_count`, `wave_{M}_changes_requested_cycles`, `wave_{M}_top_concentration_pct`) at top level of `cross-repo-status.json` via the shared `upsert_status_keys.py` helper. Pre-#318 these were missing, forcing manual followup commits at retro time (P3W7 `fb459b2`). Post-#318 `/wave-retro` Step 2.5 reads cleanly.

New `.claude/skills/wave-wrapup/tests/test_canonical_counter_keys.py` — **7 tests** covering top-level placement, sibling preservation, idempotent re-run, replace-with-new-values, coexistence with optional `wave_{M}_summary` block, and retro's exact jq lookup contract.

### Commit 2 — `3c4dd7b` — closes #319

`/wave-scope` Step 12.5: validate every implementer/reviewer name in the scope matrix against the relevant roster BEFORE `/wave-kickoff` fan-out. P3W7 retro recorded TWO substitutions in `wave_7_decisions.implementer_substitutions` — both worked in-flight but weren't caught at scope time.

New `.claude/skills/wave-scope/validate_matrix_names.py` — read-only validator:
- Per-repo entries → child-repo roster UNION parent roster (org-coordinators can fill child slots).
- Parent entries → parent-only roster.
- Case-insensitive match; parenthetical role suffix stripped.
- On miss: difflib top-3 suggestions to stderr.

New `.claude/skills/wave-scope/tests/test_validate_matrix_names.py` — **11 tests** covering happy paths, the Anya Volkov reproducer, unknown names, case-insensitivity, empty slots, parent-roster fallback, missing-child-roster behavior.

Empirical Anya Volkov reproducer verified during dev: `python3 validate_matrix_names.py /tmp/matrix.json` with `Anya Volkov` returns exit 1 with suggestion `Anya Kowalczyk`.

### Commit 3 — `bd39937` — closes #320

`agents.md` § Reviewer spawn brief — throughline-watch (default, #320) — mandates that EVERY reviewer-class spawn brief includes a verbatim `## Throughline-watch` template block. Explicit "no throughline observed" escape so single-PR waves still produce useful retro signal.

`agents.md` § Orchestrator checklist when spawning a reviewer — new 9-item parallel to the existing implementer checklist. Codifies post-PR#375 / #372 reviewer discipline (Direction-table format, `gh pr comment` not `gh pr review`, read-at-HEAD-not-clone, `grep -c` not `| head -N`, Approved verdict literal-strings) so reviewer spawns are architectural not memorial.

P3W7 produced its complete pre-loaded retro thesis (Idris-coined sentence + 5-reviewer confirmation) because the orchestrator ad-hoc added throughline-watch to that wave's briefs. Promoting to charter default makes this discipline propagate to every subsequent wave.

## Validation

- `python3 -m unittest discover -s .claude/skills/wave-wrapup/tests` → **7/7 OK**
- `python3 -m unittest discover -s .claude/skills/wave-scope/tests` → **20/20 OK** (9 pre-existing + 11 new)
- `uvx ruff@0.7.4 format --check .claude/skills/wave-wrapup/tests/ .claude/skills/wave-scope/` → clean
- `uvx ruff@0.7.4 check .claude/skills/wave-wrapup/tests/ .claude/skills/wave-scope/` → All checks passed
- Pre-commit hooks (ruff-format, ruff-lint, mypy) all passed on each commit (or correctly skipped for .md-only commits)
- Empirical Anya Volkov reproducer: validator exits 1 with suggestion `Anya Kowalczyk` (per W7 `wave_7_decisions.implementer_substitutions[0].actual`)

## Test plan

- [ ] CI green on all 3 commits
- [ ] Two reviewers approve with `RequestOrReplied: Approved` + `TechDebt:` line per charter § Comment-Based Reviews
- [ ] After merge to wave-9, explicit `gh issue close 318 319 320` per memory `feedback_wave_branch_issue_close` (wave-branch merges don't auto-close)
- [ ] Subsequent wave's reviewer spawn briefs use the new template block by default (verifies #320 adoption)
- [ ] Next `/wave-wrapup` run writes all 3 top-level counter keys without manual followup (verifies #318 adoption)
- [ ] Next `/wave-scope` run validates matrix names and STOPS on unresolved entries (verifies #319 adoption)

## Caveat — assignee labels

The 3 issues are labeled `WANJIKU_MWANGI` (#318, #319) and `NADIA_KHOURY` (#320). My understanding is the team-lead's brief assigned this batch to me (Aino) for execution — confirming up-front rather than relying on label-implies-ownership. If the team-lead intended these to go to Wanjiku and Nadia, this PR can be reassigned or its commits reattributed; flagging for explicit ack.

## Relates to

- Closes #318
- Closes #319
- Closes #320
- P3W7 retro feedback log § Proposed process changes #4 (counters), #5 (throughline-watch), #6 (name validation)
- Charter dependencies: `agents.md` § Reviewer slate discipline (#201), `pull-requests.md` § Comment-Based Reviews
- Skill dependencies: `wave-retro` Step 2.5 (counter-key contract), `wave-scope/upsert_status_keys.py` (main#332 fix)
- Hook dependencies: `validate_pr_review` (post-#356 Direction table), `block_gh_pr_review` (post-#372 example correction)
- Sibling memory codified into #320: `feedback_validate_pr_review_approved_not_reply`, `feedback_spawn_brief_requestor_field_semantics`, `feedback_no_head_in_surface_enumeration`, `feedback_review_against_artifact_not_framing`

