### PR TITLE
hotfix(hook-21): fix _ITEM_LOOKUP_QUERY variableNotUsed → enable Wave-field auto-sync (#448)

### DIFF
--- a/.claude/hooks/post_label_change_wave_field_sync.py
+++ b/.claude/hooks/post_label_change_wave_field_sync.py
@@ -346,15 +346,13 @@ def _get_project_ids(graphql_runner=None) -> dict | None:
 
 
 _ITEM_LOOKUP_QUERY = """
-query($org: String!, $project: Int!, $repo: String!, $num: Int!) {
-  organization(login: $org) {
-    projectV2(number: $project) {
-      items(first: 100) {
+query($org: String!, $repo: String!, $num: Int!) {
+  repository(owner: $org, name: $repo) {
+    issue(number: $num) {
+      projectItems(first: 10) {
         nodes {
           id
-          content {
-            ... on Issue { number repository { name } }
-          }
+          project { number }
         }
       }
     }
@@ -366,19 +364,19 @@ query($org: String!, $project: Int!, $repo: String!, $num: Int!) {
 def _lookup_item_id(repo: str, issue_number: str, graphql_runner=None) -> str | None:
     """Find the project 2 item ID for `noorinalabs/<repo>` issue `<issue_number>`.
 
-    `items(first: 100)` is the first page; in practice we'd need
-    pagination to be 100% correct, but a 100-item first page covers
-    every wave's working set we've seen. If the issue isn't found on
-    page 1, returns None (graceful skip — board-audit will sweep later).
-    Pagination is intentionally deferred to keep the hook cheap; if
-    we observe miss-after-first-page false-skips in production, file a
-    follow-up to extend.
+    Uses a direct repository→issue→projectItems traversal, which avoids the
+    100-item pagination limitation of the old org→projectV2→items scan and
+    eliminates the variableNotUsed GraphQL error ($repo/$num were declared
+    but never referenced in the old query body).
+
+    PROJECT_NUMBER filtering is done Python-side since the projectItems field
+    has no server-side project-number filter argument; the `first: 10` ceiling
+    is safe because issues are rarely on more than a handful of projects.
     """
     data = _gh_graphql(
         _ITEM_LOOKUP_QUERY,
         {
             "org": ORG,
-            "project": PROJECT_NUMBER,
             "repo": repo,
             "num": int(issue_number),
         },
@@ -386,14 +384,12 @@ def _lookup_item_id(repo: str, issue_number: str, graphql_runner=None) -> str | 
     )
     if not data:
         return None
-    proj = (data.get("data") or {}).get("organization", {}).get("projectV2")
-    if not proj:
+    issue = (data.get("data") or {}).get("repository", {}).get("issue")
+    if not issue:
         return None
-    nodes = (proj.get("items") or {}).get("nodes") or []
+    nodes = (issue.get("projectItems") or {}).get("nodes") or []
     for node in nodes:
-        content = node.get("content") or {}
-        repo_obj = content.get("repository") or {}
-        if content.get("number") == int(issue_number) and repo_obj.get("name") == repo:
+        if (node.get("project") or {}).get("number") == PROJECT_NUMBER:
             return node.get("id")
     return None
 

--- a/.claude/hooks/tests/test_post_label_change_wave_field_sync.py
+++ b/.claude/hooks/tests/test_post_label_change_wave_field_sync.py
@@ -100,16 +100,13 @@ def _item_lookup_response(repo: str, num: int) -> str:
     return json.dumps(
         {
             "data": {
-                "organization": {
-                    "projectV2": {
-                        "items": {
+                "repository": {
+                    "issue": {
+                        "projectItems": {
                             "nodes": [
                                 {
                                     "id": "ITEM_ID_123",
-                                    "content": {
-                                        "number": num,
-                                        "repository": {"name": repo},
-                                    },
+                                    "project": {"number": 2},
                                 }
                             ]
                         }
@@ -121,7 +118,7 @@ def _item_lookup_response(repo: str, num: int) -> str:
 
 
 def _item_lookup_empty_response() -> str:
-    return json.dumps({"data": {"organization": {"projectV2": {"items": {"nodes": []}}}}})
+    return json.dumps({"data": {"repository": {"issue": {"projectItems": {"nodes": []}}}}})
 
 
 def _mutation_success_response(_variables=None) -> str:
@@ -163,7 +160,7 @@ class FakeGraphQLRouter:
             self.calls["introspect"] += 1
             r = self.introspect() if callable(self.introspect) else self.introspect
             return r or ""
-        if "items(first:" in query:
+        if "repository(owner:" in query and "projectItems" in query:
             self.calls["item_lookup"] += 1
             r = (
                 self.item_lookup(variables.get("repo"), variables.get("num"))
@@ -611,6 +608,112 @@ class KillSwitchPureTests(unittest.TestCase):
     def test_value_true_string(self):
         os.environ[hook.KILL_SWITCH_ENV] = "true"
         self.assertFalse(hook._kill_switch_active())
+
+
+class GraphQLVariableUsageTests(unittest.TestCase):
+    """Static analysis: every declared GraphQL variable must be referenced in the body.
+
+    Catches the variableNotUsed class of bug that caused the first-production-fire
+    on Hook 21 (issue #448). The old _ITEM_LOOKUP_QUERY declared $repo and $num
+    but never used them — GitHub's GraphQL rejected with variableNotUsed errors,
+    gh exited non-zero, and the hook silently skipped with skip_no_item.
+
+    This test is intentionally query-string-level (no subprocess / network) so
+    it runs in the default suite and catches the bug class at authoring time.
+    Sibling pattern to issue #175 (Hook 15 sentinel-fallback shell-vs-Python
+    hash test gap) — same shape, different query.
+    """
+
+    _QUERIES_UNDER_TEST = [
+        ("_ITEM_LOOKUP_QUERY", hook._ITEM_LOOKUP_QUERY),
+        ("_INTROSPECT_QUERY", hook._INTROSPECT_QUERY),
+        ("_SET_FIELD_MUTATION", hook._SET_FIELD_MUTATION),
+        ("_CLEAR_FIELD_MUTATION", hook._CLEAR_FIELD_MUTATION),
+    ]
+
+    @staticmethod
+    def _declared_vars(query: str) -> set[str]:
+        """Return the set of variable names declared in `query(...)` / `mutation(...)`.
+
+        Matches `$varname` inside the leading `query(...)` or `mutation(...)` signature
+        (i.e. before the first `{`), which is where GraphQL variable declarations live.
+        """
+        import re
+
+        # Everything up to (and including) the opening brace of the operation body.
+        header_match = re.match(r"[^{]*\(([^)]*)\)", query, re.DOTALL)
+        if not header_match:
+            return set()
+        return set(re.findall(r"\$(\w+)", header_match.group(1)))
+
+    def _assert_all_declared_vars_used(self, name: str, query: str) -> None:
+        declared = self._declared_vars(query)
+        # Each declared var must appear in the query body (i.e., at least twice
+        # in the full string — once in the signature, once in the body).
+        import re
+
+        for var in declared:
+            count = len(re.findall(rf"\${re.escape(var)}\b", query))
+            self.assertGreaterEqual(
+                count,
+                2,
+                f"{name}: declared variable ${var} is never referenced in the query body "
+                f"(variableNotUsed — same class as issue #448). "
+                f"Either use it in the body or remove it from the signature.",
+            )
+
+    def test_item_lookup_query_all_vars_used(self):
+        self._assert_all_declared_vars_used("_ITEM_LOOKUP_QUERY", hook._ITEM_LOOKUP_QUERY)
+
+    def test_introspect_query_all_vars_used(self):
+        self._assert_all_declared_vars_used("_INTROSPECT_QUERY", hook._INTROSPECT_QUERY)
+
+    def test_set_field_mutation_all_vars_used(self):
+        self._assert_all_declared_vars_used("_SET_FIELD_MUTATION", hook._SET_FIELD_MUTATION)
+
+    def test_clear_field_mutation_all_vars_used(self):
+        self._assert_all_declared_vars_used("_CLEAR_FIELD_MUTATION", hook._CLEAR_FIELD_MUTATION)
+
+    def test_old_buggy_query_would_have_failed(self):
+        """Regression guard: the old _ITEM_LOOKUP_QUERY shape fails this check.
+
+        Ensures the test catches the exact bug class from issue #448 — if someone
+        accidentally reverts to the old query, this test turns red.
+        """
+        old_buggy_query = """
+query($org: String!, $project: Int!, $repo: String!, $num: Int!) {
+  organization(login: $org) {
+    projectV2(number: $project) {
+      items(first: 100) {
+        nodes {
+          id
+          content {
+            ... on Issue { number repository { name } }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+        import re
+
+        declared = self._declared_vars(old_buggy_query)
+        unused = []
+        for var in declared:
+            count = len(re.findall(rf"\${re.escape(var)}\b", old_buggy_query))
+            if count < 2:
+                unused.append(var)
+        self.assertIn(
+            "repo",
+            unused,
+            "Old buggy query should have $repo as unused — test regression guard failed",
+        )
+        self.assertIn(
+            "num",
+            unused,
+            "Old buggy query should have $num as unused — test regression guard failed",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Hook 21 (`post_label_change_wave_field_sync`) was silently a no-op on every fire. The root cause: `_ITEM_LOOKUP_QUERY` declared `$repo` and `$num` as required GraphQL variables but never referenced them in the query body. GitHub's GraphQL API rejected every call with `variableNotUsed` errors, `gh api graphql` exited non-zero, `_default_graphql_runner` returned `""`, `_lookup_item_id` returned `None`, and `check()` returned `skip_no_item` silently (that path has no `log_posttooluse_event` call) — making all 39 remaining W11 label-batch ops no-ops.

## Design Rationale

**Why server-side traversal beats Python-side project scan:**

The old query scanned `org → projectV2 → items(first: 100)` and filtered client-side by repo name and issue number. Beyond the variable declaration bug, this had two compounding problems: (1) project 2 has 785+ items — `first: 100` caps at GitHub's GraphQL ceiling per page, silently missing any issue beyond position 100; (2) the unused `$repo`/`$num` variables are wasted declaration space that caused the entire query to fail.

The new query traverses `repository(owner, name) → issue(number) → projectItems(first: 10)` — a direct server-side path that uses all declared variables (`$org`, `$repo`, `$num`) in the body. PROJECT_NUMBER filtering remains Python-side because `projectItems` has no server-side `projectNumber` filter argument; the `first: 10` ceiling is safe since issues are rarely on more than a handful of projects.

**Why the static variable-reference test catches this bug class:**

The injection-mock pattern in `FakeGraphQLRouter` bypasses real GraphQL validation — the fake routes by query substring, not by parsing the query. A test that exercises the full `check()` path with a mock runner will always pass regardless of variable declaration bugs. The new `GraphQLVariableUsageTests` class performs regex-based static analysis on the query string itself: for each declared `$var: Type!` in the operation signature, it asserts that `$var` appears at least twice in the full string (once in the signature, once or more in the body). This catches variableNotUsed at authoring time, zero network needed.

## Ontology Context

- **Hook 21** (`post_label_change_wave_field_sync.py`): PostToolUse Bash hook, registered in `post_dispatcher.py` line 63 (runs LAST in the Bash chain after `annunaki_monitor` → `auto_add_issue_to_board` → `post_wave_kickoff_comment`). Fires on `gh issue edit --add-label / --remove-label` commands with canonical wave labels.
- **post_dispatcher.py**: Routes PostToolUse Bash events to registered hook modules.
- **Project 2** ("Cross-Repo Wave Plan"): GitHub ProjectV2 board; Wave field is a single-select field. Hook 21 syncs this field on label-edit events.
- **Companion Hook 13** (`auto_add_issue_to_board.py`): Covers the CREATE surface; Hook 21 covers the EDIT surface. Both are required for complete Wave-field invariant coverage.

## Acceptance Criteria

### Actionable (this PR closes)
- [ ] `_ITEM_LOOKUP_QUERY` uses all declared variables (`$org`, `$repo`, `$num`) in the query body — no `variableNotUsed` errors from GitHub GraphQL
- [ ] `GraphQLVariableUsageTests` passes and catches the variableNotUsed class for all 4 query/mutation strings
- [ ] All 36 existing tests pass (0 regressions)
- [ ] Hook 21 fires successfully against a real production-shape command (confirmed via 4 manual compensations that used the same verified query shape: deploy#284, data-acquisition#52, deploy#11, main#448)

### Informational (not in this PR)
- Hook 13 (`auto_add_issue_to_board`) also doesn't set the Wave field on `gh issue create` — separate follow-up to file post-merge
- `skip_no_item` path (lines 540-547) has no `log_posttooluse_event` call — deferred decision on whether silent skip is the right shape
- Integration test variant (b) — real `gh api graphql` call against a test project — deferred for follow-up

## Out of Scope

- Hook 13 Wave-field gap on create events
- Annunaki logging of `skip_no_item` / `skip_no_auth_scope` paths
- Integration test variant using live GraphQL endpoint
- Pagination of `projectItems` beyond `first: 10` (issues are rarely on >10 projects; `first: 10` is safe in practice)

## Retro Evidence Trail

4 W11 ops were manually compensated via direct GraphQL before this fix landed:
- `deploy#284` — op 1 (Batch A)
- `data-acquisition#52` — op 2 (Batch A)
- `deploy#11` — op manually applied
- `main#448` — the issue tracking this bug itself

These need `/board-audit` Wave-field reconcile (noted as pending task #1).

Sibling pattern: #175 (Hook 15 sentinel-fallback shell-vs-Python hash test gap) — same shape of unit-test injection mask hiding a production-layer failure. NOT a dup.

Fixes #448
