### PR TITLE
tech-debt(lint+cross-repo-tracking): #317 main-repo portion + #161/#160 follow-up filing (closes #317 #161 #160)

### DIFF
--- a/.claude/skills/wave-kickoff/_orchestration/w4-kickoff.py
+++ b/.claude/skills/wave-kickoff/_orchestration/w4-kickoff.py
@@ -1,91 +1,360 @@
 #!/usr/bin/env python3
-"""P3W4 kickoff: label + kickoff comment for 31 issues across 6 repos."""
-import json, subprocess, sys, time
+# ruff: noqa: E501
+"""P3W4 kickoff: label + kickoff comment for 31 issues across 6 repos.
+
+Frozen historical script: long lines inside the kickoff-comment f-string
+body preserve the exact text that was posted on GH issues at the time
+(comment-headers, charter section names) — reflowing would distort the
+audit-trail record. Per-file E501 exemption is the right granularity.
+"""
+
+import json
+import subprocess
 
 # (repo_short, issue_num, assignee_label, branch_slug, reviewers, tier, bundled_with, wave_bootstrap)
 ISSUES = [
     # T1 — bundle PR (1 PR closing 3 issues): A.Virtanen/0244-pr-review-canonicalization
-    ("noorinalabs-main", 244, "AINO_VIRTANEN", "A.Virtanen/0244-pr-review-canonicalization",
-     ("Wanjiku.Mwangi","Nadia.Khoury"), 1, "#233 #228", False),
-    ("noorinalabs-main", 233, "AINO_VIRTANEN", "A.Virtanen/0244-pr-review-canonicalization",
-     ("Wanjiku.Mwangi","Nadia.Khoury"), 1, "#244 #228", False),
-    ("noorinalabs-main", 228, "AINO_VIRTANEN", "A.Virtanen/0244-pr-review-canonicalization",
-     ("Wanjiku.Mwangi","Nadia.Khoury"), 1, "#244 #233", False),
+    (
+        "noorinalabs-main",
+        244,
+        "AINO_VIRTANEN",
+        "A.Virtanen/0244-pr-review-canonicalization",
+        ("Wanjiku.Mwangi", "Nadia.Khoury"),
+        1,
+        "#233 #228",
+        False,
+    ),
+    (
+        "noorinalabs-main",
+        233,
+        "AINO_VIRTANEN",
+        "A.Virtanen/0244-pr-review-canonicalization",
+        ("Wanjiku.Mwangi", "Nadia.Khoury"),
+        1,
+        "#244 #228",
+        False,
+    ),
+    (
+        "noorinalabs-main",
+        228,
+        "AINO_VIRTANEN",
+        "A.Virtanen/0244-pr-review-canonicalization",
+        ("Wanjiku.Mwangi", "Nadia.Khoury"),
+        1,
+        "#244 #233",
+        False,
+    ),
     # T2 — main: bundle PR closing 7 issues: A.Virtanen/0226-hook-matcher-sanitization
-    ("noorinalabs-main", 226, "AINO_VIRTANEN", "A.Virtanen/0226-hook-matcher-sanitization",
-     ("Nadia.Khoury","Wanjiku.Mwangi"), 2, "#227 #223 #216 #188 #144 #189", False),
-    ("noorinalabs-main", 227, "AINO_VIRTANEN", "A.Virtanen/0226-hook-matcher-sanitization",
-     ("Nadia.Khoury","Wanjiku.Mwangi"), 2, "#226 #223 #216 #188 #144 #189", False),
-    ("noorinalabs-main", 223, "AINO_VIRTANEN", "A.Virtanen/0226-hook-matcher-sanitization",
-     ("Nadia.Khoury","Wanjiku.Mwangi"), 2, "#226 #227 #216 #188 #144 #189", False),
-    ("noorinalabs-main", 216, "AINO_VIRTANEN", "A.Virtanen/0226-hook-matcher-sanitization",
-     ("Nadia.Khoury","Wanjiku.Mwangi"), 2, "#226 #227 #223 #188 #144 #189", False),
-    ("noorinalabs-main", 188, "AINO_VIRTANEN", "A.Virtanen/0226-hook-matcher-sanitization",
-     ("Nadia.Khoury","Wanjiku.Mwangi"), 2, "#226 #227 #223 #216 #144 #189", False),
-    ("noorinalabs-main", 144, "AINO_VIRTANEN", "A.Virtanen/0226-hook-matcher-sanitization",
-     ("Nadia.Khoury","Wanjiku.Mwangi"), 2, "#226 #227 #223 #216 #188 #189", False),
-    ("noorinalabs-main", 189, "AINO_VIRTANEN", "A.Virtanen/0226-hook-matcher-sanitization",
-     ("Nadia.Khoury","Wanjiku.Mwangi"), 2, "#226 #227 #223 #216 #188 #144", False),
+    (
+        "noorinalabs-main",
+        226,
+        "AINO_VIRTANEN",
+        "A.Virtanen/0226-hook-matcher-sanitization",
+        ("Nadia.Khoury", "Wanjiku.Mwangi"),
+        2,
+        "#227 #223 #216 #188 #144 #189",
+        False,
+    ),
+    (
+        "noorinalabs-main",
+        227,
+        "AINO_VIRTANEN",
+        "A.Virtanen/0226-hook-matcher-sanitization",
+        ("Nadia.Khoury", "Wanjiku.Mwangi"),
+        2,
+        "#226 #223 #216 #188 #144 #189",
+        False,
+    ),
+    (
+        "noorinalabs-main",
+        223,
+        "AINO_VIRTANEN",
+        "A.Virtanen/0226-hook-matcher-sanitization",
+        ("Nadia.Khoury", "Wanjiku.Mwangi"),
+        2,
+        "#226 #227 #216 #188 #144 #189",
+        False,
+    ),
+    (
+        "noorinalabs-main",
+        216,
+        "AINO_VIRTANEN",
+        "A.Virtanen/0226-hook-matcher-sanitization",
+        ("Nadia.Khoury", "Wanjiku.Mwangi"),
+        2,
+        "#226 #227 #223 #188 #144 #189",
+        False,
+    ),
+    (
+        "noorinalabs-main",
+        188,
+        "AINO_VIRTANEN",
+        "A.Virtanen/0226-hook-matcher-sanitization",
+        ("Nadia.Khoury", "Wanjiku.Mwangi"),
+        2,
+        "#226 #227 #223 #216 #144 #189",
+        False,
+    ),
+    (
+        "noorinalabs-main",
+        144,
+        "AINO_VIRTANEN",
+        "A.Virtanen/0226-hook-matcher-sanitization",
+        ("Nadia.Khoury", "Wanjiku.Mwangi"),
+        2,
+        "#226 #227 #223 #216 #188 #189",
+        False,
+    ),
+    (
+        "noorinalabs-main",
+        189,
+        "AINO_VIRTANEN",
+        "A.Virtanen/0226-hook-matcher-sanitization",
+        ("Nadia.Khoury", "Wanjiku.Mwangi"),
+        2,
+        "#226 #227 #223 #216 #188 #144",
+        False,
+    ),
     # T2 — isnad-graph: 1 PR closing 2 issues: L.Pham/0819-hook-cross-repo-roster
-    ("noorinalabs-isnad-graph", 819, "LINH_PHAM", "L.Pham/0819-hook-cross-repo-roster",
-     ("Jelani.Mwangi","Arjun.Raghavan"), 2, "#814", False),
-    ("noorinalabs-isnad-graph", 814, "LINH_PHAM", "L.Pham/0819-hook-cross-repo-roster",
-     ("Jelani.Mwangi","Arjun.Raghavan"), 2, "#819", False),
+    (
+        "noorinalabs-isnad-graph",
+        819,
+        "LINH_PHAM",
+        "L.Pham/0819-hook-cross-repo-roster",
+        ("Jelani.Mwangi", "Arjun.Raghavan"),
+        2,
+        "#814",
+        False,
+    ),
+    (
+        "noorinalabs-isnad-graph",
+        814,
+        "LINH_PHAM",
+        "L.Pham/0819-hook-cross-repo-roster",
+        ("Jelani.Mwangi", "Arjun.Raghavan"),
+        2,
+        "#819",
+        False,
+    ),
     # T3 — 3 PRs in main
-    ("noorinalabs-main", 238, "WANJIKU_MWANGI", "W.Mwangi/0238-wave-kickoff-multi-repo",
-     ("Aino.Virtanen","Nadia.Khoury"), 3, "(standalone)", False),
-    ("noorinalabs-main", 158, "AINO_VIRTANEN", "A.Virtanen/0158-promotion-audit-fallback",
-     ("Wanjiku.Mwangi","Santiago.Ferreira"), 3, "(standalone)", False),
-    ("noorinalabs-main", 196, "WANJIKU_MWANGI", "W.Mwangi/0196-wave-scope-skill",
-     ("Nadia.Khoury","Aino.Virtanen"), 3, "(standalone)", False),
+    (
+        "noorinalabs-main",
+        238,
+        "WANJIKU_MWANGI",
+        "W.Mwangi/0238-wave-kickoff-multi-repo",
+        ("Aino.Virtanen", "Nadia.Khoury"),
+        3,
+        "(standalone)",
+        False,
+    ),
+    (
+        "noorinalabs-main",
+        158,
+        "AINO_VIRTANEN",
+        "A.Virtanen/0158-promotion-audit-fallback",
+        ("Wanjiku.Mwangi", "Santiago.Ferreira"),
+        3,
+        "(standalone)",
+        False,
+    ),
+    (
+        "noorinalabs-main",
+        196,
+        "WANJIKU_MWANGI",
+        "W.Mwangi/0196-wave-scope-skill",
+        ("Nadia.Khoury", "Aino.Virtanen"),
+        3,
+        "(standalone)",
+        False,
+    ),
     # T4 — main bundle PR: A.Virtanen/0225-charter-docs-sweep (closes 6)
-    ("noorinalabs-main", 225, "AINO_VIRTANEN", "A.Virtanen/0225-charter-docs-sweep",
-     ("Wanjiku.Mwangi","Nadia.Khoury"), 4, "#239 #240 #200 #201 #197", False),
-    ("noorinalabs-main", 239, "AINO_VIRTANEN", "A.Virtanen/0225-charter-docs-sweep",
-     ("Wanjiku.Mwangi","Nadia.Khoury"), 4, "#225 #240 #200 #201 #197", False),
-    ("noorinalabs-main", 240, "AINO_VIRTANEN", "A.Virtanen/0225-charter-docs-sweep",
-     ("Wanjiku.Mwangi","Nadia.Khoury"), 4, "#225 #239 #200 #201 #197", False),
-    ("noorinalabs-main", 200, "AINO_VIRTANEN", "A.Virtanen/0225-charter-docs-sweep",
-     ("Wanjiku.Mwangi","Nadia.Khoury"), 4, "#225 #239 #240 #201 #197", False),
-    ("noorinalabs-main", 201, "AINO_VIRTANEN", "A.Virtanen/0225-charter-docs-sweep",
-     ("Wanjiku.Mwangi","Nadia.Khoury"), 4, "#225 #239 #240 #200 #197", False),
-    ("noorinalabs-main", 197, "AINO_VIRTANEN", "A.Virtanen/0225-charter-docs-sweep",
-     ("Wanjiku.Mwangi","Nadia.Khoury"), 4, "#225 #239 #240 #200 #201", False),
+    (
+        "noorinalabs-main",
+        225,
+        "AINO_VIRTANEN",
+        "A.Virtanen/0225-charter-docs-sweep",
+        ("Wanjiku.Mwangi", "Nadia.Khoury"),
+        4,
+        "#239 #240 #200 #201 #197",
+        False,
+    ),
+    (
+        "noorinalabs-main",
+        239,
+        "AINO_VIRTANEN",
+        "A.Virtanen/0225-charter-docs-sweep",
+        ("Wanjiku.Mwangi", "Nadia.Khoury"),
+        4,
+        "#225 #240 #200 #201 #197",
+        False,
+    ),
+    (
+        "noorinalabs-main",
+        240,
+        "AINO_VIRTANEN",
+        "A.Virtanen/0225-charter-docs-sweep",
+        ("Wanjiku.Mwangi", "Nadia.Khoury"),
+        4,
+        "#225 #239 #200 #201 #197",
+        False,
+    ),
+    (
+        "noorinalabs-main",
+        200,
+        "AINO_VIRTANEN",
+        "A.Virtanen/0225-charter-docs-sweep",
+        ("Wanjiku.Mwangi", "Nadia.Khoury"),
+        4,
+        "#225 #239 #240 #201 #197",
+        False,
+    ),
+    (
+        "noorinalabs-main",
+        201,
+        "AINO_VIRTANEN",
+        "A.Virtanen/0225-charter-docs-sweep",
+        ("Wanjiku.Mwangi", "Nadia.Khoury"),
+        4,
+        "#225 #239 #240 #200 #197",
+        False,
+    ),
+    (
+        "noorinalabs-main",
+        197,
+        "AINO_VIRTANEN",
+        "A.Virtanen/0225-charter-docs-sweep",
+        ("Wanjiku.Mwangi", "Nadia.Khoury"),
+        4,
+        "#225 #239 #240 #200 #201",
+        False,
+    ),
     # T4 — child doc-sync (single-reviewer wave-bootstrap-class)
-    ("noorinalabs-isnad-graph", 852, "INGRID_LINDQVIST", "I.Lindqvist/0852-claude-md-branching-sync",
-     ("Anya.Kowalczyk",), 4, "(child sync)", True),
-    ("noorinalabs-user-service", 90, "MATEO_SALAZAR", "M.Salazar/0090-claude-md-branching-sync",
-     ("Anya.Kowalczyk",), 4, "(child sync)", True),
-    ("noorinalabs-design-system", 62, "KOFI_MENSAH", "K.Mensah/0062-claude-md-branching-sync",
-     ("Maeve.Callahan",), 4, "(child sync)", True),
-    ("noorinalabs-data-acquisition", 33, "SOFIA_CARDOSO", "S.Cardoso/0033-claude-md-branching-sync",
-     ("Dilara.Erdogan",), 4, "(child sync)", True),
+    (
+        "noorinalabs-isnad-graph",
+        852,
+        "INGRID_LINDQVIST",
+        "I.Lindqvist/0852-claude-md-branching-sync",
+        ("Anya.Kowalczyk",),
+        4,
+        "(child sync)",
+        True,
+    ),
+    (
+        "noorinalabs-user-service",
+        90,
+        "MATEO_SALAZAR",
+        "M.Salazar/0090-claude-md-branching-sync",
+        ("Anya.Kowalczyk",),
+        4,
+        "(child sync)",
+        True,
+    ),
+    (
+        "noorinalabs-design-system",
+        62,
+        "KOFI_MENSAH",
+        "K.Mensah/0062-claude-md-branching-sync",
+        ("Maeve.Callahan",),
+        4,
+        "(child sync)",
+        True,
+    ),
+    (
+        "noorinalabs-data-acquisition",
+        33,
+        "SOFIA_CARDOSO",
+        "S.Cardoso/0033-claude-md-branching-sync",
+        ("Dilara.Erdogan",),
+        4,
+        "(child sync)",
+        True,
+    ),
     # T5 — firm scope per owner directive
-    ("noorinalabs-main", 214, "AINO_VIRTANEN", "A.Virtanen/0214-parent-canonical-hook-paths",
-     ("Wanjiku.Mwangi","Nadia.Khoury"), 5, "(standalone)", False),
-    ("noorinalabs-main", 215, "AINO_VIRTANEN", "A.Virtanen/0215-settings-json-fanout",
-     ("Wanjiku.Mwangi","Santiago.Ferreira"), 5, "(standalone)", False),
-    ("noorinalabs-main", 236, "NADIA_KHOURY", "N.Khoury/0236-pattern-c-promotion",
-     ("Aino.Virtanen","Santiago.Ferreira"), 5, "(standalone)", False),
-    ("noorinalabs-main", 198, "AINO_VIRTANEN", "A.Virtanen/0198-validate-edit-completion",
-     ("Wanjiku.Mwangi","Nadia.Khoury"), 5, "(standalone)", False),
-    ("noorinalabs-main", 203, "AINO_VIRTANEN", "A.Virtanen/0203-validate-workflow-paths-coverage",
-     ("Wanjiku.Mwangi","Nadia.Khoury"), 5, "(standalone)", False),
-    ("noorinalabs-main", 219, "AINO_VIRTANEN", "A.Virtanen/0219-hook14-neutral-bypass",
-     ("Wanjiku.Mwangi","Santiago.Ferreira"), 5, "(standalone)", False),
+    (
+        "noorinalabs-main",
+        214,
+        "AINO_VIRTANEN",
+        "A.Virtanen/0214-parent-canonical-hook-paths",
+        ("Wanjiku.Mwangi", "Nadia.Khoury"),
+        5,
+        "(standalone)",
+        False,
+    ),
+    (
+        "noorinalabs-main",
+        215,
+        "AINO_VIRTANEN",
+        "A.Virtanen/0215-settings-json-fanout",
+        ("Wanjiku.Mwangi", "Santiago.Ferreira"),
+        5,
+        "(standalone)",
+        False,
+    ),
+    (
+        "noorinalabs-main",
+        236,
+        "NADIA_KHOURY",
+        "N.Khoury/0236-pattern-c-promotion",
+        ("Aino.Virtanen", "Santiago.Ferreira"),
+        5,
+        "(standalone)",
+        False,
+    ),
+    (
+        "noorinalabs-main",
+        198,
+        "AINO_VIRTANEN",
+        "A.Virtanen/0198-validate-edit-completion",
+        ("Wanjiku.Mwangi", "Nadia.Khoury"),
+        5,
+        "(standalone)",
+        False,
+    ),
+    (
+        "noorinalabs-main",
+        203,
+        "AINO_VIRTANEN",
+        "A.Virtanen/0203-validate-workflow-paths-coverage",
+        ("Wanjiku.Mwangi", "Nadia.Khoury"),
+        5,
+        "(standalone)",
+        False,
+    ),
+    (
+        "noorinalabs-main",
+        219,
+        "AINO_VIRTANEN",
+        "A.Virtanen/0219-hook14-neutral-bypass",
+        ("Wanjiku.Mwangi", "Santiago.Ferreira"),
+        5,
+        "(standalone)",
+        False,
+    ),
 ]
 
 assert len(ISSUES) == 31, f"Expected 31 issues, got {len(ISSUES)}"
 
