### PR TITLE
tech-debt(upsert_status_keys): structural top-level filter for sibling-finder (#456)

### DIFF
--- a/.claude/lib/tests/test_upsert_status_keys.py
+++ b/.claude/lib/tests/test_upsert_status_keys.py
@@ -205,5 +205,144 @@ class UpsertMultiLineFinalKeyTests(unittest.TestCase):
         self.assertEqual(parsed["wave_8_carry_forward"], ["#341"])
 
 
+class UpsertNestedSiblingFalseMatchTests(unittest.TestCase):
+    """main#456 regression — the sibling-finder must NOT match keys whose
+    name happens to look like a wave_N_* sibling but is actually nested
+    inside a multi-line value at the same indent level.
+
+    Reproducer: pretty-printed JSON where the outer wave_N_scope dict has
+    inner keys at 2-space indent (which happens when the user wrote a
+    multi-line value with `json.dumps(value, indent=2)` or hand-formatted
+    pretty JSON without re-indenting). The pre-#456 regex would match
+    those nested keys and treat them as wave_N_* siblings, then call
+    _find_value_end on the wrong position and insert IN THE MIDDLE of the
+    wave_N_scope dict.
+
+    These tests pin the structural-top-level filter so the insertion
+    always lands at the genuine top level.
+    """
+
+    def test_nested_wave_key_at_2_space_indent_does_not_confuse_sibling_finder(self):
+        """The reproducer that motivated #456. Nested `wave_11_inner_*` keys
+        at the same 2-space indent as the outer `wave_11_scope` opener must
+        NOT count as wave_11_* siblings — they're inside wave_11_scope's
+        value, not at the top level."""
+        text = (
+            "{\n"
+            '  "phase": "phase-3",\n'
+            '  "wave_11_scope": {\n'
+            '  "wave_11_inner_a": 1,\n'
+            '  "wave_11_inner_b": 2\n'
+            "  }\n"
+            "}\n"
+        )
+        out = upsert_top_level_key(text, "wave_11_meta_issue", "447")
+        parsed = json.loads(out)
+        # The new key must land at TOP LEVEL, not inside wave_11_scope.
+        self.assertEqual(parsed.get("wave_11_meta_issue"), 447)
+        # wave_11_scope's nested keys must remain unchanged.
+        self.assertEqual(
+            parsed.get("wave_11_scope"),
+            {"wave_11_inner_a": 1, "wave_11_inner_b": 2},
+        )
+
+    def test_nested_wave_key_replace_does_not_target_nested_match(self):
+        """When upserting `wave_11_inner_a` at top level (with no top-level
+        key by that name), the regex MUST NOT match the nested `wave_11_inner_a`
+        inside `wave_11_scope`. The insertion should add a NEW top-level key."""
+        text = '{\n  "phase": "phase-3",\n  "wave_11_scope": {\n  "wave_11_inner_a": 1\n  }\n}\n'
+        out = upsert_top_level_key(text, "wave_11_inner_a", "999")
+        parsed = json.loads(out)
+        # Top-level wave_11_inner_a should be 999.
+        self.assertEqual(parsed["wave_11_inner_a"], 999)
+        # Nested wave_11_inner_a inside wave_11_scope should STILL be 1.
+        self.assertEqual(parsed["wave_11_scope"]["wave_11_inner_a"], 1)
+
+    def test_nested_wave_key_at_4_space_indent_still_ignored(self):
+        """Already worked pre-#456 (indent mismatch) but pinned as a guard."""
+        text = (
+            "{\n"
+            '  "phase": "phase-3",\n'
+            '  "wave_11_scope": {\n'
+            '    "wave_11_inner_a": 1,\n'
+            '    "wave_11_inner_b": 2\n'
+            "  }\n"
+            "}\n"
+        )
+        out = upsert_top_level_key(text, "wave_11_meta_issue", "447")
+        parsed = json.loads(out)
+        self.assertEqual(parsed["wave_11_meta_issue"], 447)
+        self.assertEqual(
+            parsed["wave_11_scope"],
+            {"wave_11_inner_a": 1, "wave_11_inner_b": 2},
+        )
+
+    def test_sequenced_upsert_after_inserting_multiline_dict(self):
+        """The 5-key call shape from the #456 issue body. Sequence:
+        1. start with compact-inline wave_11_* keys
+        2. upsert a multi-line dict for wave_11_scope
+        3. upsert another wave_11_* key
+
+        The multi-line dict insertion must not leave the text in a state
+        where the next upsert's sibling-finder mis-matches a nested key.
+        """
+        text = '{\n  "phase": "phase-3",\n  "wave_11_active": true\n}\n'
+        # Step 1: insert a multi-line dict value (as the helper produces
+        # when the json_value arg is pretty-printed).
+        ml_dict = '{\n    "wave_11_inner_a": 1,\n    "wave_11_inner_b": 2\n  }'
+        text2 = upsert_top_level_key(text, "wave_11_scope", ml_dict)
+        json.loads(text2)  # must parse
+        # Step 2: insert another wave_11_* key
+        text3 = upsert_top_level_key(text2, "wave_11_meta_issue", "447")
+        parsed = json.loads(text3)
+        self.assertEqual(parsed["wave_11_meta_issue"], 447)
+        self.assertEqual(
+            parsed["wave_11_scope"],
+            {"wave_11_inner_a": 1, "wave_11_inner_b": 2},
+        )
+
+
+class IsTopLevelPositionTests(unittest.TestCase):
+    """Pure-function coverage for `_is_top_level_position` — the depth
+    walker that powers the #456 fix."""
+
+    def test_inside_outer_object_is_top_level(self):
+        from upsert_status_keys import _is_top_level_position
+
+        text = '{\n  "a": 1\n}\n'
+        # Position of `"a"` is at depth 1 (inside the outer `{`).
+        pos = text.index('"a"')
+        self.assertTrue(_is_top_level_position(text, pos))
+
+    def test_inside_nested_object_is_not_top_level(self):
+        from upsert_status_keys import _is_top_level_position
+
+        text = '{\n  "outer": {\n    "inner": 1\n  }\n}\n'
+        pos = text.index('"inner"')
+        self.assertFalse(_is_top_level_position(text, pos))
+
+    def test_inside_nested_array_is_not_top_level(self):
+        from upsert_status_keys import _is_top_level_position
+
+        text = '{\n  "list": [\n    "item"\n  ]\n}\n'
+        pos = text.index('"item"')
+        self.assertFalse(_is_top_level_position(text, pos))
+
+    def test_inside_string_value_is_not_top_level(self):
+        from upsert_status_keys import _is_top_level_position
+
+        text = '{\n  "note": "contains { brace } chars"\n}\n'
+        # Position INSIDE the string value
+        pos = text.index("brace")
+        self.assertFalse(_is_top_level_position(text, pos))
+
+    def test_brace_chars_inside_strings_dont_change_depth(self):
+        from upsert_status_keys import _is_top_level_position
+
+        text = '{\n  "a": "before {b} brace",\n  "real_top": 1\n}\n'
+        pos = text.index('"real_top"')
+        self.assertTrue(_is_top_level_position(text, pos))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.claude/lib/upsert_status_keys.py
+++ b/.claude/lib/upsert_status_keys.py
@@ -32,6 +32,50 @@ import sys
 from pathlib import Path
 
 
+def _is_top_level_position(text: str, position: int) -> bool:
+    """Return True iff `position` in `text` is at JSON top-level depth.
+
+    Walks the text from the start tracking bracket depth and JSON string
+    state. Depth-1 (i.e., directly inside the outermost `{...}`) is what
+    "top-level sibling" means for cross-repo-status.json. Positions inside
+    nested objects/arrays or inside string values return False.
+
+    This is the structural check that catches the bug class where the
+    regex sibling-finder happens to match a key NAME that's nested inside
+    a multi-line value (e.g., `wave_11_inner_key` at 2-space indent inside
+    `wave_11_scope: {...}`). Without this check the helper would insert a
+    new top-level key in the middle of a value, producing either invalid
+    JSON or a logical/text divergence caught only by the post-write
+    validation (which then aborts the entire upsert batch).
+
+    Performance: O(position) per call — for cross-repo-status.json
+    (~2700 lines, ~108KB) a single check is ~108K char-iterations, well
+    under 10ms even on slow hardware. Called once per sibling-finder
+    candidate, so worst case is ~108K × N candidates; N is typically 1–5
+    so the total per-upsert cost remains negligible.
+    """
+    depth = 0
+    in_string = False
+    escape = False
+    i = 0
+    while i < position and i < len(text):
+        c = text[i]
+        if escape:
+            escape = False
+        elif c == "\\" and in_string:
+            escape = True
+        elif c == '"':
+            in_string = not in_string
+        elif not in_string:
+            if c in "{[":
+                depth += 1
+            elif c in "}]":
+                depth -= 1
+        i += 1
+    # Depth 1 means we're directly inside the outermost object's body.
+    return depth == 1 and not in_string
+
+
 def _find_value_end(text: str, opener_match_end: int) -> int:
     """Given the regex-match end of a top-level key:value opener line,
     return the position immediately AFTER that key's value terminates
@@ -89,13 +133,28 @@ def upsert_top_level_key(text: str, key: str, json_value: str) -> str:
     is placed AFTER the sibling's structural close, not after the opening
     line (main#332 fix).
 
+    Both the existing-key match AND the sibling-finder match are filtered
+    by `_is_top_level_position` — a regex match whose position is nested
+    inside a multi-line value (e.g., `wave_11_inner_key` at 2-space indent
+    inside `wave_11_scope: {...}`) is rejected so insertions never land
+    mid-value. This is the fix for main#456 — the regex sibling-finder
+    pre-#456 would match nested keys and insert ON TOP of them, producing
+    either invalid JSON or a logical/text divergence aborted by the
+    post-write validation.
+
     Falls back to inserting right after the opening `{` line if no sibling
     exists.
     """
     line_re = re.compile(r'^(  )"' + re.escape(key) + r'":\s.*?,?\s*$', re.MULTILINE)
     new_line = f'  "{key}": {json_value},'
-    m = line_re.search(text)
-    if m:
+    # Replace-in-place: walk every match and pick the first one that's at
+    # top-level depth. The pre-#456 code took the first regex match
+    # unconditionally; that mis-matched nested keys whose NAME happened to
+    # equal `key` (e.g., a top-level `wave_11_meta_issue` upsert mis-matching
+    # a nested `wave_11_meta_issue` inside a wave_11_scope dict).
+    for m in line_re.finditer(text):
+        if not _is_top_level_position(text, m.start()):
+            continue
         existing = m.group(0)
         last_existing = existing.rstrip()
         if last_existing.endswith(","):
@@ -110,7 +169,9 @@ def upsert_top_level_key(text: str, key: str, json_value: str) -> str:
             r'^(  )"wave_' + re.escape(wave_num_match.group(1)) + r'_[^"]+":.*$',
             re.MULTILINE,
         )
