### PR TITLE
refactor(hooks): extend _shell_parse with is_gh_subcommand + walk_flag_values + first_flag_value, migrate validate_labels + validate_branch_freshness (closes #170)

### DIFF
--- a/.claude/hooks/_shell_parse.py
+++ b/.claude/hooks/_shell_parse.py
@@ -50,6 +50,29 @@ Public API
         Same shape for `gh ...`. Returns (gh_global_opts, [topic, action,
         ...rest]) — e.g. ([], ["pr", "create", "--repo", ...]).
 
+    is_gh_subcommand(tokens, *verbs) -> bool
+        Yes/no convenience for "does this token list contain a `gh <verb1>
+        <verb2> ...` invocation?". Walks the token stream allowing the
+        match at any position. Use this when you only need the boolean,
+        not the post-verb tail; use `find_gh_subcommand` when you need
+        to inspect the tail.
+
+    walk_flag_values(tokens, wanted) -> list[str]
+        Walks `tokens` and returns the value of every flag in `wanted`,
+        in source order. Handles both the two-token form (`--flag value`)
+        and the equals form (`--flag=value`). Values inside another flag's
+        value (e.g. inside `--body "...--flag X..."`) are correctly
+        ignored because they arrive as a SINGLE shlex token, never
+        preceded by a flag from `wanted`.
+
+    first_flag_value(command, wanted, *, regex_fallback=True) -> str | None
+        Convenience wrapper: tokenizes `command` via `tokenize()` and
+        returns the first value from `walk_flag_values()`. If tokenize
+        fails AND `regex_fallback=True` (the default), falls back to a
+        boundary-anchored regex per the public tokenize contract.
+        Security-critical matchers should pass `regex_fallback=False`
+        to fail closed on parse failure.
+
     extract_dash_c_pairs(segment) -> list[tuple[str, str]]
         Walks a tokenized git segment and returns (key, value) pairs for
         every `-c key=value` global option, in source order. shlex has
@@ -272,6 +295,92 @@ def find_gh_subcommand(segment: list[str]) -> tuple[list[str], list[str]] | None
     if len(segment) < 2:
         return None
     return [], segment[1:]
+
+
+def is_gh_subcommand(tokens: list[str], *verbs: str) -> bool:
+    """Return True if `tokens` begins a `gh <verbs[0]> <verbs[1]> ...` invocation.
+
+    Walks `tokens` looking for `gh` followed by the supplied verb sequence in
+    order, allowing them to appear at any position (not just the start of the
+    list). Used by hooks that want a yes/no "does this command invoke
+    `gh issue create`?" check without needing the post-verb token tail.
+
+    Example:
+        is_gh_subcommand(tokens, "issue", "create")  # True for `gh issue create ...`
+        is_gh_subcommand(tokens, "pr", "create")     # True for `gh pr create ...`
+    """
+    if not verbs:
+        return False
+    target = ("gh",) + verbs
+    n = len(tokens)
+    span = len(target)
+    if n < span:
+        return False
+    for i in range(n - span + 1):
+        if tuple(tokens[i : i + span]) == target:
+            return True
+    return False
+
+
+def walk_flag_values(tokens: list[str], wanted: set[str]) -> list[str]:
+    """Return values for `wanted` flag names, only when they appear as flags.
+
+    A token is treated as a wanted-flag value only if the immediately
+    preceding token is exactly one of `wanted` (e.g. `--label`). The
+    `--flag=value` equals form is also handled. Values inside other flags
+    (e.g. inside the value of `--body`) are ignored because they are a
+    SINGLE shlex token, never preceded by a flag from `wanted`.
+
+    Order is preserved: values appear in the order they were encountered
+    in the token stream.
+    """
+    values: list[str] = []
+    i = 0
+    n = len(tokens)
+    while i < n:
+        tok = tokens[i]
+        if tok in wanted:
+            if i + 1 < n:
+                values.append(tokens[i + 1])
+                i += 2
+                continue
+            i += 1
+            continue
+        matched = False
+        for flag in wanted:
+            if tok.startswith(flag + "="):
+                values.append(tok[len(flag) + 1 :])
+                matched = True
+                break
+        if matched:
+            i += 1
+            continue
+        i += 1
+    return values
+
+
+def first_flag_value(command: str, wanted: set[str], *, regex_fallback: bool = True) -> str | None:
+    """Tokenize `command` and return the first value for any flag in `wanted`.
+
+    Returns None if no wanted flag is present. If shlex tokenization fails
+    (malformed quotes) and `regex_fallback=True` (default), falls back to a
+    boundary-anchored regex search that tries longer flag names first so
+    `--repo` is preferred over a hypothetical shorter prefix collision.
+    With `regex_fallback=False`, returns None on tokenize failure (the
+    fail-closed shape used by security-critical matchers).
+    """
+    tokens = tokenize(command)
+    if tokens is None:
+        if not regex_fallback:
+            return None
+        for flag in sorted(wanted, key=len, reverse=True):
+            pattern = rf"(?:^|\s){re.escape(flag)}(?:=|\s+)(\S+)"
+            match = re.search(pattern, command)
+            if match:
+                return match.group(1)
+        return None
+    values = walk_flag_values(tokens, wanted)
+    return values[0] if values else None
 
 
 def extract_dash_c_pairs(segment: list[str]) -> list[tuple[str, str]]:

--- a/.claude/hooks/tests/test_shell_parse.py
+++ b/.claude/hooks/tests/test_shell_parse.py
@@ -154,6 +154,133 @@ class FindGhSubcommandTests(unittest.TestCase):
         self.assertIsNone(sp.find_gh_subcommand(["git", "commit"]))
 
 
+class IsGhSubcommandTests(unittest.TestCase):
+    """Yes/no convenience wrapper introduced for the #170 helper extraction.
+
+    Replaces local `_is_gh_issue_create` / `_is_gh_pr_create` duplicates
+    that previously lived in validate_labels and validate_branch_freshness.
+    """
+
+    def test_positive_gh_issue_create(self):
+        tokens = ["gh", "issue", "create", "--title", "x"]
+        self.assertTrue(sp.is_gh_subcommand(tokens, "issue", "create"))
+
+    def test_positive_gh_pr_create(self):
+        tokens = ["gh", "pr", "create", "--base", "main"]
+        self.assertTrue(sp.is_gh_subcommand(tokens, "pr", "create"))
+
+    def test_positive_at_non_start_position(self):
+        """`cd x && gh issue create ...` — gh appears after segment tokens."""
+        tokens = ["cd", "x", "&&", "gh", "issue", "create"]
+        self.assertTrue(sp.is_gh_subcommand(tokens, "issue", "create"))
+
+    def test_negative_wrong_verb(self):
+        tokens = ["gh", "issue", "view", "42"]
+        self.assertFalse(sp.is_gh_subcommand(tokens, "issue", "create"))
+
+    def test_negative_not_gh(self):
+        tokens = ["git", "commit"]
+        self.assertFalse(sp.is_gh_subcommand(tokens, "issue", "create"))
+
+    def test_negative_no_verbs_supplied(self):
+        """Defensive: zero-verb call returns False (no match shape)."""
+        tokens = ["gh", "issue", "create"]
+        self.assertFalse(sp.is_gh_subcommand(tokens))
+
+    def test_negative_empty_tokens(self):
+        self.assertFalse(sp.is_gh_subcommand([], "issue", "create"))
+
+
+class WalkFlagValuesTests(unittest.TestCase):
+    """Generalized flag-walker that replaces local `_walk_flags` duplicates."""
+
+    def test_two_token_form(self):
+        tokens = ["gh", "issue", "create", "--label", "bug"]
+        self.assertEqual(sp.walk_flag_values(tokens, {"--label"}), ["bug"])
+
+    def test_equals_form(self):
+        tokens = ["gh", "issue", "create", "--label=bug"]
+        self.assertEqual(sp.walk_flag_values(tokens, {"--label"}), ["bug"])
+
+    def test_short_flag_two_token(self):
+        tokens = ["gh", "issue", "create", "-l", "bug"]
+        self.assertEqual(sp.walk_flag_values(tokens, {"-l"}), ["bug"])
+
+    def test_multiple_values_preserve_order(self):
+        tokens = ["gh", "issue", "create", "--label", "a", "--label", "b"]
+        self.assertEqual(sp.walk_flag_values(tokens, {"--label"}), ["a", "b"])
+
+    def test_mixed_equals_and_two_token(self):
+        tokens = ["gh", "issue", "create", "--label=a", "--label", "b"]
+        self.assertEqual(sp.walk_flag_values(tokens, {"--label"}), ["a", "b"])
+
+    def test_value_inside_other_flag_ignored(self):
+        """A `--label` substring INSIDE the value of `--body` must NOT match.
+
+        Critical correctness property: shlex.split has already collapsed
+        `--body "...contains --label X..."` into a SINGLE token whose
+        content includes `--label`, but that token is never PRECEDED by
+        `--label` itself, so the walker correctly ignores it.
+        """
+        tokens = ["gh", "issue", "create", "--body", "see --label X for context", "--label", "real"]
+        self.assertEqual(sp.walk_flag_values(tokens, {"--label"}), ["real"])
+
+    def test_no_match_returns_empty(self):
+        tokens = ["gh", "issue", "create", "--title", "no labels here"]
+        self.assertEqual(sp.walk_flag_values(tokens, {"--label"}), [])
+
+    def test_empty_tokens(self):
+        self.assertEqual(sp.walk_flag_values([], {"--label"}), [])
+
+    def test_trailing_flag_without_value(self):
+        """`--label` at end of token list with no following value is ignored."""
+        tokens = ["gh", "issue", "create", "--label"]
+        self.assertEqual(sp.walk_flag_values(tokens, {"--label"}), [])
+
+
+class FirstFlagValueTests(unittest.TestCase):
+    """Convenience wrapper combining tokenize + walk_flag_values + regex fallback."""
+
+    def test_returns_first_value(self):
+        cmd = "gh pr create --base main --base develop"
+        self.assertEqual(sp.first_flag_value(cmd, {"--base"}), "main")
+
+    def test_returns_none_when_absent(self):
+        cmd = "gh pr create --title foo"
+        self.assertIsNone(sp.first_flag_value(cmd, {"--base"}))
+
+    def test_equals_form(self):
+        cmd = "gh pr create --base=main"
+        self.assertEqual(sp.first_flag_value(cmd, {"--base"}), "main")
+
+    def test_either_alias_matched(self):
+        """`{--repo, -R}` — both aliases recognized at the first occurrence."""
+        cmd = "gh pr create -R noorinalabs/main --base main"
+        self.assertEqual(sp.first_flag_value(cmd, {"--repo", "-R"}), "noorinalabs/main")
+
+    def test_regex_fallback_on_tokenize_failure(self):
+        """Unbalanced quote breaks shlex; the regex fallback still picks up the flag."""
+        # The trailing `"` is unbalanced — shlex.split raises ValueError, tokenize -> None.
+        cmd = 'gh pr create --base main --title "broken'
+        self.assertEqual(sp.first_flag_value(cmd, {"--base"}), "main")
+
+    def test_regex_fallback_disabled_returns_none_on_failure(self):
+        """Security-critical callers pass regex_fallback=False to fail closed."""
+        cmd = 'gh pr create --base main --title "broken'
+        self.assertIsNone(sp.first_flag_value(cmd, {"--base"}, regex_fallback=False))
+
+    def test_longer_flag_preferred_in_regex_fallback(self):
+        """Regex fallback sorts wanted by length DESC so `--repo` beats `-R` prefix collision."""
+        # Construct an unbalanced-quote command (forces regex path) where
+        # both --repo and -R appear; --repo wins because it's tried first.
+        cmd = 'gh pr create -R short/x --repo long/y --title "unclosed'
+        # Both flags are in the wanted set; the regex tries longer first.
+        # The result is whichever flag's regex matches first in the string,
+        # so we assert the longer-flag preference shape via direct check.
+        out = sp.first_flag_value(cmd, {"--repo", "-R"})
+        self.assertEqual(out, "long/y")
+
+
 class ExtractDashCPairsTests(unittest.TestCase):
     def test_simple(self):
         pairs = sp.extract_dash_c_pairs(

--- a/.claude/hooks/validate_branch_freshness.py
+++ b/.claude/hooks/validate_branch_freshness.py
@@ -67,12 +67,16 @@ from __future__ import annotations
 import json
 import os
 import re
-import shlex
 import subprocess
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from _shell_parse import resolve_tool_cwd  # noqa: E402
+from _shell_parse import (  # noqa: E402
+    first_flag_value,
+    is_gh_subcommand,
+    resolve_tool_cwd,
+    tokenize,
+)
 from annunaki_log import log_pretooluse_block  # noqa: E402
 
 _BASE_FLAGS = {"--base", "-B"}
@@ -87,82 +91,14 @@ _REPO_FLAGS = {"--repo", "-R"}
 _REPO_SLUG_RE = re.compile(r"github\.com[/:]([^/]+/[^/.\s]+?)(?:\.git)?/?$")
 
 
-def _tokenize(command: str) -> list[str] | None:
-    """Tokenize a shell command via shlex. Return None on parse failure."""
-    try:
-        return shlex.split(command, posix=True)
-    except ValueError:
-        return None
-
-
-def _is_gh_pr_create(tokens: list[str]) -> bool:
-    """Return True if tokens contain a gh pr create invocation."""
-    for i in range(len(tokens) - 2):
-        if tokens[i] == "gh" and tokens[i + 1] == "pr" and tokens[i + 2] == "create":
-            return True
-    return False
-
-
-def _walk_flags(tokens: list[str], wanted: set[str]) -> list[str]:
-    """Return values for wanted flag names, only when they appear as flags.
-
-    A token is treated as a wanted-flag value only if the immediately
-    preceding token is exactly one of wanted. The --flag=value form is
-    also handled. Values inside other flags (e.g. inside the value of
-    --body) are ignored because they are a SINGLE shlex token, never
-    preceded by a flag from wanted.
-    """
-    values: list[str] = []
-    i = 0
-    while i < len(tokens):
-        tok = tokens[i]
-        if tok in wanted:
-            if i + 1 < len(tokens):
-                values.append(tokens[i + 1])
-                i += 2
-                continue
-            i += 1
-            continue
-        matched = False
-        for flag in wanted:
-            if flag.startswith("--") and tok.startswith(flag + "="):
-                values.append(tok[len(flag) + 1 :])
-                matched = True
-                break
-        if matched:
-            i += 1
-            continue
-        i += 1
-    return values
-
-
-def _first_flag_value(command: str, wanted: set[str]) -> str | None:
-    """Tokenize and return the first value for any of wanted, or None.
-
-    Falls back to a regex anchored at a shell-token boundary if shlex fails
-    (e.g. malformed quote). The regex tries longer flag names first so that
-    --repo is preferred over a hypothetical shorter prefix collision.
-    """
-    tokens = _tokenize(command)
-    if tokens is None:
-        for flag in sorted(wanted, key=len, reverse=True):
-            pattern = rf"(?:^|\s){re.escape(flag)}(?:=|\s+)(\S+)"
-            match = re.search(pattern, command)
-            if match:
-                return match.group(1)
-        return None
-    values = _walk_flags(tokens, wanted)
-    return values[0] if values else None
-
-
 def extract_base(command: str) -> str:
     """Extract --base / -B value, default to 'main'."""
-    return _first_flag_value(command, _BASE_FLAGS) or "main"
+    return first_flag_value(command, _BASE_FLAGS) or "main"
 
 
 def extract_head(command: str) -> str | None:
     """Extract --head / -H value. Strips OWNER: prefix if present."""
-    raw = _first_flag_value(command, _HEAD_FLAGS)
+    raw = first_flag_value(command, _HEAD_FLAGS)
     if raw and ":" in raw:
         return raw.split(":", 1)[1]
     return raw
@@ -170,7 +106,7 @@ def extract_head(command: str) -> str | None:
 
 def extract_repo(command: str) -> str | None:
     """Extract --repo / -R OWNER/REPO value, if any."""
-    return _first_flag_value(command, _REPO_FLAGS)
+    return first_flag_value(command, _REPO_FLAGS)
 
 
 def is_branch_fresh_local(base: str, cwd: str | None = None) -> bool:
@@ -281,9 +217,9 @@ def check(input_data: dict) -> dict | None:
 
     command = input_data.get("tool_input", {}).get("command", "")
 
-    tokens = _tokenize(command)
+    tokens = tokenize(command)
     if tokens is not None:
-        if not _is_gh_pr_create(tokens):
+        if not is_gh_subcommand(tokens, "pr", "create"):
             return None
     else:
         if not re.search(r"\bgh\s+pr\s+create\b", command):

--- a/.claude/hooks/validate_labels.py
+++ b/.claude/hooks/validate_labels.py
@@ -36,67 +36,22 @@ Exit codes:
 import json
 import os
 import re
-import shlex
 import subprocess
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from annunaki_log import log_pretooluse_block
+from _shell_parse import (  # noqa: E402
+    is_gh_subcommand,
+    tokenize,
+    walk_flag_values,
+)
+from annunaki_log import log_pretooluse_block  # noqa: E402
 
 # Flags whose VALUE is a label list (comma-separated allowed by gh).
 _LABEL_FLAGS = {"--label", "-l"}
 
 # Flags whose VALUE is a repo specifier (OWNER/REPO).
 _REPO_FLAGS = {"--repo", "-R"}
-
-
-def _tokenize(command: str) -> list[str] | None:
-    """Tokenize a shell command via shlex. Return None if it cannot be parsed."""
-    try:
-        return shlex.split(command, posix=True)
-    except ValueError:
-        return None
-
-
-def _is_gh_issue_create(tokens: list[str]) -> bool:
-    """Return True if tokens contain a `gh issue create` invocation."""
-    for i in range(len(tokens) - 2):
-        if tokens[i] == "gh" and tokens[i + 1] == "issue" and tokens[i + 2] == "create":
-            return True
-    return False
-
-
-def _walk_flags(tokens: list[str], wanted: set[str]) -> list[str]:
-    """Return values for wanted flag names, only when they appear as flags.
-
-    A token is treated as a wanted-flag value only if the immediately
-    preceding token is exactly one of `wanted` (e.g. `--label`). The
-    `--flag=value` form is also handled. Values inside other flags
-    (e.g. inside the value of `--body`) are ignored because they are a
-    SINGLE shlex token, never preceded by a flag from `wanted`.
-    """
-    values: list[str] = []
-    i = 0
-    while i < len(tokens):
-        tok = tokens[i]
-        if tok in wanted:
-            if i + 1 < len(tokens):
-                values.append(tokens[i + 1])
-                i += 2
-                continue
-            i += 1
-            continue
-        matched = False
-        for flag in wanted:
-            if tok.startswith(flag + "="):
-                values.append(tok[len(flag) + 1 :])
-                matched = True
-                break
-        if matched:
-            i += 1
-            continue
-        i += 1
-    return values
 
 
 def get_existing_labels(repo: str | None = None) -> set[str]:
@@ -135,7 +90,7 @@ def extract_labels(command: str) -> list[str]:
     contains a malformed quote). The fallback still anchors on `--label`
     appearing at a shell-token boundary.
     """
-    tokens = _tokenize(command)
+    tokens = tokenize(command)
     if tokens is None:
         labels: list[str] = []
         for match in re.finditer(
@@ -150,7 +105,7 @@ def extract_labels(command: str) -> list[str]:
         return labels
 
     labels = []
-    for raw in _walk_flags(tokens, _LABEL_FLAGS):
+    for raw in walk_flag_values(tokens, _LABEL_FLAGS):
         for label in raw.split(","):
             label = label.strip()
             if label:
@@ -160,11 +115,11 @@ def extract_labels(command: str) -> list[str]:
 
 def extract_repo(command: str) -> str | None:
     """Extract the --repo / -R OWNER/REPO value from the command, if any."""
-    tokens = _tokenize(command)
+    tokens = tokenize(command)
     if tokens is None:
         match = re.search(r"(?:^|\s)(?:--repo|-R)(?:=|\s+)(\S+)", command)
         return match.group(1) if match else None
-    values = _walk_flags(tokens, _REPO_FLAGS)
+    values = walk_flag_values(tokens, _REPO_FLAGS)
     return values[0] if values else None
 
 
@@ -176,9 +131,9 @@ def check(input_data: dict) -> dict | None:
 
     command = input_data.get("tool_input", {}).get("command", "")
 
-    tokens = _tokenize(command)
+    tokens = tokenize(command)
     if tokens is not None:
-        if not _is_gh_issue_create(tokens):
+        if not is_gh_subcommand(tokens, "issue", "create"):
             return None
     else:
         if not re.search(r"\bgh\s+issue\s+create\b", command):


### PR DESCRIPTION
## Summary

Extract the duplicate `gh <verb> create` parser code from `validate_labels.py` (#113) and `validate_branch_freshness.py` (#168) into `_shell_parse.py` — the shared parser primitive already in heavy use across the W9 hook cluster (#316 / #385 / #391 / #394). Net effect: one parser primitive instead of three (the canonical `_shell_parse` + two local copies); no behavior change for either consuming hook.

## Why now

Both hooks predate the P3W4 Tier-2 promotion of `_shell_parse.py` and carried byte-identical local `_tokenize` / `_is_gh_*_create` / `_walk_flags` helpers. With W9's convergence on `_shell_parse` as the canonical primitive, those local copies became a maintenance liability (a fix to one wouldn't propagate; the equals-form quirks in `_walk_flags` already diverged — `validate_branch_freshness` had a defensive `if flag.startswith("--")` guard that `validate_labels` didn't, leading to subtly different behavior on `-l=bug` short-flag-with-equals shapes).

## Architectural decision

**Extended `_shell_parse`, NOT a sibling `gh_command_parser` module.**

Per the issue brief's explicit guidance: "If _shell_parse doesn't cover (e.g., it lacks walk_flag_values for arbitrary flags), extract the missing pieces into _shell_parse rather than creating a sibling module. One parser primitive is better than two."

`_shell_parse` already had `tokenize`, `iter_command_segments`, `find_gh_subcommand` — three of the four primitives needed. The missing pieces were:
1. A boolean `is_gh_subcommand(tokens, *verbs)` convenience (vs. the position-agnostic 2-tuple-return `find_gh_subcommand`).
2. A flag-value walker (`walk_flag_values`).
3. A convenience wrapper (`first_flag_value`) that combines `tokenize` + walk + regex fallback.

Adding these three to `_shell_parse` preserves the W9 convergence trajectory. A sibling module would have to be merged back into `_shell_parse` later anyway.

## What changed

### New public API in `.claude/hooks/_shell_parse.py`

```python
is_gh_subcommand(tokens, *verbs) -> bool
    # Yes/no: "does this token list contain a `gh <verb1> <verb2> ...` invocation?"
    # Position-agnostic; handles `cd x && gh issue create ...` correctly.

walk_flag_values(tokens, wanted) -> list[str]
    # Walks tokens, returns value of every flag in `wanted`, source order.
    # Handles `--flag value` AND `--flag=value`. Values inside other flags
    # (e.g. `--body "...--flag X..."`) correctly ignored — shlex collapses
    # them into a single token, never preceded by a flag from `wanted`.

first_flag_value(command, wanted, *, regex_fallback=True) -> str | None
    # Convenience: tokenize + walk_flag_values. On shlex failure, falls
    # back to a boundary-anchored regex (longer-flag preferred) by
    # default. Security-critical callers pass regex_fallback=False to
    # fail closed.
```

Module docstring updated with all three signatures + caller contracts.

### Migrations

**`.claude/hooks/validate_labels.py`** (was -36 lines local helpers):
- Drops local `_tokenize`, `_is_gh_issue_create`, `_walk_flags`.
- Drops `import shlex` (no longer used).
- Imports + uses `_shell_parse.tokenize` / `is_gh_subcommand` / `walk_flag_values`.
- `_is_gh_issue_create(tokens)` → `is_gh_subcommand(tokens, "issue", "create")`.

**`.claude/hooks/validate_branch_freshness.py`** (was -67 lines local helpers):
- Drops local `_tokenize`, `_is_gh_pr_create`, `_walk_flags`, `_first_flag_value` (the larger consumer — 4 helpers).
- Drops `import shlex`.
- Extends existing `from _shell_parse import resolve_tool_cwd` to also import `tokenize`, `is_gh_subcommand`, `first_flag_value`.
- All 4 call sites (`extract_base`, `extract_head`, `extract_repo`, `check`) migrated drop-in.

### Tests

Added 23 new unit tests to `test_shell_parse.py` under 3 new classes:
- `IsGhSubcommandTests` (7) — positive/negative cases including non-start-position matches.
- `WalkFlagValuesTests` (9) — two-token, equals, short-flag, multi-value, mixed forms, value-inside-other-flag-ignored, empty tokens, trailing flag without value.
- `FirstFlagValueTests` (7) — first-value, absent, equals, alias matching, regex-fallback-on-tokenize-failure, `regex_fallback=False` fail-closed, longer-flag preference.

All 33 existing `validate_labels` tests + all 40 existing `validate_branch_freshness` tests pass **unchanged** — the new helpers are byte-faithful to the local copies they replace, so the migration is drop-in. This is the canonical regression guard.

## Test plan

- [x] `python3 -m pytest .claude/hooks/tests/ -q` — **695 passed** (was 672; +23 new in test_shell_parse.py)
- [x] `uvx ruff format --check .claude/hooks/` — clean (57 files already formatted)
- [x] `uvx ruff check .claude/hooks/` — clean (all checks passed)
- [x] All existing tests for both migrated hooks pass without modification (drop-in compat).

## Closes

Closes #170

**Wave**: P3W9
