### PR TITLE
tech-debt(/promotion-audit): find_already_promoted scans all charter sub-docs + loosens regex (closes #283)

### DIFF
--- a/.claude/skills/promotion-audit/SKILL.md
+++ b/.claude/skills/promotion-audit/SKILL.md
@@ -31,17 +31,17 @@ from helpers import (
     read_all_memories,
     read_all_charter_sections,
     read_all_skills,
-    find_already_promoted,
+    find_already_promoted_in_charter,
     count_retro_citations,
     count_skill_invocations,
     classify,
     render_audit_table,
 )
 
-memories  = read_all_memories(memory_dir)           # list[Memory]
-sections  = read_all_charter_sections(charter_dir)  # list[Section] — only sections with a promotion-target marker
-skills    = read_all_skills(skills_dir)              # list[Skill]
-already   = find_already_promoted(charter_hooks_md) # set[str] — from "Promotion provenance:" blocks
+memories  = read_all_memories(memory_dir)              # list[Memory]
+sections  = read_all_charter_sections(charter_dir)     # list[Section] — only sections with a promotion-target marker
+skills    = read_all_skills(skills_dir)                # list[Skill]
+already   = find_already_promoted_in_charter(charter_dir)  # set[str] — aggregates Promotion provenance: blocks AND <!-- Promoted from memory: X --> markers across all charter sub-docs (#283)
 ```
 
 ### 3. Classify each candidate (pure function)
@@ -53,7 +53,7 @@ For each memory, charter section, and skill, compute a `Decision` via `classify(
 - **KEPT** — promotion-target is `none`, thresholds not yet met, or status is `active` with no promotion intent
   - **STALE-OPT-OUT (informational sub-class)** — when a memory has `promotion_target: none` AND `retro_citations >= 2 * threshold`, the entry stays KEPT (the opt-out is authoritative) but is rendered in a separate sub-list so operators can spot drift during wave-retro. No auto-action, no issue filed, no override of the opt-out. (#158)
 - **SUPERSEDED** — status is `superseded` or `enforced-elsewhere` with an explicit `superseded_by` reference
-- **ALREADY-PROMOTED** — name appears in `find_already_promoted()` set (recognized via `Promotion provenance:` blocks in charter/hooks.md)
+- **ALREADY-PROMOTED** — name appears in `find_already_promoted_in_charter()` set (recognized via `Promotion provenance:` blocks AND `<!-- Promoted from memory: X -->` HTML-comment markers across all charter sub-docs; #283)
 
 ### 4. Produce artifacts
 

--- a/.claude/skills/promotion-audit/helpers.py
+++ b/.claude/skills/promotion-audit/helpers.py
@@ -426,20 +426,38 @@ _PROVENANCE_RE = re.compile(
     r"\*\*Promotion provenance:\*\*\s*(?P<body>.+?)(?:\n\n|\Z)",
     re.DOTALL,
 )
+
+# `<!-- Promoted from memory: <name>[.md] (optional trailing context) -->`
+# The new charter-tier promotion marker (issue #283), used inline after a
+# charter section heading instead of a `Promotion provenance:` block. The
+# captured body runs until the closing `-->` so trailing context (date,
+# rationale, retro reference) is included in the regex sweep that
+# follows.
+_HTML_COMMENT_PROMOTED_RE = re.compile(
+    r"<!--\s*Promoted from memory:\s*(?P<body>.+?)\s*-->",
+    re.DOTALL,
+)
+
+# Memory filenames can be cited with or without the `.md` suffix in
+# charter prose (e.g. hooks.md L169 cites `feedback_honest_audit_over_conclusion_claim`
+# unsuffixed inside a backticked span). The regex now makes the `.md`
+# optional and the caller backfills the suffix into the returned set so
+# both forms are recognized membership-checks.
 _SOURCE_HINT_RE = re.compile(
     r"""
     (?:
-        feedback_[a-z0-9_]+\.md       # feedback memory filenames
+        (?:feedback|project|reference)_[a-z0-9_]+(?:\.md)?  # memory filenames (with or without .md)
         |
-        project_[a-z0-9_]+\.md        # project memory filenames
-        |
-        reference_[a-z0-9_]+\.md      # reference memory filenames
-        |
-        /[\w-]+                       # slash-commands / skill names
+        /[\w-]+                                              # slash-commands / skill names
     )
     """,
     re.VERBOSE,
 )
+
+# Memory-filename prefixes the parser recognizes. Used by
+# `_normalize_memory_hit` to decide whether a no-suffix hit should be
+# backfilled with `.md`.
+_MEMORY_PREFIXES = ("feedback_", "project_", "reference_")
 
 
 # Narrative words that indicate a forward-reference rather than a
@@ -470,50 +488,125 @@ def _is_forward_reference(body: str, match_start: int) -> bool:
     return any(marker in window for marker in _FORWARD_REFERENCE_MARKERS)
 
 
-def find_already_promoted(charter_hooks_path: str) -> set[str]:
-    """Return the set of source identifiers already promoted via Hook entries.
+def _normalize_memory_hit(hit: str) -> tuple[str, ...]:
+    """Return both forms (with and without `.md`) of a memory filename hit.
 
-    The parser recognizes `**Promotion provenance:**` blocks in
-    charter/hooks.md and extracts memory filenames or skill slash-command
-    references from their body. This is the format established by Hook 15
-    in PR #153 (the worked example).
+    The caller adds all returned strings to the already-promoted set so
+    membership checks via `memory.filename` (always `.md`-suffixed) and
+    via raw-name citation work transparently.
 
-    Expected block format (compatible with Hook 15):
+    For non-memory hits (slash-commands, anything else), returns a single-
+    element tuple containing the hit unchanged.
+    """
+    if hit.startswith(_MEMORY_PREFIXES):
+        if hit.endswith(".md"):
+            return (hit, hit[:-3])
+        return (hit, hit + ".md")
+    return (hit,)
 
-        **Promotion provenance:** First end-to-end execution of the
-        memory -> charter -> hook promotion pattern ratified by the
-        owner on 2026-04-19. Rule lived in CLAUDE.md § Ontology ...
+
+def find_already_promoted(charter_path: str) -> set[str]:
+    """Return the set of source identifiers already promoted in `charter_path`.
+
+    Recognizes BOTH provenance formats used across the charter:
+
+    1. **Block style** (charter/hooks.md, the format Hook 15 established
+       in PR #153):
+
+           **Promotion provenance:** First end-to-end execution of the
+           memory -> charter -> hook promotion pattern ratified by the
+           owner on 2026-04-19. Rule lived in CLAUDE.md § Ontology ...
+
+    2. **HTML-comment marker** (newer charter-tier-only promotions, per
+       issue #283):
+
+           <!-- Promoted from memory: feedback_X.md (P3W5 retro 2026-05-06) -->
+
+       Used inline after a charter section heading when a memory is
+       promoted into the charter without a corresponding hook.
 
     Slash-commands that appear inside forward-reference phrases (e.g.
     "referenced by the future `/promotion-audit` skill design") are
     EXCLUDED — those are narrative cross-references, not promotion claims.
     See `_FORWARD_REFERENCE_MARKERS`.
 
+    Memory-filename citations are recognized in BOTH `.md`-suffixed and
+    suffix-less forms (the latter appears in hooks.md L169's backticked
+    cite of `feedback_honest_audit_over_conclusion_claim`). Both forms
+    land in the returned set so callers using `memory.filename in
+    already_promoted` continue to match transparently.
+
+    For the aggregating scan across the full charter directory, use
+    `find_already_promoted_in_charter()` — this single-path entry point
+    is retained for the smoke test and for callers that want to scope
+    the scan to a specific file.
+
     The returned set contains strings like:
-        - "feedback_enforcement_hierarchy.md" (memory filenames)
+        - "feedback_enforcement_hierarchy.md" / "feedback_enforcement_hierarchy"
         - "/ontology-librarian" (skill slash-commands with backward semantics)
         - "CLAUDE.md § Ontology" (rule references, when the Ontology
           section is cited in any provenance block)
-
-    Callers should check membership using the candidate's `filename`
-    attribute (Memory) or `/{name}` (Skill).
     """
     refs: set[str] = set()
-    if not os.path.isfile(charter_hooks_path):
+    if not os.path.isfile(charter_path):
         return refs
-    with open(charter_hooks_path, encoding="utf-8") as f:
+    with open(charter_path, encoding="utf-8") as f:
         text = f.read()
+
+    # Block-style `**Promotion provenance:**` entries (hooks.md format).
     for block in _PROVENANCE_RE.finditer(text):
         body = block.group("body")
         for hit in _SOURCE_HINT_RE.finditer(body):
             if _is_forward_reference(body, hit.start()):
                 continue
-            refs.add(hit.group(0))
+            refs.update(_normalize_memory_hit(hit.group(0)))
+
+    # HTML-comment style `<!-- Promoted from memory: X -->` (charter-tier
+    # promotion marker, issue #283). Forward-reference filtering is
+    # unnecessary for this format — the marker is by definition a
+    # backward-looking promotion claim.
+    for block in _HTML_COMMENT_PROMOTED_RE.finditer(text):
+        body = block.group("body")
+        for hit in _SOURCE_HINT_RE.finditer(body):
+            refs.update(_normalize_memory_hit(hit.group(0)))
+
     # The librarian rule's provenance cites CLAUDE.md § Ontology; capture
     # it as a synonym for the enforcement-hierarchy memory.
     if "CLAUDE.md § Ontology" in text:
         refs.add("CLAUDE.md § Ontology")
         refs.add("feedback_enforcement_hierarchy.md")
+    return refs
+
+
+def find_already_promoted_in_charter(charter_root: str) -> set[str]:
+    """Aggregate already-promoted refs across the full charter directory.
+
+    Scans `charter_root/charter/*.md` (and the optional `charter_root/charter.md`
+    top-level file, if present) using the same recognition rules as
+    `find_already_promoted()`. Returns the union of all per-file results.
+
+    This is the entry point the /promotion-audit skill should use — single-
+    file scope (charter/hooks.md only) misses charter-tier-only promotions
+    that land via the HTML-comment marker in other sub-docs (issue #283).
+    """
+    refs: set[str] = set()
+    if not os.path.isdir(charter_root):
+        return refs
+
+    candidates: list[str] = []
+    root_file = os.path.join(charter_root, "charter.md")
+    if os.path.isfile(root_file):
+        candidates.append(root_file)
+
+    subdir = os.path.join(charter_root, "charter")
+    if os.path.isdir(subdir):
+        for name in sorted(os.listdir(subdir)):
+            if name.endswith(".md"):
+                candidates.append(os.path.join(subdir, name))
+
+    for path in candidates:
+        refs.update(find_already_promoted(path))
+
     return refs
 
 

--- a/.claude/skills/promotion-audit/tests/test_helpers.py
+++ b/.claude/skills/promotion-audit/tests/test_helpers.py
@@ -402,6 +402,121 @@ class FindAlreadyPromotedTests(unittest.TestCase):
         finally:
             os.unlink(path)
 
+    def test_html_comment_charter_tier_marker_detected(self) -> None:
+        """POS (#283 gap 1): the new `<!-- Promoted from memory: X -->` HTML-
+        comment marker, used for charter-tier-only promotions (no
+        corresponding hook), must be recognized. Pre-#283 only the
+        `**Promotion provenance:**` block style was scanned, so charter-
+        tier promotions in non-hooks.md sub-docs were invisible to the
+        parser and produced false-positive AUTO classifications.
+        """
+        charter = (
+            "## Some charter section\n\n"
+            "<!-- Promoted from memory: feedback_review_against_artifact_not_framing.md "
+            "(P3W5 retro 2026-05-06; reviewer-side). -->\n\n"
+            "Body of the section.\n"
+        )
+        with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as f:
+            f.write(charter)
+            path = f.name
+        try:
+            refs = h.find_already_promoted(path)
+            self.assertIn("feedback_review_against_artifact_not_framing.md", refs)
+        finally:
+            os.unlink(path)
+
+    def test_md_less_memory_name_matched_same_as_suffixed(self) -> None:
+        """POS (#283 gap 2): a memory cited without the `.md` suffix (as in
+        hooks.md L169's backticked cite of
+        `feedback_honest_audit_over_conclusion_claim`) must be matched
+        same as a `.md`-suffixed citation. Both forms land in the
+        returned set so callers using `memory.filename in
+        already_promoted` continue to match transparently.
+        """
+        charter = (
+            "## Hook 17: Foo\n\n"
+            "- **Promotion provenance:** memory "
+            "`feedback_honest_audit_over_conclusion_claim` (2026-04-22) -> "
+            "charter rule (PR #193) -> this hook (#195).\n"
+        )
+        with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as f:
+            f.write(charter)
+            path = f.name
+        try:
+            refs = h.find_already_promoted(path)
+            # Caller checks via `memory.filename`, which is always .md-suffixed.
+            self.assertIn("feedback_honest_audit_over_conclusion_claim.md", refs)
+            # The unsuffixed form is also in the set (for completeness /
+            # callers that cite by raw name).
+            self.assertIn("feedback_honest_audit_over_conclusion_claim", refs)
+        finally:
+            os.unlink(path)
+
+    def test_hooks_md_provenance_no_regression(self) -> None:
+        """REGRESSION: extending the parser must not break recognition of
+        existing hooks.md `**Promotion provenance:**` blocks. This pins
+        the Hook 15 worked example end-to-end after the #283 changes.
+        """
+        charter = (
+            "## Hook 15: Foo\n\n"
+            "- **Promotion provenance:** First end-to-end execution of "
+            "the memory -> charter -> hook promotion pattern. Rule lived "
+            "in CLAUDE.md § Ontology; first instance cites "
+            "feedback_enforcement_hierarchy.md.\n"
+        )
+        with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as f:
+            f.write(charter)
+            path = f.name
+        try:
+            refs = h.find_already_promoted(path)
+            self.assertIn("feedback_enforcement_hierarchy.md", refs)
+            self.assertIn("CLAUDE.md § Ontology", refs)
+        finally:
+            os.unlink(path)
+
+    def test_aggregator_scans_all_charter_subdocs(self) -> None:
+        """POS (#283): `find_already_promoted_in_charter()` must aggregate
+        results across the full `<root>/charter/*.md` directory, picking
+        up charter-tier HTML-comment markers in non-hooks.md sub-docs.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            charter_subdir = os.path.join(tmpdir, "charter")
+            os.makedirs(charter_subdir)
+
+            # File 1: hooks.md with a block-style provenance entry.
+            with open(os.path.join(charter_subdir, "hooks.md"), "w") as f:
+                f.write(
+                    "## Hook 15: Foo\n\n"
+                    "- **Promotion provenance:** Worked example cites "
+                    "feedback_block_style.md.\n"
+                )
+            # File 2: pull-requests.md with an HTML-comment marker.
+            with open(os.path.join(charter_subdir, "pull-requests.md"), "w") as f:
+                f.write(
+                    "## A promoted section\n\n"
+                    "<!-- Promoted from memory: feedback_html_style.md (P3W5 retro) -->\n\n"
+                    "Body.\n"
+                )
+            # File 3: skills.md with a `.md`-less citation inside a marker.
+            with open(os.path.join(charter_subdir, "skills.md"), "w") as f:
+                f.write(
+                    "## Another promoted section\n\n"
+                    "<!-- Promoted from memory: feedback_no_suffix -->\n"
+                )
+
+            refs = h.find_already_promoted_in_charter(tmpdir)
+            self.assertIn("feedback_block_style.md", refs)
+            self.assertIn("feedback_html_style.md", refs)
+            self.assertIn("feedback_no_suffix.md", refs)
+            self.assertIn("feedback_no_suffix", refs)
+
+    def test_aggregator_handles_missing_charter_dir(self) -> None:
+        """NEG: a non-existent charter root must return an empty set
+        (not raise) — the smoke test runs against the live repo state
+        where this should never trigger, but the contract is defensive."""
+        refs = h.find_already_promoted_in_charter("/nonexistent/path/to/charter")
+        self.assertEqual(refs, set())
+
 
 # ---------------------------------------------------------------------------
 # Classification — memory

--- a/.claude/skills/promotion-audit/tests/test_smoke.py
+++ b/.claude/skills/promotion-audit/tests/test_smoke.py
@@ -31,7 +31,6 @@ _MEMORY_DIR = os.path.expanduser(
 )
 _CHARTER_ROOT = _REPO_ROOT / ".claude" / "team"
 _SKILLS_DIR = _REPO_ROOT / ".claude" / "skills"
-_HOOKS_MD = _CHARTER_ROOT / "charter" / "hooks.md"
 _FEEDBACK_LOG = _CHARTER_ROOT / "feedback_log.md"
 
 
@@ -52,7 +51,7 @@ class SmokeTests(unittest.TestCase):
         cls.memories = h.read_all_memories(_MEMORY_DIR)
         cls.sections = h.read_all_charter_sections(str(_CHARTER_ROOT))
         cls.skills = h.read_all_skills(str(_SKILLS_DIR))
-        cls.already = h.find_already_promoted(str(_HOOKS_MD))
+        cls.already = h.find_already_promoted_in_charter(str(_CHARTER_ROOT))
 
     def test_at_least_one_memory_found(self) -> None:
         self.assertGreater(len(self.memories), 0)


### PR DESCRIPTION
## Summary

Closes the two parser gaps in `/promotion-audit`'s `find_already_promoted()` that surfaced during P3W5 audit (PR #282):

1. **Charter-tier blind spot** — only `charter/hooks.md` was scanned, so memories promoted to charter-tier-only (no corresponding hook) were invisible to the parser, producing false-positive `AUTO` classifications.
2. **Suffix-sensitive regex** — required the `.md` suffix on memory names, missing `hooks.md` L169's backticked cite of `feedback_honest_audit_over_conclusion_claim` (no suffix).

After this PR, the live audit on current wave-9 HEAD reports **0 AUTO / 0 DECIDE / 13 ALREADY-PROMOTED / 5 SUPERSEDED / 132 KEPT** — the 2 specific W5 misses correctly classify as `ALREADY-PROMOTED`, and 10 additional charter-tier-only promotions previously invisible are now recognized.

## What changed

### `.claude/skills/promotion-audit/helpers.py`

- New `_HTML_COMMENT_PROMOTED_RE` recognizer for the `<!-- Promoted from memory: X -->` marker (the charter-tier promotion convention since P3W5).
- Loosen `_SOURCE_HINT_RE` to make the `.md` suffix optional for memory names. New `_normalize_memory_hit()` helper backfills both forms (`feedback_X.md` AND `feedback_X`) into the returned set so callers using `memory.filename in already_promoted` continue to match transparently.
- Rewrite `find_already_promoted(path)` to scan BOTH block-style `**Promotion provenance:**` entries AND HTML-comment markers in whatever file is passed. Single-path signature retained for the smoke test and scoped callers.
- New `find_already_promoted_in_charter(charter_root)` aggregator that unions results across `charter/*.md` (and the optional `charter.md` top-level file). This is the entry point `/promotion-audit` should call going forward.

### `.claude/skills/promotion-audit/SKILL.md`

- Switch the canonical call site (`### 2. Gather inputs`) from the single-file `find_already_promoted(charter_hooks_md)` to `find_already_promoted_in_charter(charter_dir)`.
- Update the `### 3. Classify each candidate` ALREADY-PROMOTED bullet to reflect the new dual-format recognition.

### `.claude/skills/promotion-audit/tests/test_smoke.py`

- Switch the smoke test's already-promoted setup to the aggregator. Drop the now-unused `_HOOKS_MD` constant.

### `.claude/skills/promotion-audit/tests/test_helpers.py`

Add 5 new unit tests to `FindAlreadyPromotedTests`:

- `test_html_comment_charter_tier_marker_detected` — closes #283 gap 1 (HTML-comment scan).
- `test_md_less_memory_name_matched_same_as_suffixed` — closes #283 gap 2 (suffix tolerance), uses the exact hooks.md L169 shape.
- `test_hooks_md_provenance_no_regression` — pins the Hook 15 worked example end-to-end after the changes.
- `test_aggregator_scans_all_charter_subdocs` — aggregator end-to-end with synthetic charter sub-docs.
- `test_aggregator_handles_missing_charter_dir` — defensive contract for missing directory.

## Acceptance verification

Per issue #283 acceptance criterion — the 2 W5 misses (`feedback_review_against_artifact_not_framing` + `feedback_honest_audit_over_conclusion_claim`) must move from `AUTO` to `ALREADY-PROMOTED`:

Live audit on wave-9 HEAD (`/promotion-audit` driven directly via `helpers`):

```
Decision counts: {'KEPT': 132, 'ALREADY-PROMOTED': 13, 'SUPERSEDED': 5}
AUTO items (0): []
ALREADY-PROMOTED items (13):
  - feedback_canonical_source_via_git_show.md
  - feedback_child_repo_implementer_rule.md
  - feedback_enforcement_hierarchy.md
  - feedback_honest_audit_over_conclusion_claim.md       <-- W5 miss #1 ✓
  - feedback_live_trace_over_synthetic_acceptance.md
  - feedback_origin_over_local_for_still_has_claims.md
  - feedback_pr_state_in_refresh.md
  - feedback_pr_vs_runtime_acceptance_criteria.md
  - feedback_pre_spawn_brief_verified_at_head.md
  - feedback_refresh_before_acting.md
  - feedback_review_against_artifact_not_framing.md      <-- W5 miss #2 ✓
  - feedback_security_guard_inline_not_followup.md
  - feedback_verify_diagnosis_before_delegating.md
```

Both W5 misses now in `ALREADY-PROMOTED`; zero `AUTO` false positives.

## Test plan

- [x] `python3 -m pytest .claude/skills/promotion-audit/tests/ -v` — **66 passed** (was 61; +5 new unit tests)
- [x] `python3 -m pytest .claude/hooks/tests/ -q` — **642 passed** (unchanged from wave-9 HEAD baseline — no hook source touched)
- [x] `uvx ruff format --check .claude/hooks/ .claude/skills/promotion-audit/` — clean (58 files already formatted)
- [x] `uvx ruff check .claude/hooks/ .claude/skills/promotion-audit/` — clean (all checks passed)
- [x] Live audit acceptance: `AUTO=0`, both W5 misses → `ALREADY-PROMOTED`
- [x] Smoke test `test_zero_auto_zero_decide_on_first_run` still passes — this is the canonical regression guard for the "no false-positive AUTO" property and confirms the fix end-to-end through the real repo state.

## Closes

Closes #283

**Wave**: P3W9
