### PR TITLE
ci(paths-coverage): widen ci.yml pull_request paths to include all workflows (precursor to #403)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,14 +6,14 @@ on:
     paths:
       - ".claude/hooks/**"
       - ".claude/skills/**"
-      - ".github/workflows/ci.yml"
+      - ".github/workflows/**"
       - "pyproject.toml"
   pull_request:
     branches: [main, "deployments/**"]
     paths:
       - ".claude/hooks/**"
       - ".claude/skills/**"
-      - ".github/workflows/ci.yml"
+      - ".github/workflows/**"
       - "pyproject.toml"
 
 jobs:


### PR DESCRIPTION
## Summary

Precursor PR for #403. Widens `.github/workflows/ci.yml` `pull_request.paths:` filter from `".github/workflows/ci.yml"` to `".github/workflows/**"` so that future PRs touching any workflow file in this repo trigger CI lint/format/typecheck/smoke.

## Why this needs to land first

Hook 17 (`validate_workflow_paths_coverage`) blocks `gh pr create` if any workflow file in the PR diff is not covered by some BASE-branch workflow's `pull_request.paths:` filter. The follow-up PR for #403 adds `.github/workflows/branch-protection-audit.yml`, which currently has no coverage on the base wave-10 branch. The hook recommends a precursor PR for the path widening — this is that.

## Scope

Exactly one file changed, two lines flipped: `ci.yml` → `.github/workflows/ci.yml` becomes `.github/workflows/**` in both the `push.paths` and `pull_request.paths` blocks.

```diff
   push:
     branches: [main, "deployments/**"]
     paths:
       - ".claude/hooks/**"
       - ".claude/skills/**"
-      - ".github/workflows/ci.yml"
+      - ".github/workflows/**"
       - "pyproject.toml"
   pull_request:
     branches: [main, "deployments/**"]
     paths:
       - ".claude/hooks/**"
       - ".claude/skills/**"
-      - ".github/workflows/ci.yml"
+      - ".github/workflows/**"
       - "pyproject.toml"
```

## Risk

Low. The widening only ADDS paths that trigger CI; nothing that was previously gated becomes ungated. The cost is occasional ci.yml job runs on workflow edits that wouldn't have triggered otherwise — acceptable for the coverage guarantee.

## Local validation

- `actionlint -no-color .github/workflows/ci.yml` (with shellcheck on PATH) — clean
- `git diff` shows only the two intended `paths:` lines flipped

## Test plan

- [ ] CI green on this PR (ci.yml runs because the file is in the diff and matches the new `.github/workflows/**` filter)
- [ ] Follow-up PR for #403 opens without Hook 17 blocking

## Reviewers

- **R1**: @Nino-Kavtaradze (Security Engineer)
- **R2**: @Bereket-Tadesse (Engineering Manager)

Refs #403

🤖 Generated with [Claude Code](https://claude.com/claude-code)
