### PR TITLE
process(lifecycle): codify phase/wave/session skill order in lifecycle.md (#426)

### DIFF
--- a/.claude/skills/annunaki-attack/SKILL.md
+++ b/.claude/skills/annunaki-attack/SKILL.md
@@ -5,6 +5,8 @@ description: Analyze captured errors, propose automation (hooks/skills/charter),
 
 Process the Annunaki error log, deduplicate errors, propose preventative automation, create GitHub issues, and implement fixes. This is the **action** counterpart to the `/annunaki` status viewer.
 
+> See [`.claude/team/lifecycle.md`](../../team/lifecycle.md) § Wave Lifecycle for the canonical skill order and preconditions.
+
 > Note: all repo paths in bash blocks below are rooted at `$REPO_ROOT` to avoid cwd drift when the skill is invoked from a worktree or child-repo subdirectory (#149).
 
 ## When to run

--- a/.claude/skills/board-audit/SKILL.md
+++ b/.claude/skills/board-audit/SKILL.md
@@ -11,6 +11,8 @@ Detect drift between GitHub Project 2 (the Cross-Repo Wave Plan board) and the a
 
 Closes main#199.
 
+> See [`.claude/team/lifecycle.md`](../../team/lifecycle.md) § Wave Lifecycle for the canonical skill order and preconditions.
+
 ## Background
 
 On 2026-04-23 a manual audit found **72 of 193 open issues (37%) missing from project 2**. Root cause: Hook 13 (`auto_add_issue_to_board.py`) only catches `gh issue create` calls in active sessions — bot-created, manual-UI-created, and pre-hook-13 issues all drift off the board silently.

--- a/.claude/skills/handoff/SKILL.md
+++ b/.claude/skills/handoff/SKILL.md
@@ -6,6 +6,8 @@ args: notes
 
 Generate a handoff summary for the next session. The optional `notes` argument lets the user add specific context (e.g., "was debugging the auth flow" or "next step is PR review").
 
+> See [`.claude/team/lifecycle.md`](../../team/lifecycle.md) § Session Lifecycle for the canonical skill order and preconditions.
+
 > Note: all repo paths in bash blocks below are rooted at `$REPO_ROOT` to avoid cwd drift when the skill is invoked from a worktree or child-repo subdirectory (#149).
 
 ## Instructions

--- a/.claude/skills/phase-review/SKILL.md
+++ b/.claude/skills/phase-review/SKILL.md
@@ -6,6 +6,8 @@ args: Phase number
 
 Phase-level track check. **Mandatory before every `/wave-scope`.** Surfaces accomplishments, blockers, and remaining end-state criteria so the owner can choose the next wave's theme deliberately, not reactively.
 
+> See [`.claude/team/lifecycle.md`](../../team/lifecycle.md) § Phase Lifecycle for the canonical skill order and preconditions.
+
 > Note: all repo paths in bash blocks below are rooted at `$REPO_ROOT` to avoid cwd drift when the skill is invoked from a worktree or child-repo subdirectory (#149).
 
 ## When to use

--- a/.claude/skills/phase-review/SKILL.md
+++ b/.claude/skills/phase-review/SKILL.md
@@ -14,13 +14,13 @@ Phase-level track check. **Mandatory before every `/wave-scope`.** Surfaces acco
 
 - **Before every `/wave-scope`.** Mandatory pre-step. `/wave-scope` Step 0.5 will block until `/phase-review` has been invoked in the same session.
 - **On demand** — owner can run anytime to check phase health.
-- Not a replacement for `/retro` (per-wave) or `/roadmap` (cross-phase).
+- Not a replacement for `/retro` (per-wave) or `/plan-phase` (phase-creation).
 
 ## What this skill is NOT
 
 - Not a wave reconciliation step — that's `/wave-scope`.
 - Not a retrospective — that's `/wave-retro`.
-- Not a phase-creation step — `/roadmap` is the phase-transition skill.
+- Not a phase-creation step — `/plan-phase` is the phase-creation skill.
 - Does NOT pick the next wave's theme — that's the owner's call after seeing the picture.
 - Does NOT modify the phase plan doc without owner confirmation.
 
@@ -37,13 +37,13 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 PHASE_DOC="$REPO_ROOT/.claude/team/phases/phase-{P}.md"
 if [ ! -f "$PHASE_DOC" ]; then
   echo "ERROR: phase plan doc missing at $PHASE_DOC"
-  echo "Run /roadmap first to create one — without a phase plan, /phase-review has nothing to check against."
+  echo "Run /plan-phase first to draft the phase scope, then hand-author the phase plan doc — without it, /phase-review has nothing to check against."
   exit 1
 fi
 cat "$PHASE_DOC"
 ```
 
-If the phase plan doc is missing, STOP and direct the owner to `/roadmap`.
+If the phase plan doc is missing, STOP and direct the owner to `/plan-phase` (which proposes the wave structure that the phase plan doc captures). The phase plan doc itself is hand-authored.
 
 ### 2. Pull current state of each tracking issue
 

--- a/.claude/skills/plan-phase/SKILL.md
+++ b/.claude/skills/plan-phase/SKILL.md
@@ -6,6 +6,8 @@ args: team_name, Phase number
 
 Plan a phase of work for the `{team_name}` team. Decomposes phase scope into GitHub Issues, assigns them, reviews from multiple perspectives, and proposes a wave structure.
 
+> See [`.claude/team/lifecycle.md`](../../team/lifecycle.md) § Phase Lifecycle for the canonical skill order and preconditions.
+
 > Note: all repo paths in bash blocks below are rooted at `$REPO_ROOT` to avoid cwd drift when the skill is invoked from a worktree or child-repo subdirectory (#149).
 
 ## Instructions

--- a/.claude/skills/promotion-audit/SKILL.md
+++ b/.claude/skills/promotion-audit/SKILL.md
@@ -6,6 +6,8 @@ args: wave_name (optional — defaults to the current wave from cross-repo-statu
 
 Run a deterministic audit of the promotion pipeline. Every step below is backed by a pure function in `helpers.py` so the same input produces byte-identical output.
 
+> See [`.claude/team/lifecycle.md`](../../team/lifecycle.md) § Wave Lifecycle for the canonical skill order and preconditions.
+
 ## Context
 
 The project's enforcement hierarchy is **hook > skill > charter > memory** (see `.claude/team/charter.md` § Enforcement Hierarchy and memory `feedback_enforcement_hierarchy.md`). Rules migrate upward along that path as evidence accumulates.

--- a/.claude/skills/retro/SKILL.md
+++ b/.claude/skills/retro/SKILL.md
@@ -6,6 +6,8 @@ args: team_name
 
 Run a lightweight retrospective for the `{team_name}` team. This is a **mid-wave health check**, not a full end-of-wave retrospective. Use `/wave-retro` for the comprehensive end-of-wave engine with trust matrix updates and charter proposals.
 
+> See [`.claude/team/lifecycle.md`](../../team/lifecycle.md) § Wave Lifecycle for the canonical skill order and preconditions.
+
 > Note: all repo paths in bash blocks below are rooted at `$REPO_ROOT` to avoid cwd drift when the skill is invoked from a worktree or child-repo subdirectory (#149).
 
 ## When to use

--- a/.claude/skills/session-start/SKILL.md
+++ b/.claude/skills/session-start/SKILL.md
@@ -7,6 +7,8 @@ description: "MANDATORY first action in every session — runs full startup prot
 
 **This skill MUST be invoked as the FIRST action in every new session.** Do not respond to the user's message, do not read files, do not run any other tool — invoke `/session-start` first. The user's actual request is handled AFTER this completes.
 
+> See [`.claude/team/lifecycle.md`](../../team/lifecycle.md) § Session Lifecycle for the canonical skill order and preconditions.
+
 > Note: all repo paths in bash blocks below are rooted at `$REPO_ROOT` to avoid cwd drift when the skill is invoked from a worktree or child-repo subdirectory (#149).
 
 ## Instructions

--- a/.claude/skills/wave-kickoff/SKILL.md
+++ b/.claude/skills/wave-kickoff/SKILL.md
@@ -6,6 +6,8 @@ args: team_name, Phase number, Wave number
 
 Automate the wave kickoff process for the `{team_name}` team.
 
+> See [`.claude/team/lifecycle.md`](../../team/lifecycle.md) § Wave Lifecycle for the canonical skill order and preconditions.
+
 > Note: all repo paths in bash blocks below are rooted at `$REPO_ROOT` to avoid cwd drift when the skill is invoked from a worktree or child-repo subdirectory (#149).
 
 ## Instructions

--- a/.claude/skills/wave-retro/SKILL.md
+++ b/.claude/skills/wave-retro/SKILL.md
@@ -6,6 +6,8 @@ args: team_name, Phase number, Wave number
 
 Run a retrospective for a completed wave of the `{team_name}` team.
 
+> See [`.claude/team/lifecycle.md`](../../team/lifecycle.md) § Wave Lifecycle for the canonical skill order and preconditions.
+
 ## Instructions
 
 ### 1. Ontology check

--- a/.claude/skills/wave-scope/SKILL.md
+++ b/.claude/skills/wave-scope/SKILL.md
@@ -6,6 +6,8 @@ args: Phase number, Wave number
 
 Reconcile **declared scope** (next-wave meta-issue body) with **actual scope** (issues labeled `p{P}-wave-{M}` across all repos) before kickoff. Surfaces drift that accumulated during the prior wave, folds in retro carry-forwards and memory-tracked must-includes, and produces a clean meta-issue + label set for `/wave-kickoff` to act on.
 
+> See [`.claude/team/lifecycle.md`](../../team/lifecycle.md) § Wave Lifecycle for the canonical skill order and preconditions.
+
 > Note: all repo paths in bash blocks below are rooted at `$REPO_ROOT` to avoid cwd drift when the skill is invoked from a worktree or child-repo subdirectory (#149).
 
 ## When to use

--- a/.claude/skills/wave-start/SKILL.md
+++ b/.claude/skills/wave-start/SKILL.md
@@ -6,6 +6,8 @@ args: team_name, Phase number, Wave number
 
 Initialize infrastructure for a new wave. This is the **setup step** that creates the deployment branch and cleans up stale worktrees. For full wave planning with issue assignment and kickoff comments, use `/wave-kickoff` after this completes.
 
+> See [`.claude/team/lifecycle.md`](../../team/lifecycle.md) § Wave Lifecycle for the canonical skill order and preconditions.
+
 > Note: all repo paths in bash blocks below are rooted at `$REPO_ROOT` to avoid cwd drift when the skill is invoked from a worktree or child-repo subdirectory (#149).
 
 ## Instructions

--- a/.claude/skills/wave-wrapup/SKILL.md
+++ b/.claude/skills/wave-wrapup/SKILL.md
@@ -6,6 +6,8 @@ args: team_name, Phase number, Wave number
 
 Finalize a wave by reviewing all open PRs, merging in dependency order, closing resolved issues, and cleaning up. This is the **exit gate** before running `/wave-retro`.
 
+> See [`.claude/team/lifecycle.md`](../../team/lifecycle.md) § Wave Lifecycle for the canonical skill order and preconditions.
+
 > Note: all repo paths in bash blocks below are rooted at `$REPO_ROOT` to avoid cwd drift when the skill is invoked from a worktree or child-repo subdirectory (#149).
 
 ## Instructions

--- a/.claude/team/lifecycle.md
+++ b/.claude/team/lifecycle.md
@@ -32,13 +32,11 @@ flowchart LR
 | Step | Skill | Precondition | Side effects + state written | Next skill |
 |------|-------|--------------|------------------------------|------------|
 | P0 | `/plan-phase {team} {P}` | Project board (project 2) reflects current open-issue state across all 8 repos. Pre-phase drift audit (Step 1) STOPs if any open issue across the org is missing from project 2. | Reads project 2 as authoritative backlog. Creates per-issue GitHub Issues with phase / assignee / category labels (Step 2-3). Posts 6-perspective review comments per issue (Step 4). Presents a proposed wave structure for owner approval (Steps 5-7). The `phase-{P}.md` plan doc that `/phase-review` reads from is hand-authored — `/plan-phase` proposes the wave structure but does not directly write the plan doc. | `/phase-review {P}` |
-| P1 | `/phase-review {P}` | `.claude/team/phases/phase-{P}.md` exists. STOPs and directs to a phase-creation step (the `phase-{P}.md` plan doc is the only required input — author it hand-in-hand with `/plan-phase` Step 7's owner-approved wave structure). | (none) — read-only diagnostic. Surfaces tech-debt ratio against the 10% exit gate. May edit `phase-{P}.md` with owner confirmation. | `/wave-scope {P} {M}` (mandatory next; gates Wave Lifecycle Gate A) |
+| P1 | `/phase-review {P}` | `.claude/team/phases/phase-{P}.md` exists. STOPs and directs to `/plan-phase` if missing (the `phase-{P}.md` plan doc is the only required input — hand-author it from `/plan-phase` Step 7's owner-approved wave structure). | (none) — read-only diagnostic. Surfaces tech-debt ratio against the 10% exit gate. May edit `phase-{P}.md` with owner confirmation. | `/wave-scope {P} {M}` (mandatory next; gates Wave Lifecycle Gate A) |
 
 **Phase close-out:** there is no explicit close-out skill. A phase ends when every tracking issue in `phase-{P}.md` is closed and the tech-debt ratio is under the 10% exit gate. A subsequent `/plan-phase` invocation marks the next phase's planning pass.
 
 **`/phase-review` cadence:** mandatory before every `/wave-scope` (gated by `/wave-scope` Step 0.5 Gate A — a transcript check for a same-session invocation against phase `{P}`). May also be run on demand.
-
-**Note on the `/roadmap` reference in `phase-review/SKILL.md`:** `/phase-review` Step 1 mentions `/roadmap` as the source of `phase-{P}.md`, but no `/roadmap` skill exists in `.claude/skills/` as of this PR. `/plan-phase` is the closest existing skill; the `phase-{P}.md` plan doc is currently hand-authored. Follow-up issue should be filed if a dedicated `/roadmap` skill is wanted; otherwise update `phase-review/SKILL.md` to drop the `/roadmap` reference.
 
 ---
 

--- a/.claude/team/lifecycle.md
+++ b/.claude/team/lifecycle.md
@@ -1,0 +1,148 @@
+# Skill Lifecycle — Canonical Order and Preconditions
+
+Single source of truth for the order, preconditions, and state effects of the lifecycle skills that bracket a **phase**, a **wave**, and a **session**. Closes [noorinalabs-main#426](https://github.com/noorinalabs/noorinalabs-main/issues/426).
+
+Every cell in the tables below was derived by reading the corresponding `SKILL.md` at this PR's HEAD — not an idealized order. Where this doc and a `SKILL.md` disagree, the `SKILL.md` is authoritative until the discrepancy is filed and resolved as a follow-up.
+
+## How to use this doc
+
+- **New session, unsure what to run next?** Read the table for the current bracket (session / wave / phase), find the row whose "Side effects + state written" you have already, and run the row below it.
+- **Onboarding a teammate?** The diagrams in each section show the canonical flow.
+- **Adding a new lifecycle skill or rearranging an existing one?** Update this file in the same PR.
+
+## Conventions used in the tables
+
+- **Precondition** column names the `cross-repo-status.json` keys (or transcript signals) the skill checks before proceeding. `(none)` means no machine-checked precondition.
+- **State written** lists the `cross-repo-status.json` keys the skill upserts. `(none)` means no state change; `(side-effect only)` means the skill mutates external state (issues, PRs, branches) without writing to `cross-repo-status.json`.
+- **Counter ownership.** When a counter is written by one skill and verified by another (e.g., wrapup → retro), the writer is the authoritative source and the verifier loud-fails on mismatch. The "Owner" column in the wave table calls this out.
+
+---
+
+## Phase Lifecycle
+
+```mermaid
+flowchart LR
+    A[/plan-phase team P/] --> B[/phase-review P/]
+    B --> C[Wave Lifecycle<br/>see next section]
+    C --> B
+    style A fill:#e8f4ff,stroke:#1d76db
+    style B fill:#e8f4ff,stroke:#1d76db
+```
+
+| Step | Skill | Precondition | Side effects + state written | Next skill |
+|------|-------|--------------|------------------------------|------------|
+| P0 | `/plan-phase {team} {P}` | Project board (project 2) reflects current open-issue state across all 8 repos. Pre-phase drift audit (Step 1) STOPs if any open issue across the org is missing from project 2. | Reads project 2 as authoritative backlog. Creates per-issue GitHub Issues with phase / assignee / category labels (Step 2-3). Posts 6-perspective review comments per issue (Step 4). Presents a proposed wave structure for owner approval (Steps 5-7). The `phase-{P}.md` plan doc that `/phase-review` reads from is hand-authored — `/plan-phase` proposes the wave structure but does not directly write the plan doc. | `/phase-review {P}` |
+| P1 | `/phase-review {P}` | `.claude/team/phases/phase-{P}.md` exists. STOPs and directs to a phase-creation step (the `phase-{P}.md` plan doc is the only required input — author it hand-in-hand with `/plan-phase` Step 7's owner-approved wave structure). | (none) — read-only diagnostic. Surfaces tech-debt ratio against the 10% exit gate. May edit `phase-{P}.md` with owner confirmation. | `/wave-scope {P} {M}` (mandatory next; gates Wave Lifecycle Gate A) |
+
+**Phase close-out:** there is no explicit close-out skill. A phase ends when every tracking issue in `phase-{P}.md` is closed and the tech-debt ratio is under the 10% exit gate. A subsequent `/plan-phase` invocation marks the next phase's planning pass.
+
+**`/phase-review` cadence:** mandatory before every `/wave-scope` (gated by `/wave-scope` Step 0.5 Gate A — a transcript check for a same-session invocation against phase `{P}`). May also be run on demand.
+
+**Note on the `/roadmap` reference in `phase-review/SKILL.md`:** `/phase-review` Step 1 mentions `/roadmap` as the source of `phase-{P}.md`, but no `/roadmap` skill exists in `.claude/skills/` as of this PR. `/plan-phase` is the closest existing skill; the `phase-{P}.md` plan doc is currently hand-authored. Follow-up issue should be filed if a dedicated `/roadmap` skill is wanted; otherwise update `phase-review/SKILL.md` to drop the `/roadmap` reference.
+
+---
+
+## Wave Lifecycle
+
+```mermaid
+flowchart TD
+    subgraph "Start of wave"
+        WS1[/wave-scope P M/]
+        WS2[/wave-start P M/]
+        WS3[/board-audit/]
+        WS4[/wave-kickoff P M/]
+        WS1 --> WS2 --> WS3 --> WS4
+    end
+
+    subgraph "Mid-wave (on demand)"
+        M1[/retro/]
+        M2[/promotion-audit/]
+    end
+
+    subgraph "End of wave"
+        WE1[/wave-wrapup P M/]
+        WE2[/wave-retro P M/]
+        WE2_5[/promotion-audit/<br/>Step 7.5]
+        WE2_6[/annunaki-attack/<br/>Step 7.6]
+        WE3[/wave-scope P M+1/<br/>Step 9 auto-invoke]
+        WE1 --> WE2
+        WE2 --> WE2_5
+        WE2_5 --> WE2_6
+        WE2_6 --> WE3
+    end
+
+    WS4 --> M1
+    M1 --> WE1
+    WE3 -.->|next wave| WS2
+
+    style WS1 fill:#e8f4ff,stroke:#1d76db
+    style WS3 fill:#fff4e8,stroke:#d76b1d
+    style WS4 fill:#e8f4ff,stroke:#1d76db
+    style WE1 fill:#ffe8e8,stroke:#d61d1d
+    style WE2 fill:#ffe8e8,stroke:#d61d1d
+```
+
+### Start-of-wave
+
+| Step | Skill | Precondition | Side effects + state written | Owner of writes | Next skill |
+|------|-------|--------------|------------------------------|-----------------|------------|
+| W1 | `/wave-scope {P} {M}` | **Gate A:** `/phase-review {P}` ran in this transcript (STOP otherwise). **Gate B:** owner-set theme written to `cross-repo-status.json wave_{M}_scope.theme` + meta-issue body has `## Theme` heading (STOP otherwise). | Meta-issue body refreshed (or authored as stub if absent). Label churn applied. Upserts: `wave_{M}_scope_reconciled_at`, `wave_{M}_repos_in_scope`, `wave_{M}_meta_issue`, `wave_{M}_scope`. Optional: `wave_{M}_scope_reconciliation_note`. | `/wave-scope` | `/wave-start {P} {M}` |
+| W2 | `/wave-start {P} {M}` | (none — operates from any clean checkout). For wave N>1, expects `deployments/phase-{P}/wave-{M-1}` to exist or fall back to main. | Prunes stale worktrees. Creates `deployments/phase-{P}/wave-{M}` branch + `p{P}-wave-{M}` label. Commits `cross-repo-status.json` updates directly to the wave branch (wave-branch-scoped commits only — main-targeting writes use the PUT-contents recipe described in `/wave-kickoff` Step 1a). | `/wave-start` | `/board-audit` |
+| W3 | `/board-audit` | (none — runs against project 2 and all 8 repos). Optional Wave-field options must exist on the project for label sync. | Side-effect only: bulk-adds orphan issues to project 2, bulk-syncs the Wave single-select field from `p{P}-wave-{M}` labels. Confirmation gate before any mutation. No `cross-repo-status.json` writes. | `/board-audit` | `/wave-kickoff {P} {M}` |
+| W4 | `/wave-kickoff {P} {M}` | **Step 0:** `/board-audit` should have run (charter precondition; not transcript-gated yet). **Step 0a:** `wave_{M}_scope_reconciled_at` MUST exist and (if present) post-date `wave_{M-1}_retro_completed_at` / `wave_{M-1}_completed_at`. **Step 0:** `wave_{M}_repos_in_scope` MUST exist and be non-empty. **Step 0.5:** 6-check pre-flight (wave branch in every repo, child-repo implementer rule, scope correctness, 2-reviewer slate, agent naming, spawn-brief ordering). | Creates `deployments/phase-{P}/wave-{M}` branch in every repo in `wave_{M}_repos_in_scope` (Step 1). Writes `wave_{M}_branches` (per-repo SHA + status). Labels issues, hook auto-posts per-issue kickoff comments, manual all-hands kickoff on meta-issue. Status commit (active state, `wave_{M}_kicked_off_at`) lands on `main` via `gh api PUT /contents` recipe (Step 1a). | `/wave-kickoff` for `wave_{M}_branches`; the PUT-contents status commit on main uses Wanjiku (TPM) identity per Step 1a. | Implementation work; mid-wave `/retro` and `/promotion-audit` on demand. |
+
+### Mid-wave (on demand)
+
+| Skill | Precondition | Side effects + state written | When to run |
+|-------|--------------|------------------------------|-------------|
+| `/retro` | Active wave (read from `cross-repo-status.json` `current_wave`). | (none) — inline diagnostic output only. No trust-matrix updates, no feedback_log writes. | Mid-wave checkpoint, after an incident, or when the team lead wants a quick pulse without the overhead of `/wave-retro`. |
+| `/promotion-audit [{wave_name}]` | Resolves `current_wave` from `cross-repo-status.json` if not provided. | Two writes: appends to `feedback_log.md` (under current retro if today's date matches, else new section); writes `.claude/team/promotion_audit_log/{wave_name}.md`. May open AUTO-tier PRs (memory→charter, charter→skill) and file DECIDE-tier issues (skill→hook always DECIDE). | Auto-invoked from `/wave-retro` Step 7.5. Standalone run between retros if drift is suspected. |
+
+### End-of-wave
+
+| Step | Skill | Precondition | Side effects + state written | Owner of writes | Next skill |
+|------|-------|--------------|------------------------------|-----------------|------------|
+| W5 | `/wave-wrapup {P} {M}` | `wave_{M}_repos_in_scope` exists. Open PRs targeting `deployments/phase-{P}/wave-{M}` exist or have been resolved. | Merges approved PRs. Closes resolved issues. Cleans wave worktrees. Runs `/ontology-rebuild` (Step 12). Step 10.5 upserts the three canonical counter keys: `wave_{M}_final_pr_count`, `wave_{M}_changes_requested_cycles`, `wave_{M}_top_concentration_pct` (all top-level). Final-wave-of-phase: opens wave→main PR per repo and runs the reachability gate (Step 11.5). May run `/annunaki-attack` (Step 13) + memory-to-automation audit (Step 14) as fallback; both check the run-markers `wave_{M}_annunaki_attack_ran_at` / `wave_{M}_memory_audit_ran_at` to avoid double-execution with `/wave-retro` Step 7.6 / 7.7. | `/wave-wrapup` for all three counters (authoritative — `/wave-retro` Step 2.5 verifies, never writes). Run-markers: whichever surface (wrapup or retro) runs first writes the marker. | `/wave-retro {P} {M}` |
+| W6 | `/wave-retro {P} {M}` | The three counter keys exist at top level (Step 2.5 verifies against PR-level recomputation; drift > ±2 or > ±5% blocks the retro until reconciled). Runs `/ontology-librarian` (Step 1) and `/board-audit` (Step 1.5) before assessments. | Updates `.claude/team/trust_matrix.md` directly on the retro branch (NOT a side branch). Appends to `.claude/team/feedback_log.md`. Step 7.5 invokes `/promotion-audit`. Step 7.6 invokes `/annunaki-attack` if run-marker absent. Step 7.7 runs memory-to-automation audit if run-marker absent. Step 9 auto-invokes `/wave-scope {P} {M+1}` if next-wave meta-issue exists; surfaces as kickoff blocker if not. May write `wave_{M}_counter_corrections`, `wave_{M}_annunaki_attack_ran_at`, `wave_{M}_memory_audit_ran_at`. | `/wave-retro` for corrections + run-markers. Counter writes remain owned by `/wave-wrapup`. | `/wave-scope {P} {M+1}` (auto-invoked from Step 9 → next wave) |
+
+### Drift surfaces this doc closes (per #426)
+
+- **`/board-audit` is a `/wave-kickoff` precondition, not an inferred one.** W10 kickoff skipped Step 0 board-audit on the assumption that `/wave-scope` had just synced the board; 62 wave-labeled issues had their Wave-field unset on project 2 as a result. The Wave table above makes `/board-audit` an explicit W3 step.
+- **Counter-write ownership lives in `/wave-wrapup` Step 10.5, not `/wave-retro`.** W9 wrapup had counter-write gaps that retro Step 2.5 had to recompute — the Owner column above codifies wrapup as the authoritative writer and retro as the verifier. Counters that drift > ±5% block the retro (per `/wave-retro` Step 2.5).
+- **`/wave-retro` Step 9 auto-invokes `/wave-scope {P} {M+1}`.** Pre-this-doc, the W9-retro → W10-scope auto-chain was documented only in `/wave-retro` itself. The end-of-wave table above and the Mermaid `WE3 -.->|next wave| WS2` edge make it visible from the lifecycle view.
+- **Annunaki-attack + memory-to-automation audit moved retro-side (P3W9 #344).** Wrapup Steps 13 / 14 remain as fallback for retro-delayed cases; both surfaces guard with the `wave_{M}_annunaki_attack_ran_at` / `wave_{M}_memory_audit_ran_at` run-markers so the audit runs at most once per wave. The Owner column calls out "whichever surface runs first writes the marker."
+
+---
+
+## Session Lifecycle
+
+```mermaid
+flowchart LR
+    S1[/session-start/] --> WORK[Session work]
+    WORK --> S2[/handoff/]
+    S2 -.->|writes<br/>session_handoff.md| S1NEXT[next session<br/>/session-start/]
+    style S1 fill:#e8f4ff,stroke:#1d76db
+    style S2 fill:#e8f4ff,stroke:#1d76db
+```
+
+| Step | Skill | Precondition | Side effects + state written | Next skill |
+|------|-------|--------------|------------------------------|------------|
+| S1 | `/session-start` | MANDATORY first action in every session (per `CLAUDE.md § Session start`). | Step 0: prunes worktrees. Step 1: `TeamDelete` then `TeamCreate noorinalabs` (single-leader constraint — additional TeamCreates in the session fail). Step 2: reads project-memory `session_handoff.md`. Step 3: runs `/ontology-rebuild` for any dirty files. Step 4: runs `/annunaki` (status only, not attack). Step 5: reads `cross-repo-status.json`, may invoke `/board-audit` if board↔label drift is observed. Step 6: reads `feedback_log.md` tail for unapplied retro proposals. | Whatever the user asks for. |
+| S2 | `/handoff [notes]` | (none) — run before ending a session for richer context than the automatic `Stop` hook. | Writes `session_handoff.md` to project memory (auto-loaded at next session's Step 2). Updates `MEMORY.md` index (replaces any previous handoff entry). Echoes full handoff to console for cross-machine paste. | (end of session) |
+
+### Session-start vs. automatic Stop hook
+
+A `Stop` hook auto-writes a handoff to project memory after every response (throttled to 5 min). The next `/session-start` Step 2 reads whichever handoff is freshest. Manual `/handoff` adds conversational context (decisions, discussion) that the automatic hook cannot infer.
+
+---
+
+## Cross-references
+
+- Charter rules backing the lifecycle: `.claude/team/charter/agents.md` (orchestrator + spawn discipline), `.claude/team/charter/skills.md` (promotion + marker conventions), `.claude/team/charter/state-claims.md` (refresh-before-claim, refresh-before-acting), `.claude/team/charter/pull-requests.md` (retro PR body-vs-diff, origin > local).
+- Per-skill SKILL.md files each contain a one-line link back to this doc in their preconditions section.
+
+## Maintenance
+
+- This doc is hand-maintained. Any new lifecycle skill MUST add a row to the relevant table and a Mermaid node in the same PR.
+- Any rearrangement of skill order (e.g., a new precondition gate, a moved run-marker) MUST update the relevant table BEFORE the SKILL.md change lands.
+- If a SKILL.md and this doc disagree, the SKILL.md is authoritative until the discrepancy is filed and resolved as a follow-up issue.


### PR DESCRIPTION
## Summary

Codifies the canonical order, preconditions, and state effects of the 13 lifecycle skills that bracket a phase, a wave, and a session. Adds `.claude/team/lifecycle.md` as a single source of truth; cross-references it from each lifecycle skill's preconditions section.

Closes #426.

## Doc structure

`.claude/team/lifecycle.md` has three top-level sections, each with a Mermaid flowchart and a table:

- **Phase Lifecycle** — `/plan-phase` → `/phase-review` → Wave Lifecycle (loops back)
- **Wave Lifecycle** — split into Start-of-wave (`/wave-scope` → `/wave-start` → `/board-audit` → `/wave-kickoff`), Mid-wave (`/retro`, `/promotion-audit` on demand), and End-of-wave (`/wave-wrapup` → `/wave-retro` → auto-invoked `/wave-scope` for next wave)
- **Session Lifecycle** — `/session-start` (7 steps) and `/handoff` (manual end-of-session)

Each table column names the `cross-repo-status.json` keys the skill reads as preconditions and the keys it writes as state. An "Owner of writes" column on the wave end-of-wave table makes counter-write ownership explicit (wrapup writes, retro verifies).

## Drift surfaces this doc closes (per #426)

1. **`/board-audit` is an explicit `/wave-kickoff` precondition (W3 step), not an inferred one** — surfaced by W10's `/wave-kickoff` skipping Step 0 on the assumption that scope's prior pass synced the board.
2. **Counter-write ownership lives in `/wave-wrapup` Step 10.5; `/wave-retro` Step 2.5 verifies and loud-fails on drift** — surfaced by W9 counter-write gaps that retro had to recompute.
3. **`/wave-retro` Step 9 auto-invokes `/wave-scope {P} {M+1}`** — previously documented only inside the retro skill; now visible from the lifecycle view via the dashed `WE3 -.->|next wave| WS2` Mermaid edge.

## Files changed (14)

- **New:** `.claude/team/lifecycle.md` — the canonical doc
- **Cross-reference added (one-line block in the intro section) to 13 SKILL.md files:**
  - Phase: `plan-phase`, `phase-review`
  - Wave: `wave-scope`, `wave-start`, `wave-kickoff`, `board-audit`, `wave-wrapup`, `wave-retro`, `retro`, `promotion-audit`, `annunaki-attack`
  - Session: `session-start`, `handoff`

The board-audit cross-ref lands in the Background section (top of file), avoiding the Step 4/5/7/8 region that #427 is editing in parallel.

## `/roadmap` → `/plan-phase` reconciliation (added in fixup commit `417c632`)

Owner picked option C on the in-flight review: reconcile in this PR rather than file a W11 follow-up. `phase-review/SKILL.md` had 4 references to a non-existent `/roadmap` skill (intro note, "What this skill is NOT" bullet, error message in Step 1, trailing STOP-and-direct line); all four now point to `/plan-phase`, which proposes the wave structure the `phase-{P}.md` plan doc is hand-authored from. `lifecycle.md` drops the trailing "Note on `/roadmap`" paragraph since the underlying inconsistency is fixed.

## Out of scope

- The optional `/lifecycle-guide` slash command (issue's "Proposed shape" item 3) is deliberately deferred per the issue. Will file a follow-up if it proves warranted in practice.

## Reviewers

- **Aino Virtanen** (Standards & Quality Lead) — process-doc rigor, charter-cross-ref correctness. Prior Approved at `12b1374` is invalidated by the fixup SHA; needs a NEW Approved comment per `feedback_verdict_amendment_edit_not_append`.
- **Wanjiku Mwangi** (TPM) — sequencing/coordination angle, counter-write ownership accuracy against retro/wrapup history. In-flight review re-targets at `417c632`.

## Test Plan

- [ ] Reviewers hand-trace a "given a fresh session, the doc tells me what to run next" scenario:
  - State X: `cross-repo-status.json` has `wave_10_kicked_off_at` set, `wave_10_final_pr_count` unset, every PR targeting `deployments/phase-3/wave-10` is merged. Expected next skill from the doc: `/wave-wrapup 3 10`. (Verifies the End-of-wave table row W5.)
  - State X: `wave_10_final_pr_count`, `wave_10_changes_requested_cycles`, `wave_10_top_concentration_pct` all set; `wave_10_repos_in_scope` set; `wave_10_meta_issue` set. Expected next skill: `/wave-retro 3 10`. (Verifies the W5 → W6 handoff.)
- [ ] All 13 cross-reference links resolve to `.claude/team/lifecycle.md` (verify each `../../team/lifecycle.md` relative path is correct from `.claude/skills/<name>/`).
- [ ] Mermaid blocks render in the GitHub PR preview (the three flowcharts are valid Mermaid syntax — verifiable by opening the Files-changed view on the PR).
- [ ] No remaining `/roadmap` references in `phase-review/SKILL.md` or `lifecycle.md` (`grep -rn roadmap .claude/skills/phase-review .claude/team/lifecycle.md` returns empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
