### PR TITLE
tech-debt(wave-wrapup): mirror retro PR body-vs-diff sanity check from /wave-retro Step 6.5 (closes #414)

### DIFF
--- a/.claude/skills/wave-wrapup/SKILL.md
+++ b/.claude/skills/wave-wrapup/SKILL.md
@@ -174,6 +174,40 @@ Flag any changes to:
 - Architecture (update diagrams)
 - Charter or process files (note for retro)
 
+### 9.5. Retro PR body-vs-diff sanity check (added P3W9 #414 — 2026-05-13)
+
+Per `charter/pull-requests.md § Retro PR Body-vs-Diff Discipline` (Skill enforcement clause): if a retro PR for this wave is already open, every charter/skill/trust-matrix file claimed in its PR body MUST appear in the PR's diff. Direct-to-main commits for ratified retro outputs are forbidden — they bypass the two-reviewer gate and `validate_pr_ci_status`, and break the audit trail.
+
+Run this check before emitting the Step 10 wrapup table so any mismatch surfaces in the table itself:
+
+```bash
+# Discover the open retro PR for this wave (if any).
+# Retro PRs are conventionally titled `retro(P{P}W{M}…)`.
+RETRO_PR=$(gh pr list --repo noorinalabs/noorinalabs-main --state open \
+  --search 'retro( in:title' \
+  --json number,title \
+  --jq ".[] | select(.title | test(\"retro\\\\(P{P}W{M}\")) | .number" | head -1)
+
+if [ -z "$RETRO_PR" ]; then
+  echo "No open retro PR for P{P}W{M} — skipping body-vs-diff check."
+else
+  gh pr view "$RETRO_PR" --repo noorinalabs/noorinalabs-main --json files --jq '[.files[].path] | sort' > /tmp/retro_${RETRO_PR}_diff.json
+  gh pr view "$RETRO_PR" --repo noorinalabs/noorinalabs-main --json body --jq '.body' > /tmp/retro_${RETRO_PR}_body.md
+
+  # Manually inspect /tmp/retro_${RETRO_PR}_body.md's "Files changed" section and
+  # compare each claimed path against /tmp/retro_${RETRO_PR}_diff.json. For each
+  # path claimed in the body but missing from the diff JSON, ABORT with a clear
+  # "body claims X not in diff" error and surface the mismatch in the Step 10
+  # wrapup table. Do NOT proceed to Step 10 until the retro author either
+  # commits the missing file to the retro branch (preferred) or amends the body
+  # to remove the unsupported claim.
+fi
+```
+
+Worked example of the failure mode this catches: PR [#124](https://github.com/noorinalabs/noorinalabs-main/pull/124) (W8 retro) body claimed 7 files, diff contained 2 (`feedback_log.md` + `ontology/checksums.json`); the other 5 (`trust_matrix.md`, `charter/pull-requests.md`, `charter/hooks.md`, `skills/wave-retro/SKILL.md`, `skills/wave-kickoff/SKILL.md`) were committed direct-to-main as `2b92605` + `ecd1c76`, bypassing review and CI. The check above would have flagged all 5 missing paths and blocked Step 10 emission until the retro PR was fixed. Filed as [#126](https://github.com/noorinalabs/noorinalabs-main/issues/126); skill-side mirror filed as [#414](https://github.com/noorinalabs/noorinalabs-main/issues/414).
+
+This step mirrors `/wave-retro` Step 6.5 by design — the same check fires from both skills so a body-vs-diff mismatch is caught whether the operator runs `/wave-retro` first (post-author check before requesting reviewers) or `/wave-wrapup` after the retro PR is open (pre-wrapup-table check). The two skills converge on the authoritative shape in `charter/pull-requests.md § Retro PR Body-vs-Diff Discipline`.
+
 ### 10. Final wave report
 
 ```


### PR DESCRIPTION
## Summary

- Adds Step 9.5 "Retro PR body-vs-diff sanity check" to `.claude/skills/wave-wrapup/SKILL.md`, placed immediately before Step 10 "Final wave report" per the charter clause's "before emitting…the wrapup table" wording.
- Mirrors `/wave-retro` Step 6.5 (added in PR #412) — both skills converge on the authoritative shape in `charter/pull-requests.md § Retro PR Body-vs-Diff Discipline`.
- Discovers the open retro PR via `gh pr list --search 'retro( in:title'` filtered by `P{P}W{M}` title pattern; tolerant when no retro PR is open yet.

## Why

PR #412 codified `charter/pull-requests.md § Retro PR Body-vs-Diff Discipline` and the charter's "Skill enforcement" clause names BOTH `/wave-retro` AND `/wave-wrapup` as adopters. PR #412 only updated `/wave-retro`. That charter-discoverable gap is what #414 tracks: future agents reading the charter will see two adopters named, then find one of them unimplemented. This PR closes the coherence gap by adding the mirrored step to `/wave-wrapup`.

The two-skill mirror has practical value beyond charter coherence:
- `/wave-retro` runs the check at retro-author time, before requesting reviewers.
- `/wave-wrapup` runs the check at wrapup time, when the retro PR may already have been opened (by `/wave-retro`) and accumulated body-edits or commits. Catching a divergence at wrapup time prevents the wrapup table from being emitted against a stale body-vs-diff snapshot.

## What changed in `/wave-wrapup`

Inserted Step 9.5 between Step 9 "Update documentation" and Step 10 "Final wave report":

- Discovers the open retro PR for the current wave via `gh pr list --repo noorinalabs/noorinalabs-main --state open --search 'retro( in:title' --json number,title --jq '.[] | select(.title | test("retro\\(P{P}W{M}")) | .number'`.
- Tolerant when no retro PR exists yet — emits `No open retro PR for P{P}W{M} — skipping body-vs-diff check.` and proceeds to Step 10.
- When a retro PR is open: fetches `[.files[].path] | sort` (note: `gh pr view --json files` emits `path`, distinct from `gh api .../pulls/N/files` which emits `filename`) and the body, then instructs the operator to manually compare each path claimed in the body's "Files changed" section against the diff JSON.
- On mismatch: ABORT Step 10 emission, surface the mismatch in the wrapup table, do NOT proceed until the retro author either commits the missing file to the retro branch (preferred) or amends the body to remove the unsupported claim.
- Cross-references `charter/pull-requests.md § Retro PR Body-vs-Diff Discipline` as the authoritative shape, and `/wave-retro` Step 6.5 as the sibling adopter.

## Test plan

- [x] Dry-run discovery against PR #124 (the worked-example violator from W8 retro):

  ```bash
  $ gh pr view 124 --repo noorinalabs/noorinalabs-main --json files --jq '[.files[].path] | sort'
  [".claude/team/feedback_log.md","ontology/checksums.json"]
  ```

  Charter worked-example enumerates 7 files claimed in PR #124's body (`feedback_log.md`, `trust_matrix.md`, `charter/pull-requests.md`, `charter/hooks.md`, `skills/wave-retro/SKILL.md`, `skills/wave-kickoff/SKILL.md`, `ontology/checksums.json`). Diff fetch returns 2. Manual comparison would flag **5 missing claimed files** (`trust_matrix.md`, `charter/pull-requests.md`, `charter/hooks.md`, `skills/wave-retro/SKILL.md`, `skills/wave-kickoff/SKILL.md`), matching the charter's worked-example exactly. The check would have blocked Step 10 wrapup-table emission until PR #124's diff was fixed.

- [x] Dry-run discovery shape against a real recent retro (P3W6 #297):

  ```bash
  $ gh pr list --repo noorinalabs/noorinalabs-main --state all --search 'retro( in:title' --json number,title --jq '.[] | select(.title | test("retro\\(P3W6")) | .number'
  297
  ```

  Discovery returns the expected PR number.

- [x] Tolerant-when-absent shape — discovery returns empty when no retro PR for the wave exists; step prints skip-message and proceeds. (Inspection of the inserted bash block confirms `[ -z "$RETRO_PR" ]` branch.)

- [x] `ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/ -q` → 740 passed, 19 subtests passed (no python changes; sanity-check only).

- [x] `uvx ruff format --check .claude/skills/` — pre-existing format drift on `wave-kickoff/_orchestration/w4-kickoff.py` is unrelated (untouched by this PR; `git diff --stat HEAD` shows only `.claude/skills/wave-wrapup/SKILL.md` modified). SKILL.md is markdown, not Python, so ruff format does not apply to it.

- [x] `uvx ruff check .claude/skills/` — all checks passed.

## Closes

Closes #414.

## Wave

P3W9 — tech-debt (skill mirror to close charter-coherence gap from PR #412).

## Charter reference

`.claude/team/charter/pull-requests.md § Retro PR Body-vs-Diff Discipline § Skill enforcement` (line 568–579 at PR #412 HEAD). This PR is the `/wave-wrapup` half of the two-adopter clause.