-        siblings = list(sibling_re.finditer(text))
+        # Filter to top-level matches only; the pre-#456 code took ALL
+        # matches including nested wave_N_* names inside value dicts.
+        siblings = [m for m in sibling_re.finditer(text) if _is_top_level_position(text, m.start())]
         if siblings:
             last = siblings[-1]
             value_end = _find_value_end(text, last.end())
@@ -161,19 +222,35 @@ def main(argv: list[str]) -> int:
     try:
         reparsed = json.loads(text)
     except json.JSONDecodeError as exc:
+        # Surface the offending key=value pairs so the issue filer can
+        # paste them straight into a reproducer (main#456 follow-up).
+        key_repr = ", ".join(f"{k}={raw[:80]}" for k, raw, _ in pairs)
         print(
             f"ERROR: text-level upsert produced invalid JSON: {exc}\n"
-            "  This usually means the helper's sibling-finder mis-located\n"
-            "  the insertion point inside a multi-line array/object value\n"
-            "  (main#332 reproducer). File the failing input as an issue\n"
-            "  with the offending key=value upsert command.",
+            f"  This usually means the helper's sibling-finder mis-located\n"
+            f"  the insertion point inside a multi-line array/object value\n"
+            f"  (main#332/#456 reproducer class). File the failing input as\n"
+            f"  an issue with the offending key=value upsert command.\n"
+            f"  Offending pairs: {key_repr}",
             file=sys.stderr,
         )
         return 1
 
     if reparsed != parsed:
