### PR TITLE
tech-debt(ontology): record cross-repo repository_dispatch event-type contracts (closes #163)

### DIFF
--- a/ontology/checksums.json
+++ b/ontology/checksums.json
@@ -477,9 +477,9 @@
     },
     "ontology/repos/deploy.yaml": {
       "last_resolved": "f8ec9084df54486965c759809f0fff10615fc35cdc39c405204bbae327824ad4",
-      "last_tracked": "f8ec9084df54486965c759809f0fff10615fc35cdc39c405204bbae327824ad4",
+      "last_tracked": "10323ac668f0786c67005c401507ccc8d2a6cf59b5a4648fe155ad5810888e61",
       "resolved_at": "2026-04-25T04:26:20.060747+00:00",
-      "tracked_at": "2026-04-25T04:26:20.060747+00:00"
+      "tracked_at": "2026-05-12T22:33:09.401126+00:00"
     },
     "ontology/repos/design-system.yaml": {
       "last_resolved": "64f1eb7a16e3c9284f92d018eed4ce2a0da2aa761f60353c98117f3b2319a1a8",
@@ -495,9 +495,9 @@
     },
     "ontology/repos/isnad-graph.yaml": {
       "last_resolved": "175ebd6c739a9e336fc3d04a8b549ea0ff5cb8a5c58a1982e33ffe5e2a838c14",
-      "last_tracked": "175ebd6c739a9e336fc3d04a8b549ea0ff5cb8a5c58a1982e33ffe5e2a838c14",
+      "last_tracked": "f3e768d33c227f9b51e1cdb80b5d28fb9b0e413a098218bec7029fba406d44a8",
       "resolved_at": "2026-04-11T16:26:02.575946+00:00",
-      "tracked_at": "2026-04-11T16:26:02.575946+00:00"
+      "tracked_at": "2026-05-12T22:33:09.401126+00:00"
     },
     "ontology/repos/isnad-ingest-platform.yaml": {
       "last_resolved": "b8ca5cc2f951054d287dd600c4eab104311e56dd4987bece91bb7e697855e27c",
@@ -507,21 +507,21 @@
     },
     "ontology/repos/landing-page.yaml": {
       "last_resolved": "731a0bc1230da639a9f21eb153a3b63eac3d4934bf2fc8c7481900405199064d",
-      "last_tracked": "731a0bc1230da639a9f21eb153a3b63eac3d4934bf2fc8c7481900405199064d",
+      "last_tracked": "d1f9ff47da7a4781b9e356330690c0736c6800dace7b3d63bddbbf6cd5feeb8e",
       "resolved_at": "2026-05-10T14:39:49.331048+00:00",
-      "tracked_at": "2026-05-10T14:39:49.331048+00:00"
+      "tracked_at": "2026-05-12T22:33:09.401126+00:00"
     },
     "ontology/repos/user-service.yaml": {
-      "last_tracked": "c65db1d071a6995d3781272054b305247b7c00230d39294612ccdb6361df681c",
+      "last_tracked": "49adea4c252834ed1faa08cf0b0e1c1908681f466fea7a3f99080bc3ed0f07b2",
       "last_resolved": "c65db1d071a6995d3781272054b305247b7c00230d39294612ccdb6361df681c",
-      "tracked_at": "2026-04-30T21:45:14.854949+00:00",
+      "tracked_at": "2026-05-12T22:33:09.401126+00:00",
       "resolved_at": "2026-04-30T23:20:21.264004+00:00"
     },
     "ontology/services.yaml": {
       "last_resolved": "ec477dffc7b92ddb367af3f3cee17ff5e84f3962d43a83a2faa58234d8e4b72a",
-      "last_tracked": "ec477dffc7b92ddb367af3f3cee17ff5e84f3962d43a83a2faa58234d8e4b72a",
+      "last_tracked": "13e4ac381c3767fcb076cac6463d1f0796ef2f0c8e46d3f9059b5babe51758c6",
       "resolved_at": "2026-04-25T04:26:20.060747+00:00",
-      "tracked_at": "2026-04-25T04:26:20.060747+00:00"
+      "tracked_at": "2026-05-12T22:33:09.401126+00:00"
     },
     "aino-ig-0194/.claude/settings.json": {
       "last_tracked": "d002e78433abf04bc3cc28f432bd23b9250ce3ca2a3e52290b1fb380f8868011",

--- a/ontology/repos/deploy.yaml
+++ b/ontology/repos/deploy.yaml
@@ -83,8 +83,9 @@ docker_services:
     kafka-ui: { image: "provectuslabs/kafka-ui:v0.7.2", port: "127.0.0.1:8085", auth: basic, readonly: true }
 
 workflows:
-  deploy_isnad_graph: { trigger: repository_dispatch, target: [api, frontend], health_check: 120s }
-  deploy_landing: { trigger: workflow_dispatch, target: [landing], health_check: 60s }
+  deploy_isnad_graph: { trigger: workflow_dispatch, target: [api, frontend], health_check: 120s, note: "Legacy single-VPS path. Was repository_dispatch listener pre-W10; now workflow_dispatch-only (manual rollback). Decom tracked in deploy#86." }
+  deploy_landing: { trigger: workflow_dispatch, target: [landing], health_check: 60s, note: "Legacy single-VPS path. Manual-only rollback to legacy VPS; decom tracked in deploy#86." }
+  deploy_stg: { trigger: "repository_dispatch + workflow_dispatch", target: "stg fan-in for isnad-graph + user-service + landing-page", note: "Active listener — see dispatch_contracts_received below." }
   deploy_all: { trigger: workflow_dispatch, target: all, health_check: 120s }
   verify_deploy: { trigger: workflow_run, checks: [HTTPS, health, TLS] }
   terraform:
@@ -120,6 +121,21 @@ workflows:
     status: merged
     description: "Smoke test asserting Contract v6 invariants — exactly 4 publish-side tags (sha-<short>, latest, stg-<short>, stg-latest) + exactly 2 promote-side tags (prod-<short>, prod-latest) per image."
     invariant_script: integration-tests/scripts/check_tag_invariants.py
+
+dispatch_contracts_received:
+  # Cross-link: services.yaml § cross_repo_dispatch_contracts. The literal event_type
+  # strings ARE the contract — sender/listener mismatch returns 204 silently (#162).
+  # Active listener is deploy-stg.yml; deploy-isnad-graph.yml + deploy-landing-page.yml
+  # are workflow_dispatch-only (legacy single-VPS rollback path).
+  - listener_workflow: .github/workflows/deploy-stg.yml
+    types: [deploy-noorinalabs-isnad-graph, deploy-noorinalabs-user-service, deploy-noorinalabs-landing-page]
+    senders:
+      - { name: deploy-isnad-graph, event_type: deploy-noorinalabs-isnad-graph, sender_repo: noorinalabs-isnad-graph, sender_workflow: .github/workflows/ghcr-publish.yml, sender_job: notify-deploy }
+      - { name: deploy-user-service, event_type: deploy-noorinalabs-user-service, sender_repo: noorinalabs-user-service, sender_workflow: .github/workflows/ghcr-publish.yml, sender_job: notify-deploy }
+      - { name: deploy-landing-page, event_type: deploy-noorinalabs-landing-page, sender_repo: NO_SENDER, note: "Asymmetric — listener accepts but no sender wires. Tracked in deploy#285. See services.yaml § cross_repo_dispatch_contracts[name=deploy-landing-page]." }
+    discrimination: "Listener jobs gate on `github.event.action` to identify the source service (e.g., the alembic-stg job runs only when action == 'deploy-noorinalabs-user-service')."
+    notes:
+      - "#162 origin: literal event-type drifted across the repo rename in isnad-graph#548ba9f; the contract is now recorded in services.yaml so a future rename has a single source-of-truth to grep for."
 
 environments:
   staging:

--- a/ontology/repos/isnad-graph.yaml
+++ b/ontology/repos/isnad-graph.yaml
@@ -88,3 +88,23 @@ build_commands:
     test: "npm run test"
     lint: "npm run lint"
     e2e: "npm run test:e2e"
+
+ci:
+  ghcr_publish:
+    workflow: .github/workflows/ghcr-publish.yml
+    notify_deploy:
+      job: notify-deploy
+      action: peter-evans/repository-dispatch@v3
+      gates: ["github.event_name == 'push'", "github.ref == 'refs/heads/main'", "needs: build-and-push success"]
+      description: "Fires repository_dispatch to noorinalabs-deploy after both api+frontend images are published. Replaces the legacy standalone notify-deploy.yml which fired before publish (race condition)."
+
+dispatch_contracts_sent:
+  # Cross-link: services.yaml § cross_repo_dispatch_contracts[name=deploy-isnad-graph]
+  - name: deploy-isnad-graph
+    event_type: deploy-noorinalabs-isnad-graph
+    sender_workflow: .github/workflows/ghcr-publish.yml
+    sender_job: notify-deploy
+    target: noorinalabs/noorinalabs-deploy → .github/workflows/deploy-stg.yml
+    payload_keys: [repo, sha, ref, actor]
+    notes:
+      - "#162: literal event-type drifted (deploy-isnad-graph → deploy-noorinalabs-isnad-graph) at repo rename 548ba9f; sender wasn't updated until #162. This contract is now recorded in services.yaml as the source-of-truth pairing."

--- a/ontology/repos/landing-page.yaml
+++ b/ontology/repos/landing-page.yaml
@@ -84,6 +84,15 @@ ci:
     workflows_touched: [.github/workflows/deploy.yml, .github/workflows/ci.yml]
     description: "Bump GitHub Actions to Node 20-compatible majors per parent#309 audit (actions/checkout@v6, etc)."
 
+dispatch_contracts_sent:
+  # Cross-link: services.yaml § cross_repo_dispatch_contracts[name=deploy-landing-page]
+  # ASYMMETRIC — listener accepts the event-type but no sender wires it.
+  - name: deploy-landing-page
+    event_type: deploy-noorinalabs-landing-page
+    status: NO_SENDER
+    listener: "noorinalabs-deploy/.github/workflows/deploy-stg.yml (types: [..., deploy-noorinalabs-landing-page])"
+    rationale: "Landing-page intentionally omits a notify-deploy job per Contract v6 (#71, Kofi). Production rollout flows through deploy/promote.yml registry retag, not push-time dispatch. The deploy-stg.yml listener still declares the event-type — either landing-page grows a sender, or the listener drops the type. Tracked in deploy#285."
+
 local_hooks:
   pattern: "dispatcher-style — local settings.json delegates to parent canonical hooks"
   settings_align_pr: "landing-page#90 (P3W8)"

--- a/ontology/repos/user-service.yaml
+++ b/ontology/repos/user-service.yaml
@@ -104,3 +104,17 @@ ci:
     pr_trigger: "On PR (paths: workflow / Dockerfile / src/**), build single-arch amd64 + load locally + Trivy scan by sha-<short> tag. No registry login on PR. Push events build multi-arch + push."
     trivy_security: "Idris CR Q2 — Resolve-Trivy-image-reference and Summary steps bind GHA expressions (github.event_name, steps.meta.outputs.tags, etc.) to env vars to close shell script-injection sink. Both PR and push paths block on CRITICAL/HIGH (exit-code: 1, ignore-unfixed: true)."
     notify_deploy: "Fires repository_dispatch event-type=deploy-noorinalabs-user-service to noorinalabs-deploy with payload {repo,sha,ref,actor}. Requires DEPLOY_REPO_PAT secret (NOT yet provisioned — tracked in user-service#84, P3 carry-forward)."
+
+dispatch_contracts_sent:
+  # Cross-link: services.yaml § cross_repo_dispatch_contracts[name=deploy-user-service]
+  - name: deploy-user-service
+    event_type: deploy-noorinalabs-user-service
+    sender_workflow: .github/workflows/ghcr-publish.yml
+    sender_job: notify-deploy
+    sender_action: peter-evans/repository-dispatch@v3
+    target: noorinalabs/noorinalabs-deploy → .github/workflows/deploy-stg.yml
+    payload_keys: [repo, sha, ref, actor]
+    gates: ["github.event_name == 'push'", "github.ref == 'refs/heads/main'", "needs: build-and-push success"]
+    notes:
+      - "DEPLOY_REPO_PAT secret pending (user-service#84). Until provisioned, this dispatch fails at runtime and deploy-stg.yml workflow_dispatch is the operator fallback."
+      - "Listener (deploy-stg.yml) uses `github.event.action == 'deploy-noorinalabs-user-service'` to gate the user-service-only alembic pre-deploy step. Renaming this event_type without updating that conditional would silently skip the alembic gate."

--- a/ontology/services.yaml
+++ b/ontology/services.yaml
@@ -203,6 +203,65 @@ data_stores:
     consumers: [user-service]
     purpose: [session_state, rate_limiting, verification_tracking]
 
+# --- Cross-repo repository_dispatch contracts ---
+# Each entry pairs a sender workflow (`peter-evans/repository-dispatch` step) with the
+# listener workflow whose `on.repository_dispatch.types` accepts the literal `event_type`
+# string. The literal string is the contract — GitHub returns 204 to unmatched dispatches,
+# so a sender/listener mismatch fails silently until a deploy is missed (#162 lesson).
+# Resolution: every contract here MUST be validated against both workflow files at HEAD —
+# any mismatch is a bug surface, file separately (this section documents, doesn't fix).
+cross_repo_dispatch_contracts:
+  - name: deploy-isnad-graph
+    event_type: deploy-noorinalabs-isnad-graph
+    sender:
+      repo: noorinalabs-isnad-graph
+      workflow: .github/workflows/ghcr-publish.yml
+      job: notify-deploy
+      action: peter-evans/repository-dispatch@v3
+      target_repo: noorinalabs/noorinalabs-deploy
+      auth: DEPLOY_REPO_PAT secret
+      client_payload: { repo: noorinalabs-isnad-graph, sha: github.sha, ref: github.ref_name, actor: github.actor }
+    listener:
+      repo: noorinalabs-deploy
+      workflow: .github/workflows/deploy-stg.yml
+      types: [deploy-noorinalabs-isnad-graph, deploy-noorinalabs-user-service, deploy-noorinalabs-landing-page]
+    gates: ["github.event_name == 'push'", "github.ref == 'refs/heads/main'", "needs: build-and-push success"]
+    notes:
+      - "Originally listened on deploy/.github/workflows/deploy-isnad-graph.yml (legacy single-VPS) — that workflow is now workflow_dispatch-only (manual rollback path, decom tracked in deploy#86). Active stg fan-in is deploy-stg.yml."
+      - "Rename from deploy-isnad-graph → deploy-noorinalabs-isnad-graph happened in isnad-graph#548ba9f; #162 fixed the sender mismatch and authored this ontology record."
+
+  - name: deploy-user-service
+    event_type: deploy-noorinalabs-user-service
+    sender:
+      repo: noorinalabs-user-service
+      workflow: .github/workflows/ghcr-publish.yml
+      job: notify-deploy
+      action: peter-evans/repository-dispatch@v3
+      target_repo: noorinalabs/noorinalabs-deploy
+      auth: DEPLOY_REPO_PAT secret
+      client_payload: { repo: noorinalabs-user-service, sha: github.sha, ref: github.ref_name, actor: github.actor }
+    listener:
+      repo: noorinalabs-deploy
+      workflow: .github/workflows/deploy-stg.yml
+      types: [deploy-noorinalabs-isnad-graph, deploy-noorinalabs-user-service, deploy-noorinalabs-landing-page]
+    gates: ["github.event_name == 'push'", "github.ref == 'refs/heads/main'", "needs: build-and-push success"]
+    notes:
+      - "DEPLOY_REPO_PAT secret not yet provisioned in user-service — tracked in user-service#84 (P3 carry-forward). Until provisioned, the dispatch step fails at runtime; deploy-stg.yml workflow_dispatch is the operator fallback."
+      - "Listener path discriminates `github.event.action == 'deploy-noorinalabs-user-service'` to run the user-service-only alembic pre-deploy gate (deploy-stg.yml § alembic-stg)."
+
+  - name: deploy-landing-page
+    event_type: deploy-noorinalabs-landing-page
+    sender:
+      status: NO_SENDER
+      note: "No workflow in noorinalabs-landing-page dispatches this event-type. Landing-page#71 (Contract v6) intentionally omits a notify-deploy job — landing-page deploy flows through deploy/promote.yml registry retag, not push-time dispatch (per landing-page RUNBOOK.md § 4 and ontology/repos/landing-page.yaml § ci.deploy_workflow). Listener accepts the event-type but no sender wires it."
+    listener:
+      repo: noorinalabs-deploy
+      workflow: .github/workflows/deploy-stg.yml
+      types: [deploy-noorinalabs-isnad-graph, deploy-noorinalabs-user-service, deploy-noorinalabs-landing-page]
+    gates: ["n/a — no active sender"]
+    notes:
+      - "Asymmetric contract: listener-only. Either landing-page should grow a notify-deploy job mirroring isnad-graph/user-service, OR the deploy-stg.yml listener should drop the deploy-noorinalabs-landing-page type. Tracked in deploy#285."
+
 # --- Integration points ---
 integrations:
   - name: jwt_validation


### PR DESCRIPTION
## Summary

Records the literal `event-type` strings for all cross-repo `repository_dispatch` chains in the ontology, so a future rename has one source-of-truth to grep instead of failing silently like #162 did.

## Why

#162 was a silently-broken cross-repo deploy chain. `isnad-graph/.github/workflows/ghcr-publish.yml` was dispatching `event-type: deploy-isnad-graph` while the listener had been renamed to expect `deploy-noorinalabs-isnad-graph` (after the repo rename in isnad-graph#548ba9f). GitHub returns 204 to dispatches with no matching listener — so the failure was invisible until a deploy was missed. Jelani Mwangi (PR #837 review) flagged that neither `services.yaml` nor `repos/deploy.yaml` recorded the literal event-type string, only the trigger pattern. That gap is what let the rename slip through.

This PR closes that documentation gap.

## What chains documented

Three contracts enumerated org-wide:

| Contract | Sender | Listener | Status |
|---|---|---|---|
| `deploy-isnad-graph` | `noorinalabs-isnad-graph/.github/workflows/ghcr-publish.yml` job `notify-deploy` | `noorinalabs-deploy/.github/workflows/deploy-stg.yml` | OK — verified at HEAD |
| `deploy-user-service` | `noorinalabs-user-service/.github/workflows/ghcr-publish.yml` job `notify-deploy` | `noorinalabs-deploy/.github/workflows/deploy-stg.yml` | OK — verified at HEAD (DEPLOY_REPO_PAT pending per user-service#84) |
| `deploy-landing-page` | **NO_SENDER** | `noorinalabs-deploy/.github/workflows/deploy-stg.yml` | Asymmetric — filed deploy#285 |

### Why deploy-stg.yml, not deploy-isnad-graph.yml?

The issue body cites `deploy-isnad-graph.yml` as the listener (from the pre-W10 single-VPS topology). Verified at wave-9 HEAD: `deploy-isnad-graph.yml` is now `workflow_dispatch`-only (legacy single-VPS rollback path, decom tracked in deploy#86). The active stg-fan-in `repository_dispatch` listener is `deploy-stg.yml`, which accepts all three event-types and discriminates via `github.event.action`. Ontology now reflects reality, not the pre-W10 topology.

### Asymmetric contract — deploy#285

`deploy-stg.yml`'s `types:` list accepts `deploy-noorinalabs-landing-page` but **no workflow in `noorinalabs-landing-page` dispatches it**. Landing-page intentionally omits a `notify-deploy` job per Contract v6 (landing-page#71) — production rollout flows through `deploy/promote.yml` registry retag, not push-time dispatch (RUNBOOK § 4, in-line comment in `deploy.yml`). The listener still declares the type. Filed [deploy#285](https://github.com/noorinalabs/noorinalabs-deploy/issues/285) for the owner to decide:
- **Option A:** grow a `notify-deploy` job in landing-page (uniform stg fan-in)
- **Option B:** drop the type from `deploy-stg.yml` (consistent with reality)

This PR documents the asymmetry; deploy#285 fixes it.

## Files touched

- `ontology/services.yaml` — new `cross_repo_dispatch_contracts:` section (3 entries)
- `ontology/repos/isnad-graph.yaml` — new `ci:` + `dispatch_contracts_sent:` blocks
- `ontology/repos/user-service.yaml` — new `dispatch_contracts_sent:` block under existing `ci.ghcr_publish`
- `ontology/repos/landing-page.yaml` — `dispatch_contracts_sent:` documenting `NO_SENDER` status
- `ontology/repos/deploy.yaml` — new `dispatch_contracts_received:` + clarification in `workflows.deploy_isnad_graph` / `deploy_landing` (legacy workflow_dispatch-only) + new `deploy_stg` entry
- `ontology/checksums.json` — `last_tracked` advanced for 5 touched ontology files

## Validation

Every contract's `event_type` string was programmatically verified against the actual workflow YAML at HEAD:

- **Listener-side:** fetched `deploy-stg.yml` at `deployments/phase-3/wave-9` via `gh api contents` (memory: `feedback_origin_over_local_for_still_has_claims.md`). Parsed `on.repository_dispatch.types`. All 3 literal `event_type` strings appear in the listener's `types:` list.
- **Sender-side:** fetched `ghcr-publish.yml` from both isnad-graph and user-service at `main` HEAD. Confirmed literal `event-type: deploy-noorinalabs-<service>` line in each sender. Landing-page has no sender — confirmed by exhaustive `gh search code "peter-evans/repository-dispatch" --owner noorinalabs` (memory: `feedback_verify_third_party_integrity_claims.md`).

Validation result: **3/3 contracts match HEAD reality.** One asymmetric surface (deploy-landing-page sender absent) filed as deploy#285.

YAML parses for all 5 touched files validated with `python3 -c 'import yaml; yaml.safe_load(open(F))'`.

## Closes

Closes #163.

## Wave

P3W9 — pure tech-debt reduction (label `p3-wave-9`).

## Test plan

- [x] YAML parses for all 5 ontology files
- [x] Listener-side validation: all 3 event_type strings present in deploy-stg.yml's `types:` at wave-9 HEAD
- [x] Sender-side validation: 2 sender event-type literals present at sender workflows' main HEAD
- [x] Asymmetric contract (landing-page) filed as deploy#285 with project board add
- [x] No backward-incompatible ontology shape changes — new sections only
