### PR TITLE
tech-debt(skill): wave-audit/SKILL.md:75 fix prose drift fixed-in-phase{N}-wave{M} (closes #388)

### DIFF
--- a/.claude/skills/wave-audit/SKILL.md
+++ b/.claude/skills/wave-audit/SKILL.md
@@ -72,7 +72,7 @@ EOF
 )"
 ```
 
-Add the `fixed-in-phase{N}-wave{M}` label:
+Add the `fixed-in-phase{N}-wave-{M}` label:
 
 ```bash
 gh issue edit {NUMBER} --add-label "fixed-in-phase{N}-wave-{M}"


### PR DESCRIPTION
## Summary

Single-line prose fix in `.claude/skills/wave-audit/SKILL.md` line 75 — `fixed-in-phase{N}-wave{M}` → `fixed-in-phase{N}-wave-{M}` to match the canonical label form already used on lines 70 and 78. The `gh issue edit ... --add-label` invocation on line 78 was already canonical; this PR brings the prose descriptor into agreement.

Closes #388. Wave: P3W9. Sibling-of-#246 follow-up filed during PR #387 review.

## What changed

One line in `.claude/skills/wave-audit/SKILL.md`:

```diff
-Add the `fixed-in-phase{N}-wave{M}` label:
+Add the `fixed-in-phase{N}-wave-{M}` label:
```

Post-edit verification: `grep -n "fixed-in-phase" .claude/skills/wave-audit/SKILL.md` yields all 3 occurrences in the canonical hyphenated form.

## Why tech-debt, not blocking

Cosmetic prose drift in a SKILL.md descriptor — the actual gh CLI label-add command was already canonical, so no automation was affected. Caught by both reviewers (Aino + Nadia) during PR #387 verification as a follow-up rather than a #387 ChangesRequested. Pure docs cleanup.

## Test plan

- [x] `grep -n "fixed-in-phase"` shows 3/3 occurrences canonical post-edit.
- [x] Diff is exactly 1 line changed.
- [ ] Reviewer 1: confirms line 75 matches lines 70 and 78.
- [ ] Reviewer 2: confirms no other `wave{M}` (non-hyphenated) variants exist in this SKILL.md.
