### PR TITLE
process(P3W10): apply 4 owner-approved W9-retro changes — phase plan + 3 charter promotions (#421)

### DIFF
--- a/.claude/skills/wave-wrapup/SKILL.md
+++ b/.claude/skills/wave-wrapup/SKILL.md
@@ -237,15 +237,44 @@ Write the **top-level** canonical counter keys that `/wave-retro` Step 2.5 verif
 
 Use the shared `upsert_status_keys.py` helper at `.claude/lib/` — it does targeted text-level upsert that preserves the compact-inline shape of `cross-repo-status.json` (a naive `jq … > tmp && mv` reformats every compact line to pretty form, producing a 500-line cosmetic diff per wave — see `main#332`). The helper also validates JSON before AND after the rewrite. Promoted from `/wave-scope` to `.claude/lib/` per `main#292` (multi-consumer → shared lib).
 
+> **Mechanical computation (added P3W10 #421 — 2026-05-13).** Pre-#421 the
+> `CHANGES_REQUESTED_CYCLES` and `TOP_CONCENTRATION_PCT` placeholders here
+> were filled in by hand by the orchestrator; the resulting null/wrong
+> values had to be recomputed at retro for 3 consecutive waves (W4 80%,
+> W5 6→4, W9 null+null). The mechanical computation below eliminates the
+> recompute pattern by deriving both counters directly from the merged-PR
+> set across `wave_{M}_repos_in_scope`. `FINAL_PR_COUNT` remains the
+> already-computed Step 10 "PRs: Merged" number.
+
 ```bash
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 STATUS="$REPO_ROOT/cross-repo-status.json"
 UPSERT="$REPO_ROOT/.claude/lib/upsert_status_keys.py"
 
-# Compute the three canonical counters from the wave-wrapup report numbers.
-FINAL_PR_COUNT={count_of_merged_PRs}            # same as Step 10 "PRs: Merged"
-CHANGES_REQUESTED_CYCLES={cr_cycle_count}       # count of `ChangesRequested` verdict comments across the wave's PRs
-TOP_CONCENTRATION_PCT={highest_repo_pct}        # PRs-in-top-repo / PRs-total * 100, rounded int
+# FINAL_PR_COUNT is the Step 10 "PRs: Merged" number — already in hand.
+FINAL_PR_COUNT={count_of_merged_PRs}
+
+# Build the wave's merged-PR set across all repos in scope.
+PRS_JSON=$(jq -r '.["wave_{M}_repos_in_scope"][]' "$STATUS" | while read -r REPO; do
+  gh pr list --repo "noorinalabs/$REPO" --state merged \
+    --base "deployments/phase-{P}/wave-{M}" \
+    --json number,headRefOid --jq ".[] | . + {repo: \"$REPO\"}"
+done | jq -s .)
+
+# CHANGES_REQUESTED_CYCLES — count `RequestOrReplied: ChangesRequested` verdict
+# comments across every wave PR's issue-comments timeline.
+CHANGES_REQUESTED_CYCLES=$(echo "$PRS_JSON" | jq -r '.[] | "\(.repo) \(.number)"' | while read -r R N; do
+  gh api "repos/noorinalabs/$R/issues/$N/comments" \
+    --jq '[.[] | select(.body | test("RequestOrReplied:\\s*ChangesRequested"))] | length'
+done | awk '{s+=$1} END {print s+0}')
+
+# TOP_CONCENTRATION_PCT — derived from commit-identity concentration on each
+# PR's head: count PRs per commit-author name, take the top author's PR count
+# as a percentage of total. awk `%d` truncates toward zero (4/6 = 66.67 → 66).
+TOP_CONCENTRATION_PCT=$(echo "$PRS_JSON" | jq -r '.[] | "\(.repo) \(.headRefOid)"' | while read -r R SHA; do
+  gh api "repos/noorinalabs/$R/commits/$SHA" --jq '.commit.author.name'
+done | sort | uniq -c | sort -rn | awk -v total="$(echo "$PRS_JSON" | jq 'length')" \
+  'NR==1 {printf "%d\n", $1 * 100 / total}')
 
 # Each value MUST be a self-contained JSON literal (integer here — no quotes).
 python3 "$UPSERT" "$STATUS" \

--- a/.claude/skills/wave-wrapup/SKILL.md
+++ b/.claude/skills/wave-wrapup/SKILL.md
@@ -270,11 +270,13 @@ done | awk '{s+=$1} END {print s+0}')
 
 # TOP_CONCENTRATION_PCT — derived from commit-identity concentration on each
 # PR's head: count PRs per commit-author name, take the top author's PR count
-# as a percentage of total. awk `%d` truncates toward zero (4/6 = 66.67 → 66).
+# as a percentage of total. Half-up rounding via awk `printf "%d\n", x + 0.5`
+# (4/6 = 66.67 → 67) so the counter matches the human-recorded W9 history row
+# (Wanjiku TPM-vote 2026-05-13).
 TOP_CONCENTRATION_PCT=$(echo "$PRS_JSON" | jq -r '.[] | "\(.repo) \(.headRefOid)"' | while read -r R SHA; do
   gh api "repos/noorinalabs/$R/commits/$SHA" --jq '.commit.author.name'
 done | sort | uniq -c | sort -rn | awk -v total="$(echo "$PRS_JSON" | jq 'length')" \
-  'NR==1 {printf "%d\n", $1 * 100 / total}')
+  'NR==1 {printf "%d\n", $1 * 100 / total + 0.5}')
 
 # Each value MUST be a self-contained JSON literal (integer here — no quotes).
 python3 "$UPSERT" "$STATUS" \

--- a/.claude/team/charter/agents.md
+++ b/.claude/team/charter/agents.md
@@ -306,6 +306,49 @@ Every reviewer-class spawn prompt MUST include, **in order**:
 3. **Throughline-watch block** (per § Reviewer spawn brief — throughline-watch above) — copy-paste the verbatim template block. Default, not per-wave addition (#320).
 4. **`Requestor: <reviewer name>` / `Requestee: <PR author name>` / `RequestOrReplied: Approved | ChangesRequested` / `TechDebt:` format** — explicit reminder using the canonical Direction-table form (per `pull-requests.md` § Comment-Based Reviews, post-#372 / PR #375 fix). The brief should embed the verbatim "Use `gh pr comment <PR#> --body '...'` with this format:" template block to prevent W9 PR#349-style cascades from re-emerging (per memory `feedback_spawn_brief_requestor_field_semantics`).
    - TechDebt MUST be in the SAME comment as the verdict — edit-appending after the fact gets the verdict-comment dropped from hook counting (per memory `feedback_verdict_amendment_edit_not_append`).
+
+<!-- Promoted from memory: feedback_techdebt_attestation_literal_line.md (P3W9 retro 2026-05-12, owner-approved 2026-05-13) -->
+
+   **Verbatim verdict-comment template (copy-paste into reviewer spawn briefs):**
+
+   ```bash
+   # Use `gh pr comment <PR#> --body "..."` — NOT `gh pr review` (block_gh_pr_review enforces).
+   # Write the body to a /tmp file FIRST, then comment in the very next tool call
+   # (block_stale_tmp_message_file enforces 30s freshness):
+
+   cat > /tmp/<PR#>-review-<reviewer-firstname>.md <<'BODYEOF'
+   **Requestor:** <reviewer-firstname> <reviewer-lastname>
+   **Requestee:** <PR-author-firstname> <PR-author-lastname>
+   **RequestOrReplied:** Approved
+   **TechDebt:** none
+
+   <verdict body — prose, line comments, throughline observations…>
+
+   ## Throughline observations
+
+   <per § Reviewer spawn brief — throughline-watch>
+   BODYEOF
+
+   gh pr comment <PR#> --body-file /tmp/<PR#>-review-<reviewer-firstname>.md
+   ```
+
+   **Required literal forms (hook-enforced):**
+   - The line MUST literally start with `TechDebt:` (optional `**` bold wrapping OK). `## TechDebt` section headers + prose do NOT satisfy the regex.
+   - Valid values:
+     - `TechDebt: none`
+     - `TechDebt: none — addressed inline by fixup commit <sha>`
+     - `TechDebt: #15, #16` (when issues were filed pre-verdict)
+   - `RequestOrReplied: Approved` (NOT `Reply` — `validate_pr_review` counts Approved-only).
+
+   For a ChangesRequested verdict, swap to:
+   ```
+   **RequestOrReplied:** ChangesRequested
+   **TechDebt:** none
+   ```
+   (TechDebt still required even on ChangesRequested — the regex is unconditional.)
+
+   **Why literal:** P3W9 PR #409 cascade — both reviewers followed the prior prose template that prescribed `## TechDebt\n\n…` section header; `gh pr merge` blocked with `BLOCKED: PR #409 has review(s) missing the mandatory TechDebt: attestation line` at merge time, requiring per-comment PATCH amendments. Sibling pattern to P3W8 Approved-vs-Reply cascade — both fixable by spawning-brief template fixed-literal rewrite.
+
 5. **`gh pr review` vs `gh pr comment` discipline** — explicit reminder NOT to use `gh pr review` (`block_gh_pr_review` enforces; spawn-brief mention prevents the trip).
 6. **Read-the-diff-at-HEAD discipline** — `gh api repos/.../contents/<path>?ref=<head_sha>` not local clone (per `pull-requests.md` § Origin > Local Clone for "Still-Has-X" File-Content Claims).
 7. **Pre-enumeration discipline** — `grep -c` per file then sum, never `| head -N` (per memory `feedback_no_head_in_surface_enumeration`).

--- a/.claude/team/charter/agents.md
+++ b/.claude/team/charter/agents.md
@@ -123,6 +123,37 @@ When all PRs for a wave are merged into the deployments branch, the orchestrator
 
 Failure to manage agent lifecycle leads to resource exhaustion and duplicate agent confusion. This is a **moderate feedback event** for the orchestrator.
 
+<!-- Promoted from memory: feedback_reuse_idle_teammates_not_clones.md (P3W9 retro 2026-05-12, owner-approved 2026-05-13; pre-promote-on-first-occurrence variant of the enforcement-hierarchy rule) -->
+
+## Orchestrator Spawn Discipline — Reuse Idle Teammates, Don't Clone <!-- promotion-target: none -->
+
+When the orchestrator needs to assign new work to a teammate whose persona already exists in the session team, `SendMessage` the idle existing instance — do NOT spawn a fresh `Agent` with a numeric-suffix name (`aino2`, `nadia2`, `wanjiku3`).
+
+### Why
+
+Idle teammates can receive messages — `SendMessage` wakes them up. Spawning a clone creates:
+
+- **Roster clutter.** `aino` and `aino2` side-by-side for the same persona confuses both the operator (which one has the PR context?) and `SendMessage` routing.
+- **No shared session memory.** Each fresh `Agent` is a blank slate; the original's accumulated context (PR #409 review history, scratch-file paths, mid-task partial work) is lost.
+- **Duplicated Hook 15 librarian overhead.** Every clone must re-invoke `/ontology-librarian` from scratch.
+- **Identity-hygiene drift.** Over a multi-PR session the roster grows linearly with PR count instead of staying at the canonical N team members.
+
+### How to apply
+
+- After a teammate sends a "PR ready" or "review complete" idle notification, they are AVAILABLE for the next task. `SendMessage` them with the new spawn-brief content; idle teammates wake on message receipt.
+- Only spawn a fresh `Agent` when (a) the persona doesn't yet exist in the session team, OR (b) the existing instance is mid-task and the new work must run truly concurrently with theirs.
+- `wanjiku2` (P3W9) is a legitimate parallel-collision precedent: Wanjiku reviewed PR #409 AND PR #410 in the same window; #410 was assigned to `wanjiku2` to keep `/tmp/<reviewer>_review_<PR#>.md` namespaces separate per the [[parallel-reviewer-tmp-filename-collision]] discipline. That precedent does NOT generalize to "always clone for the next task."
+- If unsure whether to reuse or clone, default to reuse — clones are recoverable (`SendMessage` shutdown_request, respawn fresh), but the wasted spawn cost is not.
+
+### Severity if violated
+
+- One unnecessary clone in a session: **minor** (roster clutter; ~5min context loss when the clone has to rebuild what the original already knew).
+- Pattern across a session (3+ clones in a single wave, as observed in P3W9 with `aino2`/`nadia2`/`wanjiku3`): **moderate** — pre-emptive promotion to charter on first-occurrence rather than waiting for second instance, since the cost (~15min per clone) and the recovery friction justify codifying immediately.
+
+### Origin
+
+P3W9 instances 2026-05-12: orchestrator spawned `aino2` for issue #401 work, `wanjiku3` for issue #163 work, `nadia2` for issue #126 work despite `aino`, `wanjiku2`, `nadia` being idle from prior W9 tasks. Owner flagged the pattern mid-session; this section codifies the correction. Companion to `feedback_throttle_takeover` (orchestrator-class spawn-discipline family — both are "use the agent you have, not a fresh one").
+
 ## Hub-and-Spoke Orchestration Model <!-- promotion-target: none -->
 The orchestrator is the **single point that can create agents**. The Program Director coordinates and plans; the orchestrator executes the spawning. This is a hub-and-spoke model, not recursive delegation.
 

--- a/.claude/team/charter/agents.md
+++ b/.claude/team/charter/agents.md
@@ -342,16 +342,18 @@ Every reviewer-class spawn prompt MUST include, **in order**:
 
    **Verbatim verdict-comment template (copy-paste into reviewer spawn briefs):**
 
+   > **Canonical source:** see `pull-requests.md § Review Prompt Template (Mandatory)` for the underlying spec. This block is the spawn-brief view; the `pull-requests.md` template is the verbatim source-of-truth reviewers must follow — plain form, no bold markers, no parenthetical descriptions, no extra fields.
+
    ```bash
-   # Use `gh pr comment <PR#> --body "..."` — NOT `gh pr review` (block_gh_pr_review enforces).
+   # Use `gh pr comment <PR#> --body-file <path>` — NOT `gh pr review` (block_gh_pr_review enforces).
    # Write the body to a /tmp file FIRST, then comment in the very next tool call
    # (block_stale_tmp_message_file enforces 30s freshness):
 
    cat > /tmp/<PR#>-review-<reviewer-firstname>.md <<'BODYEOF'
-   **Requestor:** <reviewer-firstname> <reviewer-lastname>
-   **Requestee:** <PR-author-firstname> <PR-author-lastname>
-   **RequestOrReplied:** Approved
-   **TechDebt:** none
+   Requestor: <reviewer-firstname> <reviewer-lastname>
+   Requestee: <PR-author-firstname> <PR-author-lastname>
+   RequestOrReplied: Approved
+   TechDebt: none
 
    <verdict body — prose, line comments, throughline observations…>
 
@@ -364,7 +366,7 @@ Every reviewer-class spawn prompt MUST include, **in order**:
    ```
 
    **Required literal forms (hook-enforced):**
-   - The line MUST literally start with `TechDebt:` (optional `**` bold wrapping OK). `## TechDebt` section headers + prose do NOT satisfy the regex.
+   - The line MUST literally start with `TechDebt:` (plain form; `pull-requests.md § Review Prompt Template` forbids bold markers — `validate_pr_review.py` regex tolerates optional `**` for backward-compat with pre-#420 verdicts, but new briefs MUST use plain form). `## TechDebt` section headers + prose do NOT satisfy the regex.
    - Valid values:
      - `TechDebt: none`
      - `TechDebt: none — addressed inline by fixup commit <sha>`
@@ -373,8 +375,8 @@ Every reviewer-class spawn prompt MUST include, **in order**:
 
    For a ChangesRequested verdict, swap to:
    ```
-   **RequestOrReplied:** ChangesRequested
-   **TechDebt:** none
+   RequestOrReplied: ChangesRequested
+   TechDebt: none
    ```
    (TechDebt still required even on ChangesRequested — the regex is unconditional.)
 

--- a/.claude/team/charter/agents.md
+++ b/.claude/team/charter/agents.md
@@ -365,6 +365,8 @@ Every reviewer-class spawn prompt MUST include, **in order**:
    gh pr comment <PR#> --body-file /tmp/<PR#>-review-<reviewer-firstname>.md
    ```
 
+   > Inline `gh pr comment <PR#> --body "..."` is also valid when no /tmp file is involved; `--body-file <path>` is the required form when the body is written to /tmp first (`block_stale_tmp_message_file` 30s freshness rule applies only when a /tmp file is the source). This reconciles the new block above with `pull-requests.md § Review Prompt Template (Mandatory)` lines 47–53 which use inline `--body "..."` — both are legitimate; flag form follows write-path.
+
    **Required literal forms (hook-enforced):**
    - The line MUST literally start with `TechDebt:` (plain form; `pull-requests.md § Review Prompt Template` forbids bold markers — `validate_pr_review.py` regex tolerates optional `**` for backward-compat with pre-#420 verdicts, but new briefs MUST use plain form). `## TechDebt` section headers + prose do NOT satisfy the regex.
    - Valid values:

--- a/.claude/team/phases/phase-3.md
+++ b/.claude/team/phases/phase-3.md
@@ -49,7 +49,7 @@ Both tracks must move together. Finishing only one is not phase exit.
 
 Owner runs `/phase-review` and verifies all 9 end-state rows are `Done`, plus the tech-debt ratio test (criterion 9) holds. On confirmation, owner runs `/roadmap` to define Phase 4 before any P4 wave can kick off.
 
-## Phase history — P3W1 to P3W8
+## Phase history — P3W1 to P3W9
 
 | Wave | Theme | Outcome |
 |------|-------|---------|
@@ -61,8 +61,28 @@ Owner runs `/phase-review` and verifies all 9 end-state rows are `Done`, plus th
 | W6 | Cross-repo backlog triage (Tier-1 across 8 repos + runbook fan-out) | 11 PRs, 0 admin overrides, top-concentration 18% |
 | W7 | Hook parser-fixture coverage backport audit | 12 PRs, 0 admin overrides |
 | W8 | Foundation reset — hook/skill/charter ownership disambiguation + artifact-CI scope definition | 11 PRs, 0 admin overrides, 0 ChangesRequested cycles |
+| W9 | Tech-debt reduction (main-only) | 6 PRs, 0 admin overrides, 0 CR cycles, 67% concentration (Aino 4/6 by commit identity) |
 
-8 of 8 waves were tooling/meta (W3 had a small frontend feature; no deploy work shipped yet). This is the gap that drove the 2026-05-08 phase reset and shapes W9 scoping.
+9 of 9 waves were tooling/meta (W3 had a small frontend feature; no deploy work shipped yet). This is the gap that drove the 2026-05-08 phase reset and shapes W9 scoping.
+
+## Wave plan addendum — 2026-05-12 owner partition directive
+
+After W9 wrapped main-only (6 PRs Aino-concentrated by theme-fit), the
+remaining 115 W9-labeled issues were partitioned by owner directive
+2026-05-12T22:30Z:
+
+- **W10 = non-deploy remainder** — 54 issues across 5 child repos (isnad-graph 27,
+  user-service 12, landing-page 9, design-system 3, data-acquisition 3) + 7 main
+  issues (#402/#403/#255 carry-forwards + #262 promoted from W9 + #417/#418/#419
+  audit follow-ups + #421 this issue).
+- **W11 = deploy entirety** — 60 deploy issues + deploy#285 (sender-side
+  asymmetric dispatch contract from #413 review). Single-repo wave.
+
+Theme directive for W10: tech-debt reduction continues. Phase-3 exit
+criterion #9 (`<10% tech-debt ratio`) is NOT softened — additional sweep
+wave(s) may be added after W11 if math still doesn't close.
+
+Stored mirror: `cross-repo-status.json` § `wave_9_decisions.partition_directive_2026_05_12`.
 
 ## Open questions
 

--- a/.claude/team/phases/phase-3.md
+++ b/.claude/team/phases/phase-3.md
@@ -72,7 +72,7 @@ remaining 115 W9-labeled issues were partitioned by owner directive
 2026-05-12T22:30Z:
 
 - **W10 = non-deploy remainder** — 54 issues across 5 child repos (isnad-graph 27,
-  user-service 12, landing-page 9, design-system 3, data-acquisition 3) + 7 main
+  user-service 12, landing-page 9, design-system 3, data-acquisition 3) + 8 main
   issues (#402/#403/#255 carry-forwards + #262 promoted from W9 + #417/#418/#419
   audit follow-ups + #421 this issue).
 - **W11 = deploy entirety** — 60 deploy issues + deploy#285 (sender-side


### PR DESCRIPTION
## Summary

Closes #421. Apply 4 owner-approved W9-retro changes (2 phase-plan edits + 3 charter promotions) so W10 kickoff lands on a refreshed phase plan and a hook-aligned reviewer-spawn / wrapup contract.

Owner approved 2026-05-12 ("yes yes …") after PR #420 (W9 retro). Pre-W10 cleanup; PR targets `main`, not a wave branch.

## Changes

5 logical changes across 3 files, in 4 commits:

| # | File | Change | Commit |
|---|------|--------|--------|
| 1 | `.claude/team/phases/phase-3.md` | Append W9 row to "Phase history" table (renamed to P3W1–P3W9), update "8 of 8 waves" → "9 of 9", add new "Wave plan addendum" section recording the 2026-05-12 owner partition directive (W10 non-deploy / W11 deploy) | `cef9e3e` |
| 2 | `.claude/team/charter/agents.md` (§ Orchestrator checklist when spawning a reviewer, item #4) | Embed verbatim verdict-comment template (bash + heredoc) immediately after item #4, before item #5; preceded by HTML-comment provenance marker per the Shape-1 convention from PR #409. Promotes `feedback_techdebt_attestation_literal_line` | `835b6be` |
| 3 | `.claude/skills/wave-wrapup/SKILL.md` (Step 10.5) | Replace `CHANGES_REQUESTED_CYCLES={cr_cycle_count}` and `TOP_CONCENTRATION_PCT={highest_repo_pct}` placeholders with mechanical computation derived from the wave's merged-PR set across `wave_{M}_repos_in_scope`. Eliminates the W4/W5/W9 recompute-at-retro pattern | `a2af7d0` |
| 4 | `.claude/team/charter/agents.md` (new top-level § Orchestrator Spawn Discipline — Reuse Idle Teammates, Don't Clone) | Codify reuse-over-clone for already-existing personas; SendMessage idle existing instance instead of spawning `{name}2`/`{name}3` numeric-suffix clones. Pre-emptive promotion at moderate severity on first-occurrence (P3W9 `aino2`/`wanjiku3`/`nadia2` for #401/#163/#126). Promotes `feedback_reuse_idle_teammates_not_clones` | `41b4cdd` |

### Rationale per change

1. **Phase-plan refresh.** P3W9 closed; phase-plan file needs to mirror the closed state and the 2026-05-12 partition directive that produced W10/W11 scope. `cross-repo-status.json` already stores the mirror under `wave_9_decisions.partition_directive_2026_05_12`; this edit puts the human-readable counterpart in the phase plan where `/phase-review` reads it.

2. **Verbatim verdict-comment template.** P3W9 PR #409 cascade — both reviewers followed the prior prose template that prescribed `## TechDebt\n\n…` section header; `gh pr merge --squash` blocked at merge time (`BLOCKED: PR #409 has review(s) missing the mandatory TechDebt: attestation line`), requiring per-comment PATCH amendments. The fix is literal: `validate_pr_review.py` only regex-matches lines that literally start with `TechDebt:`. Embedding the canonical bash + heredoc template directly into the reviewer-checklist item puts the binding text in front of every future spawn-brief author. Sibling pattern to the P3W8 `Approved`-vs-`Reply` cascade — both are "spawn-brief template defects bypass hooks until merge time", both fixable by fixed-literal rewrite.

3. **Mechanical CR-cycles + concentration counters.** Pre-#421 these were placeholder lines the orchestrator filled in by hand at wrapup, with the resulting null/wrong values then corrected manually at retro — W4 (80%), W5 (6→4), W9 (null+null). Three consecutive recompute incidents is enough signal to mechanize. The new Step 10.5 derives both counters directly from the wave's merged-PR set across `wave_{M}_repos_in_scope`, using:
   - `gh api .../issues/<N>/comments` filtered on `RequestOrReplied:\s*ChangesRequested` for the CR-cycles counter.
   - `gh api .../commits/<headRefOid>.commit.author.name` clustered with `sort | uniq -c` for the top-concentration counter, then `awk '{printf "%d\n", $1 * 100 / total}'` for the integer percentage.

   The `wanjiku2`-style reviewer-tmp namespace remains preserved as the documented exception.

4. **Reuse idle teammates.** P3W9 saw 3 clones (`aino2`/`wanjiku3`/`nadia2`) for #401/#163/#126 despite idle existing instances. Owner flagged the pattern mid-session. Pre-emptive promotion at moderate severity on first-occurrence rather than waiting for second instance, since the per-clone ~15min context-rebuild cost and the routing-ambiguity (`aino` vs `aino2` for the same persona) justify codifying immediately. Companion to `feedback_throttle_takeover` (orchestrator-class spawn-discipline family).

## Verification

- **Phase-3.md.** Phase history table header now reads "P3W1 to P3W9"; the W9 row records `6 PRs, 0 admin overrides, 0 CR cycles, 67% concentration (Aino 4/6 by commit identity)`. The "Wave plan addendum" section appears immediately after the history table and before "Open questions", mirroring `cross-repo-status.json § wave_9_decisions.partition_directive_2026_05_12`.
- **Agents.md verdict template.** The new code block is inside the existing `### Orchestrator checklist when spawning a reviewer`, between items 4 and 5 (numbering unchanged). HTML-comment marker `<!-- Promoted from memory: feedback_techdebt_attestation_literal_line.md ... -->` is on its own line immediately above the inserted block, matching the Shape-1 form codified in `hooks.md` § "HTML-comment marker form codified in #283 / #393".
- **Wave-wrapup SKILL.md Step 10.5.** The pre-prose note flags the mechanical-computation rationale and links to W4/W5/W9 history. The bash block walks `wave_{M}_repos_in_scope`, builds `PRS_JSON`, then computes both counters; the existing `python3 "$UPSERT"` invocation is unchanged.
- **Agents.md reuse-idle-teammates.** New top-level `## Orchestrator Spawn Discipline — Reuse Idle Teammates, Don't Clone` section lands between `§ Agent Lifecycle Management` (ends line 124) and `§ Hub-and-Spoke Orchestration Model`. HTML-comment marker on the line immediately above.

### Mental test of the Step 10.5 computation against W9 actuals

With `wave_9_repos_in_scope = ["noorinalabs-main", ...]` and 6 merged PRs against `deployments/phase-3/wave-9`:

- CR cycles: 0 verdict comments contain `RequestOrReplied: ChangesRequested` body lines → `CHANGES_REQUESTED_CYCLES=0`. Matches the recorded W9 value.
- Top concentration: Aino's commit-identity name appears on 4 of 6 PR head SHAs; `awk '{printf "%d\n", $1 * 100 / total}'` with `$1=4, total=6` → `66`. Recorded W9 value is `67` (half-up rounding).

### Rounding-rule question (reviewers please decide)

The mechanical formula uses awk `%d` which **truncates** toward zero: `4/6 = 66.67 → 66`. The recorded W9 `top_concentration_pct = 67` used half-up rounding.

Two options:

- **Truncate (current `%d`)** — simplest; matches awk default; consistent across all waves regardless of size. W9 would re-state as 66.
- **Half-up (`printf "%.0f"`)** — matches recorded W9 value; matches what most operators would compute mentally. Slightly more rounding logic. Use `printf "%.0f\n", $1 * 100 / total` instead of `%d`.

Both options are one-character edits in the SKILL.md block. Reviewer-decision land on whichever; I'll fast-follow with the edit + a counter-correction for W9 if half-up is preferred so the stored value matches whichever rule is canonical.

## Body-vs-diff sanity check (per /wave-retro Step 6.5)

| Claim | File path | Diff lines |
|---|---|---|
| Phase-history table renamed P3W1→P3W9 with new W9 row + "9 of 9 waves" prose update | `.claude/team/phases/phase-3.md` | history-table heading + new W9 row + prose update (diff present) |
| New "Wave plan addendum" section in phase-3.md before "Open questions" | `.claude/team/phases/phase-3.md` | new section block (diff present) |
| Verbatim verdict-comment template embedded in agents.md § Orchestrator checklist when spawning a reviewer, item #4 | `.claude/team/charter/agents.md` | insertion between items 4 and 5 with HTML-comment marker (diff present) |
| Step 10.5 mechanical computation replaces placeholders in /wave-wrapup SKILL.md | `.claude/skills/wave-wrapup/SKILL.md` | replaced placeholder block + new prose note (diff present) |
| New top-level § Orchestrator Spawn Discipline — Reuse Idle Teammates section in agents.md | `.claude/team/charter/agents.md` | new section between Lifecycle Management and Hub-and-Spoke (diff present) |

All 5 claims map to lines in the 3-file diff (`.claude/team/phases/phase-3.md`, `.claude/team/charter/agents.md`, `.claude/skills/wave-wrapup/SKILL.md`).

## Memory marker updates (out-of-PR-scope, recorded for audit trail)

The two source memories are being marked SUPERSEDED in local auto-memory (NOT part of this PR's diff):

- `feedback_techdebt_attestation_literal_line.md` — promoted to `agents.md § Orchestrator checklist when spawning a reviewer` (item #4 verbatim template).
- `feedback_reuse_idle_teammates_not_clones.md` — promoted to `agents.md § Orchestrator Spawn Discipline — Reuse Idle Teammates, Don't Clone`.

MEMORY.md index lines for those two entries are being updated to reflect SUPERSEDED status, mirroring the existing pattern from PR #346 / #393 / #420 supersession entries.

## Reviewers

- **Nadia Khoury** (Program Director) — charter/program angle.
- **Wanjiku Mwangi** (TPM) — wave-wrapup/process angle.

Manager-boundary verified: Aino, Nadia, Wanjiku are peer managers in the parent repo; no implementer→manager relationship between any pairing.

TechDebt: none
