### PR TITLE
tech-debt(hook): validate_review_comment_format — narrow to Approved/ChangesRequested (closes #378)

### DIFF
--- a/.claude/hooks/fixtures/validate_review_comment_format/block_approved_swapped.json
+++ b/.claude/hooks/fixtures/validate_review_comment_format/block_approved_swapped.json
@@ -1,0 +1,6 @@
+{
+  "description": "Approved verdict with swapped Requestor/Requestee (Requestee.lastname matches branch-author). Pre-path-2 blocked behavior preserved — verdict scope is exactly where the swap heuristic remains sound.",
+  "command": "gh pr comment 42 --body \"$(cat <<'EOF'\nRequestor: Nadia Khoury\nRequestee: Aino Virtanen\nRequestOrReplied: Approved\nTechDebt: none\nEOF\n)\"",
+  "branch_ref": "A.Virtanen/0378-direction-table-oos",
+  "expect": "block:swapped"
+}

--- a/.claude/hooks/fixtures/validate_review_comment_format/block_changes_requested_spaced_swapped.json
+++ b/.claude/hooks/fixtures/validate_review_comment_format/block_changes_requested_spaced_swapped.json
@@ -1,0 +1,6 @@
+{
+  "description": "`Changes Requested` (two-word, space-separated) verdict form — the literal value `validate_pr_review` counts per feedback_validate_pr_review_approved_not_reply. Swapped fields must still block on the spaced form.",
+  "command": "gh pr comment 42 --body \"$(cat <<'EOF'\nRequestor: Nadia Khoury\nRequestee: Aino Virtanen\nRequestOrReplied: Changes Requested\nTechDebt: none\nEOF\n)\"",
+  "branch_ref": "A.Virtanen/0378-direction-table-oos",
+  "expect": "block:swapped"
+}

--- a/.claude/hooks/fixtures/validate_review_comment_format/block_changes_requested_swapped.json
+++ b/.claude/hooks/fixtures/validate_review_comment_format/block_changes_requested_swapped.json
@@ -1,0 +1,6 @@
+{
+  "description": "ChangesRequested verdict (camelCase form) with swapped Requestor/Requestee. Verdict scope, swap heuristic sound — block.",
+  "command": "gh pr comment 42 --body \"$(cat <<'EOF'\nRequestor: Nadia Khoury\nRequestee: Aino Virtanen\nRequestOrReplied: ChangesRequested\nTechDebt: none\nEOF\n)\"",
+  "branch_ref": "A.Virtanen/0378-direction-table-oos",
+  "expect": "block:swapped"
+}

--- a/.claude/hooks/fixtures/validate_review_comment_format/happy_approved_proper_direction.json
+++ b/.claude/hooks/fixtures/validate_review_comment_format/happy_approved_proper_direction.json
@@ -1,0 +1,6 @@
+{
+  "description": "Happy path (current hook behavior preserved): Approved verdict where Requestee.lastname != branch-author.lastname. Branch is A.Virtanen/...; Requestee is Nadia Khoury — no swap signal, allow. Note: the existing hook's swap heuristic is independent of the charter Direction-table semantics — path-2 narrows the scope where the heuristic fires but does NOT alter the heuristic's check itself. Full Direction-table semantic realignment is out of scope per #378 path-2.",
+  "command": "gh pr comment 42 --body \"$(cat <<'EOF'\nRequestor: Aino Virtanen\nRequestee: Nadia Khoury\nRequestOrReplied: Approved\nTechDebt: none\nEOF\n)\"",
+  "branch_ref": "A.Virtanen/0378-direction-table-oos",
+  "expect": "allow"
+}

--- a/.claude/hooks/fixtures/validate_review_comment_format/oos_reply_direction.json
+++ b/.claude/hooks/fixtures/validate_review_comment_format/oos_reply_direction.json
@@ -1,0 +1,6 @@
+{
+  "description": "Out-of-scope: `Reply` direction. Requestee.lastname (Virtanen) matches branch-author.lastname (Virtanen). Pre-path-2 hook would have BLOCKED as a swap; path-2 narrowing returns None for non-verdict directions and lets the Reply through. Coverage for the second non-verdict row of the Direction table.",
+  "command": "gh pr comment 42 --body \"$(cat <<'EOF'\nRequestor: Nadia Khoury\nRequestee: Aino Virtanen\nRequestOrReplied: Reply\n\nThanks for the review; rolled out the change.\nEOF\n)\"",
+  "branch_ref": "A.Virtanen/0378-direction-table-oos",
+  "expect": "allow"
+}

--- a/.claude/hooks/fixtures/validate_review_comment_format/oos_request_direction.json
+++ b/.claude/hooks/fixtures/validate_review_comment_format/oos_request_direction.json
@@ -1,0 +1,6 @@
+{
+  "description": "Out-of-scope: `Request` direction. The comment body has Requestee.lastname (Virtanen) matching the branch author lastname (Virtanen) — under the pre-path-2 hook this would have BLOCKED as a 'swap'. Path-2 narrows the hook to verdict directions only, so the Request comment passes through. This is the false-positive surface the narrowing eliminates.",
+  "command": "gh pr comment 42 --body \"$(cat <<'EOF'\nRequestor: Nadia Khoury\nRequestee: Aino Virtanen\nRequestOrReplied: Request\nEOF\n)\"",
+  "branch_ref": "A.Virtanen/0378-direction-table-oos",
+  "expect": "allow"
+}

--- a/.claude/hooks/fixtures/validate_review_comment_format/oos_unknown_direction.json
+++ b/.claude/hooks/fixtures/validate_review_comment_format/oos_unknown_direction.json
@@ -1,0 +1,6 @@
+{
+  "description": "Out-of-scope fail-open: unrecognized `RequestOrReplied` value (typo / future verdict not in the canonical set). The hook does NOT validate the verdict word itself — that is `validate_pr_review`'s responsibility. Returns None and lets the comment through.",
+  "command": "gh pr comment 42 --body \"$(cat <<'EOF'\nRequestor: Aino Virtanen\nRequestee: Aino Virtanen\nRequestOrReplied: Asdf\nTechDebt: none\nEOF\n)\"",
+  "branch_ref": "A.Virtanen/0378-direction-table-oos",
+  "expect": "allow"
+}

--- a/.claude/hooks/tests/test_validate_review_comment_format_parser.py
+++ b/.claude/hooks/tests/test_validate_review_comment_format_parser.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Fixture-driven Direction-table tests for validate_review_comment_format hook.
+
+Each JSON file in fixtures/validate_review_comment_format/ is one test case:
+
+    {
+        "description": "<human label>",
+        "command": "<raw bash command string>",
+        "branch_ref": "<head ref name returned by get_branch_name() mock>",
+        "expect": "allow" | "block:<reason-keyword>"
+    }
+
+The `branch_ref` field is mocked into `validate_review_comment_format.get_branch_name`
+so tests do not hit the network. The `expect` field:
+  - "allow"      → check() must return None
+  - "block:<kw>" → check() must return a block decision; <kw> is a
+                   substring of the reason (case-insensitive) for
+                   self-documenting test output, not strict matching.
+
+Fixtures cover the four `RequestOrReplied` Direction-table values
+(charter pull-requests.md § Comment-Based Reviews):
+  - Approved / ChangesRequested — verdict directions, swap heuristic in
+    scope (block on Requestee.lastname == branch-author).
+  - Request / Reply — role bindings inverted, hook narrows OOS (allow).
+  - Unrecognized value — fail-open (allow); the hook does not validate
+    the verdict word itself, that is `validate_pr_review`'s scope.
+
+Run:  python3 -m pytest .claude/hooks/tests/test_validate_review_comment_format_parser.py -v
+      (or the full suite: python3 -m pytest .claude/hooks/tests/ -v)
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+_HERE = Path(__file__).resolve().parent
+_HOOKS_DIR = _HERE.parent
+_FIXTURES_DIR = _HOOKS_DIR / "fixtures" / "validate_review_comment_format"
+
+sys.path.insert(0, str(_HOOKS_DIR))
+
+import validate_review_comment_format as hook  # noqa: E402
+
+
+def _load_fixtures() -> list[tuple[str, dict]]:
+    """Return (fixture_name, fixture_data) pairs for every JSON in the fixture dir."""
+    fixtures = []
+    for path in sorted(_FIXTURES_DIR.glob("*.json")):
+        data = json.loads(path.read_text(encoding="utf-8"))
+        fixtures.append((path.stem, data))
+    return fixtures
+
+
+def _make_input(command: str) -> dict:
+    return {"tool_name": "Bash", "tool_input": {"command": command}}
+
+
+class FixtureDrivenDirectionTableTests(unittest.TestCase):
+    """One test method per fixture file — generated dynamically."""
+
+
+def _add_fixture_test(name: str, fixture: dict) -> None:
+    """Attach a test method to FixtureDrivenDirectionTableTests for `fixture`."""
+    description = fixture.get("description", name)
+    command = fixture["command"]
+    branch_ref = fixture.get("branch_ref", "")
+    expect = fixture["expect"]
+
+    def test_method(self: unittest.TestCase) -> None:
+        with mock.patch.object(hook, "get_branch_name", return_value=branch_ref):
+            result = hook.check(_make_input(command))
+        if expect == "allow":
+            self.assertIsNone(
+                result,
+                f"{description!r}: expected allow (None) but got: {result}",
+            )
+        elif expect.startswith("block:"):
+            self.assertIsNotNone(
+                result,
+                f"{description!r}: expected block but got allow (None)",
+            )
+            assert result is not None  # for mypy
+            self.assertEqual(
+                result.get("decision"),
+                "block",
+                f"{description!r}: result decision is not 'block': {result}",
+            )
+        else:
+            raise ValueError(f"Unknown expect value {expect!r} in fixture {name!r}")
+
+    test_method.__name__ = f"test_{name}"
+    test_method.__doc__ = description
+    setattr(FixtureDrivenDirectionTableTests, test_method.__name__, test_method)
+
+
+for _fixture_name, _fixture_data in _load_fixtures():
+    _add_fixture_test(_fixture_name, _fixture_data)
+
+
+class DirectionVerdictHelperTests(unittest.TestCase):
+    """Direct coverage of `_direction_is_verdict` shape."""
+
+    def _body(self, direction: str) -> str:
+        return f"Requestor: A\nRequestee: B\nRequestOrReplied: {direction}"
+
+    def test_approved_verdict(self):
+        self.assertTrue(hook._direction_is_verdict(self._body("Approved")))
+
+    def test_changes_requested_camelcase_verdict(self):
+        self.assertTrue(hook._direction_is_verdict(self._body("ChangesRequested")))
+
+    def test_changes_requested_two_word_verdict(self):
+        """`Changes Requested` (space-separated) — the form validate_pr_review counts.
+
+        Per feedback_validate_pr_review_approved_not_reply.md, the literal
+        two-word form is the one the sibling hook counts. Both forms must
+        be recognized here.
+        """
+        self.assertTrue(hook._direction_is_verdict(self._body("Changes Requested")))
+
+    def test_approved_lowercase_verdict(self):
+        self.assertTrue(hook._direction_is_verdict(self._body("approved")))
+
+    def test_approved_markdown_bold_verdict(self):
+        """`**Approved**` markdown bolding is stripped before comparison."""
+        self.assertTrue(hook._direction_is_verdict(self._body("**Approved**")))
+
+    def test_approved_with_trailing_token_verdict(self):
+        """Trailing parenthetical / explanatory text after the verdict word allowed."""
+        self.assertTrue(hook._direction_is_verdict(self._body("Approved (post-merge)")))
+
+    def test_request_not_verdict(self):
+        self.assertFalse(hook._direction_is_verdict(self._body("Request")))
+
+    def test_reply_not_verdict(self):
+        self.assertFalse(hook._direction_is_verdict(self._body("Reply")))
+
+    def test_unknown_not_verdict(self):
+        self.assertFalse(hook._direction_is_verdict(self._body("Asdf")))
+
+    def test_bare_changes_not_verdict(self):
+        """`Changes` alone (without `Requested`) is NOT a verdict — must NOT match.
+
+        Defensive guard: tolerating the bare prefix would over-narrow and
+        leave legitimate non-verdict comments mis-classified as verdicts.
+        """
+        self.assertFalse(hook._direction_is_verdict(self._body("Changes")))
+
+    def test_empty_value_not_verdict(self):
+        self.assertFalse(hook._direction_is_verdict("Requestor: A\nRequestOrReplied: "))
+
+    def test_missing_label_not_verdict(self):
+        self.assertFalse(hook._direction_is_verdict("Requestor: A\nRequestee: B"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/hooks/validate_review_comment_format.py
+++ b/.claude/hooks/validate_review_comment_format.py
@@ -4,9 +4,37 @@
 Blocks `gh pr comment` if the Requestee matches the branch author, which
 indicates the Requestor and Requestee fields are swapped.
 
+Scope (closes #378)
+===================
+
+This hook enforces Requestor/Requestee non-swap detection ONLY for
+`Approved` and `ChangesRequested` verdict comments — i.e., the rows of
+the charter `pull-requests.md` § Comment-Based Reviews Direction table
+where `Requestee = PR-author`. For these verdicts, "Requestee.lastname
+== branch-author.lastname" is a reliable swap signal because the
+reviewer (Requestor) should never share the lastname of the PR author
+on whose branch they are commenting (modulo same-lastname collisions,
+which are out of scope).
+
+For `Request` and `Reply` comments — where the Direction-table role
+bindings invert (Requestee = reviewer, Requestor = PR-author) — the
+"Requestee.lastname == branch-author.lastname" heuristic misfires: a
+legitimate Request to a reviewer from the PR author would have
+Requestee = reviewer, which has no relation to the branch author's
+lastname. Author/reviewer discipline for Request/Reply traffic is
+operator-trusted and not hook-gated.
+
+Unrecognized `RequestOrReplied` values (typos, future verdict types
+the hook doesn't know about) fail OPEN — the hook returns None and
+lets the comment through. Validating the verdict word itself is
+covered by a sibling hook (`validate_pr_review`); duplicating that
+logic here would couple two hooks that should remain independent.
+
 Exit codes:
-  0 — allow (not a comment command, not a review comment, or fields correct)
-  2 — block (Requestee matches branch author — fields are swapped)
+  0 — allow (not a comment command, not a review comment, fields correct,
+       or RequestOrReplied is not Approved/ChangesRequested)
+  2 — block (Requestee matches branch author on an Approved /
+       ChangesRequested verdict — fields are swapped)
 """
 
 import json
@@ -94,6 +122,64 @@ def extract_branch_author_lastname(head_ref: str) -> str | None:
     return None
 
 
+# Verdict direction values from charter `pull-requests.md` § Comment-Based
+# Reviews Direction table. These are the rows where the swap heuristic is
+# sound (Requestee = PR-author).
+#
+# Tolerated form variants: validate_pr_review counts the literal
+# "Changes Requested" (with space) per `feedback_validate_pr_review_approved_not_reply`,
+# while some templates and older fixtures use the camelCase "ChangesRequested".
+# Both are accepted here. Comparison is case-insensitive on the canonical token
+# match. The bare "Changes" prefix is NOT a verdict on its own — we require
+# the full token (with or without internal space) to avoid false-narrowing.
+_VERDICT_DIRECTIONS = frozenset(
+    {
+        "approved",
+        "changesrequested",
+        "changes requested",
+    }
+)
+
+
+def _direction_is_verdict(body: str) -> bool:
+    """True if the comment body's `RequestOrReplied:` value is a verdict direction.
+
+    Matches the value on the same line as the `RequestOrReplied:` label. The
+    value is stripped of trailing markdown bolding / whitespace and lowercased
+    before comparison against `_VERDICT_DIRECTIONS`. If no value is captured
+    (label present but value empty), returns False (fail-out-of-scope —
+    consistent with the path-2 stance of narrowing rather than blocking on
+    ambiguous shapes).
+    """
+    match = re.search(r"RequestOrReplied:\s*(.+)", body)
+    if not match:
+        return False
+    raw = match.group(1).strip()
+    raw = raw.strip("*").strip()
+    if not raw:
+        return False
+    # Take the leading verdict word(s). The value may be followed by additional
+    # text on the same line in some custom shapes; we only look at what comes
+    # before a newline (already handled by `.+` group consuming up to EOL).
+    # Lowercase for case-insensitive match against the canonical set.
+    canonical = raw.lower()
+    # Direct match against the canonical set covers both "approved",
+    # "changesrequested", and "changes requested" forms.
+    if canonical in _VERDICT_DIRECTIONS:
+        return True
+    # Tolerate trailing-token noise: e.g. "Approved (post-merge)" should still
+    # be treated as Approved. Split on whitespace and join the first 1-2 tokens
+    # to attempt the camelCase / two-word verdict match.
+    parts = canonical.split()
+    if not parts:
+        return False
+    if parts[0] in _VERDICT_DIRECTIONS:
+        return True
+    if len(parts) >= 2 and " ".join(parts[:2]) in _VERDICT_DIRECTIONS:
+        return True
+    return False
+
+
 def check(input_data: dict) -> dict | None:
     """Check review comment format. Returns result dict if blocking/warning, None if allowed."""
     tool_name = input_data.get("tool_name", "")
@@ -113,6 +199,16 @@ def check(input_data: dict) -> dict | None:
     has_request_or_replied = re.search(r"RequestOrReplied:", body)
 
     if not (has_requestee and has_request_or_replied):
+        return None
+
+    if not _direction_is_verdict(body):
+        # Scope-narrowing per #378 / path 2: the Requestee == branch-author
+        # swap heuristic is only sound for verdict directions (Approved /
+        # ChangesRequested), where the charter Direction table binds
+        # Requestee = PR-author. For Request / Reply (or unrecognized
+        # directions) the role bindings invert or are unknown — we cannot
+        # safely block on the swap signal. Allow through and let
+        # operator/orchestrator discipline cover those surfaces.
         return None
 
     pr_number = extract_pr_number(command)

--- a/.claude/team/charter/pull-requests.md
+++ b/.claude/team/charter/pull-requests.md
@@ -29,6 +29,8 @@ The role names always describe the **comment** (not the PR):
 
 **Key consequence for verdict comments**: on `Approved` and `ChangesRequested` comments, `Requestor` is the reviewer (because the reviewer is the comment author). The hook counts distinct `Requestor` values across `Approved`/`ChangesRequested` comments to verify the 2-reviewer rule (resolves main#244 — the prior hook counted distinct `Requestee` values, which on verdict comments is the PR author, not the reviewer).
 
+**Scope of the `validate_review_comment_format` hook** (resolves main#378): This hook enforces Requestor/Requestee non-swap detection ONLY for `Approved` and `Changes Requested` verdict comments, where the Direction table above binds `Requestee = PR author`. For `Request` and `Reply` comments — where the role bindings invert (`Requestee = reviewer`, `Requestor = PR author`) — the swap heuristic does not apply and the hook returns `None`. Author/reviewer discipline for `Request`/`Reply` traffic is operator-trusted; the hook does not gate it. Unrecognized `RequestOrReplied` values also pass through (the verdict-word vocabulary is `validate_pr_review`'s scope, not this hook's).
+
 ### Validation
 
 - The `Requestor` of a `Request`-kind comment must differ from the comment author of the `Approved`/`ChangesRequested` comments (a PR author cannot self-approve their own PR via comment-based review). Enforced by `block_gh_pr_review.py` PreToolUse hook + `validate_pr_review.py` at merge time.


### PR DESCRIPTION
## Summary

- Narrow `validate_review_comment_format` enforcement scope to `Approved` and `Changes Requested` verdict comments only (path-2 resolution of #378). For `Request`/`Reply` (and unrecognized) `RequestOrReplied` values, the hook returns `None` and lets the comment through.
- Add a corresponding scope-disclaimer paragraph to `.claude/team/charter/pull-requests.md` § Comment-Based Reviews so future readers find the rationale next to the Direction table.
- Add 7 JSON fixtures + a fixture-driven test file (`test_validate_review_comment_format_parser.py`) covering the four Direction-table values plus an unknown-value fail-open case. fix + fixtures + tests land together per `charter/hooks.md` § Parser-Fixture Coverage Requirements.

## Why

`validate_review_comment_format` blocks `gh pr comment` when `Requestee.lastname == branch-author.lastname`. That signal is sound for verdict comments (`Approved` / `Changes Requested`) where the charter Direction table binds `Requestee = PR-author`, but it misfires on the `Request` / `Reply` rows where the role bindings invert (`Requestee = reviewer`, `Requestor = PR-author`).

Surfaced during PR #377 (parser-fixture batch). Issue #378 enumerates three resolution paths — owner picked **path 2** ("explicitly out-of-scope Request/Reply traffic"). Smallest blast radius: hook narrows scope, charter documents the scope, no semantic realignment of the existing detection heuristic.

## What changed

- `.claude/hooks/validate_review_comment_format.py` — new `_direction_is_verdict(body)` helper recognizes `Approved`, `ChangesRequested`, `Changes Requested` (case-insensitive, markdown-bold-tolerant, trailing-token-tolerant). `check()` gains an early-return-None gate for non-verdict directions after the `Requestee:` + `RequestOrReplied:` presence check. Hook docstring updated with full scope explanation.
- `.claude/team/charter/pull-requests.md` — Comment-Based Reviews § gains one paragraph documenting the hook's scope (after the existing "Key consequence for verdict comments" line, before the "Validation" sub-section).
- `.claude/hooks/fixtures/validate_review_comment_format/` — new directory, 7 fixtures.
- `.claude/hooks/tests/test_validate_review_comment_format_parser.py` — new fixture-driven parser-class test file modeled on `test_validate_commit_identity_parser.py` / `test_block_stale_tmp_message_file_parser.py` (the latter from #316). Each fixture's `branch_ref` is mocked into `get_branch_name` to keep tests offline. Includes 12 direct-helper unit tests for the `_direction_is_verdict` shape.

## Fixture audit

- 0 pre-existing JSON fixtures (the fixture dir did not yet exist for this hook); the brief's mention of "42 existing fixtures" referred to unit-test methods, not JSON fixtures.
- 42 pre-existing unit tests in `test_validate_review_comment_format.py` — all use `RequestOrReplied=Approved`, so all 42 remain green under path-2 with no reclassification needed.
- 7 new JSON fixtures: `happy_approved_proper_direction.json`, `block_approved_swapped.json`, `block_changes_requested_swapped.json`, `block_changes_requested_spaced_swapped.json`, `oos_request_direction.json`, `oos_reply_direction.json`, `oos_unknown_direction.json`.
- 12 new direct-helper unit tests (`DirectionVerdictHelperTests`) covering verdict-word recognition: canonical/camelCase/spaced/bold/lowercase/trailing-token + 5 negative shapes (`Request`, `Reply`, unknown word, bare `Changes`, empty value, missing label).

## Out of scope

This PR does NOT realign the existing swap-detection heuristic with the charter Direction-table semantics. The existing heuristic ("Requestee.lastname == branch-author.lastname → block") encodes the pre-#244 reading where Requestee was expected to be the reviewer; the post-#244 charter binds `Requestee = PR-author` on verdicts. Path-2 deliberately narrows scope without touching this. A full semantic realignment is a separate concern that may surface as a follow-up issue.

## Test plan

- [x] `python3 -m pytest .claude/hooks/tests/` — 639 passed (was 614 pre-change; 25 new tests for this hook)
- [x] `python3 -m pytest .claude/hooks/tests/test_validate_review_comment_format.py .claude/hooks/tests/test_validate_review_comment_format_parser.py -v` — 61 passed (42 existing + 7 fixture-driven + 12 helper)
- [x] `uvx ruff format --check .claude/hooks/` — clean (55 files already formatted)
- [x] `uvx ruff check .claude/hooks/` — clean (all checks passed)

Closes #378.

**Wave**: P3W9
