### PR TITLE
feat(hook): post_wave_kickoff_comment — auto-post charter-format kickoff on wave-label-apply (closes #286)

### DIFF
--- a/.claude/hooks/annunaki_log.py
+++ b/.claude/hooks/annunaki_log.py
@@ -54,3 +54,29 @@ def log_pretooluse_block(
         "stderr_excerpt": "",
     }
     append_jsonl_record(ERRORS_FILE, record)
+
+
+def log_posttooluse_event(
+    hook_name: str, command: str, reason: str, tool_name: str = "Bash"
+) -> None:
+    """Append a PostToolUse non-blocking event to the Annunaki error log.
+
+    PostToolUse hooks cannot block the tool call (it has already run), so
+    they don't "block" — they record events that need follow-up. Used by
+    hooks like `post_wave_kickoff_comment` when they cannot complete their
+    post-action work (e.g., scope row missing, gh CLI failure) and want a
+    visible signal in the Annunaki sweep without raising a failure on the
+    underlying tool call.
+    """
+    record = {
+        "timestamp": datetime.now(UTC).isoformat(),
+        "type": "posttooluse_event",
+        "hook": hook_name,
+        "tool_name": tool_name,
+        "command": command[:500],
+        "exit_code": None,
+        "matched_patterns": [f"hook_event:{hook_name}"],
+        "error_lines": [reason[:500]],
+        "stderr_excerpt": "",
+    }
+    append_jsonl_record(ERRORS_FILE, record)

--- a/.claude/hooks/fixtures/post_wave_kickoff_comment/happy_label_apply_explicit_issue.json
+++ b/.claude/hooks/fixtures/post_wave_kickoff_comment/happy_label_apply_explicit_issue.json
@@ -1,0 +1,25 @@
+{
+  "description": "Happy path: gh issue edit on an explicit-issue scope row (W7+W8 shape with `id: repo#NNN`). Hook should resolve the assignment row, render the charter-format kickoff comment, and 'post' it via the injected poster mock.",
+  "command": "gh issue edit 123 --repo noorinalabs/noorinalabs-main --add-label \"p3-wave-9\"",
+  "status": {
+    "wave_9_meta_issue": 347,
+    "wave_9_scope": {
+      "tier_1_test": [
+        {"id": "noorinalabs-main#123", "implementer": "Aino Virtanen", "reviewer": "Nadia Khoury", "reviewer_2": "Santiago Ferreira", "priority": "tech-debt"}
+      ]
+    }
+  },
+  "existing_comments": [],
+  "post_succeeds": true,
+  "expect_action": "post",
+  "expect_body_contains": [
+    "Requestor: Fatima Okonkwo",
+    "Requestee: Aino Virtanen",
+    "RequestOrReplied: Request",
+    "**Wave 9 Kickoff — Phase 3**",
+    "- Peer reviewer: Nadia Khoury",
+    "- Secondary reviewer: Santiago Ferreira",
+    "- Branch from: `deployments/phase-3/wave-9`",
+    "- Priority: tech-debt"
+  ]
+}

--- a/.claude/hooks/fixtures/post_wave_kickoff_comment/idempotent_re_apply.json
+++ b/.claude/hooks/fixtures/post_wave_kickoff_comment/idempotent_re_apply.json
@@ -1,0 +1,18 @@
+{
+  "description": "Idempotency: issue already has a kickoff comment with the charter heading. Hook returns skip_idempotent — re-applying the wave label (e.g., after a disposition correction) does NOT double-post.",
+  "command": "gh issue edit 124 --repo noorinalabs/noorinalabs-main --add-label \"p3-wave-9\"",
+  "status": {
+    "wave_9_meta_issue": 347,
+    "wave_9_scope": {
+      "tier_1_test": [
+        {"id": "noorinalabs-main#124", "implementer": "Wanjiku Mwangi", "reviewer": "Aino Virtanen", "reviewer_2": "Santiago Ferreira"}
+      ]
+    }
+  },
+  "existing_comments": [
+    {"body": "Some prior unrelated comment."},
+    {"body": "Requestor: Fatima Okonkwo\nRequestee: Wanjiku Mwangi\nRequestOrReplied: Request\n\n**Wave 9 Kickoff — Phase 3**\n\nThis issue is assigned to you for p3-wave-9."}
+  ],
+  "post_succeeds": true,
+  "expect_action": "skip_idempotent"
+}

--- a/.claude/hooks/fixtures/post_wave_kickoff_comment/meta_issue_skip.json
+++ b/.claude/hooks/fixtures/post_wave_kickoff_comment/meta_issue_skip.json
@@ -1,0 +1,15 @@
+{
+  "description": "Meta-issue skip: issue number == wave_{M}_meta_issue. Hook returns skip_meta_issue without posting (the all-hands meta-issue kickoff comment is owned by /wave-kickoff Step 8b, not this hook).",
+  "command": "gh issue edit 347 --repo noorinalabs/noorinalabs-main --add-label \"p3-wave-9\"",
+  "status": {
+    "wave_9_meta_issue": 347,
+    "wave_9_scope": {
+      "tier_1_test": [
+        {"id": "noorinalabs-main#347", "implementer": "Nadia Khoury", "reviewer": "Aino Virtanen", "reviewer_2": "Santiago Ferreira"}
+      ]
+    }
+  },
+  "existing_comments": [],
+  "post_succeeds": true,
+  "expect_action": "skip_meta_issue"
+}

--- a/.claude/hooks/fixtures/post_wave_kickoff_comment/missing_scope_annunaki_log.json
+++ b/.claude/hooks/fixtures/post_wave_kickoff_comment/missing_scope_annunaki_log.json
@@ -1,0 +1,11 @@
+{
+  "description": "Failure mode: wave_{M}_scope is null/missing. Hook annunaki-logs and returns skip_no_scope without posting (the label-apply has already succeeded; the underlying gap is a /wave-scope bug not a label-apply bug).",
+  "command": "gh issue edit 125 --repo noorinalabs/noorinalabs-main --add-label \"p3-wave-9\"",
+  "status": {
+    "wave_9_meta_issue": 347,
+    "wave_9_scope": null
+  },
+  "existing_comments": [],
+  "post_succeeds": true,
+  "expect_action": "skip_no_scope"
+}

--- a/.claude/hooks/fixtures/post_wave_kickoff_comment/unmatched_label_passthrough.json
+++ b/.claude/hooks/fixtures/post_wave_kickoff_comment/unmatched_label_passthrough.json
@@ -1,0 +1,15 @@
+{
+  "description": "Passthrough: gh issue edit applying a NON-wave label (e.g., tech-debt). The matcher should not fire — check() returns None (hook does not apply) and the label-apply succeeds without any side effects.",
+  "command": "gh issue edit 126 --repo noorinalabs/noorinalabs-main --add-label \"tech-debt\"",
+  "status": {
+    "wave_9_meta_issue": 347,
+    "wave_9_scope": {
+      "tier_1_test": [
+        {"id": "noorinalabs-main#126", "implementer": "Aino Virtanen", "reviewer": "Nadia Khoury", "reviewer_2": "Santiago Ferreira"}
+      ]
+    }
+  },
+  "existing_comments": [],
+  "post_succeeds": true,
+  "expect_action": null
+}

--- a/.claude/hooks/post_wave_kickoff_comment.py
+++ b/.claude/hooks/post_wave_kickoff_comment.py
@@ -1,0 +1,472 @@
+#!/usr/bin/env python3
+"""PostToolUse hook: Auto-post charter-format kickoff comment on wave-label-apply.
+
+Fires on `gh issue edit <num> --repo noorinalabs/<repo> ... --add-label "p{N}-wave-{M}"`
+and posts a charter-format kickoff comment (per
+`.claude/team/charter/pull-requests.md` § Kickoff Comment Format — also
+mirrored in `/wave-kickoff` SKILL.md Step 8) to the labeled issue. Replaces
+the manual orchestrator loop documented in pre-#286 wave-kickoff SKILL.md
+Step 8 (closes main#286).
+
+Per `feedback_enforcement_hierarchy`: prefer hook > skill > charter. Skills
+can be skipped or mis-executed; hooks fire deterministically on the
+trigger event. Concrete failure mode this removes: orchestrator forgets to
+post comments after applying labels (caught at next wave-wrapup as silent
+drift). The hook makes the post deterministic on the trigger.
+
+Behavior summary
+================
+
+1. Parse repo, issue number, wave label from the bash command. Uses
+   `_shell_parse.tokenize` + heredoc-stripping (the third hook this wave
+   eating its own dogfood — siblings #316, #378, #386).
+2. Read `ontology/cross-repo-status.json` (or fallback paths) and find
+   the matching assignment row in `wave_{M}_scope.tier_{1,2,3,4}_*`
+   arrays. Match by:
+     - `id == "<repo>#<num>"` for explicit-issue rows (W7+W8 shape), OR
+     - `repo == "<repo>"` for Tier-1 backlog rows (W6+W7 Tier-1 shape).
+3. If found, render a charter-format kickoff comment using the row's
+   `implementer` / `reviewer` / `reviewer_2` fields.
+4. Skip if the issue == `wave_{M}_meta_issue` (meta-issue gets its own
+   all-hands kickoff comment, owned separately by /wave-kickoff Step 8b).
+5. Idempotency: skip if the issue already has a kickoff comment whose
+   body starts with the charter heading `Wave {M} Kickoff — Phase {N}`.
+6. Post via `gh issue comment <num> --repo <repo> --body-file <path>`
+   where the body file is written FRESH to `.claude/scratch/` immediately
+   before the gh call (the `block_stale_tmp_message_file` PreToolUse hook
+   would reject a stale /tmp/* path — and using .claude/scratch/ avoids
+   both that race AND the /tmp false-positive scope entirely).
+7. Failure modes: missing `wave_{M}_scope`, issue not found in any tier,
+   gh CLI failure → annunaki-log-and-skip. The underlying label-apply
+   already succeeded (this is PostToolUse); the hook never raises a
+   failure on the user-visible tool call.
+
+The hook is best-effort post-action automation. PostToolUse hooks cannot
+fail the original tool call by design (the tool has already run); a
+non-zero exit here only affects whether the harness logs a hook failure
+itself. We return 0 unconditionally to match the existing PostToolUse
+pattern in this repo (see auto_add_issue_to_board.py).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _shell_parse import (  # noqa: E402
+    find_gh_subcommand,
+    iter_command_segments,
+    strip_heredocs,
+    tokenize,
+)
+from annunaki_log import log_posttooluse_event  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+CROSS_REPO_STATUS = REPO_ROOT / "cross-repo-status.json"
+# Fallback location (subdir-rooted layouts have used this in earlier waves).
+CROSS_REPO_STATUS_ALT = REPO_ROOT / "ontology" / "cross-repo-status.json"
+
+SCRATCH_DIR = REPO_ROOT / ".claude" / "scratch"
+
+# The charter-format kickoff Requestor is the wave-kickoff orchestrator
+# persona (per /wave-kickoff SKILL.md Step 8 template). Fatima Okonkwo is
+# the named orchestrator in this roster; if the persona is renamed in the
+# future, update this constant — there is no roster lookup for "who runs
+# wave-kickoff" because that role is implicit.
+KICKOFF_REQUESTOR = "Fatima Okonkwo"
+
+# Regex matching the wave label value (e.g. "p3-wave-9"). Used both for
+# argument detection and for parsing phase/wave numerics out.
+_WAVE_LABEL_RE = re.compile(r"^p(\d+)-wave-(\d+)$")
+
+# Regex matching the kickoff comment heading the charter requires
+# (`**Wave {M} Kickoff — Phase {N}**`). Used for idempotency check. The
+# emdash is the literal character in the template; we tolerate either
+# em-dash or regular hyphen-surrounded form in case of copy-paste drift.
+_KICKOFF_HEADING_RE = re.compile(r"\*\*Wave\s+\d+\s+Kickoff\s+[—-]\s+Phase\s+\d+\*\*")
+
+
+def _read_status() -> dict | None:
+    """Read cross-repo-status.json from canonical or fallback path. Return None
+    if neither exists OR the file is malformed. Hook fails open."""
+    for path in (CROSS_REPO_STATUS, CROSS_REPO_STATUS_ALT):
+        if path.is_file():
+            try:
+                return json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                return None
+    return None
+
+
+def parse_label_apply_command(command: str) -> tuple[str, str, str] | None:
+    """Parse `gh issue edit <num> --repo <repo> --add-label "p{N}-wave-{M}"`.
+
+    Returns (repo, issue_number, wave_label) if the command applies a wave
+    label, else None. Tolerates additional flags (e.g. extra --add-label
+    arguments for implementer label) and arbitrary flag ordering.
+
+    Implementation: tokenize via _shell_parse (heredoc-strip + shlex), walk
+    pipeline segments looking for a `gh issue edit` segment with an
+    `--add-label "p{N}-wave-{M}"` flag-value pair. Returns the FIRST such
+    match per command.
+    """
+    cleaned = strip_heredocs(command)
+    tokens = tokenize(cleaned)
+    if tokens is None:
+        return None
+
+    for segment in iter_command_segments(tokens):
+        gh = find_gh_subcommand(segment)
+        if gh is None:
+            continue
+        _globals, rest = gh
+        if len(rest) < 3 or rest[0] != "issue" or rest[1] != "edit":
+            continue
+
+        # The issue number is the first positional arg after `edit`.
+        issue_number = None
+        repo = None
+        wave_label = None
+        i = 2
+        n = len(rest)
+        while i < n:
+            tok = rest[i]
+            if issue_number is None and re.fullmatch(r"\d+", tok):
+                issue_number = tok
+                i += 1
+                continue
+            if tok == "--repo" and i + 1 < n:
+                repo_full = rest[i + 1]
+                # Accept "owner/name" or just "name"
+                repo = repo_full.split("/")[-1]
+                i += 2
+                continue
+            if tok.startswith("--repo="):
+                repo_full = tok[len("--repo=") :]
+                repo = repo_full.split("/")[-1]
+                i += 1
+                continue
+            if tok == "--add-label" and i + 1 < n:
+                value = rest[i + 1]
+                if _WAVE_LABEL_RE.match(value):
+                    wave_label = value
+                i += 2
+                continue
+            if tok.startswith("--add-label="):
+                value = tok[len("--add-label=") :]
+                if _WAVE_LABEL_RE.match(value):
+                    wave_label = value
+                i += 1
+                continue
+            i += 1
+
+        if issue_number and repo and wave_label:
+            return repo, issue_number, wave_label
+
+    return None
+
+
+def find_assignment_row(status: dict, repo: str, issue_number: str, wave_num: int) -> dict | None:
+    """Locate the assignment row for (repo, issue_number) in wave_{M}_scope.
+
+    Match priority:
+      1. Exact `id == "<repo>#<issue_number>"` in any tier_N array
+         (W7+W8 shape — explicit issue rows).
+      2. Exact `repo == "<repo>"` AND row has no `id` field, in any
+         tier_N array (W6+W7 Tier-1 backlog shape — applies to all
+         backlog issues in that repo).
+
+    Returns the row dict (with `implementer` / `reviewer` / `reviewer_2`
+    fields) or None if no match.
+    """
+    scope = status.get(f"wave_{wave_num}_scope") or {}
+    if not isinstance(scope, dict):
+        return None
+
+    expected_id = f"{repo}#{issue_number}"
+
+    # Pass 1: match by explicit id.
+    for key, value in scope.items():
+        if not key.startswith("tier_") or not isinstance(value, list):
+            continue
+        for row in value:
+            if isinstance(row, dict) and row.get("id") == expected_id:
+                return row
+
+    # Pass 2: match by repo (backlog-tier fallback).
+    for key, value in scope.items():
+        if not key.startswith("tier_") or not isinstance(value, list):
+            continue
+        for row in value:
+            if isinstance(row, dict) and "id" not in row and row.get("repo") == repo:
+                return row
+
+    return None
+
+
+def render_kickoff_comment(row: dict, wave_num: int, phase_num: int, repo: str) -> str:
+    """Render the charter-format kickoff comment body per pull-requests.md
+    § Kickoff Comment Format / wave-kickoff SKILL.md Step 8 template.
+
+    Required row fields: `implementer`. Optional: `reviewer`, `reviewer_2`,
+    `priority`. Missing optional fields are rendered as "(unassigned)"
+    placeholders rather than blanking the bullet — the orchestrator
+    follow-up sweep can backfill, and an empty bullet looks like a bug.
+    """
+    implementer = row.get("implementer") or "(unassigned)"
+    reviewer = row.get("reviewer") or "(unassigned)"
+    reviewer_2 = row.get("reviewer_2") or "(unassigned)"
+    priority = row.get("priority") or "feature"
+
+    branch_base = f"deployments/phase-{phase_num}/wave-{wave_num}"
+
+    lines = [
+        f"Requestor: {KICKOFF_REQUESTOR}",
+        f"Requestee: {implementer}",
+        "RequestOrReplied: Request",
+        "",
+        f"**Wave {wave_num} Kickoff — Phase {phase_num}**",
+        "",
+        f"This issue is assigned to you for p{phase_num}-wave-{wave_num}.",
+        f"- Peer reviewer: {reviewer}",
+        f"- Secondary reviewer: {reviewer_2}",
+        f"- Branch from: `{branch_base}`",
+        "- Branch naming: `{FirstInitial}.{LastName}/{IIII}-{issue-slug}`",
+        f"- Priority: {priority} (per charter § Wave Planning & Priority)",
+        "",
+        "Please begin implementation.",
+    ]
+    return "\n".join(lines)
+
+
+def kickoff_already_posted(repo: str, issue_number: str, fetch_comments=None) -> bool:
+    """Idempotency check: True if any existing comment body matches the
+    charter kickoff heading regex.
+
+    The `fetch_comments` callable defaults to a real `gh issue view` call;
+    tests inject a mock. Returns False on any error fetching comments
+    (don't suppress on broken state — let the hook attempt to post and
+    surface real errors via annunaki on the actual post call).
+    """
+    if fetch_comments is None:
+        fetch_comments = _gh_fetch_comments
+
+    comments = fetch_comments(repo, issue_number)
+    if comments is None:
+        return False
+
+    for c in comments:
+        body = c.get("body", "") if isinstance(c, dict) else ""
+        if _KICKOFF_HEADING_RE.search(body):
+            return True
+    return False
+
+
+def _gh_fetch_comments(repo: str, issue_number: str) -> list[dict] | None:
+    """Fetch existing comments on an issue via gh. Returns None on any error."""
+    try:
+        result = subprocess.run(
+            [
+                "gh",
+                "issue",
+                "view",
+                issue_number,
+                "--repo",
+                f"noorinalabs/{repo}",
+                "--json",
+                "comments",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        if result.returncode != 0:
+            return None
+        data = json.loads(result.stdout)
+        comments = data.get("comments")
+        return comments if isinstance(comments, list) else None
+    except (subprocess.TimeoutExpired, json.JSONDecodeError, FileNotFoundError, OSError):
+        return None
+
+
+def _gh_post_comment(repo: str, issue_number: str, body_file: Path) -> bool:
+    """Post a comment to an issue via gh, reading the body from body_file.
+
+    Returns True on success, False on failure. Failures are NOT raised —
+    the caller annunaki-logs and the original label-apply stays succeeded.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "gh",
+                "issue",
+                "comment",
+                issue_number,
+                "--repo",
+                f"noorinalabs/{repo}",
+                "--body-file",
+                str(body_file),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        return result.returncode == 0
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return False
+
+
+def _write_fresh_body_file(body: str, repo: str, issue_number: str) -> Path:
+    """Write the comment body to .claude/scratch/ with a unique fresh name.
+
+    Uses `.claude/scratch/` (not /tmp/) to evade both the
+    `block_stale_tmp_message_file` PreToolUse hook entirely AND the false-
+    positive scope. Filename includes a millisecond timestamp so concurrent
+    label applies on the same issue from a kickoff loop never collide.
+    """
+    SCRATCH_DIR.mkdir(parents=True, exist_ok=True)
+    ts_ms = int(time.time() * 1000)
+    safe_repo = re.sub(r"[^A-Za-z0-9_-]", "_", repo)
+    path = SCRATCH_DIR / f"kickoff-{safe_repo}-{issue_number}-{ts_ms}.md"
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def check(
+    input_data: dict,
+    status_loader=None,
+    comment_fetcher=None,
+    comment_poster=None,
+    body_writer=None,
+) -> dict | None:
+    """Pure decision function. Returns a dict describing the action taken
+    (or skipped), or None when the hook does not apply.
+
+    Result shape (always returned as advisory, never blocking):
+      None                                     — hook didn't apply
+      {"action": "post", "issue": "<n>", ...}  — comment posted
+      {"action": "skip_meta_issue", ...}       — meta-issue skipped
+      {"action": "skip_idempotent", ...}       — kickoff already posted
+      {"action": "skip_no_scope", ...}         — wave_{M}_scope missing
+      {"action": "skip_no_row", ...}           — issue not in any tier
+      {"action": "skip_post_failed", ...}      — gh post call failed
+
+    Injection points let tests mock external state without mocking
+    subprocess: `status_loader()` returns the status dict, `comment_fetcher
+    (repo, num)` returns the comment list, `comment_poster(repo, num, path)`
+    returns success bool, `body_writer(body, repo, num)` returns the Path
+    of the written body file.
+    """
+    if input_data.get("tool_name", "") != "Bash":
+        return None
+
+    command = input_data.get("tool_input", {}).get("command", "")
+    if not command:
+        return None
+
+    parsed = parse_label_apply_command(command)
+    if parsed is None:
+        return None
+    repo, issue_number, wave_label = parsed
+
+    m = _WAVE_LABEL_RE.match(wave_label)
+    if m is None:
+        return None
+    phase_num = int(m.group(1))
+    wave_num = int(m.group(2))
+
+    status = (status_loader or _read_status)()
+    if status is None:
+        log_posttooluse_event(
+            "post_wave_kickoff_comment",
+            command,
+            "cross-repo-status.json missing or malformed; cannot resolve assignment row.",
+        )
+        return {"action": "skip_no_scope", "repo": repo, "issue": issue_number}
+
+    # Meta-issue skip: this hook is for per-issue kickoff; the meta-issue
+    # gets a different all-hands comment owned by /wave-kickoff Step 8b.
+    meta = status.get(f"wave_{wave_num}_meta_issue")
+    if meta is not None and str(meta) == issue_number and repo == "noorinalabs-main":
+        return {"action": "skip_meta_issue", "repo": repo, "issue": issue_number}
+
+    scope = status.get(f"wave_{wave_num}_scope")
+    if not scope:
+        log_posttooluse_event(
+            "post_wave_kickoff_comment",
+            command,
+            (
+                f"wave_{wave_num}_scope is missing or empty in cross-repo-status.json; "
+                f"cannot render kickoff comment for {repo}#{issue_number}."
+            ),
+        )
+        return {"action": "skip_no_scope", "repo": repo, "issue": issue_number}
+
+    row = find_assignment_row(status, repo, issue_number, wave_num)
+    if row is None:
+        log_posttooluse_event(
+            "post_wave_kickoff_comment",
+            command,
+            (
+                f"No assignment row found in wave_{wave_num}_scope tiers for "
+                f"{repo}#{issue_number}. /wave-scope may have missed this issue."
+            ),
+        )
+        return {"action": "skip_no_row", "repo": repo, "issue": issue_number}
+
+    # Idempotency: don't double-post.
+    if kickoff_already_posted(repo, issue_number, fetch_comments=comment_fetcher):
+        return {"action": "skip_idempotent", "repo": repo, "issue": issue_number}
+
+    body = render_kickoff_comment(row, wave_num, phase_num, repo)
+    writer = body_writer or _write_fresh_body_file
+    body_path = writer(body, repo, issue_number)
+
+    poster = comment_poster or _gh_post_comment
+    success = poster(repo, issue_number, body_path)
+    if not success:
+        log_posttooluse_event(
+            "post_wave_kickoff_comment",
+            command,
+            f"gh issue comment failed for {repo}#{issue_number} (body at {body_path}).",
+        )
+        return {"action": "skip_post_failed", "repo": repo, "issue": issue_number}
+
+    return {
+        "action": "post",
+        "repo": repo,
+        "issue": issue_number,
+        "wave_label": wave_label,
+        "body_path": str(body_path),
+    }
+
+
+def main() -> None:
+    try:
+        input_data = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        sys.exit(0)
+
+    try:
+        check(input_data)
+    except Exception as e:  # noqa: BLE001
+        # PostToolUse hooks are advisory — never raise. Log the unexpected
+        # error and exit clean. The label apply has already succeeded.
+        try:
+            log_posttooluse_event(
+                "post_wave_kickoff_comment",
+                input_data.get("tool_input", {}).get("command", "")[:500],
+                f"Unexpected hook error: {type(e).__name__}: {e}",
+            )
+        except Exception:
+            pass
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/tests/test_post_wave_kickoff_comment.py
+++ b/.claude/hooks/tests/test_post_wave_kickoff_comment.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+"""Tests for post_wave_kickoff_comment PostToolUse hook.
+
+Two test surfaces:
+
+1. **Fixture-driven scenarios** — `.claude/hooks/fixtures/post_wave_kickoff_comment/`
+   contains JSON test cases with this shape:
+
+       {
+           "description": "<human label>",
+           "command": "<raw bash command string>",
+           "status": <cross-repo-status.json dict>,
+           "existing_comments": [<comment dicts>],
+           "post_succeeds": <bool>,
+           "expect_action": "post" | "skip_*" | null,
+           "expect_body_contains": [<substrings>]   # only meaningful for "post"
+       }
+
+   The injectors in `post_wave_kickoff_comment.check()` (`status_loader`,
+   `comment_fetcher`, `comment_poster`, `body_writer`) let each test mock
+   the four external interactions (status JSON read, gh comments fetch,
+   gh comment post, body file write) without monkeypatching subprocess.
+
+2. **Direct unit tests** — `parse_label_apply_command`,
+   `find_assignment_row`, `render_kickoff_comment`,
+   `kickoff_already_posted`. These pin behaviors that don't fit cleanly
+   into fixture form (regex shapes, table-driven row lookups).
+
+Run:  python3 -m pytest .claude/hooks/tests/test_post_wave_kickoff_comment.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_HOOKS_DIR = _HERE.parent
+_FIXTURES_DIR = _HOOKS_DIR / "fixtures" / "post_wave_kickoff_comment"
+
+sys.path.insert(0, str(_HOOKS_DIR))
+
+import post_wave_kickoff_comment as hook  # noqa: E402
+
+
+def _load_fixtures() -> list[tuple[str, dict]]:
+    fixtures = []
+    for path in sorted(_FIXTURES_DIR.glob("*.json")):
+        data = json.loads(path.read_text(encoding="utf-8"))
+        fixtures.append((path.stem, data))
+    return fixtures
+
+
+def _bash(command: str) -> dict:
+    return {"tool_name": "Bash", "tool_input": {"command": command}}
+
+
+class FixtureDrivenScenarioTests(unittest.TestCase):
+    """One test per fixture file — generated dynamically."""
+
+
+def _add_fixture_test(name: str, fixture: dict) -> None:
+    description = fixture.get("description", name)
+    command = fixture["command"]
+    status = fixture.get("status")
+    existing_comments = fixture.get("existing_comments", [])
+    post_succeeds = fixture.get("post_succeeds", True)
+    expect_action = fixture.get("expect_action")
+    expect_body_contains = fixture.get("expect_body_contains", [])
+
+    def test_method(self: unittest.TestCase) -> None:
+        captured: dict = {}
+
+        def fake_status():
+            return status
+
+        def fake_fetch(repo, num):
+            return existing_comments
+
+        def fake_post(repo, num, body_path):
+            captured["repo"] = repo
+            captured["num"] = num
+            captured["body_path"] = body_path
+            captured["body"] = Path(body_path).read_text(encoding="utf-8")
+            return post_succeeds
+
+        with tempfile.TemporaryDirectory() as td:
+
+            def fake_writer(body, repo, num):
+                path = Path(td) / f"body-{repo}-{num}.md"
+                path.write_text(body, encoding="utf-8")
+                return path
+
+            result = hook.check(
+                _bash(command),
+                status_loader=fake_status,
+                comment_fetcher=fake_fetch,
+                comment_poster=fake_post,
+                body_writer=fake_writer,
+            )
+
+            if expect_action is None:
+                self.assertIsNone(
+                    result,
+                    f"{description!r}: expected hook to not apply (None), got: {result}",
+                )
+                return
+
+            self.assertIsNotNone(
+                result,
+                f"{description!r}: expected action={expect_action!r}, got None",
+            )
+            assert result is not None
+            self.assertEqual(
+                result.get("action"),
+                expect_action,
+                f"{description!r}: action mismatch: {result}",
+            )
+
+            if expect_action == "post":
+                for needle in expect_body_contains:
+                    self.assertIn(
+                        needle,
+                        captured.get("body", ""),
+                        f"{description!r}: missing expected substring {needle!r} in body:\n"
+                        f"{captured.get('body', '(no body captured)')}",
+                    )
+
+    test_method.__name__ = f"test_{name}"
+    test_method.__doc__ = description
+    setattr(FixtureDrivenScenarioTests, test_method.__name__, test_method)
+
+
+for _fixture_name, _fixture_data in _load_fixtures():
+    _add_fixture_test(_fixture_name, _fixture_data)
+
+
+class ParseLabelApplyCommandTests(unittest.TestCase):
+    """Direct coverage of the bash-command parser."""
+
+    def test_canonical_form(self):
+        self.assertEqual(
+            hook.parse_label_apply_command(
+                'gh issue edit 123 --repo noorinalabs/noorinalabs-main --add-label "p3-wave-9"'
+            ),
+            ("noorinalabs-main", "123", "p3-wave-9"),
+        )
+
+    def test_flag_order_swapped(self):
+        self.assertEqual(
+            hook.parse_label_apply_command(
+                'gh issue edit 456 --add-label "p3-wave-9" --repo noorinalabs/noorinalabs-deploy'
+            ),
+            ("noorinalabs-deploy", "456", "p3-wave-9"),
+        )
+
+    def test_equals_form(self):
+        self.assertEqual(
+            hook.parse_label_apply_command(
+                "gh issue edit 789 --repo=noorinalabs/noorinalabs-isnad-graph --add-label=p3-wave-8"
+            ),
+            ("noorinalabs-isnad-graph", "789", "p3-wave-8"),
+        )
+
+    def test_multiple_add_label_picks_wave_label(self):
+        """When the command applies BOTH a wave label and an implementer
+        label, only the wave label matters for hook trigger."""
+        self.assertEqual(
+            hook.parse_label_apply_command(
+                "gh issue edit 100 --repo noorinalabs/noorinalabs-main "
+                '--add-label "Aino_Virtanen" --add-label "p3-wave-9"'
+            ),
+            ("noorinalabs-main", "100", "p3-wave-9"),
+        )
+
+    def test_non_wave_label_returns_none(self):
+        self.assertIsNone(
+            hook.parse_label_apply_command(
+                'gh issue edit 100 --repo noorinalabs/noorinalabs-main --add-label "tech-debt"'
+            )
+        )
+
+    def test_non_issue_edit_command_returns_none(self):
+        self.assertIsNone(
+            hook.parse_label_apply_command(
+                'gh pr edit 42 --repo noorinalabs/noorinalabs-main --add-label "p3-wave-9"'
+            )
+        )
+
+    def test_unrelated_command_returns_none(self):
+        self.assertIsNone(hook.parse_label_apply_command("echo hello"))
+
+    def test_empty_command_returns_none(self):
+        self.assertIsNone(hook.parse_label_apply_command(""))
+
+    def test_compound_command_picks_label_segment(self):
+        """`true && gh issue edit ... --add-label "p3-wave-9"` still matches."""
+        self.assertEqual(
+            hook.parse_label_apply_command(
+                "true && gh issue edit 999 --repo noorinalabs/noorinalabs-main "
+                '--add-label "p3-wave-9"'
+            ),
+            ("noorinalabs-main", "999", "p3-wave-9"),
+        )
+
+
+class FindAssignmentRowTests(unittest.TestCase):
+    """Direct coverage of tier-array row lookup with both shapes."""
+
+    def test_explicit_issue_id_match(self):
+        status = {
+            "wave_9_scope": {
+                "tier_1_x": [
+                    {"id": "noorinalabs-main#123", "implementer": "A"},
+                    {"id": "noorinalabs-deploy#9", "implementer": "B"},
+                ]
+            }
+        }
+        row = hook.find_assignment_row(status, "noorinalabs-main", "123", 9)
+        self.assertEqual(row["implementer"], "A")
+
+    def test_repo_backlog_match_when_no_explicit_id(self):
+        """W6+W7 Tier-1 backlog shape: row has `repo`, no `id`."""
+        status = {
+            "wave_9_scope": {
+                "tier_1_backlog": [
+                    {"repo": "noorinalabs-deploy", "implementer": "Santiago Ferreira"}
+                ]
+            }
+        }
+        row = hook.find_assignment_row(status, "noorinalabs-deploy", "555", 9)
+        self.assertEqual(row["implementer"], "Santiago Ferreira")
+
+    def test_explicit_id_wins_over_repo_match(self):
+        """If both shapes are present, the explicit-id row wins."""
+        status = {
+            "wave_9_scope": {
+                "tier_1_backlog": [{"repo": "noorinalabs-main", "implementer": "BACKLOG"}],
+                "tier_2_explicit": [{"id": "noorinalabs-main#42", "implementer": "EXPLICIT"}],
+            }
+        }
+        row = hook.find_assignment_row(status, "noorinalabs-main", "42", 9)
+        self.assertEqual(row["implementer"], "EXPLICIT")
+
+    def test_no_match_returns_none(self):
+        status = {"wave_9_scope": {"tier_1": [{"id": "other#999", "implementer": "X"}]}}
+        self.assertIsNone(hook.find_assignment_row(status, "noorinalabs-main", "1", 9))
+
+    def test_empty_scope_returns_none(self):
+        self.assertIsNone(hook.find_assignment_row({}, "noorinalabs-main", "1", 9))
+
+    def test_non_tier_keys_ignored(self):
+        """Keys not starting with `tier_` (theme, declared_total, etc.) are skipped."""
+        status = {
+            "wave_9_scope": {
+                "theme": "tech-debt",
+                "tier_1": [{"id": "noorinalabs-main#1", "implementer": "Y"}],
+            }
+        }
+        row = hook.find_assignment_row(status, "noorinalabs-main", "1", 9)
+        self.assertEqual(row["implementer"], "Y")
+
+
+class RenderKickoffCommentTests(unittest.TestCase):
+    """Direct coverage of comment body rendering."""
+
+    def test_canonical_render(self):
+        row = {
+            "implementer": "Aino Virtanen",
+            "reviewer": "Nadia Khoury",
+            "reviewer_2": "Santiago Ferreira",
+            "priority": "tech-debt",
+        }
+        body = hook.render_kickoff_comment(row, wave_num=9, phase_num=3, repo="noorinalabs-main")
+        self.assertIn("Requestor: Fatima Okonkwo", body)
+        self.assertIn("Requestee: Aino Virtanen", body)
+        self.assertIn("RequestOrReplied: Request", body)
+        self.assertIn("**Wave 9 Kickoff — Phase 3**", body)
+        self.assertIn("- Peer reviewer: Nadia Khoury", body)
+        self.assertIn("- Secondary reviewer: Santiago Ferreira", body)
+        self.assertIn("- Branch from: `deployments/phase-3/wave-9`", body)
+        self.assertIn("- Priority: tech-debt", body)
+
+    def test_missing_optional_fields_show_unassigned(self):
+        """Missing reviewer/reviewer_2 render as `(unassigned)`, not blank."""
+        row = {"implementer": "Aino Virtanen"}
+        body = hook.render_kickoff_comment(row, wave_num=9, phase_num=3, repo="noorinalabs-main")
+        self.assertIn("- Peer reviewer: (unassigned)", body)
+        self.assertIn("- Secondary reviewer: (unassigned)", body)
+        self.assertIn("- Priority: feature", body)  # default priority
+
+    def test_implementer_missing_shows_unassigned(self):
+        body = hook.render_kickoff_comment({}, wave_num=9, phase_num=3, repo="noorinalabs-main")
+        self.assertIn("Requestee: (unassigned)", body)
+
+
+class KickoffAlreadyPostedTests(unittest.TestCase):
+    """Idempotency check across various comment shapes."""
+
+    def test_returns_true_on_charter_heading(self):
+        def fetch(r, n):
+            return [{"body": "**Wave 9 Kickoff — Phase 3**\n\nbody"}]
+
+        self.assertTrue(hook.kickoff_already_posted("x", "1", fetch_comments=fetch))
+
+    def test_returns_true_on_hyphen_form(self):
+        """Tolerate a hyphen-surrounded form in case the em-dash got dropped."""
+
+        def fetch(r, n):
+            return [{"body": "**Wave 9 Kickoff - Phase 3**"}]
+
+        self.assertTrue(hook.kickoff_already_posted("x", "1", fetch_comments=fetch))
+
+    def test_returns_false_on_no_kickoff_comment(self):
+        def fetch(r, n):
+            return [{"body": "Some other comment."}]
+
+        self.assertFalse(hook.kickoff_already_posted("x", "1", fetch_comments=fetch))
+
+    def test_returns_false_on_no_comments(self):
+        def fetch(r, n):
+            return []
+
+        self.assertFalse(hook.kickoff_already_posted("x", "1", fetch_comments=fetch))
+
+    def test_returns_false_on_fetch_failure(self):
+        """fetch returning None (gh CLI failed) → don't suppress; let the
+        downstream post attempt and annunaki-log on real failure."""
+
+        def fetch(r, n):
+            return None
+
+        self.assertFalse(hook.kickoff_already_posted("x", "1", fetch_comments=fetch))
+
+
+class NonBashToolTests(unittest.TestCase):
+    """tool_name != Bash → early return None."""
+
+    def test_edit_tool_not_matched(self):
+        result = hook.check(
+            {
+                "tool_name": "Edit",
+                "tool_input": {"command": 'gh issue edit 1 --repo r --add-label "p3-wave-9"'},
+            }
+        )
+        self.assertIsNone(result)
+
+    def test_empty_command_not_matched(self):
+        result = hook.check({"tool_name": "Bash", "tool_input": {"command": ""}})
+        self.assertIsNone(result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -119,6 +119,16 @@
         ]
       },
       {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/post_wave_kickoff_comment.py",
+            "timeout": 60
+          }
+        ]
+      },
+      {
         "matcher": "Edit",
         "hooks": [
           {

--- a/.claude/skills/wave-kickoff/SKILL.md
+++ b/.claude/skills/wave-kickoff/SKILL.md
@@ -305,29 +305,22 @@ For each issue, apply the wave label and assignee label:
 gh issue edit {NUMBER} --add-label "p{N}-wave-{M}" --add-label "{FIRSTNAME_LASTNAME}"
 ```
 
+**The kickoff comment is posted automatically.** A `PostToolUse` hook (`.claude/hooks/post_wave_kickoff_comment.py`, closes #286) fires on the `--add-label "p{N}-wave-{M}"` pattern, reads the matching assignment row from `cross-repo-status.json` `wave_{M}_scope.tier_*` arrays, and posts the charter-format kickoff comment to the issue. Per `feedback_enforcement_hierarchy`: hook > skill > charter — the prior manual loop (old Step 8) could be skipped or partial-fail, the hook fires deterministically.
+
+Hook behavior:
+- Idempotent: re-applying the wave label after disposition correction does NOT double-post (the hook detects the charter heading `**Wave {M} Kickoff — Phase {N}**` in existing comments and skips).
+- Meta-issue skip: when the labeled issue is `wave_{M}_meta_issue`, the per-issue kickoff is skipped (the meta-issue gets its own all-hands kickoff comment — see § 8 below).
+- Failure-tolerant: if `wave_{M}_scope` is missing or the issue isn't in any tier, the hook logs to `.claude/annunaki/errors.jsonl` and lets the label-apply succeed. A missing scope row is a `/wave-scope` bug, not a label-apply bug.
+
 ### 7a. Per-wave orchestration scripts (optional automation)
 
-For waves with many issues across many repos, the labeling + project-board adds in steps 7 and 8 may be automated by a per-wave orchestration script. Write these scripts to `.claude/skills/wave-kickoff/_orchestration/` using the naming convention `w{N}-{purpose}.py` (e.g., `w5-kickoff.py`, `w5-project-add.py`). The directory is tracked for audit-trail visibility (see #247). Do NOT use `.claude/scratch/` — that location is gitignored and reserved for true ephemeral artifacts (commit messages, mid-task notes).
+For waves with many issues across many repos, the labeling + project-board adds in step 7 may be automated by a per-wave orchestration script. Write these scripts to `.claude/skills/wave-kickoff/_orchestration/` using the naming convention `w{N}-{purpose}.py` (e.g., `w5-kickoff.py`, `w5-project-add.py`). The directory is tracked for audit-trail visibility (see #247). Do NOT use `.claude/scratch/` — that location is gitignored and reserved for true ephemeral artifacts (commit messages, mid-task notes).
 
-### 8. Post kickoff comments
+### 8. Post the meta-issue all-hands kickoff comment
 
-Post a kickoff comment on each issue using charter format:
+The per-issue kickoff comments (charter format with `Requestor: Fatima Okonkwo`, `Requestee: {Implementer}`) are posted automatically by the hook described in § 7. **This step covers only the meta-issue kickoff** — a single all-hands comment on the wave meta-issue (`wave_{M}_meta_issue`) summarizing the wave theme, all participating implementers, and tier breakdown. Format and exact text vary by wave; recent precedent is #284 (W6) — read it before authoring.
 
-```
-Requestor: Fatima.Okonkwo
-Requestee: {Assignee.Name}
-RequestOrReplied: Request
-
-**Wave {M} Kickoff — Phase {N}**
-
-This issue is assigned to you for p{N}-wave-{M}.
-- Peer reviewer: {reviewer name}
-- Branch from: `deployments/phase-{N}/wave-{M}`
-- Branch naming: `{FirstInitial}.{LastName}/{IIII}-{issue-slug}`
-- Priority: {hotfix|security|bug|feature} (per charter § Wave Planning & Priority)
-
-Please begin implementation.
-```
+If the wave has no meta-issue (rare; pre-#284 waves), skip this step.
 
 ### 9. Ontology librarian — both bakes required (MANDATORY)
 


### PR DESCRIPTION
## Summary

- New PostToolUse hook `post_wave_kickoff_comment.py` auto-posts charter-format kickoff comments on `gh issue edit ... --add-label "p{N}-wave-{M}"`. Removes the "orchestrator forgets to post comments" failure mode caught during P3W6 kickoff.
- `/wave-kickoff` SKILL.md Step 7 expanded to document the hook; old Step 8 (manual per-issue kickoff loop) deleted. Step 8 section number reused for the meta-issue all-hands kickoff (which was previously implicit — now explicitly documented as the surviving manual step).
- 30 new tests (5 fixture-driven scenarios + 25 direct-helper unit tests). Full hook suite: 672 passed (was 642).

## Why a hook (vs. continuing as skill steps)

Per `feedback_enforcement_hierarchy`: hook > skill > charter. Skills can be skipped or mis-executed; hooks fire deterministically on the trigger event. The W6 kickoff workaround (`/tmp/wave6_kickoff_comments.py` write-then-post wrapper) worked but was fragile — partial failure left partial state. A hook firing per-label-apply is naturally idempotent and recoverable.

This is also the third hook this wave eating its own `_shell_parse.tokenize` dogfood (siblings #316 PR #383, #378 PR #385, #386 PR #391). Same parser pattern, same heredoc-strip + tokenize discipline.

## What changed

**New hook** `.claude/hooks/post_wave_kickoff_comment.py`
- Trigger: `PostToolUse` Bash matching `gh issue edit <num> --repo noorinalabs/<repo> ... --add-label "p{N}-wave-{M}"`. Tolerates flag order, equals-form, multiple `--add-label` invocations.
- Parser uses `_shell_parse.tokenize` + `strip_heredocs` + `iter_command_segments` + `find_gh_subcommand`.
- Reads `cross-repo-status.json` (canonical path, with `ontology/cross-repo-status.json` fallback).
- Finds the assignment row in `wave_{M}_scope.tier_*` arrays via two passes: explicit `id == "<repo>#<num>"` first, then `repo == "<repo>"` backlog-tier fallback (W6+W7 Tier-1 shape).
- Renders charter-format kickoff body per `pull-requests.md` § Kickoff Comment Format / `wave-kickoff` SKILL.md Step 8 template.
- Posts via `gh issue comment --body-file <path>` where the body is written to `.claude/scratch/` (NOT `/tmp/` — sidesteps both the `block_stale_tmp_message_file` PreToolUse hook AND the /tmp false-positive scope).
- Skips when issue == `wave_{M}_meta_issue` (meta-issue has its own all-hands kickoff comment owned by `/wave-kickoff` Step 8b).
- Idempotent: skips when any existing comment body contains the charter heading `**Wave {M} Kickoff — Phase {N}**`. Tolerates em-dash and hyphen-surrounded forms.
- Failure-tolerant: missing/null `wave_{M}_scope`, no-row-found, or `gh` failure → `log_posttooluse_event` and return skip dict. Label-apply has already succeeded (this is PostToolUse); the hook never raises a failure on the user-visible tool call. Matches the existing PostToolUse pattern in this repo (see `auto_add_issue_to_board.py`).

**`annunaki_log.py`** gains a `log_posttooluse_event(hook_name, command, reason, tool_name)` companion to the existing `log_pretooluse_block`. PostToolUse hooks can't block (the tool ran already) — they record events that need follow-up. `post_wave_kickoff_comment` is the first caller.

**`.claude/settings.json`** registers the hook as a third `PostToolUse` `Bash` entry alongside `auto_add_issue_to_board` and `annunaki_monitor` (the existing per-hook PostToolUse pattern; no dispatcher needed). Timeout 60s to allow for a `gh issue view --json comments` fetch + a `gh issue comment` post.

**`.claude/skills/wave-kickoff/SKILL.md`**
- Step 7 expanded to document the hook with `feedback_enforcement_hierarchy` citation and a 3-bullet behavior summary (idempotency / meta-skip / failure-tolerant).
- Old Step 8 (manual per-issue kickoff loop) DELETED.
- Step 8 section number reused for the meta-issue all-hands kickoff comment (previously implicit; now explicitly named as the surviving manual step).
- Step 7a (per-wave orchestration scripts) updated to drop "step 8" reference.

## Which PostToolUse dispatcher pattern was used

**Direct per-hook registration in `settings.json`** (not a new `post_dispatcher.py`). The existing PostToolUse pattern in this repo is one entry per hook (3 Bash hooks pre-#286: `auto_add_issue_to_board`, `annunaki_monitor`, `suggest_generic_prompt`-via-Edit). Adding `post_wave_kickoff_comment` as a fourth `Bash` entry matches the existing pattern with zero refactor surface.

A future `post_dispatcher.py` (mirroring the PreToolUse `dispatcher.py`) would be a worthwhile refactor when PostToolUse Bash hooks grow past ~5 — out of scope for #286.

## Test plan

- [x] `python3 -m pytest .claude/hooks/tests/` — **672 passed** (was 642 + 30 new for this hook)
- [x] `python3 -m pytest .claude/hooks/tests/test_post_wave_kickoff_comment.py -v` — 30 passed
- [x] `uvx ruff format --check .claude/hooks/` — clean (57 files already formatted)
- [x] `uvx ruff check .claude/hooks/` — clean (all checks passed)
- [x] Settings.json validates as JSON; PostToolUse Bash hooks listed correctly

**30 new tests breakdown:**
- 5 fixture-driven scenarios under `.claude/hooks/fixtures/post_wave_kickoff_comment/`:
  - `happy_label_apply_explicit_issue.json` — full happy-path with body-substring assertions
  - `meta_issue_skip.json` — meta-issue early-return
  - `idempotent_re_apply.json` — existing kickoff comment → skip
  - `missing_scope_annunaki_log.json` — null scope → skip + log
  - `unmatched_label_passthrough.json` — non-wave label → hook returns None
- 9 ParseLabelApplyCommandTests — parser shape coverage
- 6 FindAssignmentRowTests — tier-array lookup with both shapes
- 3 RenderKickoffCommentTests — body rendering + unassigned placeholders
- 5 KickoffAlreadyPostedTests — idempotency check with em-dash / hyphen / no-kickoff / no-comments / fetch-failure shapes
- 2 NonBashToolTests — non-Bash / empty command early returns

## Sequencing

Dependencies #278 (`/wave-scope` Step 13 JSON-write) and #285 (`/wave-kickoff` Step 1 EXISTING_SHA fix) both merged pre-#286 per the issue body sequencing. `wave_{M}_scope` rows must be populated before the hook can resolve assignments; #278 makes that populated by default.

Closes #286.

**Wave**: P3W9