+        # Pinpoint which key diverged so reviewers can read the bug without
+        # diffing the full file (main#456 follow-up).
+        diverged_keys = sorted(set(reparsed.keys()) ^ set(parsed.keys()))
+        # Also catch same-key different-value divergence.
+        for k in set(reparsed.keys()) & set(parsed.keys()):
+            if reparsed[k] != parsed[k]:
+                diverged_keys.append(k)
+        key_repr = ", ".join(f"{k}={raw[:80]}" for k, raw, _ in pairs)
         print(
-            "ERROR: text-level upsert diverged from logical upsert; aborting write",
+            f"ERROR: text-level upsert diverged from logical upsert; aborting write.\n"
+            f"  Diverged keys: {sorted(set(diverged_keys))}\n"
+            f"  Offending pairs (this call): {key_repr}\n"
+            f"  This usually means a previous key in the same call was\n"
+            f"  inserted at the wrong position (main#456 sibling-finder bug).",
             file=sys.stderr,
         )
         return 1


### PR DESCRIPTION
Closes #456.

## Root cause

The sibling-finder regex matched any line shaped like `^(  )"wave_N_..."` at exactly 2-space indent. When a top-level multi-line value (e.g., `wave_11_scope`) contains nested keys at the same 2-space indent (which happens when the value was hand-formatted as pretty JSON, or produced by `json.dumps(value, indent=2)` where the outer object lives at 2-space depth), the regex matched the nested key too. The helper then called `_find_value_end` on the wrong position and inserted the new key IN THE MIDDLE of the wave_11_scope dict.

## Fix

Added `_is_top_level_position(text, position) -> bool` — a structural walker that tracks bracket depth + JSON string state from the start of the text. Returns True only when `position` is at depth 1 (directly inside the outermost object) and not inside a string.

Both the in-place-replace match and the sibling-finder match are now filtered through this check, so regex matches nested inside multi-line values are rejected.

Performance: O(position) per check on a ~108KB cross-repo-status.json is well under 10ms. Called once per candidate (typically 1–5 per upsert), so per-upsert cost stays negligible.

## Error message improvements (#456 acceptance criteria)

When the post-write JSON validation fails OR the parsed/text round-trip diverges, the error message now surfaces:
- The offending key=value pairs from this call (for paste-into-reproducer)
- The list of diverged keys (for the divergence case)

## Test plan

- [x] `ENVIRONMENT=test python3 -m pytest .claude/lib/tests/test_upsert_status_keys.py` — 18 passing (was 9, +4 false-match regression + +5 depth-walker pure-function)
- [x] `uvx ruff check + format --check` clean
- [x] Production smoke: applied to a copy of cross-repo-status.json with 4 representative upserts — passes
- [x] Pre-commit hooks all green

## Tech Debt

None introduced. PR removes 1 tech-debt item.

Generated with Claude Code
