### PR TITLE
fix(hook): auto_set_env_test — chain-aware env-var placement (#476)

### DIFF
--- a/.claude/hooks/auto_set_env_test.py
+++ b/.claude/hooks/auto_set_env_test.py
@@ -3,7 +3,7 @@
 
 Ensures ENVIRONMENT=test is present in the environment for any pytest or
 `make test` command. If not already set, blocks with a corrected command
-that prepends ENVIRONMENT=test.
+that prepends ENVIRONMENT=test to the test-bearing segment(s).
 
 Input Language
 ==============
@@ -11,16 +11,21 @@ Input Language
 Fires on:
     PreToolUse Bash
 
-Matches (blocks if ENVIRONMENT=test missing):
-    Any Bash command whose token stream, after stripping leading
-    `VAR=value` environment assignments, contains a real test-runner
-    invocation detected by the regexes `\\bpytest\\b` or `\\bmake\\s+test\\b`.
+Matches (blocks if ENVIRONMENT=test missing on the test segment):
+    Any Bash command containing a real test-runner invocation detected
+    by the regexes `\\bpytest\\b` or `\\bmake\\s+test\\b`. The command is
+    split on shell separators (`&&`, `||`, `;`, `|`) into segments; each
+    test-bearing segment is checked independently for a leading
+    `ENVIRONMENT=test` env-block.
+
     Typical matched forms:
         pytest tests/
         uv run pytest
         python -m pytest
         make test
-        DEBUG=1 pytest tests/            (env prefix preserved; still matches)
+        DEBUG=1 pytest tests/                  (env prefix preserved)
+        cd /path && pytest tests/              (chain — env must be on pytest segment)
+        pytest tests/ && pytest tests-other/   (chain — env required on BOTH segments)
 
 Does NOT match (short-circuit skips — #114 fix):
     1. Command whose effective argv[0] is `gh` — `gh` is a GitHub API
@@ -36,21 +41,30 @@ Does NOT match (short-circuit skips — #114 fix):
        the cost of blocking every review / issue / comment that
        references pytest.
 
-Both short-circuits run BEFORE the pytest/make-test regex check.
+Both short-circuits run BEFORE the pytest/make-test segment scan and
+apply to the WHOLE command (not per-segment).
 
 Detection order:
-    1. Strip leading `VAR=value` tokens from the command.
+    1. Strip leading `VAR=value` tokens from the command for argv[0] check.
     2. If the next token is `gh`, ALLOW (return None).
     3. If the command contains `--body` or `--body-file`, ALLOW.
-    4. If `\\bpytest\\b` or `\\bmake\\s+test\\b` matches, require
-       `\\bENVIRONMENT=test\\b` somewhere in the command; else BLOCK.
+    4. Split on `&&`/`||`/`;`/`|` into segments.
+    5. For each segment containing `\\bpytest\\b` or `\\bmake\\s+test\\b`,
+       require `\\bENVIRONMENT=test\\b` in that segment's leading env-block;
+       else BLOCK with a per-segment-rewritten suggestion.
+
+Per-segment env-block check (the #476 silent-bypass fix):
+    `ENVIRONMENT=test cd /x && pytest tests/` does NOT pass — even though
+    the env var appears in the command, it lives on the `cd` segment, not
+    on the pytest segment. Shell semantics apply env assignments only to
+    the immediately-following program in the same segment.
 
 Exit codes:
-    0 — allow (not a Bash tool, or skip condition met, or already has
-        ENVIRONMENT=test)
-    2 — block (real test command missing ENVIRONMENT=test)
+    0 — allow (not a Bash tool, or skip condition met, or every test
+        segment already has ENVIRONMENT=test in its leading env-block)
+    2 — block (at least one test segment is missing ENVIRONMENT=test)
 
-Enforcement artifact for: noorinalabs/noorinalabs-main#114
+Enforcement artifact for: noorinalabs/noorinalabs-main#114, #476
 """
 
 import json
@@ -68,6 +82,18 @@ _ENV_ASSIGN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=\S*\s+")
 # prevents matching `--body-foo` but still matches both `--body x`,
 # `--body=x`, and `--body-file path`.
 _BODY_FLAG = re.compile(r"(?<![\w-])--body(?:-file)?(?=[\s=]|$)")
+
+# Shell separators we split on. Order matters in the alternation: longer
+# tokens first so `&&` isn't mis-split as two `|`s by the `|` alternative.
+# Captured group preserves the separator in the split output so we can
+# splice segments back together with original glue.
+_SEPARATORS = re.compile(r"(\s*(?:&&|\|\||;|\|)\s*)")
+
+# Test-runner detection: pytest OR `make test`.
+_TEST_RUNNER = re.compile(r"\bpytest\b|\bmake\s+test\b")
+
+# The literal env-var we require.
+_ENV_TOKEN = re.compile(r"\bENVIRONMENT=test\b")
 
 
 def _strip_leading_env(command: str) -> str:
@@ -93,6 +119,62 @@ def _has_body_flag(command: str) -> bool:
     return bool(_BODY_FLAG.search(command))
 
 
+def _split_segments(command: str) -> list[str]:
+    """Split command on `&&`/`||`/`;`/`|`, preserving separators as
+    alternating list entries: [seg0, sep0, seg1, sep1, ..., segN].
+
+    The result always has odd length: segments at even indices, separators
+    at odd indices. A command with no separators returns a single-element
+    list [command].
+    """
+    return _SEPARATORS.split(command)
+
+
+def _segment_has_env_in_leading_block(segment: str) -> bool:
+    """True if `ENVIRONMENT=test` is in the LEADING env-block of segment.
+
+    The leading env-block is the sequence of `VAR=value ` tokens at the
+    start of the segment (after stripping surrounding whitespace). This
+    is the only position where a shell env assignment applies to the
+    segment's program.
+    """
+    stripped = segment.lstrip()
+    consumed = stripped[: len(stripped) - len(_strip_leading_env(stripped))]
+    return bool(_ENV_TOKEN.search(consumed))
+
+
+def _is_test_segment(segment: str) -> bool:
+    """True if segment contains pytest or `make test` as a real invocation."""
+    return bool(_TEST_RUNNER.search(segment))
+
+
+def _prepend_env_to_segment(segment: str) -> str:
+    """Return segment with `ENVIRONMENT=test ` inserted before its first
+    real (non-env-assignment, non-whitespace) token.
+
+    Preserves any existing leading env-block (e.g. `DEBUG=1 pytest` →
+    `DEBUG=1 ENVIRONMENT=test pytest`) and preserves the segment's
+    leading whitespace exactly so splicing back into the chain doesn't
+    re-shape the original command's formatting.
+    """
+    leading_ws_len = len(segment) - len(segment.lstrip())
+    leading_ws = segment[:leading_ws_len]
+    body = segment[leading_ws_len:]
+    body_after_env = _strip_leading_env(body)
+    env_block = body[: len(body) - len(body_after_env)]
+    return f"{leading_ws}{env_block}ENVIRONMENT=test {body_after_env}"
+
+
+def _rewrite_command(command: str) -> str:
+    """Splice ENVIRONMENT=test onto each test-bearing segment that lacks it."""
+    parts = _split_segments(command)
+    for i in range(0, len(parts), 2):
+        seg = parts[i]
+        if _is_test_segment(seg) and not _segment_has_env_in_leading_block(seg):
+            parts[i] = _prepend_env_to_segment(seg)
+    return "".join(parts)
+
+
 def check(input_data: dict) -> dict | None:
     """Check for ENVIRONMENT=test on test commands.
 
@@ -112,19 +194,25 @@ def check(input_data: dict) -> dict | None:
     if _has_body_flag(command):
         return None
 
-    is_test_cmd = bool(re.search(r"\bpytest\b", command) or re.search(r"\bmake\s+test\b", command))
-    if not is_test_cmd:
+    parts = _split_segments(command)
+    test_segments = [parts[i] for i in range(0, len(parts), 2) if _is_test_segment(parts[i])]
+    if not test_segments:
         return None
 
-    if re.search(r"\bENVIRONMENT=test\b", command):
+    if all(_segment_has_env_in_leading_block(seg) for seg in test_segments):
         return None
 
+    rewritten = _rewrite_command(command)
     return {
         "decision": "block",
         "reason": (
             "ENVIRONMENT=test is required for test commands but was not found in "
-            "the command. Please prepend ENVIRONMENT=test to the command:\n"
-            f"  ENVIRONMENT=test {command}"
+            "the leading env-block of each test-bearing segment. Shell env "
+            "assignments only apply to the immediately-following program in the "
+            "same segment, so chains like `cd /x && pytest` need the env on the "
+            "pytest segment, not at the start of the whole command. Suggested "
+            "command:\n"
+            f"  {rewritten}"
         ),
     }
 

--- a/.claude/hooks/tests/test_auto_set_env_test.py
+++ b/.claude/hooks/tests/test_auto_set_env_test.py
@@ -172,5 +172,174 @@ class NonTestCommandTests(unittest.TestCase):
         self.assertIsNone(result)
 
 
+class ChainedCommandTests(unittest.TestCase):
+    """Issue #476: chains like `cd /path && pytest tests/` need env on the
+    pytest segment, not on the leading `cd`. Pre-fix the hook (a) suggested
+    a broken command and (b) accepted the broken command as valid (silent
+    gate bypass). These tests pin the corrected per-segment behavior."""
+
+    def test_cd_then_pytest_blocks_with_corrected_suggestion(self) -> None:
+        """POS: `cd /path && pytest tests/` — block, suggestion places env
+        on the pytest segment."""
+        result = hook.check(_bash("cd /path && pytest tests/"))
+        assert result is not None
+        self.assertEqual(result.get("decision"), "block")
+        self.assertIn("cd /path && ENVIRONMENT=test pytest tests/", result["reason"])
+
+    def test_cd_then_env_pytest_allowed(self) -> None:
+        """NEG: `cd /path && ENVIRONMENT=test pytest tests/` — allow; env
+        is on the correct (pytest) segment."""
+        result = hook.check(_bash("cd /path && ENVIRONMENT=test pytest tests/"))
+        self.assertIsNone(result)
+
+    def test_misplaced_env_before_cd_blocks(self) -> None:
+        """POS: `ENVIRONMENT=test cd /path && pytest tests/` — BLOCK.
+
+        This is the silent-bypass case from #476. The pre-fix hook
+        accepted this command because `ENVIRONMENT=test` appeared
+        anywhere in the string, even though shell semantics apply the
+        env only to `cd` (where it has no effect) and pytest runs
+        without it. The fix requires the env to be in the leading
+        env-block of the pytest-bearing segment.
+        """
+        result = hook.check(_bash("ENVIRONMENT=test cd /path && pytest tests/"))
+        assert result is not None, "misplaced env must not pass — that's the #476 bug"
+        self.assertEqual(result.get("decision"), "block")
+        self.assertIn("ENVIRONMENT=test pytest tests/", result["reason"])
+
+    def test_two_pytest_segments_both_get_env(self) -> None:
+        """POS: `pytest tests/ && pytest tests-other/` — block, suggestion
+        prepends env to BOTH segments."""
+        result = hook.check(_bash("pytest tests/ && pytest tests-other/"))
+        assert result is not None
+        self.assertEqual(result.get("decision"), "block")
+        self.assertIn(
+            "ENVIRONMENT=test pytest tests/ && ENVIRONMENT=test pytest tests-other/",
+            result["reason"],
+        )
+
+    def test_two_pytest_segments_one_correct_still_blocks(self) -> None:
+        """POS: `ENVIRONMENT=test pytest tests/ && pytest tests-other/` —
+        block; second segment is missing env. Suggestion fixes the missing
+        one and leaves the correct one alone."""
+        result = hook.check(_bash("ENVIRONMENT=test pytest tests/ && pytest tests-other/"))
+        assert result is not None
+        self.assertEqual(result.get("decision"), "block")
+        self.assertIn(
+            "ENVIRONMENT=test pytest tests/ && ENVIRONMENT=test pytest tests-other/",
+            result["reason"],
+        )
+
+    def test_two_pytest_segments_both_correct_allowed(self) -> None:
+        """NEG: env on both pytest segments — allow."""
+        result = hook.check(
+            _bash("ENVIRONMENT=test pytest tests/ && ENVIRONMENT=test pytest tests-other/")
+        )
+        self.assertIsNone(result)
+
+    def test_cd_then_make_test_blocks(self) -> None:
+        """POS: `cd /path && make test` — chain form of make test."""
+        result = hook.check(_bash("cd /path && make test"))
+        assert result is not None
+        self.assertEqual(result.get("decision"), "block")
+        self.assertIn("cd /path && ENVIRONMENT=test make test", result["reason"])
+
+    def test_cd_then_env_make_test_allowed(self) -> None:
+        """NEG: `cd /path && ENVIRONMENT=test make test` — allow."""
+        result = hook.check(_bash("cd /path && ENVIRONMENT=test make test"))
+        self.assertIsNone(result)
+
+    def test_misplaced_env_before_cd_with_make_test_blocks(self) -> None:
+        """POS: `ENVIRONMENT=test cd /path && make test` — BLOCK, same
+        silent-bypass shape as the pytest case."""
+        result = hook.check(_bash("ENVIRONMENT=test cd /path && make test"))
+        assert result is not None
+        self.assertEqual(result.get("decision"), "block")
+        self.assertIn("ENVIRONMENT=test make test", result["reason"])
+
+    def test_cd_then_uv_run_pytest_preserves_form(self) -> None:
+        """POS: realistic repro shape from #476 — `cd /worktree && uv run pytest …`.
+        Suggestion preserves the `uv run pytest` tokens and only prepends env."""
+        result = hook.check(
+            _bash(
+                "cd /home/x/worktree && uv run pytest "
+                "tests/test_pipeline/test_reset.py --tb=line -q"
+            )
+        )
+        assert result is not None
+        self.assertEqual(result.get("decision"), "block")
+        self.assertIn(
+            "cd /home/x/worktree && ENVIRONMENT=test uv run pytest "
+            "tests/test_pipeline/test_reset.py --tb=line -q",
+            result["reason"],
+        )
+
+    def test_semicolon_separator_chain(self) -> None:
+        """POS: `;` separator behaves like `&&` for segment splitting."""
+        result = hook.check(_bash("cd /path ; pytest tests/"))
+        assert result is not None
+        self.assertEqual(result.get("decision"), "block")
+        self.assertIn("ENVIRONMENT=test pytest tests/", result["reason"])
+
+    def test_or_separator_chain(self) -> None:
+        """POS: `||` separator also splits — even though running pytest
+        only-if-cd-fails is unusual, treat it identically."""
+        result = hook.check(_bash("cd /path || pytest tests/"))
+        assert result is not None
+        self.assertEqual(result.get("decision"), "block")
+
+    def test_pipe_separator_chain(self) -> None:
+        """POS: `|` (pipe) splits too. `pytest tests/ | tee out.log` —
+        pytest must get the env."""
+        result = hook.check(_bash("pytest tests/ | tee out.log"))
+        assert result is not None
+        self.assertEqual(result.get("decision"), "block")
+        self.assertIn("ENVIRONMENT=test pytest tests/", result["reason"])
+
+    def test_env_on_pipe_target_does_not_satisfy_pytest_segment(self) -> None:
+        """POS: `pytest tests/ | ENVIRONMENT=test tee out.log` — the env is
+        in the WRONG segment (on tee, not pytest). Must still block."""
+        result = hook.check(_bash("pytest tests/ | ENVIRONMENT=test tee out.log"))
+        assert result is not None
+        self.assertEqual(result.get("decision"), "block")
+
+    def test_no_chain_suggestion_format_unchanged(self) -> None:
+        """POS: bare `pytest tests/` — single-segment suggestion is just
+        `ENVIRONMENT=test pytest tests/` (no chain glue)."""
+        result = hook.check(_bash("pytest tests/"))
+        assert result is not None
+        self.assertEqual(result.get("decision"), "block")
+        self.assertIn("ENVIRONMENT=test pytest tests/", result["reason"])
+
+    def test_extra_env_prefix_preserved_in_suggestion(self) -> None:
+        """POS: `cd /path && DEBUG=1 pytest tests/` — env-block already has
+        DEBUG=1; suggestion inserts ENVIRONMENT=test alongside, not
+        replacing the existing assignment."""
+        result = hook.check(_bash("cd /path && DEBUG=1 pytest tests/"))
+        assert result is not None
+        self.assertEqual(result.get("decision"), "block")
+        self.assertIn(
+            "cd /path && DEBUG=1 ENVIRONMENT=test pytest tests/",
+            result["reason"],
+        )
+
+
+class ShortCircuitWithChainsTests(unittest.TestCase):
+    """Verify gh/--body short-circuits remain whole-command (NOT per-segment)
+    — i.e., a `gh` command at argv[0] exempts the entire chain even if a
+    later segment mentions pytest."""
+
+    def test_gh_at_argv0_with_pytest_in_later_segment(self) -> None:
+        """NEG: `gh pr comment ... && echo "ran pytest"` — gh skip covers
+        the whole command. (Contrived; documents the boundary.)"""
+        result = hook.check(_bash('gh pr comment 1 --body "x" && echo "ran pytest"'))
+        self.assertIsNone(result)
+
+    def test_body_flag_covers_chain(self) -> None:
+        """NEG: any command with --body anywhere exempts the whole chain."""
+        result = hook.check(_bash('some-tool --body "pytest in body" && pytest tests/'))
+        self.assertIsNone(result)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #476.

## Summary

`.claude/hooks/auto_set_env_test.py` had two related bugs in `cd /path && pytest …` chains. The detection regex matched `ENVIRONMENT=test` anywhere in the command, so the malformed shape `ENVIRONMENT=test cd /path && pytest …` (where the env applied only to `cd`) silently passed the gate — pytest still ran without `ENVIRONMENT=test`. The suggestion text told operators to produce exactly that broken shape. Hook now splits the command on shell separators, checks each test-bearing segment's leading env-block independently, and rewrites only the failing segments in the suggestion.

## Bugs fixed

1. **Detection silent-bypass** — `re.search(r"\bENVIRONMENT=test\b", command)` at the whole-command level accepted misplaced env vars. Now: per test-bearing segment, the env must appear in that segment's leading env-block (the only position shell semantics apply it to the segment's program).
2. **Suggestion shape** — `f"  ENVIRONMENT=test {command}"` blindly prepended to the whole chain. Now: each test-bearing segment is rewritten with `ENVIRONMENT=test` inserted before its first real token, with all other segments and original separators (`&&`/`||`/`;`/`|`) preserved.

The `gh` argv[0] and `--body`/`--body-file` short-circuits remain whole-command (not per-segment) per the brief.

## Test plan

18 new tests added under `ChainedCommandTests` and `ShortCircuitWithChainsTests` in `.claude/hooks/tests/test_auto_set_env_test.py`. Acceptance-criteria-to-test mapping:

- [x] `cd /path && pytest tests/` → blocked, suggestion contains `cd /path && ENVIRONMENT=test pytest tests/` — `test_cd_then_pytest_blocks_with_corrected_suggestion`
- [x] `cd /path && ENVIRONMENT=test pytest tests/` → allowed — `test_cd_then_env_pytest_allowed`
- [x] `ENVIRONMENT=test cd /path && pytest tests/` → **BLOCKED** (silent-bypass case) — `test_misplaced_env_before_cd_blocks`
- [x] `pytest tests/` → blocked, suggestion = `ENVIRONMENT=test pytest tests/` — `test_no_chain_suggestion_format_unchanged`
- [x] `ENVIRONMENT=test pytest tests/` → allowed — `test_env_set_on_pytest` (pre-existing, still green)
- [x] `pytest tests/ && pytest tests-other/` → blocked, both segments fixed — `test_two_pytest_segments_both_get_env`
- [x] `make test` / `cd /path && make test` analogues — `test_cd_then_make_test_blocks`, `test_cd_then_env_make_test_allowed`, `test_misplaced_env_before_cd_with_make_test_blocks`
- [x] Existing `gh` short-circuit + `--body` short-circuit tests remain green (22 pre-existing tests all pass)

Additional coverage for separator parity (`;`, `||`, `|`), env-on-wrong-pipe-target, mixed correct-and-broken segments, env-block preservation (e.g. `DEBUG=1 pytest` → `DEBUG=1 ENVIRONMENT=test pytest`), and the realistic `cd /worktree && uv run pytest …` shape from the issue reproducer.

Local validation:

```
ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/test_auto_set_env_test.py -v
  40 passed in 0.07s   (22 pre-existing + 18 new)

uvx ruff@latest check .claude/hooks/
  All checks passed!

uvx ruff@latest format --check .claude/hooks/
  64 files already formatted
```

Pre-fix regression verification: ran the silent-bypass input through a 5-line reproduction of the old detection logic — it returned `None` (silent allow), confirming the new `test_misplaced_env_before_cd_blocks` would have failed before the fix.

## Tech Debt

None introduced. The fix replaces a brittle whole-command regex with a per-segment scan and adds 18 tests covering the new surface; no helper deferred, no TODO planted.