+
 def run(cmd, **kw):
     return subprocess.run(cmd, capture_output=True, text=True, **kw)
+
 
 results = {"labeled": [], "label_failed": [], "commented": [], "comment_failed": []}
 
 for repo, num, assignee, branch, revs, tier, bundled, wave_bs in ISSUES:
     # Step 1: label
-    label_cmd = ["gh", "issue", "edit", str(num), "--repo", f"noorinalabs/{repo}",
-                 "--add-label", "p3-wave-4", "--add-label", assignee]
+    label_cmd = [
+        "gh",
+        "issue",
+        "edit",
+        str(num),
+        "--repo",
+        f"noorinalabs/{repo}",
+        "--add-label",
+        "p3-wave-4",
+        "--add-label",
+        assignee,
+    ]
     if wave_bs:
         label_cmd += ["--add-label", "wave-bootstrap"]
     r = run(label_cmd)
@@ -95,7 +364,9 @@ for repo, num, assignee, branch, revs, tier, bundled, wave_bs in ISSUES:
         results["label_failed"].append(f"{repo}#{num}: {r.stderr.strip()[:120]}")
 
     # Step 2: kickoff comment
-    rev_str = ", ".join(revs) + (" (single-reviewer per wave-bootstrap exception)" if wave_bs else "")
+    rev_str = ", ".join(revs) + (
+        " (single-reviewer per wave-bootstrap exception)" if wave_bs else ""
+    )
     body = f"""Requestor: Nadia.Khoury
 Requestee: {assignee.replace('_', '.').title().replace('Mwangi', 'Mwangi').replace('Khoury', 'Khoury')}
 RequestOrReplied: Request
@@ -120,18 +391,29 @@ Please begin implementation per the charter (`pull-requests.md`, `commits.md`, `
 
 — Nadia Khoury, Program Director"""
 
