### PR TITLE
tech-debt(hooks): post_dispatcher.py — consolidate PostToolUse Bash + Edit/Write (closes #259 #395)

### DIFF
--- a/.claude/hooks/annunaki_monitor.py
+++ b/.claude/hooks/annunaki_monitor.py
@@ -6,6 +6,17 @@ Fires after every Bash tool call. Inspects the output for error signals
 each error to .claude/annunaki/errors.jsonl for later analysis by
 /annunaki-attack.
 
+Input Language:
+  Fires on:      PostToolUse Bash
+  Matches:       Bash with non-zero exit_code OR stdout/stderr matching any
+                 ERROR_PATTERNS regex (Traceback, fatal:, ModuleNotFoundError,
+                 etc.) and NOT matching IGNORE_PATTERNS
+  Does NOT match: any non-Bash tool, empty stdout+stderr, command-text
+                  containing grep-for-error / --error flags / error-named
+                  paths (false-positive guards), session-dedup hits
+  Flag pass-through: stdin JSON is forwarded verbatim to `check()` by the
+                     PostToolUse dispatcher (`post_dispatcher.py`)
+
 Exit codes:
   0 — always (advisory hook, never blocks)
 """
@@ -79,15 +90,15 @@ def _should_ignore(command: str, output: str) -> bool:
     return False
 
 
-def main() -> None:
-    try:
-        input_data = json.load(sys.stdin)
-    except (json.JSONDecodeError, EOFError):
-        sys.exit(0)
+def check(input_data: dict) -> dict | None:
+    """Dispatcher-compatible entry point for PostToolUse Bash.
 
-    tool_name = input_data.get("tool_name", "")
-    if tool_name != "Bash":
-        sys.exit(0)
+    Returns None when no error is detected (or input doesn't apply); returns
+    an advisory dict describing the logged record when an error is appended
+    to the JSONL log. The dispatcher treats non-None as advisory only.
+    """
+    if input_data.get("tool_name", "") != "Bash":
+        return None
 
     command = input_data.get("tool_input", {}).get("command", "")
     tool_output = input_data.get("tool_output", {})
@@ -95,36 +106,27 @@ def main() -> None:
     stderr = tool_output.get("stderr", "")
     exit_code = tool_output.get("exit_code", 0)
 
-    # Combine output for pattern matching
     combined_output = f"{stdout}\n{stderr}".strip()
-
     if not combined_output:
-        sys.exit(0)
+        return None
 
-    # Check for false positives
     if _should_ignore(command, combined_output):
-        sys.exit(0)
+        return None
 
-    # Determine if this is an error
     is_error = False
-    matched_patterns = []
+    matched_patterns: list[str] = []
 
-    # Non-zero exit code is always an error
     if exit_code and exit_code != 0:
         is_error = True
         matched_patterns.append(f"exit_code={exit_code}")
 
-    # Check stderr
     if stderr and stderr.strip():
-        # Some tools write to stderr normally (git, curl) — only flag if
-        # there's also a pattern match or non-zero exit
         for pattern in ERROR_PATTERNS:
             if pattern.search(stderr):
                 is_error = True
                 matched_patterns.append(f"stderr:{pattern.pattern}")
                 break
 
-    # Check stdout for error patterns
     for pattern in ERROR_PATTERNS:
         if pattern.search(stdout):
             is_error = True
@@ -132,21 +134,19 @@ def main() -> None:
             break
 
     if not is_error:
-        sys.exit(0)
+        return None
 
-    # Build error record
     error_lines = _extract_error_lines(combined_output)
 
-    # Session-level dedup
     dedup_input = command[:200] + "|||" + "\n".join(error_lines)[:500]
     dedup_hash = hashlib.md5(dedup_input.encode("utf-8")).hexdigest()
     if dedup_hash in _seen_hashes:
-        sys.exit(0)
+        return None
     _seen_hashes.add(dedup_hash)
 
     record = {
         "timestamp": datetime.now(timezone.utc).isoformat(),
-        "command": command[:500],  # Truncate very long commands
+        "command": command[:500],
         "exit_code": exit_code,
         "matched_patterns": matched_patterns[:5],
         "error_lines": error_lines,
@@ -156,6 +156,15 @@ def main() -> None:
 
     append_jsonl_record(ERRORS_FILE, record)
 
+    return {"action": "logged", "dedup_hash": dedup_hash}
+
+
+def main() -> None:
+    try:
+        input_data = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        sys.exit(0)
+    check(input_data)
     sys.exit(0)
 
 

--- a/.claude/hooks/auto_add_issue_to_board.py
+++ b/.claude/hooks/auto_add_issue_to_board.py
@@ -8,6 +8,15 @@ this hook automatically adds that issue to the Cross-Repo Wave Plan board
 This enforces charter § Cross-Repo Wave Plan: "New issues created during a wave
 must be added to the board immediately."
 
+Input Language:
+  Fires on:      PostToolUse Bash
+  Matches:       Bash commands containing `gh issue create` with a noorinalabs
+                 issue URL in stdout
+  Does NOT match: any non-Bash tool, Bash without `gh issue create`, or
+                  `gh issue create` whose output lacks a parseable issue URL
+  Flag pass-through: stdin JSON is forwarded verbatim to `check()` by the
+                     PostToolUse dispatcher (`post_dispatcher.py`)
+
 Exit codes:
   0 — success or not applicable (not a gh issue create, or already handled)
   Non-zero exit does NOT block (PostToolUse hooks are advisory)
@@ -23,35 +32,30 @@ PROJECT_NUMBER = 2
 ORG = "noorinalabs"
 
 
-def main() -> None:
-    try:
-        input_data = json.load(sys.stdin)
-    except (json.JSONDecodeError, EOFError):
-        sys.exit(0)
+def check(input_data: dict) -> dict | None:
+    """Dispatcher-compatible entry point for PostToolUse Bash.
 
-    tool_name = input_data.get("tool_name", "")
-    if tool_name != "Bash":
-        sys.exit(0)
+    Returns None when the hook is not applicable; returns a small advisory
+    dict (`{"action": "added", "issue_url": ...}`) when the project-board
+    add was attempted. The dispatcher treats non-None as advisory only.
+    """
+    if input_data.get("tool_name", "") != "Bash":
+        return None
 
     command = input_data.get("tool_input", {}).get("command", "")
-
-    # Only trigger on gh issue create commands
     if "gh issue create" not in command and "gh issue create" not in command.replace("  ", " "):
-        sys.exit(0)
+        return None
 
-    # Extract the issue URL from tool output (stdout)
     stdout = input_data.get("tool_output", {}).get("stdout", "")
     if not stdout:
-        sys.exit(0)
+        return None
 
-    # gh issue create outputs the URL on the last line
     url_match = re.search(r"(https://github\.com/noorinalabs/[^/]+/issues/\d+)", stdout)
     if not url_match:
-        sys.exit(0)
+        return None
 
     issue_url = url_match.group(1)
 
-    # Add to project board
     try:
         subprocess.run(
             [
@@ -71,6 +75,15 @@ def main() -> None:
     except (subprocess.TimeoutExpired, FileNotFoundError):
         pass  # Don't block on failure — advisory hook
 
+    return {"action": "added", "issue_url": issue_url}
+
+
+def main() -> None:
+    try:
+        input_data = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        sys.exit(0)
+    check(input_data)
     sys.exit(0)
 
 

--- a/.claude/hooks/ontology_tracker.py
+++ b/.claude/hooks/ontology_tracker.py
@@ -35,6 +35,16 @@ Path filtering (issue #143):
       the SKIP_PREFIXES check uses the resolved path so the filter still
       catches it.)
 
+Input Language:
+  Fires on:      PostToolUse Edit, Write
+  Matches:       Edit/Write whose `file_path` is non-empty AND resides inside
+                 REPO_ROOT AND does NOT trip _should_skip (worktree-copy,
+                 __pycache__, node_modules, /tmp/, etc.)
+  Does NOT match: any other tool, missing file_path, paths under skip-
+                  patterns, out-of-repo paths
+  Flag pass-through: stdin JSON is forwarded verbatim to `check()` by the
+                     PostToolUse dispatcher (`post_dispatcher.py`)
+
 Exit codes:
   0 — always (advisory hook, never blocks)
 """
@@ -114,34 +124,32 @@ def _relative_path(file_path: str) -> str:
         return file_path
 
 
-def main() -> None:
-    try:
-        input_data = json.load(sys.stdin)
-    except (json.JSONDecodeError, EOFError):
-        sys.exit(0)
+def check(input_data: dict) -> dict | None:
+    """Dispatcher-compatible entry point for PostToolUse Edit/Write.
 
+    Returns None when the hook is not applicable (wrong tool, skip-path,
+    unreadable file); returns an advisory dict describing the checksum
+    update when an entry is written. The dispatcher treats non-None as
+    advisory only.
+    """
     tool_name = input_data.get("tool_name", "")
     if tool_name not in ("Edit", "Write"):
-        sys.exit(0)
+        return None
 
-    # Extract file path from tool input
     file_path = input_data.get("tool_input", {}).get("file_path", "")
     if not file_path:
-        sys.exit(0)
+        return None
 
-    # Skip files that aren't relevant to ontology
     if _should_skip(file_path):
-        sys.exit(0)
+        return None
 
-    # Compute hash
     sha = _compute_sha256(Path(file_path))
     if sha is None:
-        sys.exit(0)
+        return None
 
     rel_path = _relative_path(file_path)
     now = datetime.now(timezone.utc).isoformat()
 
-    # Load existing checksums
     try:
         with open(CHECKSUMS_FILE, "r", encoding="utf-8") as f:
             data = json.load(f)
@@ -150,7 +158,6 @@ def main() -> None:
 
     files = data.setdefault("files", {})
 
-    # Update or create entry — preserve last_resolved from previous state
     existing = files.get(rel_path, {})
     files[rel_path] = {
         "last_tracked": sha,
@@ -159,7 +166,6 @@ def main() -> None:
         "resolved_at": existing.get("resolved_at", ""),
     }
 
-    # Write back atomically-ish
     try:
         CHECKSUMS_FILE.parent.mkdir(parents=True, exist_ok=True)
         tmp = CHECKSUMS_FILE.with_suffix(".tmp")
@@ -170,6 +176,15 @@ def main() -> None:
     except OSError:
         pass  # Never fail the hook
 
+    return {"action": "tracked", "path": rel_path}
+
+
+def main() -> None:
+    try:
+        input_data = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        sys.exit(0)
+    check(input_data)
     sys.exit(0)
 
 

--- a/.claude/hooks/post_dispatcher.py
+++ b/.claude/hooks/post_dispatcher.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""PostToolUse dispatcher: Single entry point for all PostToolUse hooks.
+
+Mirrors `dispatcher.py` (the PreToolUse Bash dispatcher) for the
+PostToolUse phase. Routes by matcher (Bash, Edit, Write, NotebookEdit) so
+all PostToolUse hooks run in-process per tool call instead of via N
+separate `python3` subprocess invocations.
+
+Each PostToolUse hook module exposes:
+    check(input_data: dict) -> dict | None
+        Returns None for no-op (hook didn't apply or had no advisory to
+        emit). Returns a dict with `systemMessage` to surface an advisory
+        message through the harness. Other keys (`action`, etc.) are
+        recorded for diagnostics but not surfaced.
+
+Unlike PreToolUse, PostToolUse hooks CANNOT block the tool — it already
+ran. The dispatcher runs every registered module for the matcher and
+aggregates any `systemMessage` fields into a single advisory output.
+Exit code is always 0; the dispatcher never blocks. If an individual hook
+raises an unhandled exception, the dispatcher swallows it (fail-open,
+mirroring `dispatcher.py`).
+
+Input Language:
+  Fires on:      PostToolUse Bash | Edit | Write | NotebookEdit
+  Matches:       any tool invocation whose `tool_name` is a key in
+                 `_REGISTRY` (Bash, Edit, Write, NotebookEdit)
+  Does NOT match: tool invocations whose matcher has no registered modules
+  Flag pass-through: stdin JSON is read once and passed verbatim to each
+                     registered module's `check()` function
+
+Exit codes:
+  0 — always (PostToolUse hooks are advisory; aggregated systemMessages
+      are emitted as JSON on stdout but the exit code stays 0)
+"""
+
+import importlib
+import json
+import sys
+from pathlib import Path
+
+# Ensure the hooks directory is on sys.path for imports
+_HOOKS_DIR = Path(__file__).resolve().parent
+if str(_HOOKS_DIR) not in sys.path:
+    sys.path.insert(0, str(_HOOKS_DIR))
+
+# Edit and Write share the same module set today (every module that runs on
+# Edit also runs on Write). Defining it once keeps the two matcher entries
+# in lock-step.
+_EDIT_WRITE_MODULES = [
+    "ontology_tracker",
+    "suggest_generic_prompt",
+    "validate_edit_completion",
+]
+
+# Matcher → ordered list of hook-module import names.
+# Order matters: cheap/local checks first, network-calling checks last
+# (mirroring `dispatcher.py`'s ordering convention).
+_REGISTRY: dict[str, list[str]] = {
+    "Bash": [
+        "annunaki_monitor",  # local: regex over stdout/stderr, JSONL append
+        "auto_add_issue_to_board",  # network: runs `gh project item-add`
+        "post_wave_kickoff_comment",  # network: gh fetch + post comment
+    ],
+    "Edit": _EDIT_WRITE_MODULES,
+    "Write": _EDIT_WRITE_MODULES,
+    "NotebookEdit": [
+        "validate_edit_completion",  # PostToolUse sentinel write only
+    ],
+}
+
+
+def main() -> None:
+    try:
+        input_data = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        sys.exit(0)
+
+    tool_name = input_data.get("tool_name", "")
+    modules = _REGISTRY.get(tool_name)
+    if not modules:
+        sys.exit(0)
+
+    messages: list[str] = []
+
+    for module_name in modules:
+        try:
+            mod = importlib.import_module(module_name)
+        except ImportError:
+            continue  # Skip missing modules gracefully
+
+        check_fn = getattr(mod, "check", None)
+        if check_fn is None:
+            continue
+
+        try:
+            result = check_fn(input_data)
+        except Exception:
+            continue  # Never let a hook crash propagate — advisory only
+
+        if not isinstance(result, dict):
+            continue
+
+        msg = result.get("systemMessage")
+        if msg:
+            messages.append(str(msg))
+
+    if messages:
+        output = {"systemMessage": "\n\n".join(messages)}
+        print(json.dumps(output))
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/suggest_generic_prompt.py
+++ b/.claude/hooks/suggest_generic_prompt.py
@@ -5,6 +5,16 @@ Fires after Edit or Write on files under .claude/. Emits a systemMessage
 reminding the agent to consider whether the change could be genericized
 into a product-neutral prompt for the 2real-team-framework repo.
 
+Input Language:
+  Fires on:      PostToolUse Edit, Write
+  Matches:       Edit/Write whose `file_path` contains `/.claude/` AND is
+                 NOT a tracker-managed artifact (checksums.json /
+                 annunaki/errors.jsonl)
+  Does NOT match: any other tool, missing file_path, paths outside
+                  `.claude/`, skip-listed tracker artifacts
+  Flag pass-through: stdin JSON is forwarded verbatim to `check()` by the
+                     PostToolUse dispatcher (`post_dispatcher.py`)
+
 Exit codes:
   0 — always (advisory hook, never blocks)
 """
@@ -53,31 +63,31 @@ def _classify(file_path: str) -> dict | None:
     }
 
 
-def main() -> None:
-    try:
-        input_data = json.load(sys.stdin)
-    except (json.JSONDecodeError, EOFError):
-        sys.exit(0)
+def check(input_data: dict) -> dict | None:
+    """Dispatcher-compatible entry point for PostToolUse Edit/Write.
 
+    Returns None when the hook is not applicable; returns a
+    `{"systemMessage": ...}` advisory dict when a generic-prompt suggestion
+    should surface. The dispatcher aggregates systemMessage values across
+    all hooks for the matcher.
+    """
     tool_name = input_data.get("tool_name", "")
     if tool_name not in ("Edit", "Write"):
-        sys.exit(0)
+        return None
 
     file_path = input_data.get("tool_input", {}).get("file_path", "")
     if not file_path:
-        sys.exit(0)
+        return None
 
-    # Only trigger for files under .claude/
     if "/.claude/" not in file_path:
-        sys.exit(0)
+        return None
 
-    # Skip the ontology tracker checksum updates and annunaki logs
     skip_patterns = [
         "ontology/checksums.json",
         "annunaki/errors.jsonl",
     ]
     if any(p in file_path for p in skip_patterns):
-        sys.exit(0)
+        return None
 
     category = _classify(file_path)
     rel_path = file_path.split("/.claude/")[-1] if "/.claude/" in file_path else file_path
@@ -100,8 +110,17 @@ def main() -> None:
         f"{framework_note}"
     )
 
