### PR TITLE
tech-debt(infra): branch protection manifest + audit workflow for 8 org repos (#403)

### DIFF
--- a/.claude/scripts/apply_branch_protection.py
+++ b/.claude/scripts/apply_branch_protection.py
@@ -168,7 +168,15 @@ def normalize_actual(actual: dict | None) -> dict:
     norm["required_conversation_resolution"] = _enabled("required_conversation_resolution")
 
     rpr = actual.get("required_pull_request_reviews")
-    norm["required_pull_request_reviews"] = rpr if rpr else None
+    if rpr:
+        norm["required_pull_request_reviews"] = {
+            "required_approving_review_count": int(rpr.get("required_approving_review_count", 0)),
+            "dismiss_stale_reviews": bool(rpr.get("dismiss_stale_reviews", False)),
+            "require_code_owner_reviews": bool(rpr.get("require_code_owner_reviews", False)),
+            "require_last_push_approval": bool(rpr.get("require_last_push_approval", False)),
+        }
+    else:
+        norm["required_pull_request_reviews"] = None
 
     restrictions = actual.get("restrictions")
     norm["restrictions"] = restrictions if restrictions else None

--- a/.claude/scripts/apply_branch_protection.py
+++ b/.claude/scripts/apply_branch_protection.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Apply branch-protection settings to noorinalabs org repos.
+
+Driven by `.claude/scripts/branch_protection_config.json`. The manifest's
+`_common` block holds the protections that apply to every repo; each entry in
+`repos` adds the per-repo `required_status_checks` (or null to skip required
+checks for that repo). PUT requests are issued via `gh api` so the caller's
+existing GitHub auth is reused — no PAT plumbing.
+
+The PUT body for the GitHub REST API requires EVERY top-level key (see
+https://docs.github.com/rest/branches/branch-protection#update-branch-protection).
+Omitting a key is treated by the API as "clear that setting". This script
+always sends the full schema so applying twice is idempotent.
+
+Modes:
+    --check     read-only. Compare manifest to live state, print a diff. Exit 0
+                if everything matches, exit 1 if drift is found, exit 2 on
+                hard error (network, auth, manifest schema). Suitable for CI.
+    --apply     PUT the manifest to each repo, then GET to verify. Exit 0 only
+                if every repo's post-state matches the desired state.
+    --repo NAME limit operation to a single repo (matches manifest key).
+    --owner OWN override the default `noorinalabs` org.
+
+Acceptance evidence: every repo's POST-state JSON is captured in
+`/tmp/apply_branch_protection_post_{repo}.json` and diffed against the
+manifest. The script exits non-zero on ANY drift, so CI can gate.
+
+PR-time vs runtime testing
+==========================
+
+This script's unit-mechanic correctness — diff computation, request body
+shape, idempotency — is covered by tests in `test_apply_branch_protection.py`
+(no network). The actual `gh api PUT` calls can ONLY be exercised against
+real org repos, so the post-merge Test Plan applies the manifest in real life
+and reads back the state. PR reviewers should NOT block on "did this run on
+real repos?" — that is the runtime acceptance, separately tracked.
+
+Issue: noorinalabs/noorinalabs-main#403
+Anchors: #182 (single-repo case), #222 (org-wide audit)
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+DEFAULT_OWNER = "noorinalabs"
+DEFAULT_MANIFEST = Path(__file__).parent / "branch_protection_config.json"
+DEFAULT_BRANCH = "main"
+
+# Keys we send in every PUT body. The GitHub API requires the full schema —
+# omitting a key clears it. We render `null` for fields that should be cleared
+# explicitly (required_pull_request_reviews=null, restrictions=null).
+_REQUIRED_PUT_KEYS = (
+    "required_status_checks",
+    "enforce_admins",
+    "required_pull_request_reviews",
+    "restrictions",
+    "allow_force_pushes",
+    "allow_deletions",
+    "required_linear_history",
+    "required_conversation_resolution",
+)
+
+
+class BranchProtectionError(Exception):
+    """Raised for manifest schema errors or unrecoverable API failures."""
+
+
+def load_manifest(path: Path) -> dict:
+    if not path.exists():
+        raise BranchProtectionError(f"Manifest not found: {path}")
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+    except json.JSONDecodeError as e:
+        raise BranchProtectionError(f"Manifest is not valid JSON: {e}") from e
+
+    if "_common" not in data or "repos" not in data:
+        raise BranchProtectionError("Manifest must have '_common' and 'repos' keys")
+    if not isinstance(data["repos"], dict) or not data["repos"]:
+        raise BranchProtectionError("Manifest 'repos' must be a non-empty object")
+    return data
+
+
+def build_desired_for_repo(manifest: dict, repo: str) -> dict:
+    """Return the PUT body that should be applied to `repo`.
+
+    Merges `_common` defaults with per-repo override. Strips comment keys
+    (those starting with `_`) so they don't get sent to GitHub.
+    """
+    if repo not in manifest["repos"]:
+        raise BranchProtectionError(f"Repo {repo!r} not in manifest")
+
+    desired = copy.deepcopy(manifest["_common"])
+    per_repo = manifest["repos"][repo]
+    for k, v in per_repo.items():
+        if k.startswith("_"):
+            continue
+        desired[k] = v
+
+    # Strip leftover comment keys from _common defensively.
+    for k in list(desired.keys()):
+        if k.startswith("_"):
+            del desired[k]
+
+    # Validate every required PUT key is present (avoid implicit clears).
+    missing = [k for k in _REQUIRED_PUT_KEYS if k not in desired]
+    if missing:
+        raise BranchProtectionError(
+            f"Manifest for {repo!r} is missing required PUT keys: {missing}"
+        )
+    return desired
+
+
+def fetch_actual(owner: str, repo: str, branch: str = DEFAULT_BRANCH) -> dict | None:
+    """Return the live protection state, or None if the branch is unprotected."""
+    proc = subprocess.run(
+        ["gh", "api", f"repos/{owner}/{repo}/branches/{branch}/protection"],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode == 0:
+        return json.loads(proc.stdout)
+    # 404 = unprotected, treat as None. Distinguish from other failures.
+    if "Branch not protected" in proc.stderr or "404" in proc.stderr:
+        return None
+    raise BranchProtectionError(
+        f"GET {owner}/{repo}/branches/{branch}/protection failed:\n{proc.stderr.strip()}"
+    )
+
+
+def normalize_actual(actual: dict | None) -> dict:
+    """Reduce the GET response to the same shape as the PUT body.
+
+    The GET response wraps booleans in `{"enabled": bool, ...}` and adds URL
+    fields and `checks` for status checks; the PUT body is flat. This function
+    normalizes the GET to the PUT shape so a structural diff makes sense.
+    """
+    if actual is None:
+        return {k: None for k in _REQUIRED_PUT_KEYS}
+
+    norm: dict = {}
+
+    rsc = actual.get("required_status_checks")
+    if rsc is None:
+        norm["required_status_checks"] = None
+    else:
+        norm["required_status_checks"] = {
+            "strict": bool(rsc.get("strict", False)),
+            "contexts": list(rsc.get("contexts", [])),
+        }
+
+    def _enabled(key: str) -> bool:
+        node = actual.get(key)
+        if isinstance(node, dict):
+            return bool(node.get("enabled", False))
+        return bool(node)
+
+    norm["enforce_admins"] = _enabled("enforce_admins")
+    norm["allow_force_pushes"] = _enabled("allow_force_pushes")
+    norm["allow_deletions"] = _enabled("allow_deletions")
+    norm["required_linear_history"] = _enabled("required_linear_history")
+    norm["required_conversation_resolution"] = _enabled("required_conversation_resolution")
+
+    rpr = actual.get("required_pull_request_reviews")
+    norm["required_pull_request_reviews"] = rpr if rpr else None
+
+    restrictions = actual.get("restrictions")
+    norm["restrictions"] = restrictions if restrictions else None
+
+    return norm
+
+
+def diff_state(desired: dict, actual_norm: dict) -> list[str]:
+    """Return a list of human-readable drift lines (empty == in sync)."""
+    drift = []
+    for key in _REQUIRED_PUT_KEYS:
+        d = desired.get(key)
+        a = actual_norm.get(key)
+        if d != a:
+            drift.append(f"  {key}:\n    desired={d!r}\n    actual ={a!r}")
+    return drift
+
+
+def put_protection(owner: str, repo: str, body: dict, branch: str = DEFAULT_BRANCH) -> dict:
+    """PUT the desired protection state and return the parsed response."""
+    body_json = json.dumps(body)
+    proc = subprocess.run(
+        [
+            "gh",
+            "api",
+            "-X",
+            "PUT",
+            f"repos/{owner}/{repo}/branches/{branch}/protection",
+            "--input",
+            "-",
+        ],
+        input=body_json,
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        raise BranchProtectionError(
+            f"PUT {owner}/{repo}/branches/{branch}/protection failed:\n{proc.stderr.strip()}"
+        )
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError as e:
+        raise BranchProtectionError(
+            f"PUT {owner}/{repo}/branches/{branch}/protection returned non-JSON: {e}"
+        ) from e
+
+
+def run_check(owner: str, manifest: dict, repos: list[str]) -> int:
+    """Read-only drift check. Exit 0 if in sync, 1 if drift, 2 on hard error."""
+    any_drift = False
+    for repo in repos:
+        desired = build_desired_for_repo(manifest, repo)
+        try:
+            actual = fetch_actual(owner, repo)
+        except BranchProtectionError as e:
+            print(f"[{repo}] ERROR: {e}", file=sys.stderr)
+            return 2
+        actual_norm = normalize_actual(actual)
+        drift = diff_state(desired, actual_norm)
+        if drift:
+            any_drift = True
+            print(f"[{repo}] DRIFT:")
+            print("\n".join(drift))
+        else:
+            print(f"[{repo}] in sync")
+    return 1 if any_drift else 0
+
+
+def run_apply(owner: str, manifest: dict, repos: list[str]) -> int:
+    """Apply manifest + read back for verification. Exit 0 only on full success."""
+    any_failure = False
+    for repo in repos:
+        desired = build_desired_for_repo(manifest, repo)
+        print(f"[{repo}] applying ...")
+        try:
+            put_protection(owner, repo, desired)
+            actual = fetch_actual(owner, repo)
+        except BranchProtectionError as e:
+            print(f"[{repo}] ERROR: {e}", file=sys.stderr)
+            any_failure = True
+            continue
+        actual_norm = normalize_actual(actual)
+        post_path = Path(f"/tmp/apply_branch_protection_post_{repo}.json")
+        post_path.write_text(json.dumps(actual_norm, indent=2, sort_keys=True))
+        drift = diff_state(desired, actual_norm)
+        if drift:
+            any_failure = True
+            print(f"[{repo}] POST-STATE DRIFT (manifest != GitHub after PUT):")
+            print("\n".join(drift))
+        else:
+            print(f"[{repo}] applied + verified")
+    return 1 if any_failure else 0
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    mode = p.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--check", action="store_true", help="Read-only drift check.")
+    mode.add_argument("--apply", action="store_true", help="PUT manifest + verify.")
+    p.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    p.add_argument("--owner", default=DEFAULT_OWNER)
+    p.add_argument("--repo", help="Limit to one repo (manifest key).")
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv if argv is not None else sys.argv[1:])
+    try:
+        manifest = load_manifest(args.manifest)
+    except BranchProtectionError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 2
+
+    if args.repo:
+        if args.repo not in manifest["repos"]:
+            print(f"ERROR: repo {args.repo!r} not in manifest", file=sys.stderr)
+            return 2
+        repos = [args.repo]
+    else:
+        repos = list(manifest["repos"].keys())
+
+    if args.check:
+        return run_check(args.owner, manifest, repos)
+    return run_apply(args.owner, manifest, repos)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/scripts/branch_protection_config.json
+++ b/.claude/scripts/branch_protection_config.json
@@ -1,0 +1,84 @@
+{
+  "_doc": "Per-repo branch-protection config for `main`. Run via .claude/scripts/apply_branch_protection.py. Contexts MUST match the exact check-run NAME emitted on the most recent PR head SHA (verify with `gh api repos/{owner}/{repo}/commits/{sha}/check-runs`). Mismatch causes the protection to silently never satisfy.",
+  "_common": {
+    "enforce_admins": false,
+    "required_pull_request_reviews": null,
+    "restrictions": null,
+    "allow_force_pushes": false,
+    "allow_deletions": false,
+    "required_linear_history": false,
+    "required_conversation_resolution": false
+  },
+  "repos": {
+    "noorinalabs-main": {
+      "required_status_checks": {
+        "strict": true,
+        "contexts": [
+          "Ruff lint",
+          "Ruff format check",
+          "Mypy type check",
+          "Smoke test — hooks compile and exit cleanly"
+        ]
+      }
+    },
+    "noorinalabs-isnad-graph": {
+      "required_status_checks": {
+        "strict": true,
+        "contexts": [
+          "test",
+          "lint-and-typecheck",
+          "security-audit",
+          "frontend-lint-and-test",
+          "hooks-lint",
+          "scripts-lint",
+          "lockfile-validation"
+        ]
+      }
+    },
+    "noorinalabs-user-service": {
+      "required_status_checks": {
+        "strict": true,
+        "contexts": [
+          "check"
+        ]
+      }
+    },
+    "noorinalabs-design-system": {
+      "required_status_checks": {
+        "strict": true,
+        "contexts": [
+          "ci (20.x)",
+          "validate-package"
+        ]
+      }
+    },
+    "noorinalabs-landing-page": {
+      "required_status_checks": {
+        "strict": true,
+        "contexts": [
+          "Lint, Type Check & Build",
+          "E2E Tests (Playwright)"
+        ]
+      }
+    },
+    "noorinalabs-data-acquisition": {
+      "required_status_checks": {
+        "strict": true,
+        "contexts": [
+          "Lint",
+          "Type Check",
+          "Test",
+          "Integration Tests"
+        ]
+      }
+    },
+    "noorinalabs-deploy": {
+      "_note": "noorinalabs-deploy has 14 workflows with path-filtering — the set of check-runs varies by PR. No required_status_checks until owner picks a stable cross-PR floor (file follow-up). Defensive protections applied below.",
+      "required_status_checks": null
+    },
+    "noorinalabs-isnad-ingest-platform": {
+      "_note": "No CI workflows yet (no .github/ directory). Defensive protections only until CI lands.",
+      "required_status_checks": null
+    }
+  }
+}

--- a/.claude/scripts/branch_protection_config.json
+++ b/.claude/scripts/branch_protection_config.json
@@ -1,8 +1,13 @@
 {
   "_doc": "Per-repo branch-protection config for `main`. Run via .claude/scripts/apply_branch_protection.py. Contexts MUST match the exact check-run NAME emitted on the most recent PR head SHA (verify with `gh api repos/{owner}/{repo}/commits/{sha}/check-runs`). Mismatch causes the protection to silently never satisfy.",
   "_common": {
-    "enforce_admins": false,
-    "required_pull_request_reviews": null,
+    "enforce_admins": true,
+    "required_pull_request_reviews": {
+      "required_approving_review_count": 2,
+      "dismiss_stale_reviews": true,
+      "require_code_owner_reviews": false,
+      "require_last_push_approval": false
+    },
     "restrictions": null,
     "allow_force_pushes": false,
     "allow_deletions": false,

--- a/.claude/scripts/test_apply_branch_protection.py
+++ b/.claude/scripts/test_apply_branch_protection.py
@@ -1,0 +1,369 @@
+"""Unit tests for apply_branch_protection.
+
+These tests exercise the unit-mechanic correctness — manifest validation,
+desired-state assembly, GET-normalisation, diff computation, mode dispatch —
+without making real GitHub API calls. Run with `python -m pytest` from this
+directory.
+
+The actual `gh api PUT` calls against the 7 real org repos can ONLY be
+verified by post-merge runtime acceptance. See the issue thread for the test
+plan applied after merge.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).parent))
+import apply_branch_protection as abp  # noqa: E402
+
+
+def _minimal_manifest() -> dict:
+    return {
+        "_common": {
+            "enforce_admins": False,
+            "required_pull_request_reviews": None,
+            "restrictions": None,
+            "allow_force_pushes": False,
+            "allow_deletions": False,
+            "required_linear_history": False,
+            "required_conversation_resolution": False,
+        },
+        "repos": {
+            "alpha": {"required_status_checks": {"strict": True, "contexts": ["lint"]}},
+            "beta": {
+                "_note": "ignored",
+                "required_status_checks": None,
+            },
+        },
+    }
+
+
+class TestLoadManifest(unittest.TestCase):
+    def test_load_real_manifest(self) -> None:
+        manifest = abp.load_manifest(abp.DEFAULT_MANIFEST)
+        self.assertIn("_common", manifest)
+        self.assertIn("repos", manifest)
+        # All 7 child repos plus noorinalabs-main = 8.
+        self.assertEqual(len(manifest["repos"]), 8)
+        for key in ("noorinalabs-main", "noorinalabs-isnad-graph", "noorinalabs-deploy"):
+            self.assertIn(key, manifest["repos"])
+
+    def test_missing_file(self) -> None:
+        with self.assertRaises(abp.BranchProtectionError):
+            abp.load_manifest(Path("/tmp/nonexistent-manifest-abp.json"))
+
+    def test_malformed_json(self, tmp_path: Path | None = None) -> None:
+        # write to /tmp directly (Hook 15 allow-listed)
+        p = Path("/tmp/abp_malformed.json")
+        p.write_text("{not json")
+        with self.assertRaises(abp.BranchProtectionError):
+            abp.load_manifest(p)
+
+    def test_missing_required_top_level_keys(self) -> None:
+        p = Path("/tmp/abp_missing.json")
+        p.write_text(json.dumps({"_common": {}}))
+        with self.assertRaises(abp.BranchProtectionError):
+            abp.load_manifest(p)
+
+
+class TestBuildDesired(unittest.TestCase):
+    def test_per_repo_overrides_merge_into_common(self) -> None:
+        m = _minimal_manifest()
+        desired = abp.build_desired_for_repo(m, "alpha")
+        self.assertEqual(
+            desired["required_status_checks"],
+            {"strict": True, "contexts": ["lint"]},
+        )
+        self.assertFalse(desired["enforce_admins"])
+        self.assertFalse(desired["allow_force_pushes"])
+
+    def test_comment_keys_stripped(self) -> None:
+        m = _minimal_manifest()
+        desired = abp.build_desired_for_repo(m, "beta")
+        # _note must not be present
+        for k in desired:
+            self.assertFalse(k.startswith("_"))
+
+    def test_unknown_repo_errors(self) -> None:
+        with self.assertRaises(abp.BranchProtectionError):
+            abp.build_desired_for_repo(_minimal_manifest(), "gamma")
+
+    def test_required_keys_all_present_in_output(self) -> None:
+        m = _minimal_manifest()
+        desired = abp.build_desired_for_repo(m, "alpha")
+        for key in abp._REQUIRED_PUT_KEYS:
+            self.assertIn(key, desired)
+
+    def test_missing_required_key_errors(self) -> None:
+        m = _minimal_manifest()
+        del m["_common"]["allow_deletions"]
+        with self.assertRaises(abp.BranchProtectionError):
+            abp.build_desired_for_repo(m, "alpha")
+
+
+class TestNormalizeActual(unittest.TestCase):
+    def test_none_actual(self) -> None:
+        norm = abp.normalize_actual(None)
+        for key in abp._REQUIRED_PUT_KEYS:
+            self.assertIsNone(norm[key])
+
+    def test_full_actual(self) -> None:
+        actual = {
+            "required_status_checks": {
+                "strict": True,
+                "contexts": ["x", "y"],
+                "checks": [{"context": "x", "app_id": 1}],
+                "url": "https://api.example/...",
+            },
+            "enforce_admins": {"enabled": False},
+            "allow_force_pushes": {"enabled": False},
+            "allow_deletions": {"enabled": False},
+            "required_linear_history": {"enabled": False},
+            "required_conversation_resolution": {"enabled": False},
+            "required_pull_request_reviews": None,
+            "restrictions": None,
+        }
+        norm = abp.normalize_actual(actual)
+        self.assertEqual(
+            norm["required_status_checks"],
+            {"strict": True, "contexts": ["x", "y"]},
+        )
+        self.assertFalse(norm["enforce_admins"])
+        self.assertFalse(norm["allow_force_pushes"])
+        self.assertIsNone(norm["required_pull_request_reviews"])
+
+    def test_legacy_bool_shape(self) -> None:
+        # Some older GET responses return `enforce_admins: true/false` directly.
+        actual = {
+            "required_status_checks": None,
+            "enforce_admins": True,
+            "allow_force_pushes": False,
+            "allow_deletions": False,
+            "required_linear_history": False,
+            "required_conversation_resolution": False,
+            "required_pull_request_reviews": None,
+            "restrictions": None,
+        }
+        norm = abp.normalize_actual(actual)
+        self.assertTrue(norm["enforce_admins"])
+        self.assertFalse(norm["allow_force_pushes"])
+
+
+class TestDiffState(unittest.TestCase):
+    def test_in_sync(self) -> None:
+        desired = {
+            "required_status_checks": {"strict": True, "contexts": ["lint"]},
+            "enforce_admins": False,
+            "required_pull_request_reviews": None,
+            "restrictions": None,
+            "allow_force_pushes": False,
+            "allow_deletions": False,
+            "required_linear_history": False,
+            "required_conversation_resolution": False,
+        }
+        actual_norm = dict(desired)
+        self.assertEqual(abp.diff_state(desired, actual_norm), [])
+
+    def test_drift_on_contexts(self) -> None:
+        desired = {
+            "required_status_checks": {"strict": True, "contexts": ["lint", "test"]},
+            "enforce_admins": False,
+            "required_pull_request_reviews": None,
+            "restrictions": None,
+            "allow_force_pushes": False,
+            "allow_deletions": False,
+            "required_linear_history": False,
+            "required_conversation_resolution": False,
+        }
+        actual_norm = dict(desired)
+        actual_norm["required_status_checks"] = {"strict": True, "contexts": ["lint"]}
+        drift = abp.diff_state(desired, actual_norm)
+        self.assertEqual(len(drift), 1)
+        self.assertIn("required_status_checks", drift[0])
+
+    def test_drift_on_negative_protection(self) -> None:
+        desired: dict = {k: False for k in abp._REQUIRED_PUT_KEYS}
+        desired["required_status_checks"] = None
+        desired["required_pull_request_reviews"] = None
+        desired["restrictions"] = None
+        actual_norm = dict(desired)
+        actual_norm["allow_force_pushes"] = True
+        drift = abp.diff_state(desired, actual_norm)
+        self.assertEqual(len(drift), 1)
+        self.assertIn("allow_force_pushes", drift[0])
+
+
+class TestFetchActual(unittest.TestCase):
+    def test_unprotected_returns_none(self) -> None:
+        with mock.patch.object(abp, "subprocess") as sp:
+            sp.run.return_value = subprocess.CompletedProcess(
+                args=[],
+                returncode=1,
+                stdout="",
+                stderr='{"message":"Branch not protected","status":"404"}',
+            )
+            self.assertIsNone(abp.fetch_actual("noorinalabs", "x"))
+
+    def test_protected_returns_payload(self) -> None:
+        payload = {"required_status_checks": {"strict": True, "contexts": []}}
+        with mock.patch.object(abp, "subprocess") as sp:
+            sp.run.return_value = subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout=json.dumps(payload),
+                stderr="",
+            )
+            self.assertEqual(abp.fetch_actual("noorinalabs", "x"), payload)
+
+    def test_other_failure_raises(self) -> None:
+        with mock.patch.object(abp, "subprocess") as sp:
+            sp.run.return_value = subprocess.CompletedProcess(
+                args=[],
+                returncode=1,
+                stdout="",
+                stderr="permission denied",
+            )
+            with self.assertRaises(abp.BranchProtectionError):
+                abp.fetch_actual("noorinalabs", "x")
+
+
+class TestPutProtection(unittest.TestCase):
+    def test_put_sends_full_body(self) -> None:
+        body = {"x": 1}
+        captured = {}
+
+        def fake_run(args, input=None, capture_output=None, text=None):
+            captured["args"] = args
+            captured["input"] = input
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout="{}", stderr="")
+
+        with mock.patch.object(abp.subprocess, "run", side_effect=fake_run):
+            abp.put_protection("noorinalabs", "x", body)
+        self.assertIn("-X", captured["args"])
+        self.assertIn("PUT", captured["args"])
+        self.assertIn("--input", captured["args"])
+        self.assertEqual(json.loads(captured["input"]), body)
+
+    def test_put_failure_raises(self) -> None:
+        with mock.patch.object(abp.subprocess, "run") as run:
+            run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=1, stdout="", stderr="boom"
+            )
+            with self.assertRaises(abp.BranchProtectionError):
+                abp.put_protection("noorinalabs", "x", {})
+
+
+class TestRunCheck(unittest.TestCase):
+    def test_check_in_sync(self) -> None:
+        m = _minimal_manifest()
+        with mock.patch.object(abp, "fetch_actual") as fa:
+            # Build a fake actual matching the desired.
+            fa.side_effect = [
+                {
+                    "required_status_checks": {"strict": True, "contexts": ["lint"]},
+                    "enforce_admins": {"enabled": False},
+                    "allow_force_pushes": {"enabled": False},
+                    "allow_deletions": {"enabled": False},
+                    "required_linear_history": {"enabled": False},
+                    "required_conversation_resolution": {"enabled": False},
+                    "required_pull_request_reviews": None,
+                    "restrictions": None,
+                },
+                None,  # beta is unprotected — manifest says None for rsc and
+                # False for negative protections, but None != False:
+            ]
+            # Wait: beta's manifest has required_status_checks=None AND
+            # enforce_admins=False. If actual is None, normalize_actual yields
+            # all-None which does NOT equal {enforce_admins: False, ...}. So
+            # beta SHOULD drift. Test that.
+            rc = abp.run_check("noorinalabs", m, ["alpha", "beta"])
+        self.assertEqual(rc, 1)  # beta drifts
+
+    def test_check_returns_zero_when_all_synced(self) -> None:
+        m = _minimal_manifest()
+        # Make alpha and beta both reflect the desired state.
+        alpha_actual = {
+            "required_status_checks": {"strict": True, "contexts": ["lint"]},
+            "enforce_admins": {"enabled": False},
+            "allow_force_pushes": {"enabled": False},
+            "allow_deletions": {"enabled": False},
+            "required_linear_history": {"enabled": False},
+            "required_conversation_resolution": {"enabled": False},
+            "required_pull_request_reviews": None,
+            "restrictions": None,
+        }
+        beta_actual = dict(alpha_actual)
+        beta_actual["required_status_checks"] = None
+        with mock.patch.object(abp, "fetch_actual", side_effect=[alpha_actual, beta_actual]):
+            rc = abp.run_check("noorinalabs", m, ["alpha", "beta"])
+        self.assertEqual(rc, 0)
+
+
+class TestMainCli(unittest.TestCase):
+    def test_check_requires_exactly_one_mode(self) -> None:
+        with self.assertRaises(SystemExit):
+            abp.parse_args([])  # neither --check nor --apply
+
+    def test_repo_flag_limits_scope(self) -> None:
+        m = _minimal_manifest()
+        manifest_path = Path("/tmp/abp_main_test.json")
+        manifest_path.write_text(json.dumps(m))
+        with mock.patch.object(abp, "fetch_actual") as fa:
+            fa.return_value = None
+            rc = abp.main(["--check", "--manifest", str(manifest_path), "--repo", "alpha"])
+            self.assertEqual(fa.call_count, 1)
+        # alpha's manifest is rsc={strict,contexts:[lint]} but actual is None
+        # → drift → rc 1.
+        self.assertEqual(rc, 1)
+
+
+class TestRealManifestSchema(unittest.TestCase):
+    """Schema checks for the real manifest shipped in this PR."""
+
+    def setUp(self) -> None:
+        self.manifest = abp.load_manifest(abp.DEFAULT_MANIFEST)
+
+    def test_seven_unprotected_repos_present(self) -> None:
+        # The seven unprotected (from #403 verification) + isnad-graph.
+        expected = {
+            "noorinalabs-main",
+            "noorinalabs-isnad-graph",
+            "noorinalabs-user-service",
+            "noorinalabs-deploy",
+            "noorinalabs-design-system",
+            "noorinalabs-landing-page",
+            "noorinalabs-data-acquisition",
+            "noorinalabs-isnad-ingest-platform",
+        }
+        self.assertEqual(set(self.manifest["repos"].keys()), expected)
+
+    def test_main_contexts_match_workflow_job_names(self) -> None:
+        # Verified against noorinalabs-main/.github/workflows/ci.yml job `name:` fields.
+        desired = abp.build_desired_for_repo(self.manifest, "noorinalabs-main")
+        ctx = desired["required_status_checks"]["contexts"]
+        self.assertEqual(
+            set(ctx),
+            {
+                "Ruff lint",
+                "Ruff format check",
+                "Mypy type check",
+                "Smoke test — hooks compile and exit cleanly",
+            },
+        )
+
+    def test_negative_protections_uniform(self) -> None:
+        for repo_name in self.manifest["repos"]:
+            desired = abp.build_desired_for_repo(self.manifest, repo_name)
+            self.assertFalse(desired["enforce_admins"], repo_name)
+            self.assertFalse(desired["allow_force_pushes"], repo_name)
+            self.assertFalse(desired["allow_deletions"], repo_name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/scripts/test_apply_branch_protection.py
+++ b/.claude/scripts/test_apply_branch_protection.py
@@ -154,6 +154,37 @@ class TestNormalizeActual(unittest.TestCase):
         self.assertTrue(norm["enforce_admins"])
         self.assertFalse(norm["allow_force_pushes"])
 
+    def test_required_pull_request_reviews_strips_get_only_fields(self) -> None:
+        # GET wraps RPR with `url` and may carry extra keys; normalize must
+        # strip them so the diff matches a PUT-shape desired body.
+        actual = {
+            "required_status_checks": None,
+            "enforce_admins": True,
+            "allow_force_pushes": False,
+            "allow_deletions": False,
+            "required_linear_history": False,
+            "required_conversation_resolution": False,
+            "required_pull_request_reviews": {
+                "url": "https://api.github.com/repos/x/y/branches/main/protection/required_pull_request_reviews",
+                "dismiss_stale_reviews": True,
+                "require_code_owner_reviews": False,
+                "required_approving_review_count": 2,
+                "require_last_push_approval": False,
+                "dismissal_restrictions": {},
+            },
+            "restrictions": None,
+        }
+        norm = abp.normalize_actual(actual)
+        self.assertEqual(
+            norm["required_pull_request_reviews"],
+            {
+                "required_approving_review_count": 2,
+                "dismiss_stale_reviews": True,
+                "require_code_owner_reviews": False,
+                "require_last_push_approval": False,
+            },
+        )
+
 
 class TestDiffState(unittest.TestCase):
     def test_in_sync(self) -> None:
@@ -360,9 +391,23 @@ class TestRealManifestSchema(unittest.TestCase):
     def test_negative_protections_uniform(self) -> None:
         for repo_name in self.manifest["repos"]:
             desired = abp.build_desired_for_repo(self.manifest, repo_name)
-            self.assertFalse(desired["enforce_admins"], repo_name)
             self.assertFalse(desired["allow_force_pushes"], repo_name)
             self.assertFalse(desired["allow_deletions"], repo_name)
+
+    def test_enforce_admins_uniform_true(self) -> None:
+        for repo_name in self.manifest["repos"]:
+            desired = abp.build_desired_for_repo(self.manifest, repo_name)
+            self.assertTrue(desired["enforce_admins"], repo_name)
+
+    def test_required_pull_request_reviews_uniform(self) -> None:
+        for repo_name in self.manifest["repos"]:
+            desired = abp.build_desired_for_repo(self.manifest, repo_name)
+            rpr = desired["required_pull_request_reviews"]
+            self.assertIsNotNone(rpr, repo_name)
+            self.assertEqual(rpr["required_approving_review_count"], 2, repo_name)
+            self.assertTrue(rpr["dismiss_stale_reviews"], repo_name)
+            self.assertFalse(rpr["require_code_owner_reviews"], repo_name)
+            self.assertFalse(rpr["require_last_push_approval"], repo_name)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/branch-protection-audit.yml
+++ b/.github/workflows/branch-protection-audit.yml
@@ -1,0 +1,70 @@
+name: Branch protection audit
+
+on:
+  schedule:
+    - cron: "17 7 * * 1"
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "check (read-only) | apply (PUT manifest)"
+        type: choice
+        options: [check, apply]
+        default: check
+      repo:
+        description: "Optional manifest repo key to limit scope"
+        type: string
+        default: ""
+  pull_request:
+    paths:
+      - ".claude/scripts/apply_branch_protection.py"
+      - ".claude/scripts/branch_protection_config.json"
+      - ".claude/scripts/test_apply_branch_protection.py"
+      - ".github/workflows/branch-protection-audit.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  unit-tests:
+    name: Unit tests — apply_branch_protection
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Run unit tests
+        working-directory: .claude/scripts
+        run: python -m unittest test_apply_branch_protection -v
+
+  audit:
+    name: Branch-protection drift check
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    needs: unit-tests
+    env:
+      # Cross-repo branch-protection PUT requires a PAT with `administration:write`
+      # on every targeted repo. `github.token` is repo-scoped and cannot read
+      # the other 7 repos' protection state. Set BRANCH_PROTECTION_PAT in repo
+      # secrets before the first scheduled run; missing secret leaves the audit
+      # unrun (the read-back loop will 404 on every repo).
+      GH_TOKEN: ${{ secrets.BRANCH_PROTECTION_PAT }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Verify gh CLI available
+        run: gh --version
+      - name: Audit
+        id: audit
+        env:
+          INPUT_MODE: ${{ github.event.inputs.mode }}
+          INPUT_REPO: ${{ github.event.inputs.repo }}
+        run: |
+          mode="${INPUT_MODE:-check}"
+          if [ -n "$INPUT_REPO" ]; then
+            python .claude/scripts/apply_branch_protection.py "--$mode" --repo "$INPUT_REPO"
+          else
+            python .claude/scripts/apply_branch_protection.py "--$mode"
+          fi

--- a/.github/workflows/branch-protection-audit.yml
+++ b/.github/workflows/branch-protection-audit.yml
@@ -42,6 +42,11 @@ jobs:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     needs: unit-tests
+    # Manual-approval gate: `apply` mode pins the `branch-protection-apply`
+    # Environment (which has required-reviewers configured), forcing a human
+    # ack before any PUT runs. Scheduled `check` runs and manual `check`
+    # dispatches resolve the env name to empty string -> no gate.
+    environment: ${{ github.event.inputs.mode == 'apply' && 'branch-protection-apply' || '' }}
     env:
       # Cross-repo branch-protection PUT requires a PAT with `administration:write`
       # on every targeted repo. `github.token` is repo-scoped and cannot read


### PR DESCRIPTION
## Summary

Adds a declarative, idempotent rollout of `main` branch-protection across all 8 noorinalabs org repos, plus a scheduled drift-check workflow.

- `.claude/scripts/branch_protection_config.json` — per-repo manifest with a `_common` block (admins not exempt, force-push/deletion blocked, **2-reviewer requirement with dismiss-stale-reviews**) and per-repo `required_status_checks` lists cross-checked against most-recent-merged-PR check-run **names** (not job keys) to dodge the silent-never-satisfy trap.
- `.claude/scripts/apply_branch_protection.py` — `--check` (read-only drift diff, exit 1 on drift) and `--apply` (PUT then GET-verify, writes per-repo post-state JSON to `/tmp/apply_branch_protection_post_<repo>.json`). Uses `gh api` so caller auth flows through — no PAT plumbing in the script.
- `.claude/scripts/test_apply_branch_protection.py` — 30 unit tests (no network) covering manifest load, schema validation, desired-state assembly, GET-shape normalisation (including the new `required_pull_request_reviews` strip), diff computation, PUT body shape, and CLI dispatch. Real-manifest schema test pins the 8-repo set and the uniform `enforce_admins=true` / 2-reviewer assertions.
- `.github/workflows/branch-protection-audit.yml` — runs `--check` weekly (Mon 07:17 UTC) and on workflow_dispatch; unit-tests job runs on every PR that touches these files (path-filtered). **`apply` mode is gated by the `branch-protection-apply` GitHub Environment with required-reviewer = owner**, so a manual `apply` dispatch blocks at the approval gate.

Closes: noorinalabs/noorinalabs-main#403
Anchors: #182, #222

## Precursor

This PR depends on **#430** (merged at commit `e98f74d`), which widened `ci.yml`'s `pull_request.paths` filter from `.github/workflows/ci.yml` to `.github/workflows/**`. Without that widening, Hook 17 (`validate_workflow_paths_coverage`) blocks PR open on the new `branch-protection-audit.yml`. The precursor is now in `deployments/phase-3/wave-10` as `9749bfe`, so this PR rebases cleanly atop the latest wave-10 HEAD.

## Security hardening (post-Nino review)

PR #432's first review surfaced three items, all addressed in commit `a9504db`. Source: Nino's review at `noorinalabs/noorinalabs-main#432 (comment)` — the ChangesRequested verdict (#issuecomment-4446944274).

1. **`enforce_admins=true`** in `_common`. Previous `false` contradicted the "admins not exempt" claim. With `true`, admins are subject to all rules on `main` — no direct-push, no skip-checks, no skip-reviews.

2. **`required_pull_request_reviews`** added to `_common` so every repo inherits a GitHub-level enforcement of the charter 2-reviewer minimum:
   - `required_approving_review_count: 2`
   - `dismiss_stale_reviews: true` (force-push invalidates stale Approvals)
   - `require_code_owner_reviews: false` (no CODEOWNERS files yet)
   - `require_last_push_approval: false` (no rebase-friction)

   Rationale: `validate_pr_review` hook gates agent flow only. A human `gh pr merge` currently bypasses the 2-reviewer rule. This closes that regression.

3. **GitHub Environment manual-approval** for `workflow_dispatch.mode=apply`:
   - Created `branch-protection-apply` Environment on `noorinalabs/noorinalabs-main` with required-reviewer = `parametrization` (verified at origin via `gh api repos/noorinalabs/noorinalabs-main/environments/branch-protection-apply` — `protection_rules[0].type=required_reviewers`).
   - `branch-protection-audit.yml` binds `environment: ${{ inputs.mode == 'apply' && 'branch-protection-apply' || '' }}`. Fires only for `apply` (manual approval blocks the PUT); `check` mode (scheduled or manual) stays gate-free.

`normalize_actual` was also extended to strip the GET-only `url` and `dismissal_restrictions` fields from `required_pull_request_reviews` so `--check` doesn't perma-drift after a successful apply.

## PR-time vs runtime acceptance

Per the runtime-gate-scoping convention in charter `pull-requests.md`, this PR delivers **unit-mechanic correctness only**. The actual `gh api PUT` calls against the 7 unprotected repos and the 1 partially-protected repo CANNOT be exercised at PR time — they require admin-level auth on every target repo, which the PR sandbox doesn't have.

### Post-merge Test Plan (runs against real repos, captured in issue thread)

1. Set `BRANCH_PROTECTION_PAT` in repo secrets (administration:write scope).
2. Run `python .claude/scripts/apply_branch_protection.py --check` — expect drift for all 8 repos (every repo will diff from manifest until apply runs).
3. Manually dispatch `branch-protection-audit.yml` with `mode=apply`. Approve the Environment gate. Inspect `/tmp/apply_branch_protection_post_<repo>.json` for each repo.
4. Re-run `--check` — expect exit 0 (no drift).
5. Verify on a real PR that the configured required-status-checks block `gh pr merge` when red, and that the 2-reviewer rule blocks merge until two Approvals land.
6. Verify `enforce_admins=true` is in effect by attempting an admin direct-push to `main` — should be blocked.

## Scope-bounding notes

- **`noorinalabs-deploy`** intentionally has `required_status_checks=null` — its 14 workflows are path-filtered, so the set of check-runs varies by PR and no stable floor exists yet. Defensive protections (admins-enforced, 2-reviewer, force-push/deletion block) still apply. Follow-up issue: pick the cross-PR stable set once telemetry exists.
- **`noorinalabs-isnad-ingest-platform`** has no CI workflows yet; defensive protections only until CI lands.

## Verified

- Live state queried via `gh api repos/noorinalabs/<repo>/branches/main/protection` confirms 7-of-8 unprotected at HEAD, matching the #403 issue body table.
- Per-repo `contexts` list cross-checked against most-recent-merged-PR check-run NAMES for: `noorinalabs-main`, `noorinalabs-isnad-graph`, `noorinalabs-user-service`, `noorinalabs-design-system`, `noorinalabs-landing-page`, `noorinalabs-data-acquisition`.
- Unit tests: **30 passed** (`python -m unittest`, no network; +3 from fixup).
- Lint: `uvx ruff check` + `uvx ruff format --check` pass on `.claude/scripts/`.
- Type: `uvx mypy --ignore-missing-imports` passes on `.claude/scripts/`.
- Workflow: `actionlint` (with shellcheck on PATH) passes on the new workflow file. No SC2086 violations from the dispatch-input handling.
- GitHub Environment `branch-protection-apply` created and read-back-verified at origin (id `15317363527`).

## TechDebt

None — manifest and tooling are scoped to the infrastructure gap, and the Nino-flagged regressions are all closed. The deploy and ingest-platform "no required checks" lines plus the `require_code_owner_reviews: false` flag are deliberate scope-bounding, tracked as post-merge follow-ups above.