-    comment_cmd = ["gh", "issue", "comment", str(num), "--repo", f"noorinalabs/{repo}", "--body", body]
+    comment_cmd = [
+        "gh",
+        "issue",
+        "comment",
+        str(num),
+        "--repo",
+        f"noorinalabs/{repo}",
+        "--body",
+        body,
+    ]
     r = run(comment_cmd)
     if r.returncode == 0:
         results["commented"].append(f"{repo}#{num}")
     else:
         results["comment_failed"].append(f"{repo}#{num}: {r.stderr.strip()[:200]}")
 
-print(json.dumps({k: len(v) for k,v in results.items()}, indent=2))
+print(json.dumps({k: len(v) for k, v in results.items()}, indent=2))
 print()
 if results["label_failed"]:
     print("LABEL FAILURES:")
-    for x in results["label_failed"]: print(" ", x)
+    for x in results["label_failed"]:
+        print(" ", x)
 if results["comment_failed"]:
     print("COMMENT FAILURES:")
-    for x in results["comment_failed"]: print(" ", x)
+    for x in results["comment_failed"]:
+        print(" ", x)

--- a/.claude/skills/wave-kickoff/_orchestration/w4-project-add.py
+++ b/.claude/skills/wave-kickoff/_orchestration/w4-project-add.py
@@ -1,7 +1,37 @@
-import subprocess, json
+import subprocess
+
 ISSUES = [
-    ("noorinalabs-main", [244,233,228,226,227,223,216,188,144,189,238,158,196,225,239,240,200,201,197,214,215,236,198,203,219]),
-    ("noorinalabs-isnad-graph", [819,814,852]),
+    (
+        "noorinalabs-main",
+        [
+            244,
+            233,
+            228,
+            226,
+            227,
+            223,
+            216,
+            188,
+            144,
+            189,
+            238,
+            158,
+            196,
+            225,
+            239,
+            240,
+            200,
+            201,
+            197,
+            214,
+            215,
+            236,
+            198,
+            203,
+            219,
+        ],
+    ),
+    ("noorinalabs-isnad-graph", [819, 814, 852]),
     ("noorinalabs-user-service", [90]),
     ("noorinalabs-design-system", [62]),
     ("noorinalabs-data-acquisition", [33]),
@@ -11,8 +41,11 @@ fail = []
 for repo, nums in ISSUES:
     for n in nums:
         url = f"https://github.com/noorinalabs/{repo}/issues/{n}"
-        r = subprocess.run(["gh","project","item-add","2","--owner","noorinalabs","--url",url],
-                           capture_output=True, text=True)
+        r = subprocess.run(
+            ["gh", "project", "item-add", "2", "--owner", "noorinalabs", "--url", url],
+            capture_output=True,
+            text=True,
+        )
         if r.returncode == 0:
             total += 1
         else:
@@ -24,4 +57,5 @@ for repo, nums in ISSUES:
 print(f"Added (or already on board): {total}")
 if fail:
     print("FAILURES:")
-    for f in fail: print(" ", f)
+    for f in fail:
+        print(" ", f)

--- a/.claude/skills/wave-kickoff/tests/test_existing_sha_validator.py
+++ b/.claude/skills/wave-kickoff/tests/test_existing_sha_validator.py
@@ -4,7 +4,9 @@
 The validator guards against gh api returning the raw 404 JSON error body when
 a branch doesn't exist, which was captured live during P3W7 kickoff (e906e135).
 
-Run: ENVIRONMENT=test python3 -m pytest .claude/skills/wave-kickoff/tests/test_existing_sha_validator.py -v
+Run:
+    ENVIRONMENT=test python3 -m pytest \
+        .claude/skills/wave-kickoff/tests/test_existing_sha_validator.py -v
 """
 
 from __future__ import annotations
@@ -39,7 +41,6 @@ def _jq_object_sha(fixture_path: Path) -> str:
 
 
 class TestExistingShaValidator(unittest.TestCase):
-
     def test_404_body_yields_empty(self):
         """Live-trigger fixture: 404 JSON error body must produce EXISTING_SHA=""."""
         fixture = _FIXTURES / "existing_sha_404.json"


### PR DESCRIPTION
## Summary

Closes the main-repo half of the W9 code-quality cluster (#317 + #161 + #160) and hands the cross-repo portions to filed-and-tracked follow-up issues in the affected child repos. Honors `feedback_child_repo_implementer_rule`: parent-roster (Nadia/Wanjiku/Santiago/Aino) cannot author commits in child repos, so cross-repo work gets tracked-for-handoff rather than attempted in-band.

## Disposition rationale

### #317 — W7 retro lint scan

Mixed scope. Did the main-repo-only work; filed 3 child-repo follow-ups.

- **Main-repo work**: 19 ruff errors in `.claude/skills/wave-kickoff/_orchestration/w4-*.py` + `.claude/skills/wave-kickoff/tests/test_existing_sha_validator.py`. Auto-fixable: 7 (F401 unused-import, E401 multi-import-on-one-line, I001 isort). Format-only: 3 files. Remaining 5 E501s are inside an f-string body that captures the literal historical wave-4 kickoff comment text — reflowing would distort the audit-trail record. Per-file `# ruff: noqa: E501` exemption with a docstring rationale was the right granularity (vs reflowing the historical text).
- **Cross-repo follow-ups filed** (per the W7 retro scan findings list in the issue body):
  - noorinalabs/noorinalabs-data-acquisition#52 — UP017 datetime.UTC alias (1-line auto-fix)
  - noorinalabs/noorinalabs-deploy#284 — integration-tests/run-tests.sh shellcheck 4 warnings (3× SC2155 + 1× SC2016)
  - noorinalabs/noorinalabs-user-service#102 — scripts/pre-commit.sh:53 SC2209

### #161 — frontend UserRole vs backend role divergence

Cross-repo by nature. The divergence is between `noorinalabs-isnad-graph/frontend/src/hooks/useAuth.ts` (UserRole union) and `noorinalabs-user-service` (the role authority). No main-repo code touches this surface. Closing main#161 with a tracked-elsewhere comment.

- noorinalabs/noorinalabs-isnad-graph#876 — frontend UserRole union audit + migration to backend vocabulary (per #161 Option A recommendation)
- noorinalabs/noorinalabs-user-service#103 — API-side: publish canonical UserRole string enum in OpenAPI schema so consumers can codegen-check at build time

### #160 — no OpenAPI client codegen

Cross-repo by nature. The codegen pipeline lives in the frontend (`noorinalabs-isnad-graph`) and the snapshot/spec authority lives in the API (`noorinalabs-user-service`). No main-repo code touches this surface. Closing main#160 with a tracked-elsewhere comment.

- noorinalabs/noorinalabs-isnad-graph#877 — frontend openapi-typescript codegen + CI drift gate (per #160 Option A recommendation)
- noorinalabs/noorinalabs-user-service#104 — API-side: commit `docs/openapi-snapshot.json` + CI drift gate, coupled with consumer-side codegen

## What changed in main repo

| File | Change |
|------|--------|
| `.claude/skills/wave-kickoff/_orchestration/w4-kickoff.py` | Added file-level `# ruff: noqa: E501` exemption + docstring rationale (frozen historical wave-4 kickoff-comment text). Format-only reflow elsewhere via ruff format. |
| `.claude/skills/wave-kickoff/_orchestration/w4-project-add.py` | Auto-fix: split multi-import, removed unused `json` import, isort. Format-only reflow via ruff format. |
| `.claude/skills/wave-kickoff/tests/test_existing_sha_validator.py` | E501 docstring line split into a 2-line "Run:" example. Format-only reflow via ruff format. |

Net: 0 ruff errors, 0 format diffs across the entire `.claude/` tree post-PR.

## Cross-repo follow-up summary table

| Parent issue | Child issue | Repo | What |
|--------------|-------------|------|------|
| #317 | data-acquisition#52 | noorinalabs-data-acquisition | UP017 1-line fix |
| #317 | deploy#284 | noorinalabs-deploy | shellcheck 4 warnings |
| #317 | user-service#102 | noorinalabs-user-service | SC2209 1-line fix |
| #161 | isnad-graph#876 | noorinalabs-isnad-graph | Frontend UserRole union migration |
| #161 | user-service#103 | noorinalabs-user-service | API-side: publish UserRole enum |
| #160 | isnad-graph#877 | noorinalabs-isnad-graph | Frontend openapi-typescript codegen |
| #160 | user-service#104 | noorinalabs-user-service | API-side: commit snapshot + CI drift gate |

7 child-repo follow-ups filed, all labeled `tech-debt`, all unscoped wave-wise (per the brief: "Don't add `p3-wave-9` — let next wave's /wave-scope decide").

## Test plan

- [x] `uvx ruff@0.7.4 check .claude/` — clean (all checks passed)
- [x] `uvx ruff@0.7.4 format --check .claude/` — clean (72 files already formatted)
- [x] `ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/ -q` — **720 passed, 19 subtests passed** (matches wave-9 HEAD baseline)
- [x] CI ruff gate (`ruff check .claude/hooks/`) — was clean pre-PR, still clean post-PR (this PR raises floor from CI-gated `.claude/hooks/` clean to entire `.claude/` clean)
- [x] All 7 cross-repo follow-up issues exist and labeled
- [ ] Reviewer 1: confirms the `# ruff: noqa: E501` exemption rationale (historical audit-trail preservation) is the right shape vs reflowing
- [ ] Reviewer 2: confirms cross-repo follow-up filing covers all the W7 retro scan findings + #161 + #160 both-sides

## Closes

Closes #317
Closes #161
Closes #160

(Per `feedback_wave_branch_issue_close`: `Closes #N` only fires on default-branch merges; this PR targets the wave-9 branch, so the issue-close comments are posted explicitly via `gh issue close` after the PR merges. The propagation merge to main also re-fires the closes per GitHub's auto-close on default-branch merge.)

**Wave**: P3W9
