### PR TITLE
tech-debt(infra): preserve bypass_pull_request_allowances + PUT empty list (#433)

### DIFF
--- a/.claude/scripts/apply_branch_protection.py
+++ b/.claude/scripts/apply_branch_protection.py
@@ -134,6 +134,16 @@ def fetch_actual(owner: str, repo: str, branch: str = DEFAULT_BRANCH) -> dict | 
     )
 
 
+def _actor_logins(actors: list) -> list[str]:
+    # GET returns list of {login, id, type, ...}; PUT accepts list of login strings.
+    return [a["login"] if isinstance(a, dict) else str(a) for a in actors]
+
+
+def _actor_slugs(actors: list) -> list[str]:
+    # Teams/apps GET returns list of {slug, id, name, ...}; PUT accepts slug strings.
+    return [a["slug"] if isinstance(a, dict) else str(a) for a in actors]
+
+
 def normalize_actual(actual: dict | None) -> dict:
     """Reduce the GET response to the same shape as the PUT body.
 
@@ -169,11 +179,41 @@ def normalize_actual(actual: dict | None) -> dict:
 
     rpr = actual.get("required_pull_request_reviews")
     if rpr:
+        # bypass_pull_request_allowances is a UI-configurable allow-list of
+        # actors that can merge without satisfying review requirements. It
+        # MUST be preserved so drift detection catches UI-side additions —
+        # otherwise the 2-reviewer gate is silently bypassable. Default to
+        # the empty PUT-shape (all three sub-lists empty) when the GET
+        # omits it. See noorinalabs/noorinalabs-main#433.
+        bypass = rpr.get(
+            "bypass_pull_request_allowances",
+            {"users": [], "teams": [], "apps": []},
+        )
+        # GET returns full actor objects (with id, login, type, etc.); the
+        # PUT body accepts a list of logins/slugs. Collapse to the PUT
+        # shape so the structural diff against the manifest is meaningful.
+        bypass_norm = {
+            "users": sorted(_actor_logins(bypass.get("users", []))),
+            "teams": sorted(_actor_slugs(bypass.get("teams", []))),
+            "apps": sorted(_actor_slugs(bypass.get("apps", []))),
+        }
+        # dismissal_restrictions has the same actor-list shape and is the
+        # adjacent allow-list controlling who can dismiss reviews. Same
+        # blind-spot class as bypass_pull_request_allowances; preserved
+        # together per #433 Out-of-Scope follow-up.
+        dr = rpr.get("dismissal_restrictions") or {}
+        dr_norm = {
+            "users": sorted(_actor_logins(dr.get("users", []))),
+            "teams": sorted(_actor_slugs(dr.get("teams", []))),
+            "apps": sorted(_actor_slugs(dr.get("apps", []))),
+        }
         norm["required_pull_request_reviews"] = {
             "required_approving_review_count": int(rpr.get("required_approving_review_count", 0)),
             "dismiss_stale_reviews": bool(rpr.get("dismiss_stale_reviews", False)),
             "require_code_owner_reviews": bool(rpr.get("require_code_owner_reviews", False)),
             "require_last_push_approval": bool(rpr.get("require_last_push_approval", False)),
+            "bypass_pull_request_allowances": bypass_norm,
+            "dismissal_restrictions": dr_norm,
         }
     else:
         norm["required_pull_request_reviews"] = None

--- a/.claude/scripts/branch_protection_config.json
+++ b/.claude/scripts/branch_protection_config.json
@@ -6,7 +6,17 @@
       "required_approving_review_count": 2,
       "dismiss_stale_reviews": true,
       "require_code_owner_reviews": false,
-      "require_last_push_approval": false
+      "require_last_push_approval": false,
+      "bypass_pull_request_allowances": {
+        "users": [],
+        "teams": [],
+        "apps": []
+      },
+      "dismissal_restrictions": {
+        "users": [],
+        "teams": [],
+        "apps": []
+      }
     },
     "restrictions": null,
     "allow_force_pushes": false,

--- a/.claude/scripts/test_apply_branch_protection.py
+++ b/.claude/scripts/test_apply_branch_protection.py
@@ -156,7 +156,9 @@ class TestNormalizeActual(unittest.TestCase):
 
     def test_required_pull_request_reviews_strips_get_only_fields(self) -> None:
         # GET wraps RPR with `url` and may carry extra keys; normalize must
-        # strip them so the diff matches a PUT-shape desired body.
+        # strip `url` so the diff matches a PUT-shape desired body, while
+        # preserving bypass_pull_request_allowances and dismissal_restrictions
+        # which are security-relevant actor allow-lists (#433).
         actual = {
             "required_status_checks": None,
             "enforce_admins": True,
@@ -170,7 +172,8 @@ class TestNormalizeActual(unittest.TestCase):
                 "require_code_owner_reviews": False,
                 "required_approving_review_count": 2,
                 "require_last_push_approval": False,
-                "dismissal_restrictions": {},
+                "dismissal_restrictions": {"users": [], "teams": [], "apps": []},
+                "bypass_pull_request_allowances": {"users": [], "teams": [], "apps": []},
             },
             "restrictions": None,
         }
@@ -182,7 +185,126 @@ class TestNormalizeActual(unittest.TestCase):
                 "dismiss_stale_reviews": True,
                 "require_code_owner_reviews": False,
                 "require_last_push_approval": False,
+                "bypass_pull_request_allowances": {"users": [], "teams": [], "apps": []},
+                "dismissal_restrictions": {"users": [], "teams": [], "apps": []},
             },
+        )
+        # `url` was stripped, the two allow-list fields were NOT.
+        self.assertNotIn("url", norm["required_pull_request_reviews"])
+
+    def test_required_pull_request_reviews_preserves_bypass_allowances(self) -> None:
+        # When GET omits bypass_pull_request_allowances (older shape or no
+        # bypass ever configured), normalize must still produce the empty
+        # PUT-shape so the diff against desired-empty is in-sync.
+        actual = {
+            "required_status_checks": None,
+            "enforce_admins": True,
+            "allow_force_pushes": False,
+            "allow_deletions": False,
+            "required_linear_history": False,
+            "required_conversation_resolution": False,
+            "required_pull_request_reviews": {
+                "required_approving_review_count": 2,
+                "dismiss_stale_reviews": True,
+                "require_code_owner_reviews": False,
+                "require_last_push_approval": False,
+            },
+            "restrictions": None,
+        }
+        norm = abp.normalize_actual(actual)
+        self.assertEqual(
+            norm["required_pull_request_reviews"]["bypass_pull_request_allowances"],
+            {"users": [], "teams": [], "apps": []},
+        )
+        self.assertEqual(
+            norm["required_pull_request_reviews"]["dismissal_restrictions"],
+            {"users": [], "teams": [], "apps": []},
+        )
+
+    def test_bypass_allowances_drift_flagged_when_ui_adds_user(self) -> None:
+        # The regression scenario from #433: a repo admin adds a bypass
+        # actor via the UI. GET returns the actor object; desired manifest
+        # has an empty bypass list. diff_state MUST flag drift on
+        # required_pull_request_reviews so --check exits non-zero.
+        actual = {
+            "required_status_checks": None,
+            "enforce_admins": True,
+            "allow_force_pushes": False,
+            "allow_deletions": False,
+            "required_linear_history": False,
+            "required_conversation_resolution": False,
+            "required_pull_request_reviews": {
+                "required_approving_review_count": 2,
+                "dismiss_stale_reviews": True,
+                "require_code_owner_reviews": False,
+                "require_last_push_approval": False,
+                "bypass_pull_request_allowances": {
+                    "users": [
+                        {"login": "rogue-admin", "id": 999, "type": "User"},
+                    ],
+                    "teams": [],
+                    "apps": [],
+                },
+                "dismissal_restrictions": {"users": [], "teams": [], "apps": []},
+            },
+            "restrictions": None,
+        }
+        actual_norm = abp.normalize_actual(actual)
+        # bypass-user collapsed to login string.
+        self.assertEqual(
+            actual_norm["required_pull_request_reviews"]["bypass_pull_request_allowances"]["users"],
+            ["rogue-admin"],
+        )
+        desired = {
+            "required_status_checks": None,
+            "enforce_admins": True,
+            "allow_force_pushes": False,
+            "allow_deletions": False,
+            "required_linear_history": False,
+            "required_conversation_resolution": False,
+            "required_pull_request_reviews": {
+                "required_approving_review_count": 2,
+                "dismiss_stale_reviews": True,
+                "require_code_owner_reviews": False,
+                "require_last_push_approval": False,
+                "bypass_pull_request_allowances": {"users": [], "teams": [], "apps": []},
+                "dismissal_restrictions": {"users": [], "teams": [], "apps": []},
+            },
+            "restrictions": None,
+        }
+        drift = abp.diff_state(desired, actual_norm)
+        self.assertEqual(len(drift), 1)
+        self.assertIn("required_pull_request_reviews", drift[0])
+        self.assertIn("rogue-admin", drift[0])
+
+    def test_bypass_allowances_team_drift_flagged(self) -> None:
+        # Same drift class but via a team allow-list addition (slug shape).
+        actual_rpr = {
+            "required_approving_review_count": 2,
+            "dismiss_stale_reviews": True,
+            "require_code_owner_reviews": False,
+            "require_last_push_approval": False,
+            "bypass_pull_request_allowances": {
+                "users": [],
+                "teams": [{"slug": "release-bots", "id": 7, "name": "Release Bots"}],
+                "apps": [],
+            },
+            "dismissal_restrictions": {"users": [], "teams": [], "apps": []},
+        }
+        actual = {
+            "required_status_checks": None,
+            "enforce_admins": True,
+            "allow_force_pushes": False,
+            "allow_deletions": False,
+            "required_linear_history": False,
+            "required_conversation_resolution": False,
+            "required_pull_request_reviews": actual_rpr,
+            "restrictions": None,
+        }
+        actual_norm = abp.normalize_actual(actual)
+        self.assertEqual(
+            actual_norm["required_pull_request_reviews"]["bypass_pull_request_allowances"]["teams"],
+            ["release-bots"],
         )
 
 
@@ -408,6 +530,24 @@ class TestRealManifestSchema(unittest.TestCase):
             self.assertTrue(rpr["dismiss_stale_reviews"], repo_name)
             self.assertFalse(rpr["require_code_owner_reviews"], repo_name)
             self.assertFalse(rpr["require_last_push_approval"], repo_name)
+
+    def test_bypass_pull_request_allowances_empty_in_manifest(self) -> None:
+        # #433: manifest MUST explicitly declare empty bypass + dismissal
+        # allow-lists so PUT clears any UI-added entries on every --apply,
+        # and --check flags drift between runs.
+        for repo_name in self.manifest["repos"]:
+            desired = abp.build_desired_for_repo(self.manifest, repo_name)
+            rpr = desired["required_pull_request_reviews"]
+            self.assertEqual(
+                rpr["bypass_pull_request_allowances"],
+                {"users": [], "teams": [], "apps": []},
+                repo_name,
+            )
+            self.assertEqual(
+                rpr["dismissal_restrictions"],
+                {"users": [], "teams": [], "apps": []},
+                repo_name,
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Closes #433.

`apply_branch_protection.py` `normalize_actual()` was hand-extracting exactly 4 fields from the GET `required_pull_request_reviews` payload and dropping `bypass_pull_request_allowances`. Because the manifest's PUT body also omitted that key, a repo admin could UI-add a bypass actor and `--check` would silently report in-sync — defeating the 2-reviewer enforcement #432 was specifically introduced to harden.

**Defense-in-depth fix** (Options A + B from the issue, both surfaces closed):

- **A — preserve in `normalize_actual`:** `bypass_pull_request_allowances` AND adjacent `dismissal_restrictions` are now preserved, collapsing GET-side actor objects (`{login, id, type, ...}` / `{slug, id, name, ...}`) down to the PUT-shape string lists via new `_actor_logins`/`_actor_slugs` helpers. Sorted, so list-order from GitHub doesn't trigger spurious drift. Missing GET fields default to `{users:[], teams:[], apps:[]}` so older / never-configured states still compare equal to desired-empty.

- **B — PUT explicit empty list:** `_common.required_pull_request_reviews` in `branch_protection_config.json` now declares both fields as empty lists. `--apply` actively clears any UI-side bypass-actor entries on every run, on top of `--check` flagging them at audit time.

Together: a UI-added bypass actor is **detected** at audit (A) and **reverted** on next apply (B).

## Reviewers

- Bereket Tadesse (deploy manager, security/charter angle)
- Wanjiku Mwangi (TPM, process angle)

## Test plan

- [x] `python -m unittest test_apply_branch_protection` — 34 tests pass (was 30; +4 new)
  - `test_required_pull_request_reviews_strips_get_only_fields` extended: asserts `url` is stripped AND bypass/dismissal allow-lists are preserved
  - `test_required_pull_request_reviews_preserves_bypass_allowances` — GET omits bypass → normalize defaults to empty PUT shape (in-sync, not drift)
  - `test_bypass_allowances_drift_flagged_when_ui_adds_user` — **the #433 regression case**: UI-added user surfaces in `diff_state` output containing `rogue-admin`
  - `test_bypass_allowances_team_drift_flagged` — same class via team slug shape
  - `test_bypass_pull_request_allowances_empty_in_manifest` — schema check, every repo entry declares empty bypass + dismissal lists
- [x] `ruff check .claude/scripts/` — clean
- [x] `ruff format --check .claude/scripts/` — clean
- [x] CI `unit-tests` job in `branch-protection-audit.yml` runs the new tests (path-trigger covers all 3 modified files)
- [ ] **Runtime acceptance (post-merge, manual)**: trigger `branch-protection-audit.yml` with `mode=apply` against `noorinalabs-main`, then UI-add a user under Settings → Branches → main → "Allow specified actors to bypass required pull requests", and re-run with `mode=check`. Expect drift line mentioning the added user. Tracked separately per `feedback_runtime_gate_scoping` — PR acceptance is unit-mechanic correctness, not the live PUT loop.

## Acceptance criteria (from #433)

- [x] `normalize_actual` preserves `bypass_pull_request_allowances` in normalized output
- [x] `_common.required_pull_request_reviews` declares the desired bypass-allowances state (empty users/teams/apps)
- [x] New unit test exercises GET `bypass_pull_request_allowances.users=[<one user>]` against desired-empty → drift entry from `diff_state`
- [ ] Post-merge runtime confirmation (live `gh api ...protection`) — runtime gate, tracked above
