### PR TITLE
tech-debt(hook): block_stale_tmp_message_file — strip heredocs + flag-aware extraction (closes #316)

### DIFF
--- a/.claude/hooks/block_stale_tmp_message_file.py
+++ b/.claude/hooks/block_stale_tmp_message_file.py
@@ -2,11 +2,12 @@
 """PreToolUse hook: Block stale /tmp/* message/body files on commit/PR/issue commands.
 
 Refuses commands of the form ``git commit -F /tmp/...`` and ``gh {pr,issue}
-{create,comment} --body-file /tmp/...`` when the target file's mtime is older
-than ~30s. Such files are almost always leftovers from a prior task or session
-that the current command is about to consume by mistake — see
-``feedback_tmp_msg_file_stale.md`` for the three documented surfaces and the
-2026-05-03 ontology-rebuild recurrence that motivated this hook.
+{create,comment,edit} --body-file /tmp/...`` (plus ``gh api ... --input
+/tmp/...``) when the target file's mtime is older than ~30s. Such files are
+almost always leftovers from a prior task or session that the current command
+is about to consume by mistake — see ``feedback_tmp_msg_file_stale.md`` for
+the three documented surfaces and the 2026-05-03 ontology-rebuild recurrence
+that motivated this hook.
 
 Override paths the user can take when blocked:
   - rename the file to a non-/tmp path (e.g. .claude/scratch/msg.txt)
@@ -19,62 +20,133 @@ constant. Chosen as a balance between: long enough that a Write+Bash batched
 in parallel always passes (Bash sees the file at <1s mtime), short enough that
 a leftover file from a prior task in the same session is reliably caught.
 
+Parser pattern (#316)
+=====================
+
+The matcher tokenizes the command via `_shell_parse` (strip_heredocs +
+tokenize + iter_command_segments + find_git/gh_subcommand) instead of
+regex-scanning the raw command string. This eliminates the heredoc-body /
+code-fence / positional-arg false-positives where a /tmp/* path mentioned
+inside a body file's content was being read as a body-file flag value
+(W7-retro 2026-05-08 regression captured by Annunaki).
+
+This is a warn-only matcher (no security implications when bypassed), so a
+shlex parse failure (`tokenize` returns None) fails OPEN — the command is
+allowed through and the downstream tool surfaces any real error itself.
+
 Exit codes:
-  0 — allow (no /tmp/* body-file argument, or file is fresh, or file missing)
+  0 — allow (no /tmp/* body-file argument, or file is fresh, or file missing,
+       or shlex parse failed)
   2 — block (target file mtime older than threshold)
 """
 
+from __future__ import annotations
+
 import json
 import os
-import re
 import sys
 import time
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from annunaki_log import log_pretooluse_block
+from _shell_parse import (  # noqa: E402
+    find_gh_subcommand,
+    find_git_subcommand,
+    iter_command_segments,
+    strip_heredocs,
+    tokenize,
+)
+from annunaki_log import log_pretooluse_block  # noqa: E402
 
 STALE_TMP_THRESHOLD_SECONDS = 30
 
-# Capture the path argument following each known body-file flag. The patterns
-# look for `-F`, `--file`, `--body-file` followed by a /tmp/... path. We allow
-# either a quoted or bare path, and we deliberately do NOT match the `=` form
-# (e.g. `--body-file=/tmp/x`) — none of the supported callers (git commit / gh)
-# use that form. Path capture stops at the first whitespace or shell operator.
-_PATH_CHARS = r"[^\s;&|<>()`\"']+"
-
-# Path captures for the file-flag patterns. We do NOT try to enclose the entire
-# `git ... commit ... -F path` in a single regex — quoted args (e.g.
-# `-c user.name="Aino Virtanen"`) defeat naive `\S+` skipping. Instead we split
-# the command on shell separators (&&, ||, ;, |) to get one logical command per
-# segment, decide whether the segment is a `git commit` or `gh {pr,issue}
-# {create,comment,edit}` invocation, and only THEN look for the body-file flag
-# anywhere in that segment.
-_BODY_FILE_FLAG_RE = re.compile(
-    rf"\s(?:-F|--file|--body-file)\s+(?P<path>{_PATH_CHARS})",
-)
-
-_SEGMENT_SPLIT_RE = re.compile(r"&&|\|\||;|(?<![|])\|(?![|])")
-
-_GIT_COMMIT_RE = re.compile(r"\bgit\b[^\n]*?\bcommit\b")
-_GH_BODY_RE = re.compile(r"\bgh\b\s+(?:pr|issue)\s+(?:create|comment|edit)\b")
+# Flags whose immediately-following token is a path to a body/message file.
+# Used as a two-token form (`-F <path>`) AND an equals form (`--body-file=<path>`).
+_BODY_FILE_FLAGS = frozenset({"-F", "--file", "--body-file", "--input"})
 
 
-def _segment_uses_body_file(segment: str) -> bool:
-    """True if this shell segment is a git-commit or gh-body command we cover."""
-    return bool(_GIT_COMMIT_RE.search(segment) or _GH_BODY_RE.search(segment))
+def _extract_path_after_flag(tokens: list[str], idx: int) -> str | None:
+    """Given a token list and an index pointing at a flag token, return the
+    associated path value (or None if no value is attached).
+
+    Handles:
+      - Two-token form: tokens[idx] == "-F", tokens[idx+1] is the path.
+      - Equals form: tokens[idx] == "--body-file=/tmp/x" — the path is after `=`.
+    """
+    tok = tokens[idx]
+    if "=" in tok:
+        # Equals form: split once; the prefix is the flag, the suffix is the path.
+        flag, _, value = tok.partition("=")
+        if flag in _BODY_FILE_FLAGS and value:
+            return value
+        return None
+    if tok in _BODY_FILE_FLAGS and idx + 1 < len(tokens):
+        return tokens[idx + 1]
+    return None
+
+
+def _token_is_body_file_flag(tok: str) -> bool:
+    """True if `tok` is a body-file flag in either two-token or equals form."""
+    if tok in _BODY_FILE_FLAGS:
+        return True
+    if "=" in tok:
+        flag = tok.split("=", 1)[0]
+        return flag in _BODY_FILE_FLAGS
+    return False
+
+
+def _segment_covers_body_file(segment: list[str]) -> bool:
+    """True if this command segment is one whose body-file flags we check.
+
+    Covers:
+      - git commit              (via -F / --file)
+      - gh {pr,issue} {create,comment,edit}  (via --body-file)
+      - gh api                  (via --input)
+    """
+    git_decoded = find_git_subcommand(segment)
+    if git_decoded is not None:
+        _globals, rest = git_decoded
+        if rest and rest[0] == "commit":
+            return True
+
+    gh_decoded = find_gh_subcommand(segment)
+    if gh_decoded is not None:
+        _globals, rest = gh_decoded
+        if not rest:
+            return False
+        topic = rest[0]
+        if topic == "api":
+            return True
+        if topic in ("pr", "issue") and len(rest) >= 2 and rest[1] in ("create", "comment", "edit"):
+            return True
+    return False
 
 
 def _extract_tmp_paths(command: str) -> list[str]:
-    """Return /tmp/* paths supplied to git-commit -F or gh --body-file."""
+    """Return /tmp/* paths supplied to a body-file flag in a covered command.
+
+    Strips heredocs first so a /tmp path mentioned inside a heredoc body is
+    not treated as a flag value. Falls back to "no paths" if shlex parsing
+    fails (this is a warn-only matcher — fail open).
+    """
+    cleaned = strip_heredocs(command)
+    tokens = tokenize(cleaned)
+    if tokens is None:
+        # shlex parse failure — fail open. The command will run; if it
+        # genuinely consumes a stale file, the downstream tool will surface
+        # that error. We do not block on speculation.
+        return []
+
     paths: list[str] = []
-    for segment in _SEGMENT_SPLIT_RE.split(command):
-        if not _segment_uses_body_file(segment):
+    for segment in iter_command_segments(tokens):
+        if not _segment_covers_body_file(segment):
             continue
-        for match in _BODY_FILE_FLAG_RE.finditer(segment):
-            raw = match.group("path").strip("\"'")
-            if raw.startswith("/tmp/"):
-                paths.append(raw)
+        for i, tok in enumerate(segment):
+            if not _token_is_body_file_flag(tok):
+                continue
+            value = _extract_path_after_flag(segment, i)
+            if value and value.startswith("/tmp/"):
+                paths.append(value)
     return paths
 
 

--- a/.claude/hooks/fixtures/block_stale_tmp_message_file/adjacent_quoted_identity_flags_fresh.json
+++ b/.claude/hooks/fixtures/block_stale_tmp_message_file/adjacent_quoted_identity_flags_fresh.json
@@ -1,0 +1,5 @@
+{
+  "description": "Adjacent shape: full charter-format git commit with quoted -c identity flags + -F /tmp/<path>. Regression coverage for tokenizer correctness around quoted -c values (which broke the previous regex parser).",
+  "command": "git -c user.name=\"Aino Virtanen\" -c user.email=\"parametrization+Aino.Virtanen@gmail.com\" commit -F /tmp/fixture-adjacent-quoted-identity.txt",
+  "expect": "allow"
+}

--- a/.claude/hooks/fixtures/block_stale_tmp_message_file/fp_code_fence_body_references_tmp.json
+++ b/.claude/hooks/fixtures/block_stale_tmp_message_file/fp_code_fence_body_references_tmp.json
@@ -1,0 +1,5 @@
+{
+  "description": "False-positive regression: the heredoc body has a markdown code-fence block referencing /tmp/x — since heredoc-strip runs first, the fenced content drops out before tokenization. Parser must see only the body-file value.",
+  "command": "gh issue create --title doc --body-file /tmp/fixture-fp-codefence-bodyfile.md <<EOF\n## Code\n\n\\`\\`\\`\necho hi > /tmp/fixture-fp-codefence-inside.txt\n\\`\\`\\`\nEOF",
+  "expect": "allow"
+}

--- a/.claude/hooks/fixtures/block_stale_tmp_message_file/fp_heredoc_body_references_other_tmp.json
+++ b/.claude/hooks/fixtures/block_stale_tmp_message_file/fp_heredoc_body_references_other_tmp.json
@@ -1,0 +1,5 @@
+{
+  "description": "False-positive regression (W7 retro 2026-05-08): the --body-file points to a fresh /tmp file, but the heredoc body contains another /tmp/* path as documentation reference. Heredoc-stripping must drop the inner reference so the parser sees ONLY the body-file value.",
+  "command": "gh issue create --title bug --body-file /tmp/fixture-fp-heredoc-bodyfile.md <<EOF\n## Reproducer\n\nA prior /tmp/fixture-fp-heredoc-old-reference.md was written and is documented here\nas part of the bug report body. It must NOT be treated as a body-file argument.\nEOF",
+  "expect": "allow"
+}

--- a/.claude/hooks/fixtures/block_stale_tmp_message_file/fp_positional_tmp_arg_not_body_file.json
+++ b/.claude/hooks/fixtures/block_stale_tmp_message_file/fp_positional_tmp_arg_not_body_file.json
@@ -1,0 +1,5 @@
+{
+  "description": "False-positive regression: /tmp/* appears as a positional/redirect argument unrelated to a body-file flag (`gh pr view 42 > /tmp/out.txt`). Must be ignored — only body-file flag VALUES are checked.",
+  "command": "gh pr view 42 > /tmp/fixture-fp-positional-out.txt",
+  "expect": "allow"
+}

--- a/.claude/hooks/fixtures/block_stale_tmp_message_file/happy_equals_form_body_file.json
+++ b/.claude/hooks/fixtures/block_stale_tmp_message_file/happy_equals_form_body_file.json
@@ -1,0 +1,5 @@
+{
+  "description": "Happy path: --body-file=<path> equals form. The previous regex parser did not handle the equals form at all — this fixture asserts the new tokenizer extracts /tmp/x.md from the equals-attached token.",
+  "command": "gh issue create --title fix --body-file=/tmp/fixture-happy-equals-bodyfile.md",
+  "expect": "allow"
+}

--- a/.claude/hooks/fixtures/block_stale_tmp_message_file/happy_fresh_body_file_allowed.json
+++ b/.claude/hooks/fixtures/block_stale_tmp_message_file/happy_fresh_body_file_allowed.json
@@ -1,0 +1,5 @@
+{
+  "description": "Happy path: gh issue create --body-file /tmp/<unique> when the file doesn't exist (parser extracts the path correctly; allow because mtime check on missing file is no-op)",
+  "command": "gh issue create --title fix --body-file /tmp/fixture-happy-fresh-nonexistent.md",
+  "expect": "allow"
+}

--- a/.claude/hooks/fixtures/block_stale_tmp_message_file/happy_gh_api_input.json
+++ b/.claude/hooks/fixtures/block_stale_tmp_message_file/happy_gh_api_input.json
@@ -1,0 +1,5 @@
+{
+  "description": "Happy path: gh api ... --input /tmp/<path>. Issue #316 lists --input as an additional flag to cover. Parser must recognize gh api as a covered topic and extract the path after --input.",
+  "command": "gh api repos/foo/bar/issues -X POST --input /tmp/fixture-happy-gh-api-input.json",
+  "expect": "allow"
+}

--- a/.claude/hooks/tests/test_block_stale_tmp_message_file.py
+++ b/.claude/hooks/tests/test_block_stale_tmp_message_file.py
@@ -102,6 +102,135 @@ class FreshnessGateTests(unittest.TestCase):
             self.assertEqual(result["decision"], "block")
 
 
+class FreshnessGateHeredocRegressionTests(unittest.TestCase):
+    """W7-retro 2026-05-08 false-positive regression (#316).
+
+    Reproduces the actual bug shape that motivated this fix:
+      - Fresh /tmp/body.md (mtime < threshold) — the genuine --body-file arg
+      - Stale /tmp/old.md (mtime > threshold) — mentioned only inside the
+        heredoc body as documentation
+      - Command: `gh issue create --body-file /tmp/body.md <<EOF ... EOF`
+      - Expected: allow (the stale path is NOT a body-file value)
+
+    The pre-fix regex-against-raw-command-string parser found `/tmp/old.md`
+    inside the heredoc body and blocked. The post-fix parser strips heredocs
+    BEFORE tokenization, so the stale path never reaches the matcher.
+    """
+
+    def test_fresh_bodyfile_with_stale_path_in_heredoc_body_allowed(self):
+        with tempfile.TemporaryDirectory(dir="/tmp") as td:
+            fresh = f"{td}/body.md"
+            stale = f"{td}/old-stale.md"
+            _touch(fresh, age_seconds=1)
+            _touch(stale, age_seconds=120)
+            cmd = (
+                f"gh issue create --title bug --body-file {fresh} <<EOF\n"
+                "## Reproducer\n"
+                "\n"
+                f"A prior {stale} was written and is referenced here as documentation\n"
+                "of the bug shape. The hook MUST NOT treat it as a body-file value.\n"
+                "EOF"
+            )
+            result = hook.check(_bash(cmd))
+            self.assertIsNone(
+                result,
+                f"W7-retro regression: stale path inside heredoc body was treated "
+                f"as body-file argument and blocked. Reason: {result}",
+            )
+
+    def test_fresh_bodyfile_with_code_fence_tmp_in_heredoc_body_allowed(self):
+        """Code-fence inside heredoc body referencing /tmp must not trip the matcher.
+
+        Heredoc-strip drops the entire body, so the fenced /tmp/* reference
+        falls out before the path-extractor runs.
+        """
+        with tempfile.TemporaryDirectory(dir="/tmp") as td:
+            fresh = f"{td}/body.md"
+            _touch(fresh, age_seconds=1)
+            cmd = (
+                f"gh issue create --title doc --body-file {fresh} <<EOF\n"
+                "Example:\n"
+                "```\n"
+                f"cat > /tmp/some-old-example.txt <<INNER\n"
+                "content\n"
+                "INNER\n"
+                "```\n"
+                "EOF"
+            )
+            result = hook.check(_bash(cmd))
+            self.assertIsNone(result)
+
+
+class EqualsFormTests(unittest.TestCase):
+    """Coverage for --body-file=<path> / --file=<path> / --input=<path> equals form.
+
+    Pre-fix regex required a SPACE between flag and value, silently missing the
+    equals form. Post-fix tokenizer handles both shapes.
+    """
+
+    def test_stale_body_file_equals_form_blocked(self):
+        with tempfile.TemporaryDirectory(dir="/tmp") as td:
+            body = f"{td}/body.md"
+            _touch(body, age_seconds=120)
+            cmd = f"gh issue create --title x --body-file={body}"
+            result = hook.check(_bash(cmd))
+            self.assertIsNotNone(result)
+            assert result is not None
+            self.assertEqual(result["decision"], "block")
+            self.assertIn(body, result["reason"])
+
+    def test_fresh_body_file_equals_form_allowed(self):
+        with tempfile.TemporaryDirectory(dir="/tmp") as td:
+            body = f"{td}/body.md"
+            _touch(body, age_seconds=1)
+            cmd = f"gh issue create --title x --body-file={body}"
+            result = hook.check(_bash(cmd))
+            self.assertIsNone(result)
+
+    def test_stale_git_commit_file_equals_form_blocked(self):
+        with tempfile.TemporaryDirectory(dir="/tmp") as td:
+            msg = f"{td}/msg.txt"
+            _touch(msg, age_seconds=120)
+            cmd = f"git commit --file={msg}"
+            result = hook.check(_bash(cmd))
+            self.assertIsNotNone(result)
+            assert result is not None
+            self.assertEqual(result["decision"], "block")
+
+
+class GhApiInputTests(unittest.TestCase):
+    """Coverage for `gh api ... --input <path>` (issue #316 acceptance flag list)."""
+
+    def test_stale_gh_api_input_blocked(self):
+        with tempfile.TemporaryDirectory(dir="/tmp") as td:
+            payload = f"{td}/payload.json"
+            _touch(payload, age_seconds=120)
+            cmd = f"gh api repos/foo/bar/issues -X POST --input {payload}"
+            result = hook.check(_bash(cmd))
+            self.assertIsNotNone(result)
+            assert result is not None
+            self.assertEqual(result["decision"], "block")
+            self.assertIn(payload, result["reason"])
+
+    def test_fresh_gh_api_input_allowed(self):
+        with tempfile.TemporaryDirectory(dir="/tmp") as td:
+            payload = f"{td}/payload.json"
+            _touch(payload, age_seconds=1)
+            cmd = f"gh api repos/foo/bar/issues -X POST --input {payload}"
+            result = hook.check(_bash(cmd))
+            self.assertIsNone(result)
+
+    def test_stale_gh_api_input_equals_form_blocked(self):
+        with tempfile.TemporaryDirectory(dir="/tmp") as td:
+            payload = f"{td}/payload.json"
+            _touch(payload, age_seconds=120)
+            cmd = f"gh api repos/foo/bar/issues -X POST --input={payload}"
+            result = hook.check(_bash(cmd))
+            self.assertIsNotNone(result)
+            assert result is not None
+            self.assertEqual(result["decision"], "block")
+
+
 class NonMatchingTests(unittest.TestCase):
     """Cases where the hook must stay out of the way."""
 
@@ -188,7 +317,7 @@ class NonMatchingTests(unittest.TestCase):
 
 
 class ExtractionTests(unittest.TestCase):
-    """Direct coverage of _extract_tmp_paths regex behavior."""
+    """Direct coverage of _extract_tmp_paths tokenizer behavior."""
 
     def test_extracts_git_F_path(self):
         self.assertEqual(
@@ -213,6 +342,53 @@ class ExtractionTests(unittest.TestCase):
         self.assertEqual(
             sorted(hook._extract_tmp_paths(cmd)),
             ["/tmp/a.txt", "/tmp/b.md"],
+        )
+
+    def test_extracts_equals_form_body_file(self):
+        """--body-file=<path> equals form must yield the path."""
+        self.assertEqual(
+            hook._extract_tmp_paths("gh issue create --body-file=/tmp/eq.md"),
+            ["/tmp/eq.md"],
+        )
+
+    def test_extracts_gh_api_input_path(self):
+        """`gh api ... --input <path>` yields the path."""
+        self.assertEqual(
+            hook._extract_tmp_paths("gh api repos/x/y/issues -X POST --input /tmp/payload.json"),
+            ["/tmp/payload.json"],
+        )
+
+    def test_extracts_gh_api_input_equals_form(self):
+        """`gh api ... --input=<path>` equals form yields the path."""
+        self.assertEqual(
+            hook._extract_tmp_paths("gh api repos/x/y/issues -X POST --input=/tmp/payload.json"),
+            ["/tmp/payload.json"],
+        )
+
+    def test_heredoc_body_paths_ignored(self):
+        """Paths mentioned inside heredoc bodies are stripped before tokenization."""
+        cmd = (
+            "gh issue create --body-file /tmp/fresh.md <<EOF\n"
+            "see /tmp/old-doc-reference.md for prior context\n"
+            "EOF"
+        )
+        self.assertEqual(
+            hook._extract_tmp_paths(cmd),
+            ["/tmp/fresh.md"],
+        )
+
+    def test_positional_tmp_in_redirect_ignored(self):
+        """`gh pr view 42 > /tmp/out.txt` must yield NO paths (no body-file flag)."""
+        self.assertEqual(
+            hook._extract_tmp_paths("gh pr view 42 > /tmp/out.txt"),
+            [],
+        )
+
+    def test_git_log_tmp_in_grep_arg_ignored(self):
+        """`git log --grep /tmp/foo` must yield NO paths (git log is not covered)."""
+        self.assertEqual(
+            hook._extract_tmp_paths("git log --grep /tmp/foo"),
+            [],
         )
 
 

--- a/.claude/hooks/tests/test_block_stale_tmp_message_file_parser.py
+++ b/.claude/hooks/tests/test_block_stale_tmp_message_file_parser.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Fixture-driven parser tests for block_stale_tmp_message_file hook.
+
+Each JSON file in fixtures/block_stale_tmp_message_file/ is one test case:
+
+    {
+        "description": "<human label>",
+        "command": "<raw bash command string>",
+        "expect": "allow" | "block:<reason-keyword>"
+    }
+
+The `expect` field:
+  - "allow"      → check() must return None
+  - "block:<kw>" → check() must return a block decision; <kw> is a
+                   substring of the reason (case-insensitive) for
+                   self-documenting test output, not strict matching.
+
+Fixtures cover PARSER-DISCRIMINATION cases only (does the tokenizer
+correctly identify the body-file flag value vs incidental /tmp/* mentions?).
+The mtime-staleness gate is exercised separately by the unit tests in
+test_block_stale_tmp_message_file.py which use tempfile + os.utime to
+control file freshness. Encoding mtime state in static JSON fixtures is not
+attempted — that is not what fixtures are for.
+
+Run:  python3 -m pytest .claude/hooks/tests/test_block_stale_tmp_message_file_parser.py -v
+      (or the full suite: python3 -m pytest .claude/hooks/tests/ -v)
+
+Covers:
+  Bug shape  — heredoc-body /tmp/* mention (W7 retro 2026-05-08)
+  Bug shape  — code-fence /tmp/* mention inside heredoc
+  Bug shape  — positional /tmp redirect target (`> /tmp/out`)
+  Happy path — --body-file /tmp/<fresh>
+  Happy path — --body-file=<path> equals form
+  Happy path — gh api --input /tmp/<path>
+  Adjacent   — full charter git -c identity flags + -F /tmp/<path>
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_HOOKS_DIR = _HERE.parent
+_FIXTURES_DIR = _HOOKS_DIR / "fixtures" / "block_stale_tmp_message_file"
+
+sys.path.insert(0, str(_HOOKS_DIR))
+
+import block_stale_tmp_message_file as hook  # noqa: E402
+
+
+def _load_fixtures() -> list[tuple[str, dict]]:
+    """Return (fixture_name, fixture_data) pairs for every JSON in the fixture dir."""
+    fixtures = []
+    for path in sorted(_FIXTURES_DIR.glob("*.json")):
+        data = json.loads(path.read_text(encoding="utf-8"))
+        fixtures.append((path.stem, data))
+    return fixtures
+
+
+def _make_input(command: str) -> dict:
+    return {"tool_name": "Bash", "tool_input": {"command": command}}
+
+
+class FixtureDrivenParserTests(unittest.TestCase):
+    """One test method per fixture file — generated dynamically."""
+
+
+def _add_fixture_test(name: str, fixture: dict) -> None:
+    """Attach a test method to FixtureDrivenParserTests for `fixture`."""
+    description = fixture.get("description", name)
+    command = fixture["command"]
+    expect = fixture["expect"]
+
+    def test_method(self: unittest.TestCase) -> None:
+        result = hook.check(_make_input(command))
+        if expect == "allow":
+            self.assertIsNone(
+                result,
+                f"{description!r}: expected allow (None) but got block: {result}",
+            )
+        elif expect.startswith("block:"):
+            self.assertIsNotNone(
+                result,
+                f"{description!r}: expected block but got allow (None)",
+            )
+            assert result is not None  # for mypy
+            self.assertEqual(
+                result.get("decision"),
+                "block",
+                f"{description!r}: result decision is not 'block': {result}",
+            )
+        else:
+            raise ValueError(f"Unknown expect value {expect!r} in fixture {name!r}")
+
+    test_method.__name__ = f"test_{name}"
+    test_method.__doc__ = description
+    setattr(FixtureDrivenParserTests, test_method.__name__, test_method)
+
+
+for _fixture_name, _fixture_data in _load_fixtures():
+    _add_fixture_test(_fixture_name, _fixture_data)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Refactor `block_stale_tmp_message_file.py` to use the shared `_shell_parse` helper (`strip_heredocs` + `tokenize` + `iter_command_segments` + `find_git/gh_subcommand`) instead of regex against the raw command string.
- Heredoc bodies, code-fence blocks, and positional `/tmp/*` tokens no longer falsely match. Only the VALUE of a recognized body-file flag in a covered command segment is checked for staleness.
- Adds equals-form coverage (`--body-file=/tmp/x`, `--file=/tmp/x`) and `gh api ... --input` coverage per the issue acceptance list.
- Adds 7 parser-discrimination fixtures + a fixture-driven test file, mirroring the `validate_commit_identity` pattern. fix + fixtures + tests land together per `charter/hooks.md` § Parser-Fixture Coverage Requirements.

## Why

W7-retro 2026-05-08 captured a false-positive: a `gh issue create --body-file /tmp/<fresh>.md` whose heredoc body contained an example reference to a different (stale) `/tmp/*.md` path was blocked, because the regex parser scanned the entire raw command string and found the stale path inside the heredoc body. Annunaki captured 2 instances this session.

This is the same shape as the W4 cluster (#226, #227, #223, #216, #188, #144, #189) — substring/regex matching against a raw command string cannot distinguish command-position tokens from data-position text. The fix ports the proven `_shell_parse` pattern.

The freshness gate itself (the `/tmp/*` race captured in `feedback_tmp_msg_file_stale.md`) is preserved — only the false-positive surface is removed.

## What changed

- `.claude/hooks/block_stale_tmp_message_file.py` — rewrite `_extract_tmp_paths` to use `strip_heredocs` + `tokenize` + `iter_command_segments`. Detect covered segments via `find_git_subcommand` (`commit`) and `find_gh_subcommand` (`api`, or `{pr,issue} {create,comment,edit}`). Walk tokens looking for `-F` / `--file` / `--body-file` / `--input` in both two-token and equals-attached forms. Only `/tmp/*` flag VALUES proceed to the mtime check. `tokenize` returning `None` (shlex parse failure) fails open — this is a warn-only matcher with no security implications when bypassed.
- `.claude/hooks/fixtures/block_stale_tmp_message_file/` — new directory, 7 fixtures (see test plan).
- `.claude/hooks/tests/test_block_stale_tmp_message_file_parser.py` — new fixture-driven test file modeled on `test_validate_commit_identity_parser.py`.
- `.claude/hooks/tests/test_block_stale_tmp_message_file.py` — adds `FreshnessGateHeredocRegressionTests` (end-to-end mtime test reproducing the W7-retro scenario), `EqualsFormTests`, `GhApiInputTests`, plus extended `ExtractionTests` direct coverage.

## Test plan

- [x] `python3 -m pytest .claude/hooks/tests/` — 620 passed
- [x] `python3 -m pytest .claude/hooks/tests/test_block_stale_tmp_message_file.py .claude/hooks/tests/test_block_stale_tmp_message_file_parser.py -v` — 42 passed (35 unit + 7 fixtures)
- [x] `uvx ruff format --check .claude/hooks/` — clean (54 files already formatted)
- [x] `uvx ruff check .claude/hooks/` — clean (all checks passed)
- [x] Fixtures present:
  - `happy_fresh_body_file_allowed.json`
  - `fp_heredoc_body_references_other_tmp.json`
  - `fp_code_fence_body_references_tmp.json`
  - `fp_positional_tmp_arg_not_body_file.json`
  - `happy_equals_form_body_file.json`
  - `happy_gh_api_input.json`
  - `adjacent_quoted_identity_flags_fresh.json`

Closes #316.

**Wave**: P3W9
