### PR TITLE
tech-debt(annunaki_monitor): IGNORE_PATTERNS for boolean-test idioms + 2 followup tests (#474)

### DIFF
--- a/.claude/hooks/annunaki_monitor.py
+++ b/.claude/hooks/annunaki_monitor.py
@@ -11,9 +11,12 @@ Input Language:
   Matches:       Bash with non-zero exit_code OR stdout/stderr matching any
                  ERROR_PATTERNS regex (Traceback, fatal:, ModuleNotFoundError,
                  etc.) and NOT matching IGNORE_PATTERNS
-  Does NOT match: any non-Bash tool, empty stdout+stderr, command-text
-                  containing grep-for-error / --error flags / error-named
-                  paths (false-positive guards), session-dedup hits
+  Does NOT match: any non-Bash tool, command-text containing grep-for-error /
+                  --error flags / error-named paths (false-positive guards),
+                  silent-boolean-test idioms (`[`, `[[`, `test`, `grep -q`,
+                  `pgrep`, `pkill`, `which`, `command -v`, `diff --quiet`,
+                  `git diff --quiet`, `if [...]`) when their ONLY error signal
+                  is a non-zero exit code, session-dedup hits
   Flag pass-through: stdin JSON is forwarded verbatim to `check()` by the
                      PostToolUse dispatcher (`post_dispatcher.py`)
 
@@ -64,6 +67,37 @@ IGNORE_PATTERNS = [
     re.compile(r"--error", re.IGNORECASE),  # flags containing "error"
     re.compile(r"error_log|error\.log|errorhandl", re.IGNORECASE),  # filenames
 ]
+
+# Silent-boolean-test idioms (#474): commands whose ONLY failure signal is a
+# non-zero exit code with empty stdout/stderr — by design, not an error.
+# After #473 closed the silent-failure blind spot, these idioms became noise.
+# Apply ONLY when matched_patterns is exactly ["exit_code=..."] (no stdout or
+# stderr pattern matched) — pattern matches always win, ignore-on-silent-exit
+# never suppresses a real error.
+SILENT_BOOLEAN_TEST_PATTERNS = [
+    re.compile(r"^\s*\["),  # POSIX `[ ... ]` test
+    re.compile(r"^\s*\[\["),  # Bash `[[ ... ]]` test
+    re.compile(r"^\s*test\b"),  # explicit `test` builtin
+    re.compile(r"\bgrep\s+-[a-zA-Z]*q"),  # grep -q (and -qE, -qi, etc.)
+    re.compile(r"^\s*(pgrep|pkill)\b"),  # process find/signal, exit 1 on no match
+    re.compile(r"^\s*(which|command\s+-v)\b"),  # which/command -v not-found
+    re.compile(r"\bdiff\s+--quiet\b"),  # diff --quiet: exit 1 on differences
+    re.compile(r"\bgit\s+diff\s+--quiet\b"),  # git diff --quiet: same
+    re.compile(r"^\s*if\s+\["),  # `if [ ... ]; then ...; fi` whole-conditional
+    re.compile(r"^\s*if\s+\[\["),  # `if [[ ... ]]; then ...; fi`
+]
+
+
+def _is_silent_boolean_test(command: str) -> bool:
+    """Return True if command matches a documented silent-boolean-test idiom.
+
+    Caller must additionally verify that the ONLY failure signal is exit_code
+    (no stdout/stderr pattern match) — pattern matches always take precedence.
+    """
+    for pattern in SILENT_BOOLEAN_TEST_PATTERNS:
+        if pattern.search(command):
+            return True
+    return False
 
 
 def _extract_error_lines(text: str, max_lines: int = 10) -> list[str]:
@@ -139,6 +173,14 @@ def check(input_data: dict) -> dict | None:
                 break
 
     if not is_error:
+        return None
+
+    # #474 silent-boolean-test filter: when the ONLY signal is a non-zero
+    # exit code (no stderr/stdout pattern matched), suppress documented
+    # boolean-test idioms whose failure branch is by-design. Stderr/stdout
+    # pattern matches always win — a `[ -f x ]` that somehow emits a real
+    # Traceback still logs.
+    if matched_patterns == [f"exit_code={exit_code}"] and _is_silent_boolean_test(command):
         return None
 
     error_lines = _extract_error_lines(combined_output)

--- a/.claude/hooks/tests/test_annunaki_monitor.py
+++ b/.claude/hooks/tests/test_annunaki_monitor.py
@@ -171,5 +171,210 @@ class AnnunakiMonitorTests(unittest.TestCase):
         self.assertIsNone(result)
 
 
+class SilentBooleanTestIdiomTests(unittest.TestCase):
+    """#474 coverage: documented boolean-test idioms whose by-design failure
+    branch is non-zero exit with empty output must NOT produce log entries
+    after #473 closed the silent-failure capture path. Each idiom gets a
+    NEGATIVE-match test (no log) plus a precedence test that confirms a real
+    stderr-pattern match still wins."""
+
+    def setUp(self):
+        self._saved_env = {
+            "ENVIRONMENT": os.environ.pop("ENVIRONMENT", None),
+            "NOORIN_HOOK_TEST_MODE": os.environ.pop("NOORIN_HOOK_TEST_MODE", None),
+        }
+        am._seen_hashes.clear()
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self._errors_path = Path(self._tmpdir.name) / "errors.jsonl"
+        self._orig_monitor_file = am.ERRORS_FILE
+        self._orig_log_file = alog.ERRORS_FILE
+        am.ERRORS_FILE = self._errors_path
+        alog.ERRORS_FILE = self._errors_path
+
+    def tearDown(self):
+        am.ERRORS_FILE = self._orig_monitor_file
+        alog.ERRORS_FILE = self._orig_log_file
+        self._tmpdir.cleanup()
+        for k, v in self._saved_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    # --- Each documented idiom: NEG match on silent exit-1 ---
+
+    def test_posix_bracket_silent_exit_not_logged(self):
+        """NEG: `[ -d /nonexistent ]` exit 1 silent → no log."""
+        result = am.check(_bash_event("[ -d /nonexistent ]", exit_code=1))
+        self.assertIsNone(result)
+        self.assertFalse(self._errors_path.exists())
+
+    def test_bash_double_bracket_silent_exit_not_logged(self):
+        """NEG: `[[ -f /nonexistent ]]` exit 1 silent → no log."""
+        result = am.check(_bash_event("[[ -f /nonexistent ]]", exit_code=1))
+        self.assertIsNone(result)
+
+    def test_test_builtin_silent_exit_not_logged(self):
+        """NEG: `test -f /nonexistent` exit 1 silent → no log."""
+        result = am.check(_bash_event("test -f /nonexistent", exit_code=1))
+        self.assertIsNone(result)
+
+    def test_grep_q_no_match_silent_exit_not_logged(self):
+        """NEG: `grep -q pattern file` non-error miss → no log."""
+        result = am.check(_bash_event("grep -q needle /tmp/haystack.txt", exit_code=1))
+        self.assertIsNone(result)
+
+    def test_grep_q_with_flags_silent_exit_not_logged(self):
+        """NEG: `grep -qE` / `grep -qi` variants → no log."""
+        for cmd in ("grep -qE '^foo' f.txt", "grep -qi BAR f.txt", "grep -Eq '^foo' f.txt"):
+            am._seen_hashes.clear()
+            result = am.check(_bash_event(cmd, exit_code=1))
+            self.assertIsNone(result, f"{cmd!r} must not log")
+
+    def test_pgrep_no_match_silent_exit_not_logged(self):
+        """NEG: `pgrep nginx` not-running → no log."""
+        result = am.check(_bash_event("pgrep nginx", exit_code=1))
+        self.assertIsNone(result)
+
+    def test_pkill_no_match_silent_exit_not_logged(self):
+        """NEG: `pkill -0 nginx` not-running → no log."""
+        result = am.check(_bash_event("pkill -0 nginx", exit_code=1))
+        self.assertIsNone(result)
+
+    def test_which_not_found_silent_exit_not_logged(self):
+        """NEG: `which foo` not-installed → no log."""
+        result = am.check(_bash_event("which nonexistent-binary", exit_code=1))
+        self.assertIsNone(result)
+
+    def test_command_v_not_found_silent_exit_not_logged(self):
+        """NEG: `command -v foo` not-installed → no log."""
+        result = am.check(_bash_event("command -v nonexistent-binary", exit_code=1))
+        self.assertIsNone(result)
+
+    def test_diff_quiet_differs_silent_exit_not_logged(self):
+        """NEG: `diff --quiet a b` files differ → no log."""
+        result = am.check(_bash_event("diff --quiet /tmp/a /tmp/b", exit_code=1))
+        self.assertIsNone(result)
+
+    def test_git_diff_quiet_dirty_silent_exit_not_logged(self):
+        """NEG: `git diff --quiet` working tree dirty → no log."""
+        result = am.check(_bash_event("git diff --quiet", exit_code=1))
+        self.assertIsNone(result)
+
+    def test_if_bracket_conditional_silent_exit_not_logged(self):
+        """NEG: `if [ -f x ]; then ...; fi` whole conditional with exit-1
+        false-branch → no log."""
+        result = am.check(_bash_event("if [ -f /nonexistent ]; then echo yes; fi", exit_code=1))
+        self.assertIsNone(result)
+
+    def test_if_double_bracket_conditional_silent_exit_not_logged(self):
+        """NEG: `if [[ ... ]]; then ...; fi` shape → no log."""
+        result = am.check(_bash_event("if [[ -f /nonexistent ]]; then echo yes; fi", exit_code=1))
+        self.assertIsNone(result)
+
+    # --- Precedence: pattern match wins over idiom-on-silent-exit ---
+
+    def test_idiom_with_stderr_pattern_still_logged(self):
+        """POS: `[ -f x ]` would normally be silent-skip, BUT if stderr has
+        a real error pattern (e.g., `fatal:`), it still logs. Pattern matches
+        take precedence — the idiom-skip only suppresses the bare exit_code
+        signal."""
+        result = am.check(
+            _bash_event(
+                "[ -f /nonexistent ]",
+                stderr="fatal: unexpected internal state\n",
+                exit_code=1,
+            )
+        )
+        self.assertIsNotNone(result, "stderr pattern match must override idiom skip")
+        rec = _read_records(self._errors_path)[0]
+        # Both signals present: exit_code AND stderr pattern
+        self.assertIn("exit_code=1", rec["matched_patterns"])
+        self.assertTrue(any("fatal" in p for p in rec["matched_patterns"]))
+
+    def test_idiom_with_stdout_pattern_still_logged(self):
+        """POS: silent-test idiom that produces a stdout Traceback (would be
+        absurd in reality, but the precedence rule must hold) → logs."""
+        result = am.check(
+            _bash_event(
+                "test -f /nonexistent",
+                stdout="Traceback (most recent call last):\nValueError: x\n",
+                exit_code=1,
+            )
+        )
+        self.assertIsNotNone(result)
+
+    def test_real_silent_failure_still_logged(self):
+        """POS regression for #472: `false` is NOT in the idiom list, so the
+        silent-failure capture path still works for non-idiom commands."""
+        result = am.check(_bash_event("false", exit_code=1))
+        self.assertIsNotNone(result, "non-idiom silent failures must still log")
+
+    def test_idiom_exit_zero_not_logged(self):
+        """NEG: idiom command exits 0 (true branch) → no log because not
+        even is_error=True. Sanity check that the idiom filter doesn't get
+        in the way of the happy path."""
+        result = am.check(_bash_event("[ -f /tmp ]", exit_code=0))
+        self.assertIsNone(result)
+
+
+class AinoFollowupTests(unittest.TestCase):
+    """Aino's two non-blocking follow-up cases from PR #473 review."""
+
+    def setUp(self):
+        self._saved_env = {
+            "ENVIRONMENT": os.environ.pop("ENVIRONMENT", None),
+            "NOORIN_HOOK_TEST_MODE": os.environ.pop("NOORIN_HOOK_TEST_MODE", None),
+        }
+        am._seen_hashes.clear()
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self._errors_path = Path(self._tmpdir.name) / "errors.jsonl"
+        self._orig_monitor_file = am.ERRORS_FILE
+        self._orig_log_file = alog.ERRORS_FILE
+        am.ERRORS_FILE = self._errors_path
+        alog.ERRORS_FILE = self._errors_path
+
+    def tearDown(self):
+        am.ERRORS_FILE = self._orig_monitor_file
+        alog.ERRORS_FILE = self._orig_log_file
+        self._tmpdir.cleanup()
+        for k, v in self._saved_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def test_exit_zero_with_stderr_pattern_still_captured(self):
+        """Aino #1: command succeeds (exit 0) but stderr contains a pattern
+        like `error:` → must still log via stderr pattern match. Guards
+        against a future refactor that gates pattern matching on a non-zero
+        exit code."""
+        result = am.check(
+            _bash_event(
+                "some-tool --warn",
+                stderr="error: deprecated flag --warn used, ignored\n",
+                exit_code=0,
+            )
+        )
+        self.assertIsNotNone(result, "exit-0 with stderr error pattern must capture")
+        rec = _read_records(self._errors_path)[0]
+        self.assertEqual(rec["exit_code"], 0)
+        self.assertTrue(any("error" in p for p in rec["matched_patterns"]))
+
+    def test_ignore_pattern_takes_precedence_over_nonzero_exit(self):
+        """Aino #2: command matches `_should_ignore` (e.g., `grep -i error`)
+        AND exits non-zero → ignore-pattern check fires before exit-code
+        capture, so no log. Guards against the exit-code capture path
+        bypassing the false-positive guards from `_should_ignore`."""
+        result = am.check(
+            _bash_event(
+                "grep -i error logs.txt",
+                exit_code=1,
+            )
+        )
+        self.assertIsNone(result, "_should_ignore must precede exit-code capture")
+        self.assertFalse(self._errors_path.exists())
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
Closes #474.

## Summary

Two-part fix to follow up on PR #473's silent-failure capture work:

**Part A — `SILENT_BOOLEAN_TEST_PATTERNS` (Santiago's concern)**: 10 documented Bash boolean-test idioms now skip when their ONLY failure signal is a non-zero exit code. Pattern matches always take precedence (a `[ -f x ]` that emits a real `Traceback` still logs).

**Part B — Two non-blocking test follow-ups from Aino's #473 review**:
1. `test_exit_zero_with_stderr_pattern_still_captured`
2. `test_ignore_pattern_takes_precedence_over_nonzero_exit`

## Design choice: separate list, conditional skip

The issue body specifies a NEW list (`SILENT_BOOLEAN_TEST_PATTERNS`), not an extension of the existing `IGNORE_PATTERNS`. Why this matters:

- `IGNORE_PATTERNS` is checked unconditionally at the top of `check()` — matching commands NEVER produce a log entry, regardless of output.
- `SILENT_BOOLEAN_TEST_PATTERNS` is checked AFTER `is_error` detection — only when `matched_patterns == ["exit_code=N"]` (no stdout/stderr pattern matched).

This preserves the invariant from the issue's "Out of scope" section: "Don't widen `IGNORE_PATTERNS` further than these documented idioms — over-filtering is worse than over-capturing." A `grep -q` that emits an unexpected `panic:` to stderr will still log, because the stderr pattern match populates `matched_patterns` with `stderr:panic:` and the silent-skip condition no longer holds.

## Patterns added

```python
SILENT_BOOLEAN_TEST_PATTERNS = [
    re.compile(r"^\s*\["),                       # POSIX [ test
    re.compile(r"^\s*\[\["),                     # Bash [[ test
    re.compile(r"^\s*test\b"),                   # explicit test builtin
    re.compile(r"\bgrep\s+-[a-zA-Z]*q"),         # grep -q (and -qE, -qi, etc.)
    re.compile(r"^\s*(pgrep|pkill)\b"),
    re.compile(r"^\s*(which|command\s+-v)\b"),
    re.compile(r"\bdiff\s+--quiet\b"),
    re.compile(r"\bgit\s+diff\s+--quiet\b"),
    re.compile(r"^\s*if\s+\["),                  # if [ ... ]; then ...; fi
    re.compile(r"^\s*if\s+\[\["),                # if [[ ... ]]; then ...; fi
]
```

Word-boundary anchors (`\b`) on `test` avoid false-matching `pytest`, `latest`, etc. Anchored leading-whitespace prefixes on `[`, `[[`, `test`, `pgrep`, `pkill`, `which`, `command -v`, `if [` avoid matching when these tokens appear mid-command. `grep -q` is intentionally not anchored — it matches inside chains like `cmd | grep -q ...`.

## Test plan

- [x] All 9 prior tests still pass (regression guard for #472 silent-failure capture)
- [x] 16 new `SilentBooleanTestIdiomTests` cover each idiom's NEGATIVE-match (no log on silent exit-1) plus three precedence cases (idiom-with-stderr-pattern, idiom-with-stdout-pattern, idiom-exit-0)
- [x] `test_real_silent_failure_still_logged` — `false` is NOT in the idiom list, so the silent-failure capture path still works for non-idiom commands
- [x] 2 new `AinoFollowupTests` per #473 reviewer feedback
- [x] Full hooks suite: 893 passed, no regressions
- [x] `uvx ruff@latest check .claude/hooks/` — All checks passed
- [x] `uvx ruff@latest format --check .claude/hooks/` — All formatted

### Local run

```
$ ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/test_annunaki_monitor.py -v
============================== 28 passed in 0.07s ==============================

$ ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/
============================= 893 passed in 1.51s ==============================

$ uvx ruff@latest check .claude/hooks/
All checks passed!

$ uvx ruff@latest format --check .claude/hooks/
68 files already formatted
```

## Tech Debt

None introduced. PR removes a noise class identified post-#473 as a real flood risk during normal wave work. No TODO planted, no helper deferred.

## Out of scope (per issue)

- Did not widen `IGNORE_PATTERNS` further than the 10 documented idioms — preserves the "over-filtering is worse than over-capturing" invariant from the issue body.
- Did not modify the exit-code branch ordering — #473's reorder is correct and is preserved.
