### PR TITLE
fix(promotion-audit): SKILL.md classifier prose + URL-fragment false positives (#417, #419)

### DIFF
--- a/.claude/skills/promotion-audit/SKILL.md
+++ b/.claude/skills/promotion-audit/SKILL.md
@@ -36,7 +36,9 @@ from helpers import (
     find_already_promoted_in_charter,
     count_retro_citations,
     count_skill_invocations,
-    classify,
+    classify_memory,
+    classify_section,
+    classify_skill,
     render_audit_table,
 )
 
@@ -48,7 +50,44 @@ already   = find_already_promoted_in_charter(charter_dir)  # set[str] — aggreg
 
 ### 3. Classify each candidate (pure function)
 
-For each memory, charter section, and skill, compute a `Decision` via `classify()`:
+There is no single `classify()` entry point — each tier transition has its own classifier with a distinct signature, because the signal sources differ (retro citations for memory → charter; invocation counts for charter → skill and skill → hook) and `classify_section` has no `already_promoted` analogue (sections carry their own `promoted_to` back-reference instead).
+
+| Function | Signature | `signals` keys consumed |
+|---|---|---|
+| `classify_memory(memory, signals, already_promoted)` | `(Memory, dict[str,int], set[str]) -> Decision` | `retro_citations` |
+| `classify_section(section, signals)` | `(CharterSection, dict[str,int]) -> Decision` | `skill_invocations`, `threshold` |
+| `classify_skill(skill, signals, already_promoted)` | `(Skill, dict[str,int], set[str]) -> Decision` | `skill_invocations`, `threshold` |
+
+Worked example (one item per tier):
+
+```python
+mem_decision = classify_memory(
+    memories[0],
+    signals={"retro_citations": count_retro_citations(memories[0], feedback_log_path)},
+    already_promoted=already,
+)
+
+sec_decision = classify_section(
+    sections[0],
+    signals={
+        "skill_invocations": count_skill_invocations(sections[0].promoted_to_slug or "", repo_root),
+        "threshold": 5,
+    },
+)
+
+skill_decision = classify_skill(
+    skills[0],
+    signals={
+        "skill_invocations": count_skill_invocations(skills[0].name, repo_root),
+        "threshold": 5,
+    },
+    already_promoted=already,
+)
+```
+
+Common failure mode: passing the citation/invocation count as a bare int (`classify_memory(mem, cite, already)`) rather than wrapping it in the `signals` dict (`classify_memory(mem, {"retro_citations": cite}, already)`). The classifiers all do `signals.get(...)` and will raise `AttributeError: 'int' object has no attribute 'get'` on a bare int. Always pass a dict.
+
+Each call returns a `Decision` in one of these kinds:
 
 - **AUTO** — thresholds met, promotion target is charter or skill, NOT already promoted
 - **DECIDE** — thresholds met, target is hook (always DECIDE), OR `requires_decision: true` override, OR signals ambiguous

--- a/.claude/skills/promotion-audit/helpers.py
+++ b/.claude/skills/promotion-audit/helpers.py
@@ -440,19 +440,60 @@ _HTML_COMMENT_PROMOTED_RE = re.compile(
 
 # Memory filenames can be cited with or without the `.md` suffix in
 # charter prose (e.g. hooks.md L169 cites `feedback_honest_audit_over_conclusion_claim`
-# unsuffixed inside a backticked span). The regex now makes the `.md`
-# optional and the caller backfills the suffix into the returned set so
-# both forms are recognized membership-checks.
+# unsuffixed inside a backticked span). The regex makes the `.md` optional
+# and the caller backfills the suffix into the returned set so both forms
+# are recognized in membership checks.
+#
+# Slash-command branch shape (#419): `(?<![\w/])/[a-z][a-z0-9-]{2,}` —
+# kebab-case slash-commands, alpha-leading, length >= 3, AND preceded by
+# a non-word/non-slash boundary. The alpha-leading filter rejects
+# URL-path-fragment hits like `/198` (numeric issue IDs from gh URLs);
+# the length-3 minimum rejects `/a`, `/b1`; and the lookbehind rejects
+# mid-token slashes like `/supersedes` inside the prose `augments/supersedes`
+# in charter/skills.md. Combined with `_strip_url_bodies` (applied to the
+# block body BEFORE the regex runs), this rejects the 11 URL-fragment
+# false positives documented in #419 plus the `augments/supersedes` 12th.
 _SOURCE_HINT_RE = re.compile(
     r"""
     (?:
         (?:feedback|project|reference)_[a-z0-9_]+(?:\.md)?  # memory filenames (with or without .md)
         |
-        /[\w-]+                                              # slash-commands / skill names
+        (?<![\w/])/[a-z][a-z0-9-]{2,}                       # slash-commands at word boundary
     )
     """,
     re.VERBOSE,
 )
+
+
+# URL-stripping regexes (#419). Applied to provenance-block bodies BEFORE
+# `_SOURCE_HINT_RE.finditer` so URL path fragments never reach the slash-
+# command branch. Three forms:
+#   - markdown link bodies: `[text](url)` → `[text]()` (preserves link text)
+#   - autolinks: `<url>` → ``
+#   - bare URLs: `https://...` → ``
+# The link-text preservation matters because some link labels themselves
+# contain a memory filename or slash-command reference that IS load-bearing.
+_MD_LINK_URL_RE = re.compile(r"\]\(\s*<?(?:https?|ftp)://[^\s)>]+>?\s*\)")
+_AUTOLINK_URL_RE = re.compile(r"<(?:https?|ftp)://[^>\s]+>")
+_BARE_URL_RE = re.compile(r"(?<![\[\(])(?:https?|ftp)://[^\s)>]+")
+
+
+def _strip_url_bodies(text: str) -> str:
+    """Remove URL bodies from `text` while preserving non-URL prose.
+
+    Applied to provenance-block bodies before `_SOURCE_HINT_RE.finditer`
+    so URL path fragments (`/198`, `/issues`, `/noorinalabs-main`, etc.)
+    never reach the slash-command branch as false positives (#419).
+    Markdown link text is preserved by replacing `(url)` with `()`,
+    leaving `[text]` intact — if a link label cites a real memory
+    filename or slash-command, that reference still surfaces in the
+    downstream regex sweep.
+    """
+    text = _MD_LINK_URL_RE.sub("]()", text)
+    text = _AUTOLINK_URL_RE.sub("", text)
+    text = _BARE_URL_RE.sub("", text)
+    return text
+
 
 # Memory-filename prefixes the parser recognizes. Used by
 # `_normalize_memory_hit` to decide whether a no-suffix hit should be
@@ -554,8 +595,10 @@ def find_already_promoted(charter_path: str) -> set[str]:
         text = f.read()
 
     # Block-style `**Promotion provenance:**` entries (hooks.md format).
+    # URL bodies stripped first (#419) so gh-issue-link path fragments
+    # never reach the slash-command branch.
     for block in _PROVENANCE_RE.finditer(text):
-        body = block.group("body")
+        body = _strip_url_bodies(block.group("body"))
         for hit in _SOURCE_HINT_RE.finditer(body):
             if _is_forward_reference(body, hit.start()):
                 continue
@@ -566,7 +609,7 @@ def find_already_promoted(charter_path: str) -> set[str]:
     # unnecessary for this format — the marker is by definition a
     # backward-looking promotion claim.
     for block in _HTML_COMMENT_PROMOTED_RE.finditer(text):
-        body = block.group("body")
+        body = _strip_url_bodies(block.group("body"))
         for hit in _SOURCE_HINT_RE.finditer(body):
             refs.update(_normalize_memory_hit(hit.group(0)))
 

--- a/.claude/skills/promotion-audit/tests/test_helpers.py
+++ b/.claude/skills/promotion-audit/tests/test_helpers.py
@@ -928,5 +928,137 @@ class SlugifyTests(unittest.TestCase):
         self.assertEqual(h._slugify("   "), "section")
 
 
+class SourceHintReTests(unittest.TestCase):
+    """#419 regression — `_SOURCE_HINT_RE` MUST NOT match URL path
+    fragments inside gh-issue link bodies, and MUST still match real
+    kebab-case slash-commands at word boundaries.
+
+    Exercises the regex directly (tightening) plus `_strip_url_bodies`
+    (link-context elimination). Both layers are load-bearing; tests
+    cover each independently and in combination via `find_already_promoted`.
+    """
+
+    def test_excludes_numeric_url_path_fragment(self) -> None:
+        """NEG (#419 row 1): `/198` from gh-issue URL fragments is rejected
+        purely by the regex shape — alpha-leading filter — even before
+        URL-stripping runs."""
+        matches = h._SOURCE_HINT_RE.findall("filed as /198 and /200 and /244")
+        self.assertNotIn("/198", matches)
+        self.assertNotIn("/200", matches)
+        self.assertNotIn("/244", matches)
+
+    def test_excludes_uppercase_url_path_fragment(self) -> None:
+        """NEG (#419 row 2): `/Edit` from path fragments rejected by the
+        alpha-LOWERCASE-leading filter."""
+        matches = h._SOURCE_HINT_RE.findall("see /Edit or /GitHub")
+        self.assertNotIn("/Edit", matches)
+        self.assertNotIn("/GitHub", matches)
+
+    def test_excludes_mid_token_slash(self) -> None:
+        """NEG (12th case): `/supersedes` inside `augments/supersedes`
+        prose (charter/skills.md:108) is rejected by the word-boundary
+        lookbehind."""
+        matches = h._SOURCE_HINT_RE.findall("augments/supersedes relationships")
+        self.assertNotIn("/supersedes", matches)
+
+    def test_matches_real_slash_command_at_word_boundary(self) -> None:
+        """POS (#419 acceptance): real slash-commands at word boundaries
+        (start, after whitespace, after punctuation) still match."""
+        matches = set(
+            h._SOURCE_HINT_RE.findall("see /promotion-audit and /wave-retro (/auto-promote)")
+        )
+        self.assertIn("/promotion-audit", matches)
+        self.assertIn("/wave-retro", matches)
+        self.assertIn("/auto-promote", matches)
+
+    def test_matches_memory_filename_both_forms(self) -> None:
+        """POS regression guard: memory-filename matching unaffected by
+        the slash-branch tightening."""
+        matches = set(
+            h._SOURCE_HINT_RE.findall(
+                "see feedback_foo.md and project_bar (suffixless), reference_baz.md"
+            )
+        )
+        self.assertIn("feedback_foo.md", matches)
+        self.assertIn("reference_baz.md", matches)
+        # Suffix-less form is captured separately.
+        self.assertIn("project_bar", matches)
+
+
+class StripUrlBodiesTests(unittest.TestCase):
+    """#419: `_strip_url_bodies` removes URL bodies (markdown links,
+    autolinks, bare URLs) while preserving the surrounding prose so
+    URL-path-fragment matches never reach `_SOURCE_HINT_RE`."""
+
+    def test_markdown_link_url_stripped_text_preserved(self) -> None:
+        """[text](url) → [text]() — URL gone, link text remains so any
+        memory/slash-command reference inside the text is still hit."""
+        s = h._strip_url_bodies(
+            "[#198](https://github.com/noorinalabs/noorinalabs-main/issues/198)"
+        )
+        self.assertEqual(s, "[#198]()")
+        # Downstream regex on the stripped form must NOT hit `/198`/`/issues`.
+        self.assertNotIn("/198", h._SOURCE_HINT_RE.findall(s))
+        self.assertNotIn("/issues", h._SOURCE_HINT_RE.findall(s))
+        self.assertNotIn("/noorinalabs", h._SOURCE_HINT_RE.findall(s))
+
+    def test_autolink_url_stripped(self) -> None:
+        """<https://...> → empty (no link text to preserve)."""
+        s = h._strip_url_bodies("see <https://github.com/foo/bar/issues/337>")
+        self.assertNotIn("github", s)
+        self.assertNotIn("337", s)
+
+    def test_bare_url_stripped(self) -> None:
+        """Bare `http(s)://...` in prose is stripped."""
+        s = h._strip_url_bodies("docs at https://example.com/path/to/thing")
+        self.assertNotIn("https://", s)
+        self.assertNotIn("/path", s)
+        self.assertNotIn("/thing", s)
+
+    def test_non_url_prose_unchanged(self) -> None:
+        """NEG: text without URLs is returned identically — no
+        accidental damage to charter prose."""
+        s = "see /promotion-audit and feedback_foo.md per retro"
+        self.assertEqual(h._strip_url_bodies(s), s)
+
+    def test_link_text_with_real_slash_command_preserved(self) -> None:
+        """POS: a markdown link whose LABEL cites a real slash-command
+        must still surface that slash-command after stripping."""
+        s = h._strip_url_bodies("[/promotion-audit run output](https://example.com/log)")
+        self.assertIn("/promotion-audit", h._SOURCE_HINT_RE.findall(s))
+
+    def test_find_already_promoted_rejects_url_fragments_end_to_end(self) -> None:
+        """POS end-to-end (#419 acceptance): a provenance block whose
+        body contains an issue link does NOT pollute the returned set
+        with URL-path-fragment noise.
+        """
+        charter = textwrap.dedent(
+            """\
+            ## Hook 99: Foo
+
+            - **Promotion provenance:** Rule lived in feedback_foo.md.
+              Filed as [#198](https://github.com/noorinalabs/noorinalabs-main/issues/198).
+              Worked example used /promotion-audit run output.
+            """
+        )
+        with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as f:
+            f.write(charter)
+            path = f.name
+        try:
+            refs = h.find_already_promoted(path)
+            # Real refs present.
+            self.assertIn("feedback_foo.md", refs)
+            self.assertIn("/promotion-audit", refs)
+            # URL-fragment noise absent.
+            for noise in ("/198", "/issues", "/noorinalabs", "/noorinalabs-main", "/github"):
+                self.assertNotIn(
+                    noise,
+                    refs,
+                    msg=f"URL-fragment {noise!r} leaked into already-promoted set",
+                )
+        finally:
+            os.unlink(path)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
Closes #417.
Closes #419.

## Summary

Bundle of two `/promotion-audit` drift items touching the same skill (`SKILL.md` + `helpers.py`). Diffs sit in non-overlapping regions; single PR is cleaner than two against the same files.

## #417 — SKILL.md classifier prose drift

`SKILL.md` Step 2 listed `classify` as a single import, but the real `helpers.py` surface is **three classifiers with distinct signatures**. The example block also omitted the `signals: dict[str, int]` argument, so operators copy-pasting the prose passed a bare int and hit `AttributeError: 'int' object has no attribute 'get'` at `helpers.py:672`.

**Fix (prose-only).** Replace the import line with the three real function names; add a per-classifier signature table showing the `signals` keys each consumes; add a worked-example block calling each classifier with a properly shaped `signals` dict; call out the bare-int trap explicitly.

| Function | Signature | `signals` keys consumed |
|---|---|---|
| `classify_memory(memory, signals, already_promoted)` | `(Memory, dict[str,int], set[str]) -> Decision` | `retro_citations` |
| `classify_section(section, signals)` | `(CharterSection, dict[str,int]) -> Decision` | `skill_invocations`, `threshold` |
| `classify_skill(skill, signals, already_promoted)` | `(Skill, dict[str,int], set[str]) -> Decision` | `skill_invocations`, `threshold` |

**Dispatcher extraction skipped (issue body's "optional").** The three classifiers diverge in `already_promoted` handling (section has none) and in `signals` keys. A unified `classify()` would either silently drop `already_promoted` for sections or carry a noop arg — clutter exceeds the operator-visible surface gain once the prose names the three functions correctly.

## #419 — `_SOURCE_HINT_RE` URL-fragment false positives

The `/[\w-]+` branch matched URL path fragments inside markdown link bodies like `[#198](https://github.com/.../issues/198)`. Live evidence (P3W9 retro 2026-05-12) showed 11 false positives in the `already_promoted` set.

**Issue body's recommendation was incomplete.** Empirical check: `/[a-z][a-z0-9-]{2,}` alone rejects only **6 of the 11** (numeric `/198`-class plus the uppercase `/Edit`). The remaining 5 — `/github`, `/issues`, `/noorinalabs`, `/noorinalabs-main`, `/supersedes` — are alpha-leading kebab-case and shape-indistinguishable from real slash-commands.

**Plus a 12th case discovered during fix design:** `/supersedes` inside the `augments/supersedes` prose in `charter/skills.md:108` — slash mid-token, not a URL fragment.

**Two-layer fix:**

1. **`_strip_url_bodies(text)`** — new helper, pre-strips URL bodies from provenance-block content before regex matching:
   - `[text](url)` → `[text]()` (preserves link text so memory/slash references in labels still surface)
   - `<url>` → ``
   - bare `http(s)://...` → ``

2. **Tighten `_SOURCE_HINT_RE`** slash-command branch: `/[\w-]+` → `(?<![\w/])/[a-z][a-z0-9-]{2,}`
   - alpha-leading filter rejects numeric paths
   - lowercase-leading rejects `/Edit`-class
   - length ≥ 3 rejects `/a`, `/b1`
   - word-boundary lookbehind rejects mid-token slashes (the `augments/supersedes` case)

Both layers applied at both call sites in `find_already_promoted` (provenance-block scan + HTML-comment marker scan).

Verified locally — strips all 11 issue-body FPs **+** the 12th `augments/supersedes` case, while preserving `/promotion-audit`, `/wave-retro`, `/auto-promote`, `/manual-trigger`, and memory filenames.

## Tests

- **`SourceHintReTests`** (5) — regex-level POS/NEG for numeric, uppercase, mid-token slashes; real slash-commands at word boundaries; memory filenames both forms.
- **`StripUrlBodiesTests`** (6) — markdown link / autolink / bare URL stripping; non-URL prose unchanged; link-text preservation; end-to-end `find_already_promoted` check against a provenance block containing a gh-issue link.

Local: `pytest .claude/skills/promotion-audit/tests/` → **78 passed** (61 existing + 11 new helper tests + 6 smoke).
`uvx ruff format --check`, `uvx ruff check`, `uvx mypy` all clean on the touched files.

## Reviewers

- **Wanjiku Mwangi** (TPM) — process angle, scope discipline
- **Santiago Ferreira** (Release Coordinator) — skill/charter angle

Manager-boundary check: both peers, Nadia is my PD; neither is the author (Aino, ineligible self-review).

## Test Plan

- [x] Unit + smoke tests (78 passed)
- [x] Ruff format / lint / mypy clean
- [ ] Reviewers verify URL-strip + regex tightening end-to-end against `.claude/team/charter/skills.md:108` (the `/supersedes` 12th case) via `gh api repos/.../contents/.claude/skills/promotion-audit/helpers.py?ref=<HEAD>`
- [ ] Post-merge runtime verification: re-run `find_already_promoted_in_charter('.claude/team')` after merge; expect exactly the real refs (no `/198`/`/issues`/`/noorinalabs-main`/`/supersedes` noise). This is observable via the next `/promotion-audit` run's audit log.

## Charter compliance

- 2 reviewers named in body
- Branch: `A.Virtanen/0417-promotion-audit-bundle` per convention
- Commit identity: `Aino Virtanen <parametrization+Aino.Virtanen@gmail.com>` via per-commit `-c` flags (no global/repo config touched)
- Base: `deployments/phase-3/wave-10` (not main)
- No `--no-verify`
- `Closes #417` AND `Closes #419` each on their own line at the top
