### PR TITLE
tech-debt(enforce_ontology_context): exempt coordinator-class spawns (#466)

### DIFF
--- a/.claude/hooks/enforce_ontology_context.py
+++ b/.claude/hooks/enforce_ontology_context.py
@@ -4,11 +4,11 @@
 Blocks worktree-isolated Agent tool calls unless the prompt either contains
 ontology context markers (indicating the orchestrator ran
 `/ontology-librarian` before spawning) OR the prompt opens with a
-coordinator-class role declaration (Manager, Program Director, TPM,
-Release Coordinator).
+coordinator-class role declaration (Manager, Pipeline Manager, Project
+Lead, Program Director, TPM, Release Coordinator).
 
-Coordinator-class exemption (#466)
-==================================
+Coordinator-class exemption (#466, expanded via Aino + Santiago review)
+======================================================================
 
 Coordinators communicate via SendMessage and rarely Edit/Write directly.
 Hook 15 (`enforce_librarian_consulted`) covers the Edit/Write surface for
@@ -21,6 +21,13 @@ catching real risk.
 Implementer-class roles (Engineer, Tech Lead, Standards & Quality Lead,
 Security Engineer, etc.) are NOT exempt — they Edit/Write code as the
 primary task.
+
+Title taxonomy is enumerative (not heuristic): each role string here
+corresponds to an actual canonical-composer output observed in spawn
+briefs across the 7 child rosters. Compound titles that the composer
+flattens to a different name (e.g., Bereket's "Infrastructure Manager"
+→ composer emits `, Manager`; Marcia's "Project Lead / Manager" →
+composer emits `, Project Lead`) match by their composer-output form.
 
 Exit codes:
   0 — allow (not an Agent call, non-worktree isolation, coordinator-class
@@ -48,24 +55,47 @@ ONTOLOGY_MARKERS = [
 
 # Canonical coordinator-class opener: `You are **{Name}**, {Role}[ for {repo}]`
 # where {Role} is one of the pure-coordination titles. Bold-markdown around
-# the name is optional (some shorter briefs drop it). Anchored to start so
-# only the opener matches — incidental mentions of "Manager" later in the
-# prompt do not exempt the spawn.
+# the name is optional. `re.MULTILINE` so the `^` anchor matches at the
+# start of any line — handles briefs that prepend a header (Ontology
+# Context block, task framing, etc.) before the "You are X, ..." opener.
+#
+# Title list is enumerative — see module docstring. Multi-word titles
+# precede single-word `Manager` alternation so the regex engine doesn't
+# half-consume "Pipeline Manager" as `Manager` (it wouldn't anyway because
+# `Manager` requires position right after `, `, but the explicit ordering
+# documents the intent for future maintainers).
 COORDINATOR_ROLE_OPENER = re.compile(
     r"^\s*You are\s+\*{0,2}[^,\n]+?\*{0,2},\s*"
-    r"(Manager|Program\s+Director|TPM|Technical\s+Program\s+Manager|Release\s+Coordinator)\b",
-    re.IGNORECASE,
+    r"(Pipeline\s+Manager"
+    r"|Project\s+Lead"
+    r"|Program\s+Director"
+    r"|Technical\s+Program\s+Manager"
+    r"|TPM"
+    r"|Release\s+Coordinator"
+    r"|Manager)\b",
+    re.IGNORECASE | re.MULTILINE,
 )
 
 
 def check(input_data: dict) -> dict | None:
-    """Pure decision function. Returns None to allow, or a block-dict."""
+    """Pure decision function. Returns None to allow, or a block-dict.
+
+    Returns None for malformed inputs (non-dict tool_input, non-str prompt,
+    etc.) rather than crashing — PreToolUse hooks that raise are surfaced
+    to the user as block-with-error, which is worse than allowing through
+    a malformed shape that the tool itself will reject.
+    """
     if input_data.get("tool_name", "") != "Agent":
         return None
 
-    tool_input = input_data.get("tool_input", {})
+    tool_input = input_data.get("tool_input")
+    if not isinstance(tool_input, dict):
+        return None
+
     isolation = tool_input.get("isolation", "")
     prompt = tool_input.get("prompt", "")
+    if not isinstance(isolation, str) or not isinstance(prompt, str):
+        return None
 
     if isolation != "worktree":
         return None
@@ -101,8 +131,13 @@ def main() -> None:
         sys.exit(0)
 
     print(json.dumps(result))
-    prompt = input_data.get("tool_input", {}).get("prompt", "")
-    log_pretooluse_block("enforce_ontology_context", prompt[:200], result["reason"])
+    prompt = ""
+    tool_input = input_data.get("tool_input")
+    if isinstance(tool_input, dict):
+        raw = tool_input.get("prompt", "")
+        if isinstance(raw, str):
+            prompt = raw[:200]
+    log_pretooluse_block("enforce_ontology_context", prompt, result["reason"])
     sys.exit(2)
 
 

--- a/.claude/hooks/enforce_ontology_context.py
+++ b/.claude/hooks/enforce_ontology_context.py
@@ -1,23 +1,41 @@
 #!/usr/bin/env python3
 """PreToolUse hook: Require ontology context in Agent spawn prompts.
 
-Blocks Agent tool calls for implementation agents (worktree isolation)
-unless the prompt contains ontology context markers, indicating the
-orchestrator ran /ontology-librarian before spawning.
+Blocks worktree-isolated Agent tool calls unless the prompt either contains
+ontology context markers (indicating the orchestrator ran
+`/ontology-librarian` before spawning) OR the prompt opens with a
+coordinator-class role declaration (Manager, Program Director, TPM,
+Release Coordinator).
+
+Coordinator-class exemption (#466)
+==================================
+
+Coordinators communicate via SendMessage and rarely Edit/Write directly.
+Hook 15 (`enforce_librarian_consulted`) covers the Edit/Write surface for
+the few cases where a coordinator does edit. Requiring ontology context in
+every coordinator spawn brief adds ceremony without preventive value — and
+when orchestrators forget (as in the P3W11 wave-tail re-spawn burst that
+captured 8 blocks 2026-05-17 03:54Z), the hook produces noise rather than
+catching real risk.
+
+Implementer-class roles (Engineer, Tech Lead, Standards & Quality Lead,
+Security Engineer, etc.) are NOT exempt — they Edit/Write code as the
+primary task.
 
 Exit codes:
-  0 — allow (not an Agent call, or ontology context present)
-  2 — block (implementation agent spawned without ontology context)
+  0 — allow (not an Agent call, non-worktree isolation, coordinator-class
+      spawn, or ontology context present)
+  2 — block (implementer-class spawn without ontology context)
 """
 
 import json
+import re
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from annunaki_log import log_pretooluse_block
+from annunaki_log import log_pretooluse_block  # noqa: E402
 
-# Markers that indicate ontology context was included in the prompt.
 ONTOLOGY_MARKERS = [
     "Ontology Status",
     "ontology is current",
@@ -28,33 +46,39 @@ ONTOLOGY_MARKERS = [
     "## Ontology Context",
 ]
 
+# Canonical coordinator-class opener: `You are **{Name}**, {Role}[ for {repo}]`
+# where {Role} is one of the pure-coordination titles. Bold-markdown around
+# the name is optional (some shorter briefs drop it). Anchored to start so
+# only the opener matches — incidental mentions of "Manager" later in the
+# prompt do not exempt the spawn.
+COORDINATOR_ROLE_OPENER = re.compile(
+    r"^\s*You are\s+\*{0,2}[^,\n]+?\*{0,2},\s*"
+    r"(Manager|Program\s+Director|TPM|Technical\s+Program\s+Manager|Release\s+Coordinator)\b",
+    re.IGNORECASE,
+)
 
-def main() -> None:
-    try:
-        input_data = json.load(sys.stdin)
-    except (json.JSONDecodeError, EOFError):
-        sys.exit(0)
 
-    tool_name = input_data.get("tool_name", "")
-    if tool_name != "Agent":
-        sys.exit(0)
+def check(input_data: dict) -> dict | None:
+    """Pure decision function. Returns None to allow, or a block-dict."""
+    if input_data.get("tool_name", "") != "Agent":
+        return None
 
     tool_input = input_data.get("tool_input", {})
     isolation = tool_input.get("isolation", "")
     prompt = tool_input.get("prompt", "")
 
-    # Only enforce for worktree-isolated agents (implementation agents).
-    # Non-isolated agents (research, exploration) don't need ontology context.
     if isolation != "worktree":
-        sys.exit(0)
+        return None
 
-    # Check if any ontology marker is present in the prompt
+    if COORDINATOR_ROLE_OPENER.search(prompt):
+        return None
+
     prompt_lower = prompt.lower()
     for marker in ONTOLOGY_MARKERS:
         if marker.lower() in prompt_lower:
-            sys.exit(0)
+            return None
 
-    result = {
+    return {
         "decision": "block",
         "reason": (
             "BLOCKED: Implementation agent spawned without ontology context.\n"
@@ -64,7 +88,20 @@ def main() -> None:
             "the output in the agent's prompt under a '## Ontology Context' heading."
         ),
     }
+
+
+def main() -> None:
+    try:
+        input_data = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        sys.exit(0)
+
+    result = check(input_data)
+    if result is None:
+        sys.exit(0)
+
     print(json.dumps(result))
+    prompt = input_data.get("tool_input", {}).get("prompt", "")
     log_pretooluse_block("enforce_ontology_context", prompt[:200], result["reason"])
     sys.exit(2)
 

--- a/.claude/hooks/tests/test_enforce_ontology_context.py
+++ b/.claude/hooks/tests/test_enforce_ontology_context.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Tests for enforce_ontology_context — covers #466 coordinator-class exemption.
+
+Run: ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/test_enforce_ontology_context.py -v
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_HOOKS_DIR = _HERE.parent
+sys.path.insert(0, str(_HOOKS_DIR))
+
+import enforce_ontology_context as hook  # noqa: E402
+
+
+def _spawn(prompt: str, isolation: str = "worktree") -> dict:
+    return {
+        "tool_name": "Agent",
+        "tool_input": {"isolation": isolation, "prompt": prompt},
+    }
+
+
+class NonAgentCallAllowed(unittest.TestCase):
+    def test_bash_tool_pass_through(self):
+        self.assertIsNone(hook.check({"tool_name": "Bash", "tool_input": {"command": "ls"}}))
+
+    def test_edit_tool_pass_through(self):
+        self.assertIsNone(hook.check({"tool_name": "Edit", "tool_input": {}}))
+
+
+class NonWorktreeIsolationAllowed(unittest.TestCase):
+    def test_no_isolation_allowed(self):
+        self.assertIsNone(hook.check(_spawn("Random prompt without markers", isolation="")))
+
+    def test_other_isolation_value_allowed(self):
+        self.assertIsNone(hook.check(_spawn("Random prompt", isolation="container")))
+
+
+class WorktreeImplementerWithoutContextBlocked(unittest.TestCase):
+    def test_engineer_blocked(self):
+        prompt = "You are **Mateo Salazar**, Engineer for noorinalabs-user-service. Implement #123."
+        result = hook.check(_spawn(prompt))
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+
+    def test_tech_lead_blocked(self):
+        prompt = (
+            "You are **Anya Kowalczyk**, Tech Lead for noorinalabs-isnad-graph. Implement #500."
+        )
+        result = hook.check(_spawn(prompt))
+        self.assertIsNotNone(result)
+
+    def test_security_engineer_blocked(self):
+        prompt = "You are **Idris Yusuf**, Security Engineer. Review the auth code."
+        result = hook.check(_spawn(prompt))
+        self.assertIsNotNone(result)
+
+
+class WorktreeImplementerWithContextAllowed(unittest.TestCase):
+    def test_ontology_context_heading_allowed(self):
+        prompt = (
+            "## Ontology Context\nServices: user-service\n\n"
+            "You are **Mateo**, Engineer. Implement #123."
+        )
+        self.assertIsNone(hook.check(_spawn(prompt)))
+
+    def test_status_marker_allowed(self):
+        prompt = "You are Mateo. Ontology Status: ontology is current. Implement #123."
+        self.assertIsNone(hook.check(_spawn(prompt)))
+
+    def test_yaml_path_marker_allowed(self):
+        prompt = "You are Mateo. See ontology/services.yaml for context. Implement #123."
+        self.assertIsNone(hook.check(_spawn(prompt)))
+
+
+class CoordinatorClassExempt(unittest.TestCase):
+    """Manager / Program Director / TPM / Release Coordinator spawn briefs are
+    exempt from ontology-context enforcement even with worktree isolation.
+
+    Reproduces the 8-block burst captured 2026-05-17 03:54Z (#466)."""
+
+    def test_manager_for_deploy_exempt(self):
+        prompt = "You are **Bereket Tadesse**, Manager for noorinalabs-deploy. Roster card: ..."
+        self.assertIsNone(hook.check(_spawn(prompt)))
+
+    def test_manager_for_isnad_graph_exempt(self):
+        prompt = (
+            "You are **Nadia Boukhari**, Manager for noorinalabs-isnad-graph "
+            "(NOT Nadia Khoury the parent Program Director — different person)."
+        )
+        self.assertIsNone(hook.check(_spawn(prompt)))
+
+    def test_manager_for_ingest_platform_exempt(self):
+        prompt = (
+            "You are **Adaeze Okonkwo**, Manager for noorinalabs-isnad-ingest-platform. "
+            "Roster card: ..."
+        )
+        self.assertIsNone(hook.check(_spawn(prompt)))
+
+    def test_program_director_exempt(self):
+        prompt = "You are **Nadia Khoury**, Program Director for noorinalabs. Coordinate the wave."
+        self.assertIsNone(hook.check(_spawn(prompt)))
+
+    def test_tpm_exempt(self):
+        prompt = "You are **Wanjiku Mwangi**, TPM for noorinalabs. Track timelines."
+        self.assertIsNone(hook.check(_spawn(prompt)))
+
+    def test_technical_program_manager_full_title_exempt(self):
+        prompt = (
+            "You are **Wanjiku Mwangi**, Technical Program Manager for noorinalabs. "
+            "Track timelines."
+        )
+        self.assertIsNone(hook.check(_spawn(prompt)))
+
+    def test_release_coordinator_exempt(self):
+        prompt = (
+            "You are **Santiago Ferreira**, Release Coordinator for noorinalabs. Sequence rollouts."
+        )
+        self.assertIsNone(hook.check(_spawn(prompt)))
+
+    def test_manager_without_repo_suffix_exempt(self):
+        prompt = "You are **Bereket Tadesse**, Manager. Coordinate the deploy wave."
+        self.assertIsNone(hook.check(_spawn(prompt)))
+
+    def test_manager_without_bold_markdown_exempt(self):
+        prompt = "You are Bereket Tadesse, Manager for noorinalabs-deploy. Coordinate the wave."
+        self.assertIsNone(hook.check(_spawn(prompt)))
+
+
+class CoordinatorExemptIsBoundaryStrict(unittest.TestCase):
+    """The exemption matches the canonical opener shape and NOT incidental
+    mentions of coordinator role names later in the prompt."""
+
+    def test_engineer_mentioning_manager_in_body_still_blocked(self):
+        prompt = (
+            "You are **Mateo Salazar**, Engineer. Your Manager Bereket asked for #123. "
+            "Implement it."
+        )
+        result = hook.check(_spawn(prompt))
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+
+    def test_tech_lead_not_exempted_by_lead_substring(self):
+        prompt = "You are **Anya Kowalczyk**, Tech Lead. Implement #500."
+        result = hook.check(_spawn(prompt))
+        self.assertIsNotNone(result)
+
+    def test_engineering_manager_role_does_not_match_simple_manager(self):
+        # "Engineering Manager" (a doer-manager title) won't match because
+        # the regex requires the coordinator word immediately after `, `.
+        prompt = "You are **Sam**, Engineering Manager. Implement #200."
+        result = hook.check(_spawn(prompt))
+        self.assertIsNotNone(result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/hooks/tests/test_enforce_ontology_context.py
+++ b/.claude/hooks/tests/test_enforce_ontology_context.py
@@ -131,6 +131,95 @@ class CoordinatorClassExempt(unittest.TestCase):
         prompt = "You are Bereket Tadesse, Manager for noorinalabs-deploy. Coordinate the wave."
         self.assertIsNone(hook.check(_spawn(prompt)))
 
+    def test_project_lead_exempt_marcia(self):
+        # Marcia Vasquez-Paredes (landing-page) — composer flattens
+        # "Project Lead / Manager" roster title to ", Project Lead".
+        # Was 1 of the 8 captured blocks (#466) that the initial regex missed.
+        prompt = (
+            "You are **Marcia Vasquez-Paredes**, Project Lead for noorinalabs-landing-page. "
+            "Coordinate the wave."
+        )
+        self.assertIsNone(hook.check(_spawn(prompt)))
+
+    def test_pipeline_manager_exempt_dilara(self):
+        # Dilara (data-acquisition) — Senior VP coordinator with the
+        # "Pipeline Manager" composer-output. Surfaced by Santiago's #469
+        # roster-grep during PR #468 review.
+        prompt = (
+            "You are **Dilara Aydin**, Pipeline Manager for noorinalabs-data-acquisition. "
+            "Coordinate the wave."
+        )
+        self.assertIsNone(hook.check(_spawn(prompt)))
+
+
+class CoordinatorExemptHandlesPrependedHeader(unittest.TestCase):
+    """Coordinator-class exemption must match when the spawn brief prepends
+    content (header, task framing, role-card excerpt) before the canonical
+    "You are X, Role" opener — `re.MULTILINE` enables `^` to match at line
+    starts beyond char 0. Caught by Aino's review blocker #2 on PR #468."""
+
+    def test_coordinator_after_markdown_header_exempt(self):
+        prompt = (
+            "# Wave-tail re-spawn brief\n\n"
+            "You are **Bereket Tadesse**, Manager for noorinalabs-deploy. Coordinate the wave."
+        )
+        self.assertIsNone(hook.check(_spawn(prompt)))
+
+    def test_coordinator_after_task_context_exempt(self):
+        prompt = (
+            "Task context: P3W11 wave-tail cleanup.\n"
+            "\n"
+            "You are **Adaeze Okonkwo**, Manager for noorinalabs-isnad-ingest-platform. "
+            "Coordinate the wave."
+        )
+        self.assertIsNone(hook.check(_spawn(prompt)))
+
+    def test_coordinator_after_role_card_excerpt_exempt(self):
+        prompt = (
+            "Roster card excerpt:\n"
+            "  Role: Manager for noorinalabs-landing-page\n"
+            "  Reports to: Nadia Khoury\n"
+            "\n"
+            "You are **Marcia Vasquez-Paredes**, Project Lead for noorinalabs-landing-page. "
+            "Coordinate the wave."
+        )
+        self.assertIsNone(hook.check(_spawn(prompt)))
+
+
+class CheckIsCrashSafeOnMalformedInput(unittest.TestCase):
+    """PreToolUse hooks that raise get surfaced to the user as
+    block-with-error, which is worse than silently allowing a malformed
+    shape (the tool itself will reject it). `check()` must return None on
+    any non-conforming input. Covers Aino's non-blocking concern on #468."""
+
+    def test_none_prompt_does_not_crash(self):
+        self.assertIsNone(hook.check({"tool_name": "Agent", "tool_input": {"prompt": None}}))
+
+    def test_int_prompt_does_not_crash(self):
+        self.assertIsNone(hook.check({"tool_name": "Agent", "tool_input": {"prompt": 42}}))
+
+    def test_dict_prompt_does_not_crash(self):
+        self.assertIsNone(hook.check({"tool_name": "Agent", "tool_input": {"prompt": {"x": 1}}}))
+
+    def test_none_tool_input_does_not_crash(self):
+        self.assertIsNone(hook.check({"tool_name": "Agent", "tool_input": None}))
+
+    def test_list_tool_input_does_not_crash(self):
+        self.assertIsNone(hook.check({"tool_name": "Agent", "tool_input": []}))
+
+    def test_none_isolation_does_not_crash(self):
+        self.assertIsNone(
+            hook.check(
+                {
+                    "tool_name": "Agent",
+                    "tool_input": {"isolation": None, "prompt": "You are X, Engineer."},
+                }
+            )
+        )
+
+    def test_missing_tool_input_does_not_crash(self):
+        self.assertIsNone(hook.check({"tool_name": "Agent"}))
+
 
 class CoordinatorExemptIsBoundaryStrict(unittest.TestCase):
     """The exemption matches the canonical opener shape and NOT incidental


### PR DESCRIPTION
## Summary

Add coordinator-class exemption to `enforce_ontology_context` PreToolUse Agent hook.

- Refactor hook to extract a testable `check(input_data) -> dict | None` pure function
- Add `COORDINATOR_ROLE_OPENER` regex matching the canonical spawn-brief shape `You are **{Name}**, {Role}[ for {repo}]` where {Role} is Manager / Program Director / TPM / Technical Program Manager / Release Coordinator
- Implementer-class roles (Engineer, Tech Lead, Standards & Quality Lead, Security Engineer, Engineering Manager) remain enforced
- 22-test suite, all pass — hook had no prior test coverage; this PR establishes the baseline

## Why

P3W11 wave-tail re-spawn burst captured 8 coordinator-spawn blocks on 2026-05-17 03:54Z (53-second window): Bereket (deploy Manager), Nadia Boukhari (isnad-graph Manager), Adaeze (ingest-platform Manager), plus 5 others. Coordinators communicate via SendMessage and rarely Edit/Write directly; Hook 15 (`enforce_librarian_consulted`) covers the rare Edit/Write surface for the few that do.

The hook's `isolation == "worktree"` filter is correct for implementer-class but the orchestrator also uses worktree isolation for some coordinator spawns. Two paths considered:

- **Option A (orchestrator-side):** include `/ontology-librarian` instruction in every coordinator spawn brief
- **Option B (hook-side):** add coordinator-class exemption — this PR

Option B chosen because:
1. Hook-level enforcement doesn't decay (per `feedback_enforcement_hierarchy.md`)
2. The librarian-consult adds value at the Edit/Write surface — Hook 15 covers that surface
3. Removes ceremony from every future coordinator spawn

## Test plan

- [x] `ENVIRONMENT=test pytest .claude/hooks/tests/test_enforce_ontology_context.py -v` → 22 passed
- [x] `ruff check` + `ruff format --check` clean on touched files
- [x] Pre-commit ruff-format + ruff-lint + mypy all pass
- [ ] Reviewer verifies the regex anchoring (incidental "Manager" mentions in implementer prompts should still block — `test_engineer_mentioning_manager_in_body_still_blocked`)
- [ ] Reviewer verifies no false-positive on `Engineering Manager` / `Tech Lead` / other doer titles (`test_engineering_manager_role_does_not_match_simple_manager`, `test_tech_lead_not_exempted_by_lead_substring`)

## Annunaki provenance

Filed via `/annunaki-attack` run 2026-05-17 21:58Z. The 8 blocks were the largest real-signal cluster among 436 captured errors (the other 96% were pre-#461 test-fixture pollution).

## Follow-up

Not in this PR — `enforce_ontology_context.py` is missing from `ontology/conventions.md` hooks table (only its sibling `enforce_librarian_consulted` is listed). Worth a small ontology-rebuild pass after this lands.

## Requested reviewers

- Aino Virtanen (Standards & Quality Lead — owner of hook lint/test discipline)
- Santiago Ferreira (Release Coordinator — second look on coordinator-class semantics)

Closes #466
