### PR TITLE
tech-debt(/promotion-audit): rename charter_root → charter_parent + raise on charter-dir input (#418)

### DIFF
--- a/.claude/skills/promotion-audit/SKILL.md
+++ b/.claude/skills/promotion-audit/SKILL.md
@@ -40,10 +40,12 @@ from helpers import (
     render_audit_table,
 )
 
-memories  = read_all_memories(memory_dir)              # list[Memory]
-sections  = read_all_charter_sections(charter_dir)     # list[Section] — only sections with a promotion-target marker
-skills    = read_all_skills(skills_dir)                # list[Skill]
-already   = find_already_promoted_in_charter(charter_dir)  # set[str] — aggregates Promotion provenance: blocks AND <!-- Promoted from memory: X --> markers across all charter sub-docs (#283)
+memories  = read_all_memories(memory_dir)                  # list[Memory]
+sections  = read_all_charter_sections(charter_parent)      # list[Section] — only sections with a promotion-target marker
+skills    = read_all_skills(skills_dir)                    # list[Skill]
+already   = find_already_promoted_in_charter(charter_parent)  # set[str] — aggregates Promotion provenance: blocks AND <!-- Promoted from memory: X --> markers across all charter sub-docs (#283)
+# NOTE: `charter_parent` is the directory CONTAINING `charter/` (e.g. `.claude/team`),
+# NOT the `charter/` directory itself. Passing `.claude/team/charter` raises ValueError (#418).
 ```
 
 ### 3. Classify each candidate (pure function)

--- a/.claude/skills/promotion-audit/helpers.py
+++ b/.claude/skills/promotion-audit/helpers.py
@@ -298,17 +298,36 @@ def read_charter_sections(charter_path: str) -> list[CharterSection]:
     return results
 
 
-def read_all_charter_sections(charter_root: str) -> list[CharterSection]:
+def read_all_charter_sections(charter_parent: str) -> list[CharterSection]:
     """Scan charter.md + charter/*.md for marked sections.
 
+    `charter_parent` is the directory **containing** the `charter/` subdir
+    (typically `.claude/team`), NOT the `charter/` directory itself. Sibling
+    of `find_already_promoted_in_charter` — same parameter semantics, same
+    silent-empty failure mode if the caller passes the charter dir instead
+    of its parent (issue #418).
+
     Sorted by (path, heading) for determinism.
+
+    Raises:
+        ValueError: if `charter_parent` is itself named `charter` — see #418.
     """
+    if os.path.isdir(charter_parent) and (
+        os.path.basename(os.path.normpath(charter_parent)) == "charter"
+    ):
+        raise ValueError(
+            f"read_all_charter_sections({charter_parent!r}): "
+            "argument is the charter directory itself — pass its parent "
+            "(e.g. '.claude/team', not '.claude/team/charter'). "
+            "See issue #418."
+        )
+
     candidates: list[str] = []
-    root_file = os.path.join(charter_root, "charter.md")
+    root_file = os.path.join(charter_parent, "charter.md")
     if os.path.isfile(root_file):
         candidates.append(root_file)
 
-    subdir = os.path.join(charter_root, "charter")
+    subdir = os.path.join(charter_parent, "charter")
     if os.path.isdir(subdir):
         for name in sorted(os.listdir(subdir)):
             if name.endswith(".md"):
@@ -578,27 +597,45 @@ def find_already_promoted(charter_path: str) -> set[str]:
     return refs
 
 
-def find_already_promoted_in_charter(charter_root: str) -> set[str]:
+def find_already_promoted_in_charter(charter_parent: str) -> set[str]:
     """Aggregate already-promoted refs across the full charter directory.
 
-    Scans `charter_root/charter/*.md` (and the optional `charter_root/charter.md`
-    top-level file, if present) using the same recognition rules as
-    `find_already_promoted()`. Returns the union of all per-file results.
+    `charter_parent` is the directory **containing** the `charter/` subdir
+    (typically `.claude/team`), NOT the `charter/` directory itself.
+
+    Scans `<charter_parent>/charter/*.md` (and the optional
+    `<charter_parent>/charter.md` top-level file, if present) using the same
+    recognition rules as `find_already_promoted()`. Returns the union of
+    all per-file results.
 
     This is the entry point the /promotion-audit skill should use — single-
     file scope (charter/hooks.md only) misses charter-tier-only promotions
     that land via the HTML-comment marker in other sub-docs (issue #283).
+
+    Raises:
+        ValueError: if `charter_parent` is itself a directory named `charter`
+            — a strong hint the caller passed the charter dir instead of its
+            parent (issue #418 silent-zero bug). Returns set() for any other
+            non-existent path (defensive contract preserved).
     """
     refs: set[str] = set()
-    if not os.path.isdir(charter_root):
+    if not os.path.isdir(charter_parent):
         return refs
 
+    if os.path.basename(os.path.normpath(charter_parent)) == "charter":
+        raise ValueError(
+            f"find_already_promoted_in_charter({charter_parent!r}): "
+            "argument is the charter directory itself — pass its parent "
+            "(e.g. '.claude/team', not '.claude/team/charter'). "
+            "See issue #418."
+        )
+
     candidates: list[str] = []
-    root_file = os.path.join(charter_root, "charter.md")
+    root_file = os.path.join(charter_parent, "charter.md")
     if os.path.isfile(root_file):
         candidates.append(root_file)
 
-    subdir = os.path.join(charter_root, "charter")
+    subdir = os.path.join(charter_parent, "charter")
     if os.path.isdir(subdir):
         for name in sorted(os.listdir(subdir)):
             if name.endswith(".md"):

--- a/.claude/skills/promotion-audit/tests/test_helpers.py
+++ b/.claude/skills/promotion-audit/tests/test_helpers.py
@@ -517,6 +517,40 @@ class FindAlreadyPromotedTests(unittest.TestCase):
         refs = h.find_already_promoted_in_charter("/nonexistent/path/to/charter")
         self.assertEqual(refs, set())
 
+    def test_aggregator_raises_on_charter_dir_itself(self) -> None:
+        """NEG (#418): passing the charter directory itself (e.g.
+        `.claude/team/charter`) instead of its parent must raise
+        ValueError. Previously this silently returned set() because no
+        `<root>/charter/charter/` subdir exists — the silent-zero failure
+        mode that #418 was filed to fix.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            charter_subdir = os.path.join(tmpdir, "charter")
+            os.makedirs(charter_subdir)
+            # Correct form: parent of charter/ — returns set() (empty corpus).
+            self.assertEqual(h.find_already_promoted_in_charter(tmpdir), set())
+            # Wrong form: the charter dir itself — must raise loudly.
+            with self.assertRaises(ValueError) as ctx:
+                h.find_already_promoted_in_charter(charter_subdir)
+            self.assertIn("#418", str(ctx.exception))
+
+            # Trailing slash form must still raise — normpath strips it.
+            with self.assertRaises(ValueError):
+                h.find_already_promoted_in_charter(charter_subdir + "/")
+
+    def test_read_all_charter_sections_raises_on_charter_dir_itself(self) -> None:
+        """NEG (#418, sibling): `read_all_charter_sections` has identical
+        parent-of-charter semantics and the same silent-empty failure mode.
+        Passing the charter dir itself must raise.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            charter_subdir = os.path.join(tmpdir, "charter")
+            os.makedirs(charter_subdir)
+            # Correct form: returns empty list (no marked sections in empty corpus).
+            self.assertEqual(h.read_all_charter_sections(tmpdir), [])
+            with self.assertRaises(ValueError):
+                h.read_all_charter_sections(charter_subdir)
+
 
 # ---------------------------------------------------------------------------
 # Classification — memory


### PR DESCRIPTION
## Summary

`find_already_promoted_in_charter(charter_root)` and the sibling `read_all_charter_sections(charter_root)` in `.claude/skills/promotion-audit/helpers.py` both take a parameter named `charter_root` that is the **parent** of the `charter/` subdir, not the charter dir itself. Implementations do `os.path.join(arg, "charter")`. Passing the natural reading (`.claude/team/charter`) silently returns empty.

- Rename param `charter_root` -> `charter_parent` on both functions; tighten docstrings
- Runtime guard: `ValueError` with `#418` backreference if argument is itself a dir named `charter` (loud-fail the most likely caller mistake; companion to the `feedback_gh_pr_edit_silent_noop.md` family)
- `SKILL.md` Step 2 example block updated to use the unambiguous shape with an inline NOTE
- Two new tests: wrong-form raises; sibling function also raises (parity)

## Related Issues

Closes #418.

Sibling cluster (parallel, no overlap):
- #417 — SKILL.md prose drift (Aino)
- #419 — `_SOURCE_HINT_RE` URL-fragment false positives (Aino)
- #283 — original aggregator (in-tree, referenced for context)

## Verification

At HEAD (`b7d7437`):
- Correct form (`.claude/team`): **42 refs** (29 real + URL-fragment false positives still present — addressed by Aino's parallel #419)
- Wrong form (`.claude/team/charter`): now raises `ValueError` with `#418` backreference
- Full test suite: 69 tests pass (67 prior + 2 new for #418 guard + sibling parity)
- `uvx ruff@0.13.0 format --check .claude/skills/promotion-audit/` clean

## Review Checklist

- [ ] Rename does not break any other caller (grep verified: 3 call sites — `SKILL.md` + `test_smoke.py` + `test_helpers.py`, all updated)
- [ ] Sibling function `read_all_charter_sections` correctly receives the same fix shape (parity)
- [ ] Error message points the caller at the exact mistake (charter dir vs parent) AND cites the issue for context
- [ ] SKILL.md example uses the new param name with the inline NOTE that pins semantics

## TechDebt

This is itself a tech-debt fix (silent-no-op family); no new tech debt introduced.

Co-Authored-By: Nadia Khoury <parametrization+Nadia.Khoury@gmail.com>
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
