### PR TITLE
fix(hook): validate_commit_identity — detect indirect-exec bypass (#475)

### DIFF
--- a/.claude/hooks/tests/test_validate_commit_identity.py
+++ b/.claude/hooks/tests/test_validate_commit_identity.py
@@ -427,5 +427,289 @@ class ParseFailureFailClosedTests(unittest.TestCase):
         )
 
 
+class IndirectExecBypassTests(unittest.TestCase):
+    """Issue #475 fix 2: PreToolUse hooks only see the outer Bash command,
+    so wrappers like `printf '…git commit…' | bash` and `bash <script>`
+    hide the actual git invocation. Each shape below must BLOCK with the
+    canonical-shape hint, and the matching innocent variant must ALLOW
+    (the detector requires both `git` AND `commit` in the inner payload).
+    """
+
+    @staticmethod
+    def _input(command: str, cwd: str | None = None) -> dict:
+        d: dict = {"tool_name": "Bash", "tool_input": {"command": command}}
+        if cwd is not None:
+            d["cwd"] = cwd
+        return d
+
+    def _assert_blocked_as_indirect(self, result):
+        self.assertIsNotNone(result, "indirect-exec bypass must block")
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+        self.assertIn("indirect-exec", result["reason"])
+        self.assertIn("#475", result["reason"])
+
+    # --- printf | bash family ---------------------------------------------
+
+    def test_printf_pipe_bash_with_git_commit_blocks(self):
+        """POS: `printf '<git commit ...>' | bash` — the headline #475 repro."""
+        cmd = (
+            'printf \'git -c user.name="Bjørn Henriksen" '
+            '-c user.email="..." commit -F /tmp/msg.txt\\n\' | bash'
+        )
+        self._assert_blocked_as_indirect(hook.check(self._input(cmd)))
+
+    def test_printf_pipe_sh_with_git_commit_blocks(self):
+        """POS: `printf '…' | sh` — sh is also a shell interpreter."""
+        cmd = "printf 'git -c user.name=X -c user.email=Y commit -m z\\n' | sh"
+        self._assert_blocked_as_indirect(hook.check(self._input(cmd)))
+
+    def test_printf_pipe_zsh_with_git_commit_blocks(self):
+        """POS: `printf '…' | zsh` — zsh is also a shell interpreter."""
+        cmd = "printf 'git -c user.name=X -c user.email=Y commit -m z\\n' | zsh"
+        self._assert_blocked_as_indirect(hook.check(self._input(cmd)))
+
+    def test_echo_pipe_bash_with_git_commit_blocks(self):
+        """POS: `echo '…git commit…' | bash` — same shape as printf."""
+        cmd = 'echo "git -c user.name=X -c user.email=Y commit -m z" | bash'
+        self._assert_blocked_as_indirect(hook.check(self._input(cmd)))
+
+    def test_printf_pipe_bash_without_git_commit_allows(self):
+        """NEG: `printf 'echo hello' | bash` — innocent pipe-to-shell.
+
+        The detector requires `git` AND `commit` in the inner payload.
+        This is the #475 acceptance bullet "printf 'echo hello' | bash → ALLOWED".
+        """
+        self.assertIsNone(hook.check(self._input("printf 'echo hello' | bash")))
+
+    def test_echo_pipe_bash_without_git_commit_allows(self):
+        """NEG: `echo ls | bash` — innocent pipe-to-shell."""
+        self.assertIsNone(hook.check(self._input("echo ls | bash")))
+
+    # --- shell -c family --------------------------------------------------
+
+    def test_bash_dash_c_with_git_commit_blocks(self):
+        """POS: `bash -c '…git commit…'` — direct -c invocation."""
+        cmd = 'bash -c \'git -c user.name="X" -c user.email="Y" commit -m "z"\''
+        self._assert_blocked_as_indirect(hook.check(self._input(cmd)))
+
+    def test_sh_dash_c_with_git_commit_blocks(self):
+        """POS: `sh -c '…git commit…'`."""
+        cmd = "sh -c 'cd /repo && git -c user.name=X -c user.email=Y commit -m z'"
+        self._assert_blocked_as_indirect(hook.check(self._input(cmd)))
+
+    def test_bash_dash_c_double_quoted_payload_blocks(self):
+        """POS: `bash -c "…git commit…"` — double-quoted payload form."""
+        cmd = 'bash -c "git -c user.name=X -c user.email=Y commit -m z"'
+        self._assert_blocked_as_indirect(hook.check(self._input(cmd)))
+
+    def test_bash_dash_c_without_git_commit_allows(self):
+        """NEG: `bash -c 'ls -la'` — innocent -c invocation."""
+        self.assertIsNone(hook.check(self._input("bash -c 'ls -la'")))
+
+    def test_bash_dash_c_with_git_but_no_commit_allows(self):
+        """NEG: `bash -c 'git status'` — git, but not git commit."""
+        self.assertIsNone(hook.check(self._input("bash -c 'git status'")))
+
+    # --- bash <script> family ---------------------------------------------
+
+    def test_bash_script_containing_git_commit_blocks(self):
+        """POS: `bash /tmp/script.sh` where script content contains git commit.
+
+        Script content is read from disk; if it matches the git-commit shape
+        the wrapper is blocked. This closes the `bash <script-file>` bypass
+        path explicitly called out in #475.
+        """
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".sh", delete=False, encoding="utf-8"
+        ) as f:
+            f.write('git -c user.name="X" -c user.email="Y" commit -F /tmp/msg.txt\n')
+            script_path = f.name
+        try:
+            self._assert_blocked_as_indirect(hook.check(self._input(f"bash {script_path}")))
+        finally:
+            Path(script_path).unlink(missing_ok=True)
+
+    def test_bash_script_without_git_commit_allows(self):
+        """NEG: `bash some-script.sh` whose content does NOT contain git commit.
+
+        #475 acceptance bullet: "Plain bash some-script.sh where the script
+        does NOT contain git commit → ALLOWED".
+        """
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".sh", delete=False, encoding="utf-8"
+        ) as f:
+            f.write("#!/usr/bin/env bash\nls -la\necho done\n")
+            script_path = f.name
+        try:
+            self.assertIsNone(hook.check(self._input(f"bash {script_path}")))
+        finally:
+            Path(script_path).unlink(missing_ok=True)
+
+    def test_bash_script_unreadable_allows(self):
+        """NEG: `bash /nonexistent/path.sh` — unreadable script. Allow rather
+        than block on disk errors; the operator will get a real shell error
+        immediately when bash tries to execute the missing file."""
+        self.assertIsNone(hook.check(self._input("bash /nonexistent/never/exists.sh")))
+
+    # --- process substitution ---------------------------------------------
+
+    def test_bash_process_sub_with_git_commit_blocks(self):
+        """POS: `bash <(echo '…git commit…')` — process substitution bypass."""
+        cmd = 'bash <(echo "git -c user.name=X -c user.email=Y commit -m z")'
+        self._assert_blocked_as_indirect(hook.check(self._input(cmd)))
+
+    def test_bash_process_sub_without_git_commit_allows(self):
+        """NEG: `bash <(echo "ls -la")` — innocent process substitution."""
+        self.assertIsNone(hook.check(self._input('bash <(echo "ls -la")')))
+
+    # --- bare interpreter and pass-through cases --------------------------
+
+    def test_plain_bash_no_args_allows(self):
+        """NEG: bare `bash` (interactive shell) — no inline cmd to inspect.
+
+        #475 acceptance bullet: "Plain bash (interactive shell) with no
+        inline cmd → ALLOWED (no git commit detected)".
+        """
+        self.assertIsNone(hook.check(self._input("bash")))
+
+    def test_direct_git_commit_still_validates_identity(self):
+        """NEG/regression: a direct `git -c ... commit` is still validated
+        through the existing parser — must allow when identity is valid.
+
+        #475 acceptance bullet: existing behavior preserved (still allowed
+        because identity flags present + roster name valid).
+        """
+        valid_name = next(iter(hook.ROSTER), None)
+        if not valid_name:
+            self.skipTest("local roster is empty")
+        valid_email = hook.ROSTER[valid_name]
+        cmd = (
+            f'git -c user.name="{valid_name}" -c user.email="{valid_email}" commit -F /tmp/msg.txt'
+        )
+        self.assertIsNone(hook.check(self._input(cmd)))
+
+    def test_direct_git_commit_missing_identity_still_blocks(self):
+        """NEG/regression: `git commit -m msg` (no identity flags) still blocks.
+
+        #475 acceptance bullet: existing behavior preserved (BLOCKED — current
+        rule). Indirect-exec detection must not bypass the existing
+        identity-validation path for direct invocations.
+        """
+        result = hook.check(self._input('git commit -m "x"'))
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+        # Should be the missing-name block, not the indirect-exec block.
+        self.assertNotIn("indirect-exec", result["reason"])
+        self.assertIn("user.name", result["reason"])
+
+    # --- cross-check: indirect-exec runs BEFORE segment parser ------------
+
+    def test_indirect_wrapper_wins_over_outer_innocent_commit_pattern(self):
+        """POS: a command that BOTH has an outer non-commit shape AND an
+        inner-via-wrapper git commit blocks on the wrapper, not silently
+        allows. Otherwise the wrapper detection is structurally redundant
+        with the existing parser."""
+        # Outer command does not contain a real `git commit` at the
+        # tokenize level (just `printf` and `bash`); inner payload does.
+        cmd = "printf 'git -c user.name=X -c user.email=Y commit -m z\\n' | bash"
+        result = hook.check(self._input(cmd))
+        assert result is not None
+        self.assertIn("indirect-exec", result["reason"])
+
+
+class CwdFallbackTests(unittest.TestCase):
+    """Issue #475 fix 1: when no literal `cd <path>` prefix is present, fall
+    back to the tool-call cwd for roster resolution. Lets operators commit
+    from within a child-repo worktree without composing a `cd` prefix."""
+
+    def test_cwd_fallback_loads_child_roster(self):
+        """`git -c user.name=<child-only-name> ... commit` from inside the
+        child worktree (no `cd` prefix) validates against the child roster."""
+        with tempfile.TemporaryDirectory() as td:
+            outer = Path(td)
+            _git_init(outer)
+            _write_roster(outer, {"Nadia": "nadia@example.com"})
+            child = outer / "child"
+            child.mkdir()
+            _git_init(child)
+            _write_roster(child, {"Alice": "alice@example.com"})
+
+            detected = hook._detect_target_roster("git commit -m 'x'", cwd=str(child))
+            self.assertIsNotNone(detected)
+            assert detected is not None
+            self.assertEqual(
+                detected,
+                {
+                    "Nadia": "nadia@example.com",
+                    "Alice": "alice@example.com",
+                },
+            )
+
+    def test_cwd_fallback_when_no_roster_returns_none(self):
+        """cwd has no roster.json → return None (caller uses local ROSTER)."""
+        with tempfile.TemporaryDirectory() as td:
+            empty = Path(td) / "no_roster"
+            empty.mkdir()
+            self.assertIsNone(hook._detect_target_roster("git commit -m 'x'", cwd=str(empty)))
+
+    def test_cd_prefix_wins_over_cwd_fallback(self):
+        """Explicit `cd <path>` in the command takes priority over cwd."""
+        with tempfile.TemporaryDirectory() as td:
+            outer = Path(td)
+            _git_init(outer)
+            cd_target = outer / "explicit"
+            cd_target.mkdir()
+            _git_init(cd_target)
+            _write_roster(cd_target, {"Explicit": "explicit@example.com"})
+
+            # Different repo for the cwd-fallback; should be ignored.
+            cwd_target = outer / "cwd_only"
+            cwd_target.mkdir()
+            _git_init(cwd_target)
+            _write_roster(cwd_target, {"FromCwd": "cwd@example.com"})
+
+            detected = hook._detect_target_roster(
+                f"cd {cd_target} && git commit -m 'x'",
+                cwd=str(cwd_target),
+            )
+            assert detected is not None
+            self.assertIn("Explicit", detected)
+            self.assertNotIn("FromCwd", detected)
+
+    def test_no_cd_no_cwd_returns_none(self):
+        """Regression: omitting both still returns None (existing contract)."""
+        self.assertIsNone(hook._detect_target_roster("git commit -m 'x'"))
+
+    def test_check_uses_cwd_fallback_to_accept_child_only_name(self):
+        """Integration: `check()` with a child-only roster name + cwd
+        pointing at the child repo (no `cd` prefix) → ALLOWED.
+
+        Previously this BLOCKED because `_detect_target_roster` returned
+        None without a cd prefix, the local ROSTER was used, and the
+        child-only name failed lookup. Fix 1 makes the cwd the fallback
+        anchor, restoring symmetry with the cd-prefix path.
+        """
+        with tempfile.TemporaryDirectory() as td:
+            outer = Path(td)
+            _git_init(outer)
+            _write_roster(outer, {"Nadia": "nadia@example.com"})
+            child = outer / "child"
+            child.mkdir()
+            _git_init(child)
+            _write_roster(child, {"Alice": "alice@example.com"})
+
+            cmd = 'git -c user.name="Alice" -c user.email="alice@example.com" commit -m "x"'
+            result = hook.check(
+                {
+                    "tool_name": "Bash",
+                    "tool_input": {"command": cmd},
+                    "cwd": str(child),
+                }
+            )
+            self.assertIsNone(result, f"expected allow, got block: {result}")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.claude/hooks/validate_commit_identity.py
+++ b/.claude/hooks/validate_commit_identity.py
@@ -13,6 +13,24 @@ Parent+child roster merge (#112 part a):
   coordinators commit in child repos without duplicating their entries into
   every child `roster.json`.
 
+cwd-fallback for cross-repo detection (#475 fix 1):
+  When the command has NO literal `cd <path>` prefix, the hook still needs
+  to know which repo the commit will land in. The Claude Code harness passes
+  the tool-call cwd via `input_data["cwd"]`; if that cwd has its own
+  `.claude/team/roster.json`, the hook merges that roster instead of falling
+  back to the parent ROSTER. This eliminates the brittleness of requiring
+  every operator to compose a `cd` prefix when their shell cwd already names
+  the right repo.
+
+Indirect-exec bypass detection (#475 fix 2):
+  PreToolUse hooks only see the literal Bash `command` parameter. Wrappers
+  like `printf '<git-commit-cmd>' | bash`, `bash -c '<git-commit-cmd>'`,
+  `bash <script-with-git-commit>`, and `bash <(echo '<git-commit-cmd>')`
+  hide the actual `git commit` from the outer-command tokenizer. The hook
+  now scans for these shapes and, if the payload looks like a git commit,
+  BLOCKS with a message pointing operators to the canonical shape. This
+  closes a silent bypass discovered in P3W11 PR #41 fixup.
+
 Input Language
 ==============
 
@@ -20,6 +38,8 @@ Fires on:      PreToolUse Bash
 Matches:       git [-c k=v ...] [-C path] [other globals] commit [args]
                (any segment in the compound command — split on ;, &&, ||, |;
                leading KEY=value env-vars are stripped)
+               PLUS indirect-exec wrappers whose payload contains git commit
+               (see "Indirect-exec bypass detection" above).
 Does NOT match: prose containing the literal "git commit" inside heredoc
                 bodies, --body / --body-file argument values, $(cat <<'EOF' …)
                 command substitutions. Tokenized via shlex; the matcher only
@@ -29,6 +49,7 @@ Flag pass-through:
     -c user.name=<value>   → required, validated against roster
     -c user.email=<value>  → required, validated against roster
     cd <path> && git ...   → loads <path>'s merged roster (cross-repo commit)
+    no cd prefix           → loads cwd's merged roster (fix 1, #475)
 
 Substring-bug history fixed by tokenization:
     #226 — unquoted -c user.email=val no longer slurps to EOL
@@ -37,7 +58,8 @@ Substring-bug history fixed by tokenization:
 
 Exit codes:
   0 — allow (not a git commit, or identity is valid)
-  2 — block (missing or invalid identity flags)
+  2 — block (missing or invalid identity flags, OR indirect-exec wrapper
+       hiding a git commit from outer-command inspection)
 """
 
 from __future__ import annotations
@@ -52,6 +74,7 @@ from _shell_parse import (  # noqa: E402
     extract_dash_c_pairs,
     find_git_subcommand,
     iter_command_segments,
+    resolve_tool_cwd,
     strip_heredocs,
     tokenize,
 )
@@ -104,20 +127,30 @@ def _load_merged_roster(repo_path: Path) -> dict[str, str]:
 ROSTER: dict[str, str] = _load_merged_roster(Path(__file__).resolve().parent.parent.parent)
 
 
-def _detect_target_roster(command: str) -> dict[str, str] | None:
+def _detect_target_roster(command: str, *, cwd: str | None = None) -> dict[str, str] | None:
     """Detect cross-repo commits and load the target repo's merged roster.
 
-    When the command contains `cd /path/to/repo && git commit ...`, the
-    commit targets a different repo. Load that repo's roster.json (merged
-    with its parent repo's roster if applicable — see `_load_merged_roster`)
-    so we validate against the correct team, not the local one.
+    Resolution order:
+      1. Literal `cd /path/to/repo` prefix in the command → that path.
+      2. Otherwise fall back to the tool-call `cwd` (#475 fix 1): when an
+         operator is already in a child-repo worktree and runs a bare
+         `git -c ... commit ...`, the cwd is the right anchor for roster
+         lookup. Without this fallback the hook resolves names against the
+         parent-only ROSTER and rejects valid child-repo personas.
+
+    The resolved path must (a) be an existing directory and (b) host a
+    `.claude/team/roster.json`. If either check fails the function returns
+    None and the caller uses the module-level ROSTER.
 
     Returns the target merged roster dict, or None to use the local ROSTER.
     """
     cd_match = re.search(r"cd\s+([^\s;&|]+)", command)
-    if not cd_match:
+    if cd_match:
+        target_dir = Path(cd_match.group(1)).expanduser().resolve()
+    elif cwd:
+        target_dir = Path(cwd).expanduser().resolve()
+    else:
         return None
-    target_dir = Path(cd_match.group(1)).expanduser().resolve()
     if not target_dir.is_dir():
         return None
     roster_path = target_dir / ".claude" / "team" / "roster.json"
@@ -125,6 +158,168 @@ def _detect_target_roster(command: str) -> dict[str, str] | None:
         return None
     merged = _load_merged_roster(target_dir)
     return merged or None
+
+
+# ============================================================================
+# Indirect-exec bypass detection (#475 fix 2)
+# ============================================================================
+#
+# PreToolUse hooks see only the literal outer Bash command. The wrapper
+# shapes below hide an inner `git commit` from the existing tokenizer:
+#
+#   printf '<git-commit>' | bash            (also sh / zsh; also echo)
+#   bash -c '<git-commit>'                  (also sh / zsh)
+#   bash <(echo '<git-commit>')             (process substitution)
+#   bash <script-file>                      (also sh / zsh; reads file content)
+#
+# Each detector below returns the inferred inner payload string (or None
+# if the shape doesn't match). The orchestrator `_detect_indirect_commit`
+# tries each in turn; if any payload contains a git-commit-shape, the
+# command is blocked.
+#
+# Design notes:
+# - Single-pass regexes are used because shlex.split on the OUTER command
+#   would lose the visual structure (e.g. `bash -c '<...>'` becomes
+#   `['bash', '-c', '<...>']` with the quotes consumed — useful for the
+#   `-c` case, but heredocs/process-substitutions don't survive shlex
+#   cleanly). We grep first, then re-tokenize the inner payload through
+#   the existing `_find_commit_segment` machinery for validation.
+# - Detection is intentionally narrow: requires both `git` AND `commit`
+#   in the inner payload. Innocent shapes like `printf 'echo hello' | bash`
+#   or `bash -c 'ls -la'` pass through.
+# - For `bash <script>` the script is read from disk; if unreadable the
+#   shape is reported (`payload=""`) so the orchestrator can decide. We
+#   only block when the readable content matches the git-commit shape;
+#   bare `bash some-script.sh` whose content is innocent is allowed.
+
+# Wrapper interpreters we recognise.
+_INTERPRETERS = r"(?:bash|sh|zsh)"
+
+# printf/echo … | <interpreter>. Captures the printf/echo argument body.
+# Anchor on `printf` or `echo` at word boundary, allow any chars up to the
+# pipe (so multi-arg printf works), then `| <interpreter>` followed by
+# end-of-command or another separator.
+_PIPE_TO_SHELL_RE = re.compile(
+    r"\b(?:printf|echo)\b(?P<payload>.+?)\|\s*" + _INTERPRETERS + r"\b",
+    re.DOTALL,
+)
+
+# <interpreter> -c '<payload>' or "<payload>" — captures the -c argument
+# verbatim, including its surrounding quotes (we strip them before
+# scanning).
+_DASH_C_RE = re.compile(
+    r"\b" + _INTERPRETERS + r"\s+-c\s+(?P<payload>(?P<q>['\"]).*?(?P=q)|\S+)",
+    re.DOTALL,
+)
+
+# <interpreter> <(...) — process substitution. Captures the inner content
+# of the parenthesised expression. Note: nested parens inside the
+# substitution will trip this; we accept that as a known limitation
+# because nested process-substitution-with-git-commit-inside is exotic
+# enough that the surrounding context will almost certainly trigger one
+# of the other detectors.
+_PROCESS_SUB_RE = re.compile(
+    r"\b" + _INTERPRETERS + r"\s+<\(\s*(?P<payload>[^)]+?)\s*\)",
+    re.DOTALL,
+)
+
+# <interpreter> <scriptpath> — the script path is whatever non-flag
+# non-redirect token follows. Restricted to tokens ending in `.sh` to
+# avoid false-positives on `bash -c '...'` (handled above) and `bash`
+# bare (interactive shell, no script). The path may be absolute or
+# relative; if relative we resolve against the hook's cwd.
+_SCRIPT_INVOKE_RE = re.compile(
+    r"\b" + _INTERPRETERS + r"\s+(?P<path>[^\s|;&<>]+\.sh)\b",
+)
+
+# Inner-payload commit-shape: looser than the outer `_COMMIT_FALLBACK_RE`
+# because the payload we're scanning is already known to be the inner
+# argument of a printf/echo, shell -c, process substitution, or script
+# file. It often starts inside quotes the extractor didn't strip, so
+# requiring a shell-operator or whitespace anchor before `git` rejects
+# legitimate matches (`'git ... commit ...'` payloads start with `'`).
+#
+# We use a simple `\bgit\b ... \bcommit\b` shape with a segment-boundary
+# exclusion in the middle so a payload like
+# `cd /repo; echo "not a real commit"` doesn't false-match: the `;` would
+# break the bridge between `git` and `commit`. Path-suffix exclusion is
+# preserved via the negative lookahead.
+_INNER_COMMIT_RE = re.compile(
+    r"\bgit\b[^;&|]*?\bcommit\b(?!\S*/)",
+    re.DOTALL,
+)
+
+
+def _payload_looks_like_commit(payload: str) -> bool:
+    """Return True if the (already-extracted) inner payload contains git commit."""
+    if not payload:
+        return False
+    return bool(_INNER_COMMIT_RE.search(strip_heredocs(payload)))
+
+
+def _strip_outer_quotes(s: str) -> str:
+    """If `s` is wrapped in matching single or double quotes, strip one layer."""
+    if len(s) >= 2 and s[0] == s[-1] and s[0] in ("'", '"'):
+        return s[1:-1]
+    return s
+
+
+def _read_script_if_safe(script_path: str, cwd: str | None) -> str | None:
+    """Read script content for inspection. Returns None on any error.
+
+    The path is resolved against `cwd` if relative. We restrict reads to
+    regular files under 256 KiB — if an operator is funnelling a multi-
+    megabyte payload into `bash <script>` it isn't a normal commit shape
+    and the safe answer is "don't inspect" (the caller treats that as
+    "no payload extracted" → no block).
+    """
+    try:
+        p = Path(script_path)
+        if not p.is_absolute() and cwd:
+            p = (Path(cwd) / p).resolve()
+        else:
+            p = p.resolve()
+        if not p.is_file():
+            return None
+        if p.stat().st_size > 256 * 1024:
+            return None
+        return p.read_text(encoding="utf-8", errors="replace")
+    except (OSError, ValueError):
+        return None
+
+
+def _detect_indirect_commit(command: str, *, cwd: str | None = None) -> str | None:
+    """Detect indirect-exec wrappers carrying a hidden git commit.
+
+    Returns a short label describing the matched shape (used by the
+    caller's block message) when the inner payload looks like a git
+    commit, or None when no wrapper-with-commit shape is matched.
+
+    Shapes checked, in order:
+      1. printf/echo … | bash|sh|zsh
+      2. bash|sh|zsh -c '<payload>'
+      3. bash|sh|zsh <(…)  (process substitution)
+      4. bash|sh|zsh <script.sh>  (reads the script content)
+    """
+    for m in _PIPE_TO_SHELL_RE.finditer(command):
+        if _payload_looks_like_commit(m.group("payload")):
+            return "printf/echo piped to shell"
+
+    for m in _DASH_C_RE.finditer(command):
+        payload = _strip_outer_quotes(m.group("payload"))
+        if _payload_looks_like_commit(payload):
+            return "shell -c"
+
+    for m in _PROCESS_SUB_RE.finditer(command):
+        if _payload_looks_like_commit(m.group("payload")):
+            return "process substitution"
+
+    for m in _SCRIPT_INVOKE_RE.finditer(command):
+        content = _read_script_if_safe(m.group("path"), cwd)
+        if content and _payload_looks_like_commit(content):
+            return f"shell script ({m.group('path')})"
+
+    return None
 
 
 _PARSE_FAILURE = object()  # sentinel: tokenize returned None
@@ -187,6 +382,35 @@ def check(input_data: dict) -> dict | None:
         return None
 
     command = input_data.get("tool_input", {}).get("command", "")
+    cwd = resolve_tool_cwd(input_data)
+
+    # #475 fix 2: indirect-exec bypass detection. Runs BEFORE the segment
+    # tokenizer because wrappers like `printf '…git commit…' | bash` and
+    # `bash <script>` hide the actual git invocation from the outer-command
+    # parser — if we let `_find_commit_segment` decide first it would return
+    # None and the command would slip through unvalidated.
+    indirect_shape = _detect_indirect_commit(command, cwd=cwd)
+    if indirect_shape is not None:
+        result = {
+            "decision": "block",
+            "reason": (
+                f"BLOCKED: indirect-exec wrapper detected ({indirect_shape}) "
+                "carrying a hidden `git commit`. Commit-identity validation "
+                "only sees the outer Bash command, so wrappers like "
+                "`printf '...' | bash`, `bash -c '...'`, `bash <script>`, "
+                "and `bash <(...)` would let an unvalidated commit through.\n\n"
+                "Run the git command directly so the hook can inspect the "
+                "identity flags:\n"
+                '  git -c user.name="Your Name" -c user.email="..." \\\n'
+                "      commit -F /tmp/msg.txt\n\n"
+                "If you need a different working directory, prefix with "
+                "`cd <path> && git -c ... commit ...` (canonical cross-repo "
+                "shape).\n\n"
+                "See issue #475 for the full bypass surface and rationale."
+            ),
+        }
+        log_pretooluse_block("validate_commit_identity", command, result["reason"])
+        return result
 
     commit_segment = _find_commit_segment(command)
     if commit_segment is _PARSE_FAILURE:
@@ -218,9 +442,10 @@ def check(input_data: dict) -> dict | None:
 
     assert isinstance(commit_segment, list)  # _PARSE_FAILURE and None already handled above
 
-    # Cross-repo support: if the command `cd`s into another repo, load that
-    # repo's roster instead of the local one.
-    roster = _detect_target_roster(command) or ROSTER
+    # Cross-repo support: if the command `cd`s into another repo OR the
+    # tool-call cwd already names a child-repo worktree (#475 fix 1), load
+    # that repo's merged roster instead of the local one.
+    roster = _detect_target_roster(command, cwd=cwd) or ROSTER
 
     pairs = dict(extract_dash_c_pairs(commit_segment))
     name = pairs.get("user.name")


### PR DESCRIPTION
Closes #475.

## Summary

PreToolUse hooks see only the literal outer Bash command, so wrappers that hide a `git commit` inside an inner payload bypassed the identity gate silently. Pre-fix, `printf '<git-commit>' | bash` tokenized to `['printf', '...', '|', 'bash']`, no segment started with `git`, and `check()` returned None — ALLOW. This PR adds an indirect-exec detector that runs before the outer-command parser and a cwd-fallback that closes the usability gap pushing operators toward those wrappers in the first place.

## Bugs fixed

**Fix 2 (primary, security): indirect-exec bypass.** Four wrapper shapes hid commits from the parser:

| Shape | Example |
|---|---|
| `printf` / `echo` piped to shell | `printf '<git commit>' | bash` |
| Shell `-c` | `bash -c '<git commit>'` |
| Process substitution | `bash <(echo '<git commit>')` |
| Script file | `bash some-script.sh` (script content has `git commit`) |

The new `_detect_indirect_commit(command, cwd=...)` scans the outer command for each shape, extracts the inner payload (reading from disk for the script-file case, size-capped 256 KiB, fail-open on OSError), and blocks when the payload contains a git-commit-shape. Detection requires BOTH `git` AND `commit` in the inner payload, so innocent shapes like `printf 'echo hello' | bash`, `bash -c 'ls -la'`, and bare `bash some-script.sh` (no git commit in content) pass through.

**Fix 1 (secondary, usability): cwd-fallback in roster resolution.** When the command has no literal `cd <path>` prefix, `_detect_target_roster` now falls back to the tool-call `cwd` (already exposed via `_shell_parse.resolve_tool_cwd`). Operators in a child-repo worktree can run `git -c user.name="<child-only-name>" ... commit ...` without composing a `cd` prefix every time — eliminates the brittleness that was pushing operators toward the indirect-exec patterns Fix 2 now blocks.

Explicit `cd` prefix still wins over implicit cwd; pre-existing behavior preserved.

## Test plan

25 new tests added across two new classes (`IndirectExecBypassTests`, `CwdFallbackTests`) in `.claude/hooks/tests/test_validate_commit_identity.py`. Acceptance-criteria-to-test mapping:

- [x] `printf 'git -c user.name=... commit ...' | bash` → BLOCKED — `test_printf_pipe_bash_with_git_commit_blocks` (+ sh/zsh/echo variants)
- [x] `bash -c 'git -c user.name=... commit ...'` → BLOCKED — `test_bash_dash_c_with_git_commit_blocks` (+ sh, single/double-quoted payload)
- [x] `printf 'echo hello' | bash` → ALLOWED — `test_printf_pipe_bash_without_git_commit_allows`
- [x] `git -c user.name=... commit -F /tmp/msg.txt` direct invocation → ALLOWED (identity valid) — `test_direct_git_commit_still_validates_identity`
- [x] `git commit -m msg` (no identity flags) → BLOCKED with missing-name message (NOT indirect-exec message) — `test_direct_git_commit_missing_identity_still_blocks`
- [x] `bash some-script.sh` where script has NO git commit → ALLOWED — `test_bash_script_without_git_commit_allows`
- [x] `bash some-script.sh` where script DOES have git commit → BLOCKED — `test_bash_script_containing_git_commit_blocks`
- [x] Bare `bash` (interactive shell, no inline cmd) → ALLOWED — `test_plain_bash_no_args_allows`

Additional coverage for `bash <(echo ...)` process substitution (both with + without git commit), unreadable script (allows — operator gets a real shell error), wrapper-wins-over-outer-parser layering, all three shell interpreters (bash/sh/zsh) for each shape, cwd-fallback positive case, cwd-no-roster-returns-None, cd-prefix-priority-over-cwd, and the full `check()` integration accepting a child-only persona via cwd alone.

**Pre-fix silent-bypass verification**: reconstructed the old outer-only tokenizer path on the headline `printf '<git commit>' | bash` repro — it tokenized to `['printf', '...', '|', 'bash']`, no segment started with `git`, `find_git_subcommand` returned None for both segments → ALLOW (silent bypass). The new `test_printf_pipe_bash_with_git_commit_blocks` would have failed pre-fix.

Local validation:

```
ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/test_validate_commit_identity.py -v
  46 passed in 0.10s   (21 pre-existing + 25 new)

ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/
  821 passed in 1.27s   (no sibling-hook regression)

uvx ruff@latest check .claude/hooks/
  All checks passed!

uvx ruff@latest format --check .claude/hooks/
  64 files already formatted
```

## Tech Debt

None introduced. New helpers stay alongside the existing parser (no new module) and reuse `_shell_parse.resolve_tool_cwd` and `strip_heredocs` so the file's parser surface stays consistent. The script-content read is size-capped and fail-open on OSError; no new disk-access escape hatches.
