### PR TITLE
fix(hooks): dispatcher zero-observability — #425 framed as dispatcher dead, root cause was silent-diagnostic-return pattern (sibling of #429, #437)

### DIFF
--- a/.claude/hooks/annunaki_log.py
+++ b/.claude/hooks/annunaki_log.py
@@ -87,6 +87,40 @@ def log_pretooluse_diagnostic(
     append_jsonl_record(ERRORS_FILE, record)
 
 
+def log_posttooluse_dispatch(
+    module_name: str,
+    command: str,
+    outcome: dict,
+    tool_name: str = "Bash",
+) -> None:
+    """Append a per-hook dispatch trace from `post_dispatcher`.
+
+    Distinct from `log_posttooluse_event` (which is hooks self-reporting
+    their own non-actionable conditions) because this records the
+    DISPATCHER's view of every check() call: did it return None / a
+    structured action dict / raise. Critical for #425-class debugging
+    where the harness sees only `stdout=""` and the operator concludes
+    "dispatcher dead" even when the chain is firing perfectly. Type is
+    `posttooluse_dispatch` so /annunaki can filter these out of error
+    counts — they're informational unless `outcome.raised` is set.
+
+    `outcome` shape (all JSON-safe primitives):
+      - returned: stringified repr of what check() returned (or "None")
+      - raised: exception type name, or null
+      - traceback_excerpt: first 500 chars of traceback if raised, else null
+      - elapsed_ms: optional, round-trip duration of the check() call
+    """
+    record = {
+        "timestamp": datetime.now(UTC).isoformat(),
+        "type": "posttooluse_dispatch",
+        "module": module_name,
+        "tool_name": tool_name,
+        "command": command[:500],
+        "outcome": outcome,
+    }
+    append_jsonl_record(ERRORS_FILE, record)
+
+
 def log_posttooluse_event(
     hook_name: str, command: str, reason: str, tool_name: str = "Bash"
 ) -> None:

--- a/.claude/hooks/post_dispatcher.py
+++ b/.claude/hooks/post_dispatcher.py
@@ -11,7 +11,11 @@ Each PostToolUse hook module exposes:
         Returns None for no-op (hook didn't apply or had no advisory to
         emit). Returns a dict with `systemMessage` to surface an advisory
         message through the harness. Other keys (`action`, etc.) are
-        recorded for diagnostics but not surfaced.
+        recorded for diagnostics but not surfaced — UNLESS the module
+        sets `EMIT_DISPATCH_SUMMARY = True` at module scope, in which
+        case the dispatcher synthesizes a `systemMessage` summary from
+        the action-shaped return so operators see what happened in the
+        harness UI (per-hook opt-in, default False; see #425).
 
 Unlike PreToolUse, PostToolUse hooks CANNOT block the tool — it already
 ran. The dispatcher runs every registered module for the matcher and
@@ -163,6 +167,24 @@ def main() -> None:
         msg = result.get("systemMessage")
         if msg:
             messages.append(str(msg))
+            continue
+
+        # Per-hook opt-in (#425): when the module sets
+        # `EMIT_DISPATCH_SUMMARY = True` AND the result carries an `action`
+        # key, the dispatcher synthesizes a short systemMessage from the
+        # action-shaped return. Operators then see "post_wave_kickoff_comment:
+        # action=post repo=… issue=…" in the harness UI for the specific
+        # hooks where that visibility is load-bearing. Default-off keeps
+        # hooks like annunaki_monitor (action dicts on every Bash call) from
+        # spamming the UI. The annunaki dispatch-trace record fires
+        # independently of this flag for full forensic visibility.
+        if getattr(mod, "EMIT_DISPATCH_SUMMARY", False) and result.get("action"):
+            summary_parts = [f"{module_name}: action={result['action']}"]
+            for k, v in sorted(result.items()):
+                if k in ("action", "systemMessage"):
+                    continue
+                summary_parts.append(f"{k}={v}")
+            messages.append(" ".join(summary_parts))
 
     if messages:
         output = {"systemMessage": "\n\n".join(messages)}

--- a/.claude/hooks/post_dispatcher.py
+++ b/.claude/hooks/post_dispatcher.py
@@ -35,13 +35,28 @@ Exit codes:
 
 import importlib
 import json
+import os
 import sys
+import time
+import traceback
 from pathlib import Path
 
 # Ensure the hooks directory is on sys.path for imports
 _HOOKS_DIR = Path(__file__).resolve().parent
 if str(_HOOKS_DIR) not in sys.path:
     sys.path.insert(0, str(_HOOKS_DIR))
+
+from annunaki_log import log_posttooluse_dispatch  # noqa: E402
+
+# Per-check dispatch tracing (#425). When `POST_DISPATCHER_TRACE_ALL=1` is
+# set, the dispatcher emits an annunaki `posttooluse_dispatch` record for
+# every check() call regardless of outcome. By default, only "interesting"
+# outcomes are recorded: raised exceptions OR non-None dict returns (the
+# action-shaped `{"action": "post|skip_*", ...}` returns that PostToolUse
+# hooks like post_wave_kickoff_comment use). None returns from hooks
+# legitimately not applying (overwhelming common case) stay silent so the
+# log doesn't drown in no-op entries.
+_TRACE_EVERY = os.environ.get("POST_DISPATCHER_TRACE_ALL", "").lower() in ("1", "true", "yes")
 
 # Edit and Write share the same module set today (every module that runs on
 # Edit also runs on Write). Defining it once keeps the two matcher entries
@@ -82,6 +97,17 @@ def main() -> None:
 
     messages: list[str] = []
 
+    # Command excerpt for dispatch-trace records. Bash hooks see the literal
+    # tool_input.command; Edit/Write hooks see the file_path. Other shapes
+    # fall back to a JSON-stringified preview.
+    tool_input = input_data.get("tool_input") or {}
+    if tool_name == "Bash":
+        command_excerpt = str(tool_input.get("command", ""))[:500]
+    else:
+        command_excerpt = str(
+            tool_input.get("file_path") or tool_input.get("notebook_path") or tool_input
+        )[:500]
+
     for module_name in modules:
         try:
             mod = importlib.import_module(module_name)
@@ -92,10 +118,44 @@ def main() -> None:
         if check_fn is None:
             continue
 
+        start_ns = time.perf_counter_ns()
+        raised_excinfo: tuple[str, str] | None = None
+        result = None
         try:
             result = check_fn(input_data)
-        except Exception:
-            continue  # Never let a hook crash propagate — advisory only
+        except Exception as e:  # noqa: BLE001
+            # Never let a hook crash propagate — advisory only. But unlike
+            # the pre-#425 bare `except: continue`, capture the type +
+            # traceback excerpt so the swallow is recoverable via /annunaki.
+            tb_text = traceback.format_exc()[:500]
+            raised_excinfo = (f"{type(e).__name__}: {e}", tb_text)
+
+        elapsed_ms = round((time.perf_counter_ns() - start_ns) / 1_000_000, 2)
+
+        # Emit a dispatch-trace record when (a) the env-flag forces it,
+        # (b) the check raised, or (c) the check returned a non-None dict
+        # (action-shape diagnostic). None returns stay silent — those are
+        # the legitimate "hook didn't apply" overwhelming-common case.
+        should_trace = _TRACE_EVERY or raised_excinfo is not None or isinstance(result, dict)
+        if should_trace:
+            outcome = {
+                "returned": repr(result)[:500] if result is not None else "None",
+                "raised": raised_excinfo[0] if raised_excinfo else None,
+                "traceback_excerpt": raised_excinfo[1] if raised_excinfo else None,
+                "elapsed_ms": elapsed_ms,
+            }
+            try:
+                log_posttooluse_dispatch(
+                    module_name=module_name,
+                    command=command_excerpt,
+                    outcome=outcome,
+                    tool_name=tool_name,
+                )
+            except Exception:  # noqa: BLE001
+                pass  # Logging must never crash the dispatcher
+
+        if raised_excinfo is not None:
+            continue  # Swallowed-and-logged; move on to the next hook
 
         if not isinstance(result, dict):
             continue

--- a/.claude/hooks/post_wave_kickoff_comment.py
+++ b/.claude/hooks/post_wave_kickoff_comment.py
@@ -66,6 +66,16 @@ from _shell_parse import (  # noqa: E402
 )
 from annunaki_log import log_posttooluse_event  # noqa: E402
 
+# Dispatcher opt-in (#425): when post_dispatcher sees this attribute set
+# to True AND `check()` returns an action-shaped dict, it synthesizes a
+# short `systemMessage` summary so operators see "post_wave_kickoff_comment:
+# action=post repo=… issue=…" in the harness UI. The visibility matters
+# here specifically because this hook's whole job is posting kickoff
+# comments — silent "did it post or did it skip?" was the original #425
+# symptom (operator concluded "dispatcher dead" when the hook was actually
+# returning skip_idempotent correctly).
+EMIT_DISPATCH_SUMMARY = True
+
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 CROSS_REPO_STATUS = REPO_ROOT / "cross-repo-status.json"
 # Fallback location (subdir-rooted layouts have used this in earlier waves).

--- a/.claude/hooks/tests/test_post_dispatcher.py
+++ b/.claude/hooks/tests/test_post_dispatcher.py
@@ -358,5 +358,189 @@ class BackwardCompatTests(unittest.TestCase):
         self.assertIsNone(result)
 
 
+class DispatchTraceTests(unittest.TestCase):
+    """#425: every interesting dispatched check() emits an annunaki
+    `posttooluse_dispatch` record so /annunaki can show what each hook
+    did per Bash call. "Interesting" = raised OR returned a non-None
+    dict; None returns stay silent to avoid log spam.
+    """
+
+    def setUp(self) -> None:
+        import tempfile
+
+        import annunaki_log
+
+        self._tmp_dir = tempfile.mkdtemp(prefix="post_dispatch_trace_")
+        self._orig_errors_file = annunaki_log.ERRORS_FILE
+        self._errors_file = Path(self._tmp_dir) / "errors.jsonl"
+        annunaki_log.ERRORS_FILE = self._errors_file
+
+    def tearDown(self) -> None:
+        import shutil
+
+        import annunaki_log
+
+        annunaki_log.ERRORS_FILE = self._orig_errors_file
+        shutil.rmtree(self._tmp_dir, ignore_errors=True)
+
+    def _read_records(self) -> list[dict]:
+        if not self._errors_file.exists():
+            return []
+        with self._errors_file.open("r", encoding="utf-8") as f:
+            return [json.loads(line) for line in f if line.strip()]
+
+    def test_action_dict_return_records_dispatch_trace(self) -> None:
+        """POS (#425 core case): when post_wave_kickoff_comment returns
+        `{'action': 'post', ...}` the dispatcher records a trace so the
+        action is visible in /annunaki — was previously invisible because
+        the dispatcher only surfaces `systemMessage` returns."""
+        input_data = {
+            "tool_name": "Bash",
+            "hook_event_name": "PostToolUse",
+            "tool_input": {"command": "gh issue edit 423 --add-label p3-wave-10"},
+            "tool_response": {"stdout": "", "stderr": "", "exitCode": 0},
+        }
+        action_return = {"action": "post", "repo": "noorinalabs-main", "issue": "423"}
+        with (
+            mock.patch("annunaki_monitor.check", return_value=None),
+            mock.patch("auto_add_issue_to_board.check", return_value=None),
+            mock.patch("post_wave_kickoff_comment.check", return_value=action_return),
+        ):
+            code, _ = _run_dispatcher(input_data)
+        self.assertEqual(code, 0)
+
+        traces = [r for r in self._read_records() if r["type"] == "posttooluse_dispatch"]
+        # Only the post_wave_kickoff_comment record fires (the other two
+        # returned None — those are silent per design).
+        self.assertEqual(len(traces), 1, "exactly one trace for the non-None return")
+        rec = traces[0]
+        self.assertEqual(rec["module"], "post_wave_kickoff_comment")
+        self.assertEqual(rec["tool_name"], "Bash")
+        self.assertIn("'action': 'post'", rec["outcome"]["returned"])
+        self.assertIsNone(rec["outcome"]["raised"])
+        self.assertIsNone(rec["outcome"]["traceback_excerpt"])
+        self.assertIn("gh issue edit", rec["command"])
+
+    def test_none_returns_silent_by_default(self) -> None:
+        """NEG: when every hook returns None (overwhelming common case),
+        the dispatcher writes ZERO trace records — keeps the log low-noise.
+        """
+        input_data = {
+            "tool_name": "Bash",
+            "hook_event_name": "PostToolUse",
+            "tool_input": {"command": "echo hi"},
+            "tool_response": {"stdout": "hi\n", "stderr": "", "exitCode": 0},
+        }
+        with (
+            mock.patch("annunaki_monitor.check", return_value=None),
+            mock.patch("auto_add_issue_to_board.check", return_value=None),
+            mock.patch("post_wave_kickoff_comment.check", return_value=None),
+        ):
+            code, _ = _run_dispatcher(input_data)
+        self.assertEqual(code, 0)
+        self.assertEqual(self._read_records(), [])
+
+    def test_raised_exception_records_trace_with_traceback(self) -> None:
+        """POS: a raising hook surfaces type + traceback in the trace
+        record — was previously a bare `except: continue` with zero
+        forensic visibility. Sibling hooks must still run."""
+        input_data = {
+            "tool_name": "Bash",
+            "hook_event_name": "PostToolUse",
+            "tool_input": {"command": "echo trace-test"},
+            "tool_response": {"stdout": "", "stderr": "", "exitCode": 0},
+        }
+        sibling = mock.MagicMock(return_value=None)
+        with (
+            mock.patch("annunaki_monitor.check", side_effect=RuntimeError("simulated crash")),
+            mock.patch("auto_add_issue_to_board.check", sibling),
+            mock.patch("post_wave_kickoff_comment.check", return_value=None),
+        ):
+            code, _ = _run_dispatcher(input_data)
+        self.assertEqual(code, 0, "exception still swallowed for advisory contract")
+        self.assertEqual(sibling.call_count, 1, "sibling still runs after sibling-raise")
+
+        traces = [r for r in self._read_records() if r["type"] == "posttooluse_dispatch"]
+        self.assertEqual(len(traces), 1)
+        rec = traces[0]
+        self.assertEqual(rec["module"], "annunaki_monitor")
+        self.assertIn("RuntimeError", rec["outcome"]["raised"])
+        self.assertIn("simulated crash", rec["outcome"]["raised"])
+        self.assertIsNotNone(rec["outcome"]["traceback_excerpt"])
+        # Traceback excerpt is bounded at 500 chars and the unittest.mock
+        # frames often consume that budget before the actual exception
+        # text appears. The starting "Traceback" sentinel is enough to
+        # confirm we captured one; the exception type + message are
+        # already asserted via `outcome.raised`.
+        self.assertTrue(rec["outcome"]["traceback_excerpt"].startswith("Traceback"))
+
+    def test_trace_all_env_var_forces_none_returns_logged(self) -> None:
+        """POS: when POST_DISPATCHER_TRACE_ALL=1, even None returns
+        produce a trace record — useful when debugging "did the hook
+        even run?" questions (the #425 original symptom)."""
+        import importlib
+
+        import post_dispatcher
+
+        input_data = {
+            "tool_name": "Bash",
+            "hook_event_name": "PostToolUse",
+            "tool_input": {"command": "echo trace-all"},
+            "tool_response": {"stdout": "", "stderr": "", "exitCode": 0},
+        }
+        with mock.patch.dict("os.environ", {"POST_DISPATCHER_TRACE_ALL": "1"}):
+            importlib.reload(post_dispatcher)
+            try:
+                with (
+                    mock.patch("annunaki_monitor.check", return_value=None),
+                    mock.patch("auto_add_issue_to_board.check", return_value=None),
+                    mock.patch("post_wave_kickoff_comment.check", return_value=None),
+                ):
+                    stdin = io.StringIO(json.dumps(input_data))
+                    stdout = io.StringIO()
+                    with (
+                        mock.patch.object(sys, "stdin", stdin),
+                        mock.patch.object(sys, "stdout", stdout),
+                    ):
+                        try:
+                            post_dispatcher.main()
+                        except SystemExit:
+                            pass
+            finally:
+                importlib.reload(post_dispatcher)
+
+        traces = [r for r in self._read_records() if r["type"] == "posttooluse_dispatch"]
+        self.assertEqual(
+            len(traces), 3, "TRACE_ALL must emit one record per registered Bash module"
+        )
+        modules = {t["module"] for t in traces}
+        self.assertEqual(
+            modules, {"annunaki_monitor", "auto_add_issue_to_board", "post_wave_kickoff_comment"}
+        )
+
+    def test_elapsed_ms_recorded(self) -> None:
+        """POS: every trace record carries an `elapsed_ms` field for
+        spotting slow check()s. Doesn't pin a value, just presence + type."""
+        input_data = {
+            "tool_name": "Bash",
+            "hook_event_name": "PostToolUse",
+            "tool_input": {"command": "echo timing"},
+            "tool_response": {"stdout": "", "stderr": "", "exitCode": 0},
+        }
+        with (
+            mock.patch("annunaki_monitor.check", return_value=None),
+            mock.patch("auto_add_issue_to_board.check", return_value=None),
+            mock.patch(
+                "post_wave_kickoff_comment.check",
+                return_value={"action": "skip_no_row", "repo": "x", "issue": "0"},
+            ),
+        ):
+            _run_dispatcher(input_data)
+        traces = [r for r in self._read_records() if r["type"] == "posttooluse_dispatch"]
+        self.assertEqual(len(traces), 1)
+        self.assertIsInstance(traces[0]["outcome"]["elapsed_ms"], (int, float))
+        self.assertGreaterEqual(traces[0]["outcome"]["elapsed_ms"], 0)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.claude/hooks/tests/test_post_dispatcher.py
+++ b/.claude/hooks/tests/test_post_dispatcher.py
@@ -542,5 +542,85 @@ class DispatchTraceTests(unittest.TestCase):
         self.assertGreaterEqual(traces[0]["outcome"]["elapsed_ms"], 0)
 
 
+class EmitDispatchSummaryOptInTests(unittest.TestCase):
+    """#425 followup — per-hook opt-in surfacing of action-shaped returns
+    as systemMessage. Hooks set `EMIT_DISPATCH_SUMMARY = True` at module
+    scope to opt in. Default is False; no behavior change for unmarked
+    hooks (preserves existing harness UX for annunaki_monitor, etc.)."""
+
+    def _run(self, action_return: dict, opt_in: bool) -> str:
+        """Run the dispatcher with post_wave_kickoff_comment returning the
+        given action dict and EMIT_DISPATCH_SUMMARY set per `opt_in`.
+        Returns the dispatcher's stdout."""
+        input_data = {
+            "tool_name": "Bash",
+            "hook_event_name": "PostToolUse",
+            "tool_input": {"command": "gh issue edit 423 --add-label p3-wave-10"},
+            "tool_response": {"stdout": "", "stderr": "", "exitCode": 0},
+        }
+        with (
+            mock.patch("annunaki_monitor.check", return_value=None),
+            mock.patch("auto_add_issue_to_board.check", return_value=None),
+            mock.patch("post_wave_kickoff_comment.check", return_value=action_return),
+            mock.patch("post_wave_kickoff_comment.EMIT_DISPATCH_SUMMARY", opt_in, create=True),
+        ):
+            _, out = _run_dispatcher(input_data)
+        return out
+
+    def test_opt_in_synthesizes_systemmessage_from_action(self) -> None:
+        """POS (#425 core): opt-in hook with action-return → systemMessage
+        appears in dispatcher stdout, with module name + action + extra
+        keys formatted for operator visibility."""
+        out = self._run({"action": "post", "repo": "noorinalabs-main", "issue": "423"}, opt_in=True)
+        self.assertNotEqual(out, "")
+        parsed = json.loads(out)
+        msg = parsed["systemMessage"]
+        self.assertIn("post_wave_kickoff_comment", msg)
+        self.assertIn("action=post", msg)
+        self.assertIn("issue=423", msg)
+        self.assertIn("repo=noorinalabs-main", msg)
+
+    def test_opt_out_default_stays_silent(self) -> None:
+        """NEG: default (EMIT_DISPATCH_SUMMARY absent/False) → dispatcher
+        stdout stays empty for action-shaped returns. Preserves pre-#425
+        UX for hooks that haven't opted in."""
+        out = self._run(
+            {"action": "post", "repo": "noorinalabs-main", "issue": "423"}, opt_in=False
+        )
+        self.assertEqual(out, "", "opt-out default must not surface action returns")
+
+    def test_explicit_systemmessage_always_wins_over_synthesis(self) -> None:
+        """NEG: when a hook returns BOTH `systemMessage` and `action`, the
+        explicit message is used; synthesis is skipped. (Synthesis is a
+        fallback for hooks that don't carry their own message.)"""
+        out = self._run(
+            {
+                "systemMessage": "EXPLICIT_MESSAGE",
+                "action": "post",
+                "repo": "x",
+                "issue": "1",
+            },
+            opt_in=True,
+        )
+        parsed = json.loads(out)
+        msg = parsed["systemMessage"]
+        self.assertEqual(msg.strip(), "EXPLICIT_MESSAGE")
+        self.assertNotIn("action=post", msg)
+
+    def test_opt_in_with_no_action_key_stays_silent(self) -> None:
+        """NEG: opt-in module returning a dict WITHOUT an `action` key →
+        no synthesis (synthesis requires an action-shaped dict)."""
+        out = self._run({}, opt_in=True)
+        self.assertEqual(out, "")
+
+    def test_post_wave_kickoff_comment_opts_in(self) -> None:
+        """POS contract: the real post_wave_kickoff_comment module sets
+        EMIT_DISPATCH_SUMMARY = True. Locks the opt-in attestation so a
+        future edit removing it has to update this test."""
+        import post_wave_kickoff_comment
+
+        self.assertIs(getattr(post_wave_kickoff_comment, "EMIT_DISPATCH_SUMMARY", False), True)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #425.

## Premise correction (lead-with)

**#425 was filed against a "dispatcher dead" symptom that didn't exist.** The dispatcher chain was firing `post_wave_kickoff_comment.check()` correctly all along. Investigation showed the user's reproduction on #423 was the hook correctly returning `skip_idempotent` (because #423 already had a kickoff comment from a prior smoke test — admitted in the issue body itself). The W10 direct-invoke workaround was likely unnecessary for the 61 non-#423 issues; we can't verify retroactively because the workaround ran in parallel.

**The actual bug is operator-invisible action returns.** Four legitimately distinct outcomes are indistinguishable from operators and logs:
- `check()` returned `None` — hook didn't apply
- `check()` returned `{'action': 'skip_*'}` — hook ran, decided not to act
- `check()` returned `{'action': 'post'}` — hook ran, acted
- `check()` raised an exception — swallowed by `except Exception: continue` at `post_dispatcher.py:97`

Any future regression in any PostToolUse hook lands as "dispatcher silently dead" — same misreading the operator made, same lack of forensic record. This is the H2 zero-observability pattern (sibling of PR #434 / Hook 15 and PR #437 / promotion-audit).

## Root cause reproduction

End-to-end repro with an instrumented dispatcher subprocess against the user's exact command (`gh issue edit 423 --add-label "p3-wave-10"`):

```
INSTR: annunaki_monitor.check() returned: None
INSTR: auto_add_issue_to_board.check() returned: None
INSTR: post_wave_kickoff_comment.check() returned: {'action': 'skip_idempotent', 'repo': 'noorinalabs-main', 'issue': '423'}
exit: 0
stdout: ''
```

The dispatcher IS invoking the hook. The hook IS parsing the command, finding the assignment row, fetching comments. It returns `skip_idempotent` correctly. Dispatcher stdout is empty because it only surfaces `systemMessage` returns; the hook's `{'action': ...}` diagnostic is silently dropped.

## Changes

### Commit 1 — `1e22854` `fix(post_dispatcher): per-check dispatch tracing for #425`

- `annunaki_log.py`: new `log_posttooluse_dispatch(module_name, command, outcome, tool_name)` side-channel for per-check forensics. Record type `posttooluse_dispatch` is distinct from `posttooluse_event` so `/annunaki` filters informational dispatch traces out of error counts.
- `post_dispatcher.py`: wrap each `check_fn(input_data)` call with timing + exception capture (type + 500-char traceback excerpt). Emit a `posttooluse_dispatch` record when the outcome is *interesting* (raised, or non-None dict). None returns stay silent (legitimate "hook didn't apply" overwhelming-common case). New env var `POST_DISPATCHER_TRACE_ALL=1` forces a record on every call regardless of outcome — useful for debugging "did the hook even run?" (the original #425 symptom).
- The bare `except Exception: continue` swallow is now loud (records type + traceback) but still continues — preserves the advisory contract while making the swallow recoverable.
- 5 new `DispatchTraceTests`.

### Commit 2 — `d202217` `fix(post_dispatcher): add EMIT_DISPATCH_SUMMARY per-hook opt-in (#425)`

Without commit 2, the dispatch trace from commit 1 is visible only via `/annunaki` — operators reading the harness UI still see silent stdout for hooks whose whole job is doing observable work.

- `post_dispatcher.py`: per-hook opt-in. Modules set `EMIT_DISPATCH_SUMMARY = True` at module scope. The dispatcher checks for the flag AND an `action` key in the result; if both present, synthesizes a short systemMessage of the form `module_name: action=X key=val ...` and appends to aggregation. Explicit `systemMessage` returns always win (synthesis is the fallback for hooks that don't carry their own).
- `post_wave_kickoff_comment.py`: sets `EMIT_DISPATCH_SUMMARY = True`. This hook's whole job is posting kickoff comments; silent "did it post or did it skip?" was the original #425 symptom.
- 5 new `EmitDispatchSummaryOptInTests` (including a contract attestation that the real `post_wave_kickoff_comment` module sets the flag — a future edit removing it must update the test).

Default-False preserves existing harness UX for hooks that don't opt in (`annunaki_monitor`, `auto_add_issue_to_board`, etc.) — no behavior change for the non-#425-class hooks.

## End-to-end verification

Real subprocess against the worktree dispatcher with `gh issue edit 999999 --add-label p3-wave-10`:

```
worktree annunaki delta: 878 bytes
  posttooluse_event: module=post_wave_kickoff_comment ['No assignment row found in wave_10_scope tiers for noorinalabs-main#999999. ...']
  posttooluse_dispatch: module=post_wave_kickoff_comment {'returned': "{'action': 'skip_no_row', 'repo': 'noorinalabs-main', 'issue': '999999'}", 'raised': None, ...}
```

Both the existing `posttooluse_event` (from the hook itself) AND the new `posttooluse_dispatch` trace (from the dispatcher) appear, with the hook's structured return visible in the trace.

## Local validation

- `pytest .claude/hooks/tests/` → **764 passed** (754 existing + 5 new dispatch-trace + 5 new opt-in)
- `uvx ruff format --check .claude/hooks/` clean
- `uvx ruff check .claude/hooks/` clean
- `uvx mypy .claude/hooks/ --ignore-missing-imports` clean
- End-to-end real-subprocess verification passed

## Out of scope

- Replaying W10 kickoff with the new tracing to verify whether the workaround was actually needed for the other 61 issues — informational only.
- Updating `/wave-kickoff` SKILL.md prose about "auto-posted by hook"; the prose is correct now that the dispatch path is verifiable.
- Auto-opting in every existing PostToolUse hook to `EMIT_DISPATCH_SUMMARY`; only the hook whose silent-action was the load-bearing #425 symptom opts in. Other hooks opt in case-by-case as their visibility becomes load-bearing.

## Reviewers

- **Wanjiku Mwangi** (TPM) — process angle, dispatcher-contract scrutiny
- **Santiago Ferreira** (Release Coordinator) — hook/charter angle, annunaki-record-schema review

Manager-boundary check: both peers, Nadia is PD, neither is the author (Aino, ineligible self-review).

## Test Plan

- [x] Unit tests (764 passed)
- [x] Ruff format / lint / mypy clean
- [x] End-to-end real-subprocess verification
- [ ] Reviewers verify by spawning a subagent that triggers `gh issue edit … --add-label p3-wave-{M}` and confirming (a) a `posttooluse_dispatch` record appears in `/annunaki` AND (b) the harness UI shows `post_wave_kickoff_comment: action=…` in the dispatcher's systemMessage
- [ ] **Post-merge issue-close comment** (please paste on merge): *"#425 premise was inverted — the dispatcher was firing `post_wave_kickoff_comment.check()` correctly throughout /wave-kickoff p3 10. The W10 direct-invoke workaround was likely unnecessary for the 61 non-#423 issues; #423 specifically returned `skip_idempotent` because it already had a kickoff comment from a prior smoke test (admitted in this issue's body). PR #438 fixes the REAL defect: zero-observability on the PostToolUse dispatch path. Operators / logs now distinguish 'hook didn't apply' (None) from 'hook ran-and-skipped' (action dict) from 'hook ran-and-acted' from 'hook raised' — eliminating the silent-failure surface that misread as 'dispatcher dead.' Sibling of #429/#434 (Hook 15 sentinel) and #417+#419/#437 (promotion-audit URL fragments). Future regressions in any PostToolUse hook now leave forensic records via the new `posttooluse_dispatch` annunaki record type. Operator UX for `post_wave_kickoff_comment` specifically now shows `action=…` summaries in the harness via the new `EMIT_DISPATCH_SUMMARY` per-hook opt-in."*

## Charter compliance

- 2 reviewers named in body
- Branch: `A.Virtanen/0425-post-wave-kickoff-dispatcher` per convention
- Commit identity: `Aino Virtanen <parametrization+Aino.Virtanen@gmail.com>` via per-commit `-c` flags on both commits (no global/repo config touched)
- Base: `deployments/phase-3/wave-10` (not main)
- No `--no-verify` on either commit
- `Closes #425` at the top
