### PR TITLE
hotfix(hooks): annunaki_monitor + auto_add read tool_response (partial fix #453)

### DIFF
--- a/.claude/hooks/annunaki_monitor.py
+++ b/.claude/hooks/annunaki_monitor.py
@@ -101,7 +101,9 @@ def check(input_data: dict) -> dict | None:
         return None
 
     command = input_data.get("tool_input", {}).get("command", "")
-    tool_output = input_data.get("tool_output", {})
+    # Claude Code's PostToolUse contract passes `tool_response`. Legacy hook
+    # fixtures used `tool_output`; we accept both so old tests still pass.
+    tool_output = input_data.get("tool_response") or input_data.get("tool_output", {})
     stdout = tool_output.get("stdout", "")
     stderr = tool_output.get("stderr", "")
     exit_code = tool_output.get("exit_code", 0)

--- a/.claude/hooks/auto_add_issue_to_board.py
+++ b/.claude/hooks/auto_add_issue_to_board.py
@@ -46,7 +46,10 @@ def check(input_data: dict) -> dict | None:
     if "gh issue create" not in command and "gh issue create" not in command.replace("  ", " "):
         return None
 
-    stdout = input_data.get("tool_output", {}).get("stdout", "")
+    # Claude Code's PostToolUse contract passes `tool_response`. Legacy hook
+    # fixtures used `tool_output`; we accept both so old tests still pass.
+    tool_response = input_data.get("tool_response") or input_data.get("tool_output", {})
+    stdout = tool_response.get("stdout", "")
     if not stdout:
         return None
 

--- a/.claude/hooks/tests/test_post_dispatcher.py
+++ b/.claude/hooks/tests/test_post_dispatcher.py
@@ -331,6 +331,53 @@ class BackwardCompatTests(unittest.TestCase):
         )
         self.assertIsNone(result)
 
+    def test_annunaki_monitor_reads_tool_response_production_shape(self):
+        # Regression for #453: production passes `tool_response`; legacy code
+        # read `tool_output` and silently bailed (`combined_output = ""`).
+        import annunaki_monitor as h
+
+        # Force a fresh module-level dedup set so prior fixtures don't suppress.
+        h._seen_hashes.clear()
+
+        result = h.check(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "false"},
+                "tool_response": {
+                    "stdout": "",
+                    "stderr": "fatal: simulated production failure\n",
+                    "exit_code": 1,
+                },
+            }
+        )
+        self.assertIsNotNone(result)
+        self.assertEqual(result.get("action"), "logged")
+
+    def test_auto_add_issue_to_board_reads_tool_response_production_shape(self):
+        # Regression for #453: same field-name bug class. The hook short-circuits
+        # at `stdout = tool_response.get("stdout","")` if reading the wrong key.
+        # Mock subprocess.run so we never hit the network during the test.
+        import auto_add_issue_to_board as h
+
+        with mock.patch.object(h.subprocess, "run") as mock_run:
+            mock_run.return_value.returncode = 0
+            result = h.check(
+                {
+                    "tool_name": "Bash",
+                    "tool_input": {
+                        "command": "gh issue create --repo noorinalabs/noorinalabs-main --title T",
+                    },
+                    "tool_response": {
+                        "stdout": "https://github.com/noorinalabs/noorinalabs-main/issues/999\n",
+                        "stderr": "",
+                        "exit_code": 0,
+                    },
+                }
+            )
+        self.assertIsNotNone(result)
+        # The hook attempted to add; URL was parsed from stdout.
+        mock_run.assert_called_once()
+
     def test_ontology_tracker_check_skips_non_edit_tool(self):
         import ontology_tracker as h
 


### PR DESCRIPTION
## Summary

- `annunaki_monitor.py` line 104 and `auto_add_issue_to_board.py` line 49 read `input_data.get("tool_output", {})` — but Claude Code's PostToolUse hook contract passes the field as `tool_response`. Both hooks silently bailed on every real Bash call (`stdout = ""` → `combined_output = ""` → `return None`).
- This is why the annunaki log accumulated 388 entries, ~76% of which are hook-test-suite fixtures (test code uses `tool_output`) and ~0 real production failures despite a wave of activity (see #452 for the noise side of the same finding).
- Fix: read `tool_response` first, fall back to `tool_output` so the legacy test fixtures still pass.
- Adds 2 regression tests using the production `tool_response` shape (one each for `annunaki_monitor` and `auto_add_issue_to_board`) so this class can't recur silently.

## Why partial fix

#453 has two findings:
1. **Primary** — Claude Code's PostToolUse Bash hook isn't firing the dispatcher at all in the current session (Hook 21 silent-skip resurfaced at the harness layer). Root cause still unknown.
2. **Secondary** — this `tool_output`/`tool_response` field-name bug.

This PR fixes #2. After it lands AND a session restart, if annunaki_monitor still doesn't log a `false` failure, #1 is confirmed as a harness-vs-hook issue (Claude Code 2.1.143, `--dangerously-skip-permissions`, `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`, or some combination). If annunaki DOES start logging in the fresh session, the field-name bug was load-bearing for #1 too.

## Test plan

- [x] `python3 -m unittest discover .claude/hooks/tests -v` → 778 tests pass (including 2 new)
- [x] `uvx ruff@0.6.9 format --check .claude/hooks/` → 64 files already formatted
- [x] `uvx ruff@0.6.9 check .claude/hooks/` → All checks passed
- [ ] CI: `hooks-lint`, `hooks-tests`, type-check (mypy) — relied on for full verification
- [ ] Post-merge: session restart and `false`/`ls /nonexistent` to verify annunaki logs the failure

## References

- Closes part of #453
- Sibling to #452 (annunaki test-fixture noise)
- Builds on PR #449 (Hook 21 GraphQL hotfix) — same recurring-pattern class as [[feedback_test_mock_injection_masks_production_failure]] (mocks bypass the production contract)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
