### PR TITLE
refactor(hooks): extract _consultation_sentinel helper + namespace path by skill (closes #176)

### DIFF
--- a/.claude/hooks/_consultation_sentinel.py
+++ b/.claude/hooks/_consultation_sentinel.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Shared cwd-keyed consultation sentinel helper.
+
+Generalizes the Hook 15 (`enforce_librarian_consulted`) sentinel pattern
+for any future transcript-reading enforcement hook. Pattern: a skill
+writes a marker file in the agent's cwd recording that it was invoked;
+the hook reads the marker as a second acceptance signal beside the
+transcript scan.
+
+Background
+==========
+
+Hook 15 originally scanned the session transcript JSONL for evidence of
+`/ontology-librarian` invocation. In subagent worktree sessions the
+transcript-flush race left the marker absent from the file the hook reads
+(see issue #169). PR #174 added a synchronous sentinel write from the
+skill side so the hook never blocks on stale transcript state.
+
+Issue #176 generalizes that sentinel into a reusable helper because the
+same pattern will recur for every future transcript-reading enforcement
+hook (e.g., "did /wave-kickoff run before this PR open", "did
+/security-review run before merge"). Each new transcript-reading hook
+would otherwise reinvent path-keying, hashing, and TTL logic; the helper
+centralizes that surface.
+
+Path scheme
+===========
+
+Sentinels live under each working directory:
+
+    <cwd>/.claude/.consulted/<skill_name>/<sha1(abspath(cwd)+"\\n")[:16]>.marker
+
+The directory is gitignored at the repo root. The `<skill_name>`
+namespace prevents collisions across hooks (an ontology-librarian
+sentinel and a wave-kickoff sentinel under the same cwd are distinct
+files in distinct subdirectories).
+
+The hash is `sha1(abspath(cwd) + "\\n")[:16]` — the trailing newline
+matches the shell idiom `pwd | sha1sum | cut -c1-16` so the skill can
+write the sentinel from shell and the hook can read it from Python and
+both compute the same path. The 16-char truncation balances filename
+brevity against collision resistance (one in 2^64).
+
+API
+===
+
+`write_consultation_sentinel(skill_name, cwd=None) -> Path | None`
+    Skill-side write. Resolves cwd (defaults to os.getcwd()), creates
+    the namespaced directory, writes the marker file with an ISO8601
+    timestamp + cwd. Returns the Path written, or None on OSError
+    (fail-open: a broken sentinel write must not crash the skill).
+
+`consultation_sentinel_is_fresh(cwd, skill_name, ttl_seconds=3600) -> bool`
+    Hook-side read. Recomputes the hash and checks the marker's mtime
+    against `ttl_seconds`. Returns False on missing/stale sentinel,
+    True if fresh, False on OSError (fail-closed for the freshness
+    check itself; callers should fail OPEN on the broader "can we
+    even read the filesystem" question per their own policy).
+
+`consultation_sentinel_path(cwd, skill_name) -> Path`
+    Pure function returning the canonical path. Same formula on both
+    sides. Useful for tests that want to write a sentinel manually
+    without going through `write_consultation_sentinel`.
+
+`cwd_sentinel_hash(cwd) -> str`
+    The 16-char sha1 prefix. Exported because Hook 15 tests pin the
+    shell/Python parity property against the legacy hash name; the
+    hook re-exports this under the legacy name for backward
+    compatibility.
+
+Promotion provenance
+====================
+
+- Hook 15 (#150 + #169) — original sentinel introduction.
+- PR #174 — synchronous sentinel write from skill side.
+- Issue #176 — extract into reusable helper for future transcript-reading
+  hooks. Filed by Nadia Khoury during PR #174 review.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+
+# Default freshness window. The Hook 15 sentinel uses 1 hour; future hooks
+# may want different TTLs (a longer-lived /security-review consultation might
+# be 24h; a shorter-lived /pre-merge-check might be 5min). Pass `ttl_seconds`
+# explicitly when calling `consultation_sentinel_is_fresh` to override.
+DEFAULT_TTL_SECONDS = 3600
+
+# Sentinel directory parent. Skill-side writes and hook-side reads both
+# compose this with `<skill_name>/<hash>.marker`. Kept relative so the
+# helper is cwd-rooted (each worktree has its own .claude/.consulted/).
+SENTINEL_PARENT_DIR = ".claude/.consulted"
+
+
+def cwd_sentinel_hash(cwd: str) -> str:
+    """Return the first 16 hex chars of sha1(abspath(cwd) + "\\n").
+
+    Trailing newline matches the shell idiom `pwd | sha1sum | cut -c1-16`,
+    where `pwd` always emits a trailing newline before `sha1sum` consumes
+    its stdin. Python's hashlib does not insert that newline, so callers
+    that want shell parity must append it explicitly — which we do here.
+
+    OSError / ValueError on path resolution fall back to the raw input so
+    the helper never raises on weird inputs (e.g., a cwd that's been
+    deleted underneath us).
+    """
+    try:
+        abspath = os.path.abspath(os.path.expanduser(cwd))
+    except (OSError, ValueError):
+        abspath = cwd
+    digest = hashlib.sha1((abspath + "\n").encode("utf-8")).hexdigest()
+    return digest[:16]
+
+
+def consultation_sentinel_path(cwd: str, skill_name: str) -> Path:
+    """Return the canonical sentinel path for (cwd, skill_name).
+
+    Path: `<cwd>/.claude/.consulted/<skill_name>/<sha1(cwd)[:16]>.marker`.
+
+    Pure function — no filesystem access. Tests that want to write a
+    sentinel manually (without going through `write_consultation_sentinel`)
+    should call this to compute the expected path.
+    """
+    try:
+        abspath = os.path.abspath(os.path.expanduser(cwd))
+    except (OSError, ValueError):
+        abspath = cwd
+    return Path(abspath) / SENTINEL_PARENT_DIR / skill_name / f"{cwd_sentinel_hash(abspath)}.marker"
+
+
+def write_consultation_sentinel(skill_name: str, cwd: str | None = None) -> Path | None:
+    """Skill-side: write a sentinel marker for `skill_name` keyed by `cwd`.
+
+    Creates the namespaced directory if missing and writes a single-line
+    marker containing an ISO8601 timestamp and the resolved cwd. Returns
+    the Path written, or None on OSError (a broken sentinel write must
+    not crash the skill — the transcript-scan fallback still applies on
+    the hook side).
+
+    `cwd` defaults to `os.getcwd()` when None. Skills writing from a
+    specific worktree should pass the worktree path explicitly.
+    """
+    resolved_cwd = cwd if cwd is not None else os.getcwd()
+    sentinel = consultation_sentinel_path(resolved_cwd, skill_name)
+    try:
+        sentinel.parent.mkdir(parents=True, exist_ok=True)
+        timestamp = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+        try:
+            abspath = os.path.abspath(os.path.expanduser(resolved_cwd))
+        except (OSError, ValueError):
+            abspath = resolved_cwd
+        sentinel.write_text(f"{timestamp} {abspath}\n", encoding="utf-8")
+        return sentinel
+    except OSError:
+        return None
+
+
+def consultation_sentinel_is_fresh(
+    cwd: str, skill_name: str, ttl_seconds: int = DEFAULT_TTL_SECONDS
+) -> bool:
+    """Hook-side: True iff a fresh sentinel for (cwd, skill_name) exists.
+
+    Fresh = the marker file's mtime is within `ttl_seconds` of now.
+    Returns False if the sentinel is absent, stale (older than the TTL),
+    or unreadable. Negative-mtime (future-dated) marker files are also
+    treated as not-fresh — a future-dated file is either a clock-skew
+    bug or a malicious antedate and shouldn't unlock the hook.
+
+    Note: the previous Hook 15 implementation FAIL-OPENed on OSError
+    when stat'ing the sentinel (returned True). That behavior is
+    preserved by the legacy shim in `enforce_librarian_consulted`
+    rather than here — this helper returns False on any read error so
+    callers can choose their own fail-open vs fail-closed policy.
+    Callers that want the legacy fail-open behavior should catch the
+    False return alongside their own OSError tolerance.
+    """
+    if not cwd or not skill_name:
+        return False
+    sentinel = consultation_sentinel_path(cwd, skill_name)
+    try:
+        if not sentinel.exists():
+            return False
+        age = _now_seconds() - sentinel.stat().st_mtime
+        return 0 <= age <= ttl_seconds
+    except OSError:
+        return False
+
+
+def _now_seconds() -> float:
+    """Indirection for test injection. Real time defaults; tests can
+    monkeypatch this to control freshness comparisons without touching
+    file mtimes."""
+    import time
+
+    return time.time()

--- a/.claude/hooks/enforce_librarian_consulted.py
+++ b/.claude/hooks/enforce_librarian_consulted.py
@@ -64,7 +64,7 @@ Detection signals (any ONE is sufficient):
 
 Sentinel fallback (second acceptance signal, added for #169):
     The librarian skill writes a sentinel file on invocation at:
-        <cwd>/.claude/.librarian-consulted/<hash>.marker
+        <cwd>/.claude/.consulted/ontology-librarian/<hash>.marker
     where <hash> is the first 16 hex chars of sha1(abspath(cwd)). The hook
     accepts the marker if its mtime is within SENTINEL_TTL_SECONDS (1 hour)
     of now AND the cwd reported in `input_data["cwd"]` matches the hashed
@@ -106,19 +106,28 @@ Promotion pattern example: memory -> charter (CLAUDE.md § Ontology) -> hook.
 
 from __future__ import annotations
 
-import hashlib
 import json
 import os
 import sys
-import time
 from pathlib import Path
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _consultation_sentinel import (  # noqa: E402
+    DEFAULT_TTL_SECONDS,
+    SENTINEL_PARENT_DIR,
+    consultation_sentinel_path,
+    cwd_sentinel_hash,
+)
 from annunaki_log import log_pretooluse_block  # noqa: E402
 
-# Sentinel-fallback config (see docstring § "Sentinel fallback").
-SENTINEL_DIR_NAME = ".claude/.librarian-consulted"
-SENTINEL_TTL_SECONDS = 3600  # 1 hour
+# Sentinel-fallback config — delegated to `_consultation_sentinel` per #176.
+# These module-level names are preserved as back-compat shims for tests that
+# pre-#176 referenced `hook.SENTINEL_DIR_NAME` / `hook._cwd_sentinel_hash` /
+# `hook.SENTINEL_TTL_SECONDS` directly. The values are now derived from the
+# shared helper so behavior cannot drift between the two.
+_SKILL_KEY = "ontology-librarian"
+SENTINEL_DIR_NAME = f"{SENTINEL_PARENT_DIR}/{_SKILL_KEY}"
+SENTINEL_TTL_SECONDS = DEFAULT_TTL_SECONDS  # 1 hour, inherits from helper
 
 # Tool matchers this hook enforces on.
 _MATCHED_TOOLS = {"Edit", "Write", "NotebookEdit"}
@@ -242,17 +251,15 @@ def _transcript_has_librarian(transcript_path: str) -> bool:
 
 
 def _cwd_sentinel_hash(cwd: str) -> str:
-    """Return the first 16 hex chars of sha1(abspath(cwd)).
+    """Return the first 16 hex chars of sha1(abspath(cwd) + "\\n").
 
-    Matches the hash the librarian skill writes (`pwd | sha1sum | cut -c1-16`).
+    Back-compat shim: delegates to `_consultation_sentinel.cwd_sentinel_hash`.
+    The trailing-newline hash matches the shell idiom
+    `pwd | sha1sum | cut -c1-16` so the librarian skill (which writes the
+    sentinel from shell) and the hook (which reads it from Python) compute
+    the same path.
     """
-    try:
-        abspath = os.path.abspath(os.path.expanduser(cwd))
-    except (OSError, ValueError):
-        abspath = cwd
-    # Shell `pwd | sha1sum` includes the trailing newline from pwd's output.
-    digest = hashlib.sha1((abspath + "\n").encode("utf-8")).hexdigest()
-    return digest[:16]
+    return cwd_sentinel_hash(cwd)
 
 
 def _sentinel_attests_librarian(cwd: str) -> bool:
@@ -261,19 +268,30 @@ def _sentinel_attests_librarian(cwd: str) -> bool:
     Fresh = mtime within SENTINEL_TTL_SECONDS of now. Absent, stale, or
     unreadable sentinels return False (do not attest). OSError paths fail
     open (return True) to match the transcript-scan fail-open stance.
+
+    Per #176: the path is `.claude/.consulted/ontology-librarian/<hash>.marker`
+    (was `.claude/.librarian-consulted/<hash>.marker`); the path move
+    namespaces by skill so future transcript-reading hooks can reuse the
+    same sentinel directory without colliding. The helper computes the
+    canonical path; this function wraps it with Hook 15's specific
+    fail-OPEN-on-OSError semantics.
     """
     if not cwd:
         return False
 
+    import time
+
     try:
-        abspath = os.path.abspath(os.path.expanduser(cwd))
-        sentinel = Path(abspath) / SENTINEL_DIR_NAME / f"{_cwd_sentinel_hash(abspath)}.marker"
+        sentinel = consultation_sentinel_path(cwd, _SKILL_KEY)
         if not sentinel.exists():
             return False
         age = time.time() - sentinel.stat().st_mtime
         return 0 <= age <= SENTINEL_TTL_SECONDS
     except OSError:
-        # Fail open — do not block on our own inability to stat.
+        # Fail open — do not block on our own inability to stat. (Preserved
+        # from pre-#176 behavior; the shared helper fails CLOSED on OSError
+        # for cleaner generic semantics — Hook 15 wraps it here to keep the
+        # legacy fail-open stance that its tests pin.)
         return True
 
 

--- a/.claude/hooks/tests/test_consultation_sentinel.py
+++ b/.claude/hooks/tests/test_consultation_sentinel.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Tests for `_consultation_sentinel` shared helper.
+
+Covers the four acceptance properties from #176:
+- Path namespacing by skill (no collision across skills).
+- TTL semantics (fresh vs stale via mtime).
+- Fail-open on OSError (the helper never raises).
+- Shell/Python parity via subprocess (the skill writes from shell; the
+  hook reads from Python — both must compute the same path).
+
+Plus dogfood / regression:
+- The existing `enforce_librarian_consulted` test suite remains green
+  (verified via `pytest .claude/hooks/tests/`) — this file only adds
+  coverage of the helper's surface area.
+
+Run: python3 -m pytest .claude/hooks/tests/test_consultation_sentinel.py -v
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_HOOKS_DIR = _HERE.parent
+sys.path.insert(0, str(_HOOKS_DIR))
+
+import _consultation_sentinel as sentinel  # noqa: E402
+
+
+class CwdSentinelHashTests(unittest.TestCase):
+    """Hash formula must match the shell idiom `pwd | sha1sum | cut -c1-16`."""
+
+    def test_matches_shell_idiom_with_trailing_newline(self):
+        """Python hash MUST include the trailing newline that `pwd` emits."""
+        sample = "/home/parameterization/code/noorinalabs-main"
+        expected = hashlib.sha1((sample + "\n").encode("utf-8")).hexdigest()[:16]
+        self.assertEqual(sentinel.cwd_sentinel_hash(sample), expected)
+
+    def test_hash_is_16_chars(self):
+        self.assertEqual(len(sentinel.cwd_sentinel_hash("/anywhere")), 16)
+
+    def test_different_cwds_produce_different_hashes(self):
+        h1 = sentinel.cwd_sentinel_hash("/a")
+        h2 = sentinel.cwd_sentinel_hash("/b")
+        self.assertNotEqual(h1, h2)
+
+    def test_resolves_user_expansion(self):
+        """`~/x` and the expanded form must hash identically."""
+        h_tilde = sentinel.cwd_sentinel_hash("~/x")
+        h_expanded = sentinel.cwd_sentinel_hash(os.path.expanduser("~/x"))
+        self.assertEqual(h_tilde, h_expanded)
+
+    def test_unparseable_path_falls_back_without_raising(self):
+        """Pathological inputs must not raise (helper is fail-open)."""
+        # A null byte is a path that os.path.abspath can sometimes handle,
+        # but the helper's try/except should catch any ValueError. Just
+        # confirm no exception escapes.
+        try:
+            sentinel.cwd_sentinel_hash("\x00bad")
+        except Exception as e:  # noqa: BLE001
+            self.fail(f"cwd_sentinel_hash raised on bad input: {e}")
+
+
+class ConsultationSentinelPathTests(unittest.TestCase):
+    """Pure path-composition tests (no filesystem access required)."""
+
+    def test_canonical_shape(self):
+        path = sentinel.consultation_sentinel_path("/home/user/repo", "ontology-librarian")
+        self.assertEqual(
+            path.relative_to("/home/user/repo"),
+            Path(".claude/.consulted/ontology-librarian")
+            / f"{sentinel.cwd_sentinel_hash('/home/user/repo')}.marker",
+        )
+
+    def test_namespacing_by_skill_distinct_paths(self):
+        """Two skills under the same cwd must produce distinct sentinel paths."""
+        p_lib = sentinel.consultation_sentinel_path("/x", "ontology-librarian")
+        p_wave = sentinel.consultation_sentinel_path("/x", "wave-kickoff")
+        self.assertNotEqual(p_lib, p_wave)
+        self.assertIn("/ontology-librarian/", str(p_lib))
+        self.assertIn("/wave-kickoff/", str(p_wave))
+
+    def test_namespacing_same_hash_filename(self):
+        """Different skills produce the SAME hash filename (cwd is the only
+        hash input); the namespace lives in the directory, not the filename."""
+        p1 = sentinel.consultation_sentinel_path("/x", "ontology-librarian")
+        p2 = sentinel.consultation_sentinel_path("/x", "wave-kickoff")
+        self.assertEqual(p1.name, p2.name)
+
+
+class WriteConsultationSentinelTests(unittest.TestCase):
+    """Skill-side write API."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.mkdtemp(prefix="consult_sentinel_test_")
+
+    def tearDown(self) -> None:
+        import shutil
+
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def test_write_creates_marker_at_canonical_path(self):
+        written = sentinel.write_consultation_sentinel("ontology-librarian", cwd=self._tmp)
+        self.assertIsNotNone(written)
+        assert written is not None
+        expected = sentinel.consultation_sentinel_path(self._tmp, "ontology-librarian")
+        self.assertEqual(written, expected)
+        self.assertTrue(expected.exists())
+
+    def test_write_body_contains_timestamp_and_cwd(self):
+        written = sentinel.write_consultation_sentinel("ontology-librarian", cwd=self._tmp)
+        assert written is not None
+        body = written.read_text(encoding="utf-8")
+        # ISO8601 form like YYYY-MM-DDTHH:MM:SSZ
+        self.assertRegex(body, r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z")
+        # cwd appears too (so a human inspecting the marker can identify
+        # which agent wrote it).
+        self.assertIn(self._tmp, body)
+
+    def test_write_creates_namespaced_subdirectory(self):
+        written = sentinel.write_consultation_sentinel("wave-kickoff", cwd=self._tmp)
+        assert written is not None
+        self.assertTrue(written.parent.is_dir())
+        # The subdirectory IS the skill name.
+        self.assertEqual(written.parent.name, "wave-kickoff")
+
+    def test_write_fails_open_on_oserror(self):
+        """If the path can't be created (read-only fs, etc.), return None."""
+        # Use a cwd inside a read-only directory.
+        ro_dir = os.path.join(self._tmp, "readonly")
+        os.makedirs(ro_dir)
+        os.chmod(ro_dir, 0o555)  # read+exec, no write
+        try:
+            # write should fail at mkdir time; helper returns None, no raise.
+            result = sentinel.write_consultation_sentinel("ontology-librarian", cwd=ro_dir)
+            self.assertIsNone(result)
+        finally:
+            os.chmod(ro_dir, 0o755)
+
+    def test_write_defaults_to_os_getcwd(self):
+        """No cwd arg → write under os.getcwd()."""
+        # Run from a known cwd via subprocess.
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                (
+                    f"import sys; sys.path.insert(0, {str(_HOOKS_DIR)!r}); "
+                    "import _consultation_sentinel as s; "
+                    "p = s.write_consultation_sentinel('test-skill'); "
+                    "print(p)"
+                ),
+            ],
+            cwd=self._tmp,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0)
+        written = result.stdout.strip()
+        self.assertTrue(written.startswith(self._tmp))
+        self.assertIn("/.claude/.consulted/test-skill/", written)
+
+
+class ConsultationSentinelIsFreshTests(unittest.TestCase):
+    """Hook-side read API: TTL semantics + freshness comparisons."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.mkdtemp(prefix="consult_sentinel_test_")
+
+    def tearDown(self) -> None:
+        import shutil
+
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def _write_at_offset(self, skill: str, mtime_offset: float) -> Path:
+        """Write a sentinel at the canonical path, then shift its mtime."""
+        path = sentinel.consultation_sentinel_path(self._tmp, skill)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("ts content\n", encoding="utf-8")
+        if mtime_offset != 0:
+            new_time = time.time() + mtime_offset
+            os.utime(path, (new_time, new_time))
+        return path
+
+    def test_fresh_sentinel_returns_true(self):
+        self._write_at_offset("ontology-librarian", mtime_offset=0)
+        self.assertTrue(sentinel.consultation_sentinel_is_fresh(self._tmp, "ontology-librarian"))
+
+    def test_stale_sentinel_returns_false(self):
+        """Mtime older than TTL → not fresh."""
+        self._write_at_offset(
+            "ontology-librarian", mtime_offset=-(sentinel.DEFAULT_TTL_SECONDS + 10)
+        )
+        self.assertFalse(sentinel.consultation_sentinel_is_fresh(self._tmp, "ontology-librarian"))
+
+    def test_just_within_ttl_returns_true(self):
+        """Mtime exactly TTL-10s in the past → still fresh."""
+        self._write_at_offset(
+            "ontology-librarian", mtime_offset=-(sentinel.DEFAULT_TTL_SECONDS - 10)
+        )
+        self.assertTrue(sentinel.consultation_sentinel_is_fresh(self._tmp, "ontology-librarian"))
+
+    def test_future_mtime_returns_false(self):
+        """A future-dated marker (clock skew or antedate) MUST NOT attest."""
+        self._write_at_offset("ontology-librarian", mtime_offset=+3600)
+        self.assertFalse(sentinel.consultation_sentinel_is_fresh(self._tmp, "ontology-librarian"))
+
+    def test_missing_sentinel_returns_false(self):
+        self.assertFalse(sentinel.consultation_sentinel_is_fresh(self._tmp, "ontology-librarian"))
+
+    def test_custom_ttl_seconds(self):
+        """Caller-supplied TTL overrides the default."""
+        self._write_at_offset("ontology-librarian", mtime_offset=-30)
+        # Default TTL (3600): fresh.
+        self.assertTrue(sentinel.consultation_sentinel_is_fresh(self._tmp, "ontology-librarian"))
+        # Tighter TTL (10s): stale.
+        self.assertFalse(
+            sentinel.consultation_sentinel_is_fresh(self._tmp, "ontology-librarian", ttl_seconds=10)
+        )
+
+    def test_empty_cwd_returns_false(self):
+        self.assertFalse(sentinel.consultation_sentinel_is_fresh("", "ontology-librarian"))
+
+    def test_empty_skill_returns_false(self):
+        self.assertFalse(sentinel.consultation_sentinel_is_fresh(self._tmp, ""))
+
+    def test_namespacing_isolation(self):
+        """A sentinel for skill A must NOT attest for skill B in the same cwd."""
+        self._write_at_offset("ontology-librarian", mtime_offset=0)
+        self.assertTrue(sentinel.consultation_sentinel_is_fresh(self._tmp, "ontology-librarian"))
+        self.assertFalse(sentinel.consultation_sentinel_is_fresh(self._tmp, "wave-kickoff"))
+
+    def test_different_cwds_isolation(self):
+        """A sentinel in cwd A must NOT attest for cwd B."""
+        other = tempfile.mkdtemp(prefix="consult_sentinel_test_other_")
+        try:
+            self._write_at_offset("ontology-librarian", mtime_offset=0)
+            self.assertTrue(
+                sentinel.consultation_sentinel_is_fresh(self._tmp, "ontology-librarian")
+            )
+            self.assertFalse(sentinel.consultation_sentinel_is_fresh(other, "ontology-librarian"))
+        finally:
+            import shutil
+
+            shutil.rmtree(other, ignore_errors=True)
+
+
+class ShellPythonParityTests(unittest.TestCase):
+    """The shell idiom in SKILL.md and the Python helper must produce
+    identical paths. If they diverge, no sentinel would ever match."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.mkdtemp(prefix="consult_sentinel_parity_")
+
+    def tearDown(self) -> None:
+        import shutil
+
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def test_shell_writes_path_python_reads(self):
+        """Run the canonical SKILL.md shell idiom; assert the helper sees the marker."""
+        result = subprocess.run(
+            [
+                "bash",
+                "-c",
+                (
+                    "mkdir -p .claude/.consulted/ontology-librarian && "
+                    "HASH=$(pwd | sha1sum | cut -c1-16) && "
+                    "printf '%s %s\\n' "
+                    '"$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$(pwd)" '
+                    '> .claude/.consulted/ontology-librarian/"$HASH".marker && '
+                    "echo $HASH"
+                ),
+            ],
+            cwd=self._tmp,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, f"shell failed: {result.stderr}")
+        shell_hash = result.stdout.strip()
+        py_hash = sentinel.cwd_sentinel_hash(self._tmp)
+        self.assertEqual(
+            shell_hash,
+            py_hash,
+            "Shell `pwd | sha1sum | cut -c1-16` and Python helper diverged — "
+            "skill-written sentinels would never be recognized by the hook.",
+        )
+        # And the helper must see the marker as fresh.
+        self.assertTrue(sentinel.consultation_sentinel_is_fresh(self._tmp, "ontology-librarian"))
+
+    def test_python_writes_shell_reads_same_path(self):
+        """Symmetric direction: helper writes, shell sees the same path."""
+        written = sentinel.write_consultation_sentinel("ontology-librarian", cwd=self._tmp)
+        self.assertIsNotNone(written)
+        assert written is not None
+        # Compute the expected filename via shell.
+        shell_cmd = (
+            "echo .claude/.consulted/ontology-librarian/$(pwd | sha1sum | cut -c1-16).marker"
+        )
+        result = subprocess.run(
+            ["bash", "-c", shell_cmd],
+            cwd=self._tmp,
+            capture_output=True,
+            text=True,
+        )
+        shell_relpath = result.stdout.strip()
+        py_relpath = str(written.relative_to(self._tmp))
+        self.assertEqual(shell_relpath, py_relpath)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.claude/skills/ontology-librarian/SKILL.md
+++ b/.claude/skills/ontology-librarian/SKILL.md
@@ -23,10 +23,12 @@ The `query` argument is optional. If provided, it's a natural language question 
 
 Before anything else, write a cwd-keyed sentinel file that Hook 15 (`enforce_librarian_consulted`) reads as a second acceptance signal. This is required because in worktree-subagent sessions the transcript JSONL the hook scans may not yet contain this Skill `tool_use` entry (race on transcript flush — see issue #169). The sentinel is a robust fallback that survives the flush race.
 
+Per #176 the sentinel directory is namespaced by skill name under `.claude/.consulted/<skill>/` so future transcript-reading hooks can reuse the same scheme without colliding. The shared helper lives at `.claude/hooks/_consultation_sentinel.py` and exposes `write_consultation_sentinel(skill_name)` for any future skill-side caller.
+
 ```bash
-mkdir -p .claude/.librarian-consulted
+mkdir -p .claude/.consulted/ontology-librarian
 HASH=$(pwd | sha1sum | cut -c1-16)
-printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$(pwd)" > .claude/.librarian-consulted/"$HASH".marker
+printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$(pwd)" > .claude/.consulted/ontology-librarian/"$HASH".marker
 ```
 
 **Do not remove this step.** It is the Hook 15 consultation marker for the current cwd; deleting it re-introduces the #169 regression for subagents working in worktrees. The directory is gitignored.

--- a/.claude/team/charter/hooks.md
+++ b/.claude/team/charter/hooks.md
@@ -203,6 +203,30 @@ When hooks sharing the same matcher type (Bash, Agent, SendMessage, etc.) accumu
 - **Out of scope for v1:** `gh project item-add` matcher (W8 instances of stale-path issues hit the labeling surface before the project-add surface; covering label-time is the higher-leverage gate). Cited-issue freshness ("any cited issue # must be OPEN or noted as `closed-resolved-by-X`") — heavier hook surface; deferred to retro for now. Both filed as follow-ups against this hook.
 - **Promotion provenance:** Three-occurrence W8 pattern (2026-05-09 audit, see [#337](https://github.com/noorinalabs/noorinalabs-main/issues/337) for full provenance chain). Source memory family: `feedback_origin_over_local_for_still_has_claims.md` (SUPERSEDED 2026-05-10 by charter `pull-requests.md`), `feedback_pre_spawn_brief_verified_at_head.md`, `feedback_verify_diagnosis_before_delegating.md`. Promoted to hook in P3W9.
 
+## Shared Helpers <!-- promotion-target: none -->
+
+Reusable primitives that multiple hooks (or hooks + skills) consume. Each helper has a single-source-of-truth implementation under `.claude/hooks/` with an underscore-prefix filename (`_<helper>.py`) marking it as internal, not a hook itself.
+
+### `_shell_parse.py` — Tokenize Bash commands safely
+
+Multiple PreToolUse hooks need to detect command shapes (`git commit`, `gh pr create`, etc.) without regex'ing the raw command string — a pattern that has repeatedly mis-fired on heredoc bodies, code-fence blocks, and `--body-file` argument values (issues #118, #134, #144, #188, #189, #216, #223, #226, #227). The helper exposes `tokenize`, `strip_heredocs`, `iter_command_segments`, `find_git_subcommand`, `find_gh_subcommand`, and `extract_dash_c_pairs`. Consumed by `validate_commit_identity`, `validate_branch_freshness`, `block_git_config`, `block_no_verify`, `block_shutdown_without_retro`, `block_stale_tmp_message_file`, `validate_review_comment_format`, `post_wave_kickoff_comment`. When a new transcript-or-command-reading hook needs to discriminate command shape, consume this helper rather than regex.
+
+### `_consultation_sentinel.py` — Cwd-keyed consultation sentinel
+
+Generalizes the Hook 15 sentinel pattern (introduction: [#169](https://github.com/noorinalabs/noorinalabs-main/issues/169); generalization: [#176](https://github.com/noorinalabs/noorinalabs-main/issues/176)) for any future transcript-reading enforcement hook. The pattern: a skill writes a marker file in the agent's cwd recording that it was invoked; the hook reads the marker as a second acceptance signal beside the transcript scan. Subagent worktree sessions repeatedly hit a transcript-flush race that left the marker absent from the file the hook reads — the sentinel survives that race because the skill writes it synchronously.
+
+**Path scheme:** `<cwd>/.claude/.consulted/<skill_name>/<sha1(abspath(cwd)+"\n")[:16]>.marker`. Namespaced by skill name so multiple transcript-reading hooks don't collide. The trailing-newline hash matches the shell idiom `pwd | sha1sum | cut -c1-16` so skills can write the sentinel from shell and the Python helper computes the same path (parity gated by `test_consultation_sentinel.ShellPythonParityTests`).
+
+**API:**
+- `write_consultation_sentinel(skill_name, cwd=None) -> Path | None` — skill-side write. Returns None on OSError (fail-open).
+- `consultation_sentinel_is_fresh(cwd, skill_name, ttl_seconds=3600) -> bool` — hook-side read. False on missing / stale / unreadable / future-dated marker.
+- `consultation_sentinel_path(cwd, skill_name) -> Path` — pure path composition (tests use this to write sentinels manually).
+- `cwd_sentinel_hash(cwd) -> str` — 16-char sha1 prefix, exported because Hook 15 tests pin the shell/Python parity property.
+
+**Use this helper** when authoring a new transcript-reading enforcement hook. Do NOT reinvent path-keying, hashing, or TTL logic — every divergence becomes a sentinel-doesn't-match bug in worktree subagents.
+
+**Promotion provenance:** Hook 15 (#150 + #169) original sentinel introduction. PR #174 added synchronous skill-side write. Issue #176 extracted the helper. Filed by Nadia Khoury during PR #174 review.
+
 ## Hook Sync Across Child Repos <!-- promotion-target: none -->
 
 Shared hooks live in `noorinalabs-main/.claude/hooks/` (the parent repo's hooks tree). Child repos consume them via **parent-canonical paths** — their own `.claude/settings.json` registers each hook by absolute path into the parent's hooks tree, e.g.:

--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,13 @@ temp/
 # Claude Code local state (machine-specific)
 .claude/projects/
 
-# Hook 15 librarian-consultation sentinel markers (#169 — local-only, cwd-keyed)
+# Consultation sentinels (#169 introduction, #176 generalization) — cwd-keyed
+# markers written by skills, read by transcript-enforcement hooks. Namespaced
+# by skill under .claude/.consulted/<skill_name>/. Local-only.
+.claude/.consulted/
+# Pre-#176 path. Retained in .gitignore so any leftover marker files in
+# in-flight worktrees aren't accidentally committed during the migration
+# window. Safe to remove once all worktrees have synced past #176.
 .claude/.librarian-consulted/
 
 # Hook 18 validate_edit_completion sentinel state (#198 — session-scoped, local-only)


### PR DESCRIPTION
## Summary

- New shared helper `.claude/hooks/_consultation_sentinel.py` generalizes the cwd-keyed sentinel pattern from Hook 15 for any future transcript-reading enforcement hook. API: `write_consultation_sentinel`, `consultation_sentinel_is_fresh`, `consultation_sentinel_path`, `cwd_sentinel_hash`.
- Sentinel directory moved from `.claude/.librarian-consulted/` to `.claude/.consulted/ontology-librarian/` (namespaced by skill). `.gitignore`, `ontology-librarian` SKILL.md, and `enforce_librarian_consulted.py` all updated to the new path.
- 25 new tests for the helper (path namespacing, TTL semantics, fail-open, shell/Python parity). **All 29 existing `enforce_librarian_consulted` regression tests stay green** — refactor is behavior-preserving.
- Charter `hooks.md` gets a new "Shared Helpers" section documenting both `_shell_parse` and `_consultation_sentinel` as reusable primitives, with explicit "do not reinvent" guidance for future hook authors.

## Why generalize

Hook 15 is our first transcript-reading enforcement hook. Each future transcript-reading hook (`/wave-kickoff` ran before PR open, `/security-review` ran before merge, etc.) would hit the same subagent transcript-flush race (#169) and reinvent path-keying, sha1 hashing, and TTL logic. The helper centralizes that surface so the next hook author writes their hook in 30 lines, not 100, and the path scheme stays consistent (no per-hook divergence in hash formula or filename shape).

Filed by Nadia Khoury during PR #174 review as a strategic-PD follow-up.

## API

```python
write_consultation_sentinel(skill_name, cwd=None) -> Path | None
consultation_sentinel_is_fresh(cwd, skill_name, ttl_seconds=3600) -> bool
consultation_sentinel_path(cwd, skill_name) -> Path
cwd_sentinel_hash(cwd) -> str
```

Path scheme: `<cwd>/.claude/.consulted/<skill_name>/<sha1(abspath(cwd)+"\n")[:16]>.marker`.

The trailing-newline hash matches the shell idiom `pwd | sha1sum | cut -c1-16` so skills can write sentinels from shell and the Python helper computes the same path. Parity is gated by `ShellPythonParityTests` (subprocess runs the canonical shell idiom, then asserts the helper recognizes the marker).

## Migration steps

| Step | What changed | Path before | Path after |
|---|---|---|---|
| 1 | Helper module | (didn't exist) | `.claude/hooks/_consultation_sentinel.py` |
| 2 | Sentinel directory | `.claude/.librarian-consulted/<hash>.marker` | `.claude/.consulted/ontology-librarian/<hash>.marker` |
| 3 | `.gitignore` | `.claude/.librarian-consulted/` | `.claude/.consulted/` (pre-#176 entry retained for transitional safety) |
| 4 | `ontology-librarian` SKILL.md | step 0 shell writes to old path | step 0 writes to new namespaced path; cites `_consultation_sentinel` helper |
| 5 | `enforce_librarian_consulted.py` | inline hash + sentinel logic | delegates to shared helper; module-level test-pinned names preserved as back-compat shims |
| 6 | Charter `hooks.md` | (no Shared Helpers section) | new "Shared Helpers" section documenting `_shell_parse` and `_consultation_sentinel`; explicit "do not reinvent" guidance |

The Hook 15-specific fail-OPEN-on-OSError stance during sentinel stat is preserved via local wrapping in `enforce_librarian_consulted._sentinel_attests_librarian` — the shared helper fails CLOSED for cleaner generic semantics; callers that want fail-open wrap themselves. This preserves the legacy stance that `SentinelFallbackTests` pins.

## Test plan

- [x] `python3 -m pytest .claude/hooks/tests/` — **697 passed** (was 672 + 25 new for `_consultation_sentinel`)
- [x] `python3 -m pytest .claude/hooks/tests/test_consultation_sentinel.py -v` — 25 passed
- [x] `python3 -m pytest .claude/hooks/tests/test_enforce_librarian_consulted.py -v` — 29 passed (regression-green under refactor)
- [x] `uvx ruff format --check .claude/hooks/` — clean (59 files already formatted)
- [x] `uvx ruff check .claude/hooks/` — clean (all checks passed)
- [x] Pre-commit hooks (ruff-format / ruff-lint / mypy) — all passed

### 25 new tests breakdown

- 5 `CwdSentinelHashTests` — shell-idiom parity + 16-char length + different-cwds-different-hashes + ~ expansion + pathological-input fail-open
- 3 `ConsultationSentinelPathTests` — canonical shape + skill namespacing (distinct paths, same hash filename)
- 5 `WriteConsultationSentinelTests` — canonical path + body content + namespaced subdir + read-only-fs fail-open + os.getcwd default
- 10 `ConsultationSentinelIsFreshTests` — fresh / stale / just-within-TTL / future-mtime-not-fresh / missing / custom TTL / empty cwd / empty skill / namespacing isolation / cwd isolation
- 2 `ShellPythonParityTests` — shell-writes-Python-reads round trip + Python-writes-shell-composes-same-path

### Behavior preservation evidence

All 29 existing `enforce_librarian_consulted` tests (`AllowListTests`, `NonMatchedToolTests`, `BlockingTests`, `AllowWithLibrarianTests`, `FailOpenTests`, `SignalDetectionTests`, `SentinelFallbackTests`) stay green. The `SentinelFallbackTests` in particular pin:
- Cwd-hash matches shell `pwd | sha1sum | cut -c1-16` (parity preserved across helper refactor)
- Fresh sentinel allows edit (helper-write succeeds; Hook 15 wrapper attests)
- Stale sentinel blocks (TTL semantics preserved)
- Cross-cwd sentinel doesn't attest (namespace + cwd-keying preserved)
- No sentinel + transcript signal still allows (transcript-scan path untouched)

## Dogfood verification

This refactor edits Hook 15 — which gates Edit/Write — so a sloppy intermediate state could lock me out of my own session. The cutover sequence:

1. **Initial /ontology-librarian invocation** writes a sentinel at the OLD path (`.claude/.librarian-consulted/<hash>.marker`).
2. **Pre-cutover safety writes** — I wrote a fresh sentinel at the NEW path (`.claude/.consulted/ontology-librarian/<hash>.marker`) BEFORE refactoring the hook, so the post-refactor reader would have something to attest against.
3. **Atomic refactor** — Hook 15 + SKILL.md + .gitignore all change in one Edit batch, with both the OLD and NEW sentinels on disk during the transition.
4. **Post-refactor Edit/Write tool calls** (writing this PR body file, the test file, the charter section) all succeeded — confirming the helper + the Hook 15 wrapper correctly read the NEW path.

Result: dogfood loop verified. The mid-refactor session safely transitioned from the old path to the new one without ever blocking itself.

Closes #176.

**Wave**: P3W9
