### PR TITLE
tech-debt(annunaki): env-var-gated test-mode write suppression (#452)

### DIFF
--- a/.claude/hooks/annunaki_log.py
+++ b/.claude/hooks/annunaki_log.py
@@ -7,9 +7,28 @@ commands appear in the Annunaki error log alongside PostToolUse errors.
 Usage in any blocking hook:
     from annunaki_log import log_pretooluse_block
     log_pretooluse_block(hook_name="validate_commit_identity", command=command, reason=reason)
+
+Test-mode suppression (issue #452)
+==================================
+
+When `ENVIRONMENT=test` or `NOORIN_HOOK_TEST_MODE=1` is set in the env,
+`append_jsonl_record` returns without writing. This prevents the hook
+test suite (which exercises matchers against synthetic fixtures like
+`gh pr review 42`, `gh issue create --label does-not-exist`) from
+polluting the production `.claude/annunaki/errors.jsonl` with hundreds
+of fake error entries — pre-#452 a single test-suite run produced ~293
+entries (76% of the log's content as captured 2026-05-16).
+
+`ENVIRONMENT=test` is the charter-required env var for pytest (set by
+`auto_set_env_test.py` PreToolUse hook); using it as the suppression
+signal means no conftest.py setup is needed — every existing test
+invocation already sets it. `NOORIN_HOOK_TEST_MODE` is provided as an
+explicit opt-in for non-pytest harnesses (CI matrix jobs, ad-hoc shell
+fixtures) that need annunaki suppression without claiming `ENVIRONMENT=test`.
 """
 
 import json
+import os
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -17,12 +36,36 @@ REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 ERRORS_FILE = REPO_ROOT / ".claude" / "annunaki" / "errors.jsonl"
 
 
+def _is_test_mode() -> bool:
+    """True iff annunaki should suppress writes (test harness running).
+
+    Returns True when EITHER:
+      - `ENVIRONMENT=test` is set (charter-required for pytest)
+      - `NOORIN_HOOK_TEST_MODE=1` is set (explicit non-pytest opt-in)
+
+    Empty / unset / any other value → False (production fall-through).
+    """
+    if os.environ.get("ENVIRONMENT", "") == "test":
+        return True
+    if os.environ.get("NOORIN_HOOK_TEST_MODE", "") == "1":
+        return True
+    return False
+
+
 def append_jsonl_record(path: Path, record: dict) -> None:
     """Append one JSONL record. Skips empty records and guarantees exactly
     one trailing newline per line — never a bare blank line. Shared by
     annunaki_log.py and annunaki_monitor.py so writer hardening stays in
-    one place."""
+    one place.
+
+    Test-mode suppression: when `_is_test_mode()` is True (ENVIRONMENT=test
+    or NOORIN_HOOK_TEST_MODE=1), the write is skipped entirely. This is the
+    #452 fix — the hook test suite pollutes the production error log with
+    ~293 fixture entries per run otherwise.
+    """
     if not isinstance(record, dict) or not record:
+        return
+    if _is_test_mode():
         return
     # json.dumps with default settings does not emit newlines, so the
     # serialized form is guaranteed single-line. Strip any stray ones

--- a/.claude/hooks/tests/test_annunaki_log.py
+++ b/.claude/hooks/tests/test_annunaki_log.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Tests for `annunaki_log` (#452 test-mode suppression).
+
+Coverage focuses on the env-var-gated write suppression that prevents the
+hook test suite from polluting production error log with ~293 fixture
+entries per run.
+
+Run from the repo root:
+    ENVIRONMENT=test python3 -m pytest \\
+        .claude/hooks/tests/test_annunaki_log.py -v
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_HOOKS_DIR = _HERE.parent
+sys.path.insert(0, str(_HOOKS_DIR))
+
+import annunaki_log as alog  # noqa: E402
+
+
+class IsTestModeTests(unittest.TestCase):
+    """Pure-function coverage for `_is_test_mode`."""
+
+    def setUp(self):
+        # Save and clear both env vars so each test starts clean.
+        self._saved = {
+            "ENVIRONMENT": os.environ.pop("ENVIRONMENT", None),
+            "NOORIN_HOOK_TEST_MODE": os.environ.pop("NOORIN_HOOK_TEST_MODE", None),
+        }
+
+    def tearDown(self):
+        for k, v in self._saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def test_unset_returns_false(self):
+        self.assertFalse(alog._is_test_mode())
+
+    def test_environment_test_returns_true(self):
+        os.environ["ENVIRONMENT"] = "test"
+        self.assertTrue(alog._is_test_mode())
+
+    def test_environment_production_returns_false(self):
+        os.environ["ENVIRONMENT"] = "production"
+        self.assertFalse(alog._is_test_mode())
+
+    def test_environment_empty_returns_false(self):
+        os.environ["ENVIRONMENT"] = ""
+        self.assertFalse(alog._is_test_mode())
+
+    def test_noorin_hook_test_mode_1_returns_true(self):
+        os.environ["NOORIN_HOOK_TEST_MODE"] = "1"
+        self.assertTrue(alog._is_test_mode())
+
+    def test_noorin_hook_test_mode_0_returns_false(self):
+        """Unix-tradition truthy-only — literal `1` is the only true value."""
+        os.environ["NOORIN_HOOK_TEST_MODE"] = "0"
+        self.assertFalse(alog._is_test_mode())
+
+    def test_noorin_hook_test_mode_true_string_returns_false(self):
+        """`true` does NOT activate — only literal `1`."""
+        os.environ["NOORIN_HOOK_TEST_MODE"] = "true"
+        self.assertFalse(alog._is_test_mode())
+
+    def test_either_env_var_set_suffices(self):
+        """The two env vars are OR-combined."""
+        os.environ["NOORIN_HOOK_TEST_MODE"] = "1"
+        os.environ["ENVIRONMENT"] = "production"  # ENVIRONMENT not test
+        self.assertTrue(alog._is_test_mode())
+
+
+class SuppressionTests(unittest.TestCase):
+    """End-to-end: when test-mode is active, `append_jsonl_record` MUST NOT
+    write to the file. When test-mode is inactive, it MUST write."""
+
+    def setUp(self):
+        self._saved = {
+            "ENVIRONMENT": os.environ.pop("ENVIRONMENT", None),
+            "NOORIN_HOOK_TEST_MODE": os.environ.pop("NOORIN_HOOK_TEST_MODE", None),
+        }
+
+    def tearDown(self):
+        for k, v in self._saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def test_environment_test_suppresses_write(self):
+        os.environ["ENVIRONMENT"] = "test"
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "errors.jsonl"
+            alog.append_jsonl_record(target, {"test": "fixture"})
+            self.assertFalse(target.exists(), "ENVIRONMENT=test must suppress annunaki writes")
+
+    def test_noorin_hook_test_mode_suppresses_write(self):
+        os.environ["NOORIN_HOOK_TEST_MODE"] = "1"
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "errors.jsonl"
+            alog.append_jsonl_record(target, {"test": "fixture"})
+            self.assertFalse(target.exists(), "NOORIN_HOOK_TEST_MODE=1 must suppress writes")
+
+    def test_production_env_does_not_suppress_write(self):
+        """The whole point: when neither env var is set, writes go through."""
+        # Both env vars cleared in setUp.
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "errors.jsonl"
+            alog.append_jsonl_record(target, {"production": "real_error"})
+            self.assertTrue(
+                target.exists(),
+                "Production mode (no test-mode env vars) must allow writes",
+            )
+            content = target.read_text()
+            self.assertIn("real_error", content)
+
+    def test_log_pretooluse_block_respects_suppression(self):
+        """The higher-level log_pretooluse_block helper also gets suppressed
+        in test mode (it goes through append_jsonl_record)."""
+        os.environ["ENVIRONMENT"] = "test"
+        # The hook's ERRORS_FILE is hardcoded; we redirect by temporarily
+        # patching the module attribute, which is the same shape the
+        # _wipe_cache pattern uses elsewhere in the test suite.
+        with tempfile.TemporaryDirectory() as tmp:
+            orig = alog.ERRORS_FILE
+            alog.ERRORS_FILE = Path(tmp) / "errors.jsonl"
+            try:
+                alog.log_pretooluse_block("some_hook", "gh issue create --label fake", "blocked")
+                self.assertFalse(
+                    alog.ERRORS_FILE.exists(),
+                    "log_pretooluse_block must also be suppressed in test mode",
+                )
+            finally:
+                alog.ERRORS_FILE = orig
+
+    def test_log_posttooluse_event_respects_suppression(self):
+        os.environ["ENVIRONMENT"] = "test"
+        with tempfile.TemporaryDirectory() as tmp:
+            orig = alog.ERRORS_FILE
+            alog.ERRORS_FILE = Path(tmp) / "errors.jsonl"
+            try:
+                alog.log_posttooluse_event("some_hook", "gh issue create", "advisory")
+                self.assertFalse(
+                    alog.ERRORS_FILE.exists(),
+                    "log_posttooluse_event must also be suppressed in test mode",
+                )
+            finally:
+                alog.ERRORS_FILE = orig
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Closes #452.

## Problem

`annunaki_log.append_jsonl_record` writes unconditionally to `.claude/annunaki/errors.jsonl`. The hook test suite exercises matchers against synthetic fixtures (many of which intentionally trip block hooks to verify their behavior). Each such test fires the production logger, appending a "fake error" entry to the production log.

Per the issue body (2026-05-16 capture): 293 of 388 (~76%) entries in the production log were test-fixture noise from a single test-suite run. This degrades the signal-to-noise of /annunaki and /annunaki-attack.

## Fix

Added `_is_test_mode()` to annunaki_log.py — returns True when either:
- `ENVIRONMENT=test` (charter-required env var for pytest; set by auto_set_env_test.py PreToolUse hook)
- `NOORIN_HOOK_TEST_MODE=1` (explicit non-pytest opt-in)

`append_jsonl_record` early-returns when test-mode is True. Since both `log_pretooluse_block` and `log_posttooluse_event` route through it, suppression covers every annunaki-logging caller without per-hook changes.

## Why ENVIRONMENT=test as the signal

The charter already requires `ENVIRONMENT=test` for pytest invocations (enforced by auto_set_env_test.py). Every existing test invocation already sets it. No conftest.py setup; no migration of existing test files; no per-test mocking.

## Verification

Pre-#452: `ENVIRONMENT=test pytest .claude/hooks/tests/` added 200+ fixture entries to errors.jsonl per run.

Post-#452: same command adds 0 entries. Verified with wc -l before/after.

The backfill of historical fixture entries is deferred to a follow-up — this PR delivers the prevention; the backfill is a separate ops-cleanup action.

## Test plan

- [x] `ENVIRONMENT=test pytest .claude/hooks/tests/test_annunaki_log.py` — 13 passing
- [x] Full hook test suite still passes
- [x] Production smoke: `wc -l errors.jsonl` before/after a full test run shows 0 new entries
- [x] ruff + pre-commit clean

## Tech Debt

None introduced. PR removes 1 tech-debt item.

Generated with Claude Code