-    result = {"systemMessage": message}
-    print(json.dumps(result))
+    return {"systemMessage": message}
+
+
+def main() -> None:
+    try:
+        input_data = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        sys.exit(0)
+    result = check(input_data)
+    if result is not None:
+        print(json.dumps(result))
     sys.exit(0)
 
 

--- a/.claude/hooks/tests/test_post_dispatcher.py
+++ b/.claude/hooks/tests/test_post_dispatcher.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python3
+"""Tests for post_dispatcher.py — PostToolUse single-entry dispatcher.
+
+Mirrors the structure of the PreToolUse `dispatcher.py` invariants but for
+PostToolUse semantics: hooks are advisory (no `block` decision), the
+dispatcher aggregates `systemMessage` returns, individual-hook exceptions
+are swallowed, and the registry must cover every PostToolUse entry in
+`settings.json` at HEAD.
+
+Run:  python3 -m pytest .claude/hooks/tests/test_post_dispatcher.py -v
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+_HERE = Path(__file__).resolve().parent
+_HOOKS_DIR = _HERE.parent
+_REPO_ROOT = _HOOKS_DIR.parent.parent
+
+sys.path.insert(0, str(_HOOKS_DIR))
+
+import post_dispatcher as pd  # noqa: E402
+
+
+def _run_dispatcher(input_data: dict) -> tuple[int, str]:
+    """Run `post_dispatcher.main()` against the given stdin dict.
+
+    Returns (exit_code, stdout_text). `SystemExit` is captured so the test
+    can assert exit code without terminating the test runner.
+    """
+    stdin = io.StringIO(json.dumps(input_data))
+    stdout = io.StringIO()
+    with mock.patch.object(sys, "stdin", stdin), mock.patch.object(sys, "stdout", stdout):
+        try:
+            pd.main()
+        except SystemExit as e:
+            code = int(e.code) if e.code is not None else 0
+            return code, stdout.getvalue()
+    return 0, stdout.getvalue()
+
+
+class RegistryCompletenessTests(unittest.TestCase):
+    """Every PostToolUse entry in settings.json must be in _REGISTRY."""
+
+    def test_settings_post_tool_use_entries_all_registered(self):
+        """If settings.json registered foo.py for matcher M, _REGISTRY[M] must
+        list 'foo' (or the entry must already be `post_dispatcher.py`, the
+        consolidation entry).
+        """
+        settings_path = _REPO_ROOT / ".claude" / "settings.json"
+        with open(settings_path, encoding="utf-8") as f:
+            settings = json.load(f)
+        post = settings.get("hooks", {}).get("PostToolUse", [])
+
+        per_matcher: dict[str, list[str]] = {}
+        for entry in post:
+            matcher = entry.get("matcher", "")
+            for hook in entry.get("hooks", []):
+                cmd = hook.get("command", "")
+                # Extract the module basename from the path
+                last = cmd.rsplit("/", 1)[-1]
+                module = last.replace(".py", "")
+                per_matcher.setdefault(matcher, []).append(module)
+
+        for matcher, registered in per_matcher.items():
+            # Allow either: every entry IS the dispatcher itself, OR every
+            # individual hook is listed in _REGISTRY for that matcher.
+            if all(m == "post_dispatcher" for m in registered):
+                self.assertIn(
+                    matcher,
+                    pd._REGISTRY,
+                    f"settings.json registers post_dispatcher for matcher "
+                    f"{matcher!r} but _REGISTRY has no entry for it",
+                )
+                continue
+            for module in registered:
+                if module == "post_dispatcher":
+                    continue
+                self.assertIn(
+                    module,
+                    pd._REGISTRY.get(matcher, []),
+                    f"settings.json registers {module!r} for matcher "
+                    f"{matcher!r} but _REGISTRY[{matcher!r}] does not include it",
+                )
+
+    def test_registry_modules_all_importable(self):
+        """Every module in _REGISTRY must be importable from .claude/hooks/."""
+        import importlib
+
+        for matcher, modules in pd._REGISTRY.items():
+            for module_name in modules:
+                try:
+                    importlib.import_module(module_name)
+                except ImportError as e:
+                    self.fail(
+                        f"_REGISTRY[{matcher!r}] lists {module_name!r} but it failed to import: {e}"
+                    )
+
+    def test_registry_modules_expose_check(self):
+        """Every module in _REGISTRY must expose a `check(input_data)` function."""
+        import importlib
+
+        for matcher, modules in pd._REGISTRY.items():
+            for module_name in modules:
+                mod = importlib.import_module(module_name)
+                self.assertTrue(
+                    callable(getattr(mod, "check", None)),
+                    f"{module_name} (registered for {matcher}) has no callable check()",
+                )
+
+    def test_edit_write_share_module_list(self):
+        """Edit and Write should reference the same module sequence today."""
+        self.assertEqual(pd._REGISTRY["Edit"], pd._REGISTRY["Write"])
+
+
+class DispatchPerMatcherTests(unittest.TestCase):
+    """For each matcher, verify every registered module's check() is called."""
+
+    def _assert_all_called(self, matcher: str, extra_input: dict | None = None) -> None:
+        input_data = {
+            "tool_name": matcher,
+            "hook_event_name": "PostToolUse",
+            "tool_input": {},
+            "tool_response": {},
+        }
+        if extra_input:
+            input_data.update(extra_input)
+
+        mocks: list[mock.MagicMock] = []
+        modules = pd._REGISTRY[matcher]
+
+        # Patch each module's `check` so we can assert call counts without
+        # exercising real side effects.
+        patches = []
+        for module_name in modules:
+            m = mock.MagicMock(return_value=None)
+            mocks.append(m)
+            patches.append(mock.patch(f"{module_name}.check", m))
+
+        for p in patches:
+            p.start()
+        try:
+            code, _out = _run_dispatcher(input_data)
+        finally:
+            for p in patches:
+                p.stop()
+
+        self.assertEqual(code, 0, f"matcher {matcher!r} should always exit 0")
+        for module_name, m in zip(modules, mocks):
+            self.assertEqual(
+                m.call_count,
+                1,
+                f"check() for {module_name!r} ({matcher!r}) called {m.call_count} times",
+            )
+
+    def test_bash_dispatches_all_bash_modules(self):
+        self._assert_all_called("Bash", {"tool_input": {"command": "echo hi"}})
+
+    def test_edit_dispatches_all_edit_modules(self):
+        self._assert_all_called("Edit", {"tool_input": {"file_path": "/tmp/x.py"}})
+
+    def test_write_dispatches_all_write_modules(self):
+        self._assert_all_called("Write", {"tool_input": {"file_path": "/tmp/x.py"}})
+
+    def test_notebook_edit_dispatches_all_modules(self):
+        self._assert_all_called("NotebookEdit", {"tool_input": {"notebook_path": "/tmp/x.ipynb"}})
+
+    def test_unknown_matcher_dispatches_nothing(self):
+        # No matcher → no module calls, clean exit 0
+        input_data = {
+            "tool_name": "Read",
+            "hook_event_name": "PostToolUse",
+            "tool_input": {"file_path": "/tmp/x.py"},
+            "tool_response": {},
+        }
+        code, out = _run_dispatcher(input_data)
+        self.assertEqual(code, 0)
+        self.assertEqual(out, "")
+
+
+class AggregationTests(unittest.TestCase):
+    """systemMessage returns from N hooks aggregate into one output."""
+
+    def test_two_messages_joined(self):
+        input_data = {
+            "tool_name": "Edit",
+            "hook_event_name": "PostToolUse",
+            "tool_input": {"file_path": "/tmp/x.py"},
+            "tool_response": {},
+        }
+        with (
+            mock.patch("ontology_tracker.check", return_value=None),
+            mock.patch("suggest_generic_prompt.check", return_value={"systemMessage": "MSG_A"}),
+            mock.patch("validate_edit_completion.check", return_value={"systemMessage": "MSG_B"}),
+        ):
+            code, out = _run_dispatcher(input_data)
+
+        self.assertEqual(code, 0)
+        self.assertNotEqual(out, "")
+        parsed = json.loads(out)
+        self.assertIn("MSG_A", parsed["systemMessage"])
+        self.assertIn("MSG_B", parsed["systemMessage"])
+        # Confirm separator
+        self.assertIn("\n\n", parsed["systemMessage"])
+
+    def test_all_none_yields_no_output(self):
+        input_data = {
+            "tool_name": "Edit",
+            "hook_event_name": "PostToolUse",
+            "tool_input": {"file_path": "/tmp/x.py"},
+            "tool_response": {},
+        }
+        with (
+            mock.patch("ontology_tracker.check", return_value=None),
+            mock.patch("suggest_generic_prompt.check", return_value=None),
+            mock.patch("validate_edit_completion.check", return_value=None),
+        ):
+            code, out = _run_dispatcher(input_data)
+        self.assertEqual(code, 0)
+        self.assertEqual(out, "")
+
+    def test_non_systemmessage_returns_ignored(self):
+        # `{"action": "tracked", ...}` style returns don't surface to harness
+        input_data = {
+            "tool_name": "Edit",
+            "hook_event_name": "PostToolUse",
+            "tool_input": {"file_path": "/tmp/x.py"},
+            "tool_response": {},
+        }
+        with (
+            mock.patch("ontology_tracker.check", return_value={"action": "tracked", "path": "x"}),
+            mock.patch("suggest_generic_prompt.check", return_value=None),
+            mock.patch("validate_edit_completion.check", return_value=None),
+        ):
+            code, out = _run_dispatcher(input_data)
+        self.assertEqual(code, 0)
+        self.assertEqual(out, "")
+
+
+class FailOpenTests(unittest.TestCase):
+    """Individual hook exceptions must not propagate."""
+
+    def test_hook_raises_does_not_block_others(self):
+        input_data = {
+            "tool_name": "Edit",
+            "hook_event_name": "PostToolUse",
+            "tool_input": {"file_path": "/tmp/x.py"},
+            "tool_response": {},
+        }
+        sibling = mock.MagicMock(return_value={"systemMessage": "SIBLING_FIRED"})
+        with (
+            mock.patch("ontology_tracker.check", side_effect=RuntimeError("boom")),
+            mock.patch("suggest_generic_prompt.check", sibling),
+            mock.patch("validate_edit_completion.check", return_value=None),
+        ):
+            code, out = _run_dispatcher(input_data)
+        self.assertEqual(code, 0, "exception must not propagate")
+        self.assertEqual(sibling.call_count, 1, "sibling hooks must still run")
+        self.assertIn("SIBLING_FIRED", out)
+
+    def test_malformed_stdin_exits_zero(self):
+        # Not valid JSON → exit 0 quietly
+        stdin = io.StringIO("not json at all")
+        stdout = io.StringIO()
+        with mock.patch.object(sys, "stdin", stdin), mock.patch.object(sys, "stdout", stdout):
+            try:
+                pd.main()
+                code = 0
+            except SystemExit as e:
+                code = int(e.code) if e.code is not None else 0
+        self.assertEqual(code, 0)
+        self.assertEqual(stdout.getvalue(), "")
+
+    def test_missing_check_attr_skipped(self):
+        # If a registered module somehow lacks `check`, the dispatcher skips
+        # it (mirrors PreToolUse dispatcher) rather than crashing.
+        input_data = {
+            "tool_name": "Edit",
+            "hook_event_name": "PostToolUse",
+            "tool_input": {"file_path": "/tmp/x.py"},
+            "tool_response": {},
+        }
+        with (
+            # Replace .check with None to simulate missing attribute (the
+            # dispatcher uses getattr(..., None), so None and absent are
+            # equivalent paths).
+            mock.patch("ontology_tracker.check", new=None),
+            mock.patch("suggest_generic_prompt.check", return_value={"systemMessage": "OK"}),
+            mock.patch("validate_edit_completion.check", return_value=None),
+        ):
+            code, out = _run_dispatcher(input_data)
+        self.assertEqual(code, 0)
+        self.assertIn("OK", out)
+
+
+class BackwardCompatTests(unittest.TestCase):
+    """Hooks that were refactored to expose check() must still work via main().
+
+    These are sanity checks that the in-place refactor preserved the
+    pre-refactor direct-invocation behavior. Detailed per-hook behavior is
+    covered by each hook's own test file.
+    """
+
+    def test_auto_add_issue_to_board_main_handles_non_bash(self):
+        import auto_add_issue_to_board as h
+
+        stdin = io.StringIO(json.dumps({"tool_name": "Read"}))
+        with mock.patch.object(sys, "stdin", stdin):
+            try:
+                h.main()
+                code = 0
+            except SystemExit as e:
+                code = int(e.code) if e.code is not None else 0
+        self.assertEqual(code, 0)
+
+    def test_annunaki_monitor_check_returns_none_on_clean_bash(self):
+        import annunaki_monitor as h
+
+        result = h.check(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "echo ok"},
+                "tool_output": {"stdout": "ok\n", "stderr": "", "exit_code": 0},
+            }
+        )
+        self.assertIsNone(result)
+
+    def test_ontology_tracker_check_skips_non_edit_tool(self):
+        import ontology_tracker as h
+
+        result = h.check({"tool_name": "Read", "tool_input": {"file_path": "/tmp/x.py"}})
+        self.assertIsNone(result)
+
+    def test_suggest_generic_prompt_check_skips_non_claude_paths(self):
+        import suggest_generic_prompt as h
+
+        result = h.check({"tool_name": "Edit", "tool_input": {"file_path": "/tmp/x.py"}})
+        self.assertIsNone(result)
+
+    def test_validate_edit_completion_check_routes_posttooluse_edit(self):
+        # PostToolUse Edit with no error → None (no sentinel side-effect)
+        import validate_edit_completion as h
+
+        result = h.check(
+            {
+                "tool_name": "Edit",
+                "hook_event_name": "PostToolUse",
+                "tool_input": {"file_path": "/tmp/x.py"},
+                "tool_response": {"is_error": False},
+            }
+        )
+        self.assertIsNone(result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/hooks/validate_edit_completion.py
+++ b/.claude/hooks/validate_edit_completion.py
@@ -474,20 +474,35 @@ def _pre_tool_use_blocks(input_data: dict) -> dict | None:
 
 
 def check(input_data: dict) -> dict | None:
-    """Dispatcher-compatible entry point for Bash PreToolUse.
+    """Dispatcher-compatible entry point for Bash and Edit/Write/NotebookEdit.
 
-    The Bash dispatcher (`dispatcher.py`) routes Bash tool calls through each
-    hook's `check(input_data) -> dict | None`. This hook's Bash-side risk
-    surface is `git commit` / `gh pr comment` / `gh issue comment` while the
-    sentinel has unhandled errors — exactly what `_pre_tool_use_blocks`
-    evaluates. Other matchers (Edit / Write / NotebookEdit / SendMessage) are
-    registered DIRECTLY in `settings.json` and bypass this function via
-    `main()` going through the `_pre_tool_use_blocks` / `_post_tool_use`
-    paths based on `hook_event_name`.
+    Both the PreToolUse Bash dispatcher (`dispatcher.py`) and the PostToolUse
+    dispatcher (`post_dispatcher.py`) route tool calls through this function.
 
-    Returns None to allow, or a block dict.
+    Dispatch is `hook_event_name`-aware (with a tool_response-presence
+    fallback for inputs that omit the field):
+
+      - PreToolUse Bash             → `_pre_tool_use_blocks` (may return a block)
+      - PostToolUse Edit/Write/
+        NotebookEdit                → `_post_tool_use` (records sentinel)
+
+    Other matcher/event pairs return None.
+
+    Returns None to allow, or a block dict for PreToolUse Bash. For
+    PostToolUse the return is always None (side-effect only: sentinel append).
     """
-    if input_data.get("tool_name", "") != "Bash":
+    tool_name = input_data.get("tool_name", "")
+    event = input_data.get("hook_event_name", "")
+    if not event:
+        event = "PostToolUse" if "tool_response" in input_data else "PreToolUse"
+
+    if event == "PostToolUse":
+        if tool_name in _EDIT_TOOLS:
+            _post_tool_use(input_data)
+        return None
+
+    # PreToolUse path — only Bash goes through the dispatcher for this hook
+    if tool_name != "Bash":
         return None
     return _pre_tool_use_blocks(input_data)
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -103,28 +103,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/auto_add_issue_to_board.py",
-            "timeout": 20
-          }
-        ]
-      },
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/annunaki_monitor.py",
-            "timeout": 10
-          }
-        ]
-      },
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/post_wave_kickoff_comment.py",
-            "timeout": 60
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/post_dispatcher.py",
+            "timeout": 90
           }
         ]
       },
@@ -133,18 +113,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/ontology_tracker.py",
-            "timeout": 10
-          },
-          {
-            "type": "command",
-            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/suggest_generic_prompt.py",
-            "timeout": 10
-          },
-          {
-            "type": "command",
-            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_edit_completion.py",
-            "timeout": 10
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/post_dispatcher.py",
+            "timeout": 30
           }
         ]
       },
@@ -153,18 +123,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/ontology_tracker.py",
-            "timeout": 10
-          },
-          {
-            "type": "command",
-            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/suggest_generic_prompt.py",
-            "timeout": 10
-          },
-          {
-            "type": "command",
-            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_edit_completion.py",
-            "timeout": 10
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/post_dispatcher.py",
+            "timeout": 30
           }
         ]
       },
@@ -173,8 +133,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_edit_completion.py",
-            "timeout": 10
+            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/post_dispatcher.py",
+            "timeout": 30
           }
         ]
       }


### PR DESCRIPTION
## Summary

- New `.claude/hooks/post_dispatcher.py` mirrors `dispatcher.py` (the PreToolUse Bash dispatcher) for the PostToolUse phase, dispatching by matcher (Bash / Edit / Write / NotebookEdit).
- `.claude/settings.json` `PostToolUse` consolidated: 9 individual hook entries collapsed into 4 matcher-keyed entries pointing at the dispatcher.
- 4 PostToolUse hooks refactored to expose `check(input_data)` (`auto_add_issue_to_board`, `annunaki_monitor`, `ontology_tracker`, `suggest_generic_prompt`); direct-invocation `main()` paths preserved for backward compatibility.
- `validate_edit_completion.check()` extended to handle PostToolUse Edit/Write/NotebookEdit (record-on-error sentinel write) in addition to its existing PreToolUse Bash gate.
- `test_post_dispatcher.py` added — 20 tests covering registry completeness vs `settings.json` HEAD, per-matcher dispatch, advisory aggregation, fail-open on hook exceptions, malformed-stdin handling, and direct-invocation backward-compat.

## Why

Charter § Dispatcher Consolidation Policy (`.claude/team/charter/hooks.md`, line 112): "When hooks sharing the same matcher type accumulate beyond 3, they must be consolidated into a dispatcher immediately." At wave-9 HEAD, PostToolUse Bash had 3 hooks (`auto_add_issue_to_board`, `annunaki_monitor`, `post_wave_kickoff_comment`) — at the threshold — and the Bash matcher was about to add a 4th in flight, triggering #395. Edit and Write each had 3 hooks. Closes both #259 (Bash consolidation) and #395 (pre-filing the dispatcher before the Bash matcher exceeds threshold) with a single artifact.

The PreToolUse Bash dispatcher (`dispatcher.py`, P2W1 PR #73) is the reference implementation cited by the charter section; the new dispatcher mirrors its `check()`-based registry + `importlib.import_module` + fail-open shape. Key difference: PostToolUse hooks cannot block — the tool already ran — so every registered module runs, returns are aggregated into a `systemMessage`, and the exit code is always 0.

## What changed

| File | Change |
|------|--------|
| `.claude/hooks/post_dispatcher.py` | NEW — entry point, per-matcher registry, in-process dispatch, advisory aggregation. Input Language docstring per charter § Hook Authorship Requirements. |
| `.claude/settings.json` | `PostToolUse`: 9 entries → 4 matcher-keyed entries on `post_dispatcher.py`. Bash timeout 90s (was 20+10+60 across 3 entries), Edit/Write/NotebookEdit timeout 30s each. |
| `.claude/hooks/auto_add_issue_to_board.py` | Extract `check()` from `main()`; `main()` now reads stdin → calls `check()` → exit. Added Input Language docstring. |
| `.claude/hooks/annunaki_monitor.py` | Extract `check()` from `main()`; same pattern. Added Input Language docstring. |
| `.claude/hooks/ontology_tracker.py` | Extract `check()` from `main()`; same pattern. Added Input Language docstring. |
| `.claude/hooks/suggest_generic_prompt.py` | Extract `check()` from `main()`; `main()` prints the result dict if non-None to preserve direct-invocation systemMessage emission. Added Input Language docstring. |
| `.claude/hooks/validate_edit_completion.py` | Extend `check()` to dispatch PostToolUse Edit/Write/NotebookEdit → `_post_tool_use`. PreToolUse Bash path unchanged. Docstring updated. |
| `.claude/hooks/tests/test_post_dispatcher.py` | NEW — 20 tests in 5 classes (RegistryCompleteness, DispatchPerMatcher, Aggregation, FailOpen, BackwardCompat). |

## Test plan

- [x] `ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/ -q` — **740 passed, 19 subtests passed** (20 new tests, no regressions)
- [x] `uvx ruff format --check .claude/hooks/` — clean (61 files)
- [x] `uvx ruff check .claude/hooks/` — clean (0 errors)
- [x] Manual smoke test (Edit on a real `.claude/` path) — dispatcher emits `suggest_generic_prompt` systemMessage, exits 0
- [x] Manual smoke test (Bash with clean `echo hi`) — dispatcher exits 0 silently
- [x] Manual smoke test (Edit on `/tmp/` path) — dispatcher exits 0 silently (ontology tracker correctly skips via `SKIP_PREFIXES`)

## Closes

Closes #259.
Closes #395.

## Wave

P3W9 — tech-debt (dispatcher consolidation).

## Charter reference

`.claude/team/charter/hooks.md` § Dispatcher Consolidation Policy (line 112). The charter section already covers this work; no new charter section authored.
