### PR TITLE
tech-debt(skill): /board-audit splits actionable vs no-op drift counts (#427)

### DIFF
--- a/.claude/skills/board-audit/SKILL.md
+++ b/.claude/skills/board-audit/SKILL.md
@@ -128,7 +128,19 @@ jq -r '.data.organization.projectV2.items.nodes[]
 
 # Cross-join with issue labels.
 # (For each url in the tsv, fetch its labels via gh and compare.)
+#
+# Drift bucketing (see #427 for the regression that motivated the split):
+#   DRIFT      — actionable rows where a mutation will change board state.
+#   NOOP_COUNT — issues with no wave label AND Wave field already (unset).
+#                Functionally `(unset) → (clear)`; the apply step's
+#                clearProjectV2ItemFieldValue is a no-op against a field
+#                already cleared. Counted separately so the operator sees
+#                "audit is clean" even when the no-op equivalence class is
+#                non-empty; MUST stay out of DRIFT so Step 7 doesn't emit
+#                redundant clear mutations and Step 5's gate doesn't
+#                over-report.
 DRIFT=()
+NOOP_COUNT=0
 while IFS=$'\t' read -r url item_id current_wave; do
   REPO=$(echo "$url" | sed -E 's#https://github.com/[^/]+/([^/]+)/.*#\1#')
   NUM=$(echo "$url" | sed -E 's#.*/(issues|pull)/##')
@@ -144,10 +156,15 @@ while IFS=$'\t' read -r url item_id current_wave; do
   elif [ "$current_wave" != "(unset)" ]; then
     # Labeled with no wave label but Wave field is populated — should clear.
     DRIFT+=("$url\t$current_wave\t(clear)")
+  else
+    # No wave label AND Wave field already (unset) — already in desired
+    # state. Count for visibility; do NOT add to DRIFT.
+    NOOP_COUNT=$((NOOP_COUNT + 1))
   fi
 done < /tmp/board-wave-values.tsv
 
-echo "Wave-field drift count: ${#DRIFT[@]}"
+echo "Actionable Wave-field drift:        ${#DRIFT[@]}"
+echo "No-op equivalents (unset == clear): ${NOOP_COUNT}"
 printf '%s\n' "${DRIFT[@]}" | head -30
 ```
 
@@ -159,21 +176,24 @@ Print the drift report and PAUSE for explicit user confirmation before mutating 
 
 ```
 Board audit results:
-- Orphan issues: 12 (in repo, missing from board)
-- Wave-field drift: 7 (label and Wave field disagree)
-- Missing Wave-field options: 0 (P3W9, P3W10 all present)
+- Orphan issues:                       12 (in repo, missing from board)
+- Actionable Wave-field drift:          7 (label and Wave field disagree; mutation will change state)
+- No-op equivalents (unset == clear): 83 (functional duplicates; skipped by apply, shown for visibility)
+- Missing Wave-field options:           0 (P3W9, P3W10 all present)
 
 Orphan issues:
   https://github.com/noorinalabs/noorinalabs-main/issues/250
   ...
 
-Wave-field drift:
+Actionable Wave-field drift:
   https://github.com/noorinalabs/noorinalabs-main/issues/123    P3W7 -> P3W9
   https://github.com/noorinalabs/noorinalabs-deploy/issues/87   P2W10 -> (clear)
   ...
 
 Proceed with bulk-add and bulk-sync? [y/N]
 ```
+
+The confirmation gate is keyed off the **actionable** drift count (`${#DRIFT[@]}`) plus the orphan count. No-op equivalents never appear under "Actionable Wave-field drift" and never gate the prompt — the apply step would skip them anyway, per the Step 4 forensic note.
 
 The user MUST type `y` to proceed. Any other answer aborts with `BLOCK: user declined; no mutations made`.
 
@@ -262,19 +282,20 @@ done <<< "$(printf '%s\n' "${DRIFT[@]}")"
 
 ### 8. Read-back verify
 
-Re-run step 2 (board fetch) and re-compute step 3 (orphans) + step 4 (drift). The counts SHOULD both be zero. If non-zero, surface to the user — the gh / GraphQL mutations may have silently no-op'd per the projects-classic deprecation family.
+Re-run step 2 (board fetch) and re-compute step 3 (orphans) + step 4 (drift). Success criterion is **actionable drift == 0** AND **orphan count == 0** — the `NOOP_COUNT` bucket is expected to be non-zero on a healthy board (any issue intentionally left unlabeled lives here) and MUST NOT fail the read-back. If actionable drift or orphans are non-zero post-sync, surface to the user — the gh / GraphQL mutations may have silently no-op'd per the projects-classic deprecation family.
 
 ### 9. Report
 
 ```
 Board audit complete:
 - Orphans added: {count} (was {pre} → board now has {post} items)
-- Wave fields synced: {count} (pre-drift: {pre} → post-drift: {post})
+- Wave fields synced: {count} (pre-actionable-drift: {pre} → post-actionable-drift: {post})
+- No-op equivalents (unset == clear): {count} (informational; unchanged by sync)
 - Missing Wave-field options: {list, if any}
-- Read-back drift remaining: {count}
+- Read-back actionable drift remaining: {count}
 ```
 
-If read-back drift > 0, raise a warning and link to charter `pull-requests.md § gh pr edit projects-classic deprecation` (the same silent-no-op family).
+If read-back actionable drift > 0, raise a warning and link to charter `pull-requests.md § gh pr edit projects-classic deprecation` (the same silent-no-op family). A non-zero no-op count is normal and does NOT warrant escalation.
 
 ## Acceptance criteria status (per main#199)
 


### PR DESCRIPTION
Closes #427.

## Summary

`/board-audit` previously reported `(unset) → (clear)` rows inside the headline "Wave-field drift" count even though the Step 4 bash recipe already correctly excluded them from the `DRIFT` array (the `elif [ "$current_wave" != "(unset)" ]` guard). The mismatch made the summary table, the Step 5 confirmation gate, the Step 8 read-back, and the Step 9 report all over-report when the board was actually clean — e.g., the 2026-05-13 audit showed "83 drift" when all 83 were no-ops.

This PR is a SKILL.md-only change. Single file: `.claude/skills/board-audit/SKILL.md`. 30 insertions, 9 deletions.

## How each acceptance item is satisfied

| AC item | Where |
|---|---|
| Step 4 summary emits actionable-vs-no-op counts as separate lines | New `NOOP_COUNT` variable + two `echo` lines replacing the single "Wave-field drift count" line |
| Step 5 confirmation gate shows only the actionable count | Sample report shape rewritten with "Actionable Wave-field drift" + "No-op equivalents (unset == clear)" rows; new paragraph clarifying the gate is keyed off `${#DRIFT[@]}` plus orphan count, not the no-op bucket |
| Step 7 bulk-sync `DRIFT` array continues to exclude no-ops | Step 7 untouched. The new `else` branch in Step 4 increments `NOOP_COUNT` only and does NOT push to `DRIFT`; mutation code-path is byte-identical to wave-10 HEAD |
| Step 8 read-back success criterion is "actionable drift == 0" | Step 8 prose rewritten: "Success criterion is **actionable drift == 0** AND **orphan count == 0** — the `NOOP_COUNT` bucket is expected to be non-zero on a healthy board" |
| One-line forensic note near the bash recipe explaining why `(unset) → (clear)` is a no-op | 12-line comment block prepended to the `DRIFT=()` declaration explaining the bucketing rules, cross-referencing #427, and stating why no-ops MUST stay out of `DRIFT` |

## Local validation

Sample of the new Step 4 summary output (template; live data shape after the bash recipe runs):

```
Actionable Wave-field drift:        7
No-op equivalents (unset == clear): 83
```

vs the previous (single-line) summary which was just `Wave-field drift count: 90` and conflated the two buckets.

Diff stat:

```
.claude/skills/board-audit/SKILL.md | 39 ++++++++++++++++++++++++++++---------
 1 file changed, 30 insertions(+), 9 deletions(-)
```

All edits touch lines 128–300 of SKILL.md — well clear of the first ~30 lines where #426 (Nadia's lifecycle.md cross-reference) lands. Conflict-free at merge time barring exotic reflow.

## Reviewers

- **Wanjiku Mwangi** (TPM — primary; cross-skill coherence with `/wave-kickoff` Step 7+8 callers that consume the Step 5 gate output)
- **Santiago Ferreira** (Release Coordinator — secondary; release-state implications of the read-back success-criterion change)

Both are non-author, non-PD per charter; satisfies the 2-reviewer rule.

## Test Plan

- [ ] Reviewer reads `.claude/skills/board-audit/SKILL.md` Step 4 at PR head and confirms the `NOOP_COUNT` increment is in the `else` branch only (not in `DRIFT+=`)
- [ ] Reviewer confirms Step 5 sample report shape contains both "Actionable Wave-field drift" and "No-op equivalents" rows, and the explanatory paragraph beneath the sample
- [ ] Reviewer confirms Step 7 bulk-sync code (loop body lines 232-260 of the modified file) is byte-identical to wave-10 HEAD `a3bc430` — no behavior change to mutations
- [ ] Reviewer confirms Step 8 success criterion explicitly excludes `NOOP_COUNT` from the failure condition
- [ ] Post-merge: next `/board-audit` invocation (likely during `/wave-kickoff` for the next wave) shows the split correctly and read-back does NOT fail on a non-zero no-op bucket
