### PR TITLE
tech-debt(hook): post_wave_kickoff_comment — filter between-wave relabel events (#467)

### DIFF
--- a/.claude/hooks/fixtures/post_wave_kickoff_comment/between_wave_relabel_skipped.json
+++ b/.claude/hooks/fixtures/post_wave_kickoff_comment/between_wave_relabel_skipped.json
@@ -1,0 +1,15 @@
+{
+  "description": "Issue #467: between-wave relabel (carry-forward shape) — `--add-label p3-wave-11 --remove-label p3-wave-10` on an issue moving from W10 to W11. Hook must return None silently — not log skip_no_scope. Pre-fix this shape produced one annunaki entry per relabel (36-event burst in P3W11). The status dict deliberately has wave_11_scope EMPTY to reproduce the exact pre-fix noise condition: even with no scope, the hook should not log.",
+  "command": "gh issue edit 262 --repo noorinalabs/noorinalabs-main --add-label \"p3-wave-11\" --remove-label \"p3-wave-10\"",
+  "status": {
+    "wave_10_meta_issue": 347,
+    "wave_10_scope": {
+      "tier_1_test": [
+        {"id": "noorinalabs-main#262", "implementer": "Aino Virtanen", "reviewer": "Nadia Khoury", "reviewer_2": "Santiago Ferreira"}
+      ]
+    }
+  },
+  "existing_comments": [],
+  "post_succeeds": true,
+  "expect_action": null
+}

--- a/.claude/hooks/post_wave_kickoff_comment.py
+++ b/.claude/hooks/post_wave_kickoff_comment.py
@@ -19,7 +19,10 @@ Behavior summary
 
 1. Parse repo, issue number, wave label from the bash command. Uses
    `_shell_parse.tokenize` + heredoc-stripping (the third hook this wave
-   eating its own dogfood — siblings #316, #378, #386).
+   eating its own dogfood — siblings #316, #378, #386). Silently skip
+   between-wave relabel commands (commands that both add AND remove a
+   canonical wave label in the same invocation — #467 carry-forward
+   filter) — those are not initial kickoffs.
 2. Read `ontology/cross-repo-status.json` (or fallback paths) and find
    the matching assignment row in `wave_{M}_scope.tier_{1,2,3,4}_*`
    arrays. Match by:
@@ -102,15 +105,33 @@ def parse_label_apply_command(command: str) -> tuple[str, str, str] | None:
     ordering. The kickoff hook only fires on label-APPLY, so commands
     that only `--remove-label` a wave label return None here.
 
+    Between-wave relabel filter (#467): commands that ALSO remove a
+    canonical wave label in the same invocation
+    (e.g. `--add-label "p3-wave-11" --remove-label "p3-wave-10"`) are
+    the carry-forward shape used during wave-tail relabeling. These are
+    NOT initial kickoffs — they're moving an already-assigned issue from
+    one wave to the next. Silently return None on this shape so the hook
+    doesn't fire on each relabel, which previously produced a 36-event
+    annunaki noise burst in P3W11 (all hitting the `skip_no_scope` log
+    path because the new wave wasn't kicked off yet). The post-merge
+    behavior is intentional: real initial kickoffs use bare `--add-label`
+    without `--remove-label` and still trigger the comment.
+
     Delegates to the shared `_wave_label_parse.parse_wave_label_change`
     helper (extracted in #445 alongside Hook 21). The shim narrows the
     helper's WaveLabelChange shape down to the (repo, issue, label)
-    tuple this hook's downstream code already expects — preserves the
-    pre-extraction behavior exactly so existing fixtures continue to
-    pass without modification.
+    tuple this hook's downstream code already expects.
     """
     change = parse_wave_label_change(command)
     if change is None or change.add_label is None:
+        return None
+    # #467: between-wave relabel filter. If the same command also removes
+    # a canonical wave label, treat as a relabel (carry-forward) and skip.
+    # `parse_wave_label_change` only populates `remove_label` when the
+    # removed value matches the canonical `p{N}-wave-{M}` regex, so a
+    # non-wave `--remove-label` (e.g., removing an implementer label)
+    # does NOT trigger this filter.
+    if change.remove_label is not None:
         return None
     return change.repo, change.issue_number, change.add_label
 

--- a/.claude/hooks/tests/test_post_wave_kickoff_comment.py
+++ b/.claude/hooks/tests/test_post_wave_kickoff_comment.py
@@ -206,6 +206,64 @@ class ParseLabelApplyCommandTests(unittest.TestCase):
             ("noorinalabs-main", "999", "p3-wave-9"),
         )
 
+    # --- #467 between-wave relabel filter ---
+
+    def test_between_wave_relabel_returns_none(self):
+        """Issue #467: `--add-label "p3-wave-11" --remove-label "p3-wave-10"`
+        is the carry-forward (between-wave relabel) shape. The kickoff hook
+        must NOT fire on these commands — they were generating a 36-event
+        annunaki noise burst in P3W11 (all `skip_no_scope`)."""
+        self.assertIsNone(
+            hook.parse_label_apply_command(
+                "gh issue edit 262 --repo noorinalabs/noorinalabs-main "
+                '--add-label "p3-wave-11" --remove-label "p3-wave-10"'
+            )
+        )
+
+    def test_between_wave_relabel_flag_order_swapped_returns_none(self):
+        """Same as above but `--remove-label` first → still skipped."""
+        self.assertIsNone(
+            hook.parse_label_apply_command(
+                "gh issue edit 262 --repo noorinalabs/noorinalabs-main "
+                '--remove-label "p3-wave-10" --add-label "p3-wave-11"'
+            )
+        )
+
+    def test_between_wave_relabel_equals_form_returns_none(self):
+        """Equals-form flags on a relabel also skip."""
+        self.assertIsNone(
+            hook.parse_label_apply_command(
+                "gh issue edit 262 --repo=noorinalabs/noorinalabs-main "
+                "--add-label=p3-wave-11 --remove-label=p3-wave-10"
+            )
+        )
+
+    def test_add_with_non_wave_remove_still_matches(self):
+        """`--add-label "p3-wave-11" --remove-label "tech-debt"` should still
+        fire the hook — removing a non-wave label doesn't make this a
+        between-wave relabel. The `parse_wave_label_change` helper only
+        populates `remove_label` for canonical wave labels, so a non-wave
+        remove leaves `remove_label=None` and the filter doesn't trigger."""
+        self.assertEqual(
+            hook.parse_label_apply_command(
+                "gh issue edit 100 --repo noorinalabs/noorinalabs-main "
+                '--add-label "p3-wave-11" --remove-label "tech-debt"'
+            ),
+            ("noorinalabs-main", "100", "p3-wave-11"),
+        )
+
+    def test_initial_add_without_remove_still_matches(self):
+        """Regression guard: the common initial-kickoff shape — bare
+        `--add-label "p3-wave-11"` with no `--remove-label` — must still
+        return the tuple so the hook proceeds to render + post the kickoff
+        comment. This pins acceptance criterion #2 from issue #467."""
+        self.assertEqual(
+            hook.parse_label_apply_command(
+                'gh issue edit 200 --repo noorinalabs/noorinalabs-main --add-label "p3-wave-11"'
+            ),
+            ("noorinalabs-main", "200", "p3-wave-11"),
+        )
+
 
 class FindAssignmentRowTests(unittest.TestCase):
     """Direct coverage of tier-array row lookup with both shapes."""


### PR DESCRIPTION
Closes #467.

## Summary

`post_wave_kickoff_comment` fires on every `gh issue edit ... --add-label "p{N}-wave-{M}"` — including the between-wave relabel shape (carry-forwards, `--add-label "p3-wave-11" --remove-label "p3-wave-10"`). In P3W11 this produced a 36-event annunaki noise burst, all hitting `skip_no_scope` because W11 wasn't kicked off yet when the carry-forwards landed. The bailout was correct; the noise from logging it was not.

## Fix

Per issue Option B (the recommended option): parse-time filter in `parse_label_apply_command`. After parsing via the shared `_wave_label_parse.parse_wave_label_change` helper, if `change.remove_label` is populated (canonical wave label), silently return None instead of the (repo, issue, label) tuple. This skips the entire downstream chain (scope lookup, log call, comment post).

The helper already only populates `remove_label` for canonical wave labels (`p{N}-wave-{M}` regex fullmatch), so removing a non-wave label like `tech-debt` does NOT trigger the filter — pinned by `test_add_with_non_wave_remove_still_matches`.

Base: `deployments/phase-3/wave-11` (HEAD `5509e26` post-#481 merge).

## Changes

### `.claude/hooks/post_wave_kickoff_comment.py`

- 1 new line in `parse_label_apply_command`: `if change.remove_label is not None: return None`
- Function docstring updated to document the between-wave relabel filter + rationale
- Module-level "Behavior summary" entry 1 updated to mention the new filter

### `.claude/hooks/tests/test_post_wave_kickoff_comment.py`

5 new direct unit tests in `ParseLabelApplyCommandTests`:
- `test_between_wave_relabel_returns_none` — canonical `--add p3-wave-11 --remove p3-wave-10` skipped
- `test_between_wave_relabel_flag_order_swapped_returns_none` — `--remove` first also skipped
- `test_between_wave_relabel_equals_form_returns_none` — `=`-form flags also skipped
- `test_add_with_non_wave_remove_still_matches` — non-wave `--remove-label "tech-debt"` does NOT trigger the filter
- `test_initial_add_without_remove_still_matches` — bare `--add-label "p3-wave-11"` still returns the tuple (initial kickoff still works)

### `.claude/hooks/fixtures/post_wave_kickoff_comment/between_wave_relabel_skipped.json`

End-to-end fixture pinning the exact pre-fix repro shape: status has W10 scope but no W11 scope (the actual P3W11 noise condition). With the filter, `check()` returns None; without it, would log skip_no_scope and produce noise. `expect_action: null` pins this.

## Test Plan

- [x] 36 tests in `test_post_wave_kickoff_comment.py` pass (was 30; +5 unit tests + 1 fixture)
- [x] Full hook suite: 907 tests + 39 subtests pass, no regressions
- [x] `uvx ruff@latest check .claude/hooks/` — All checks passed
- [x] `uvx ruff@latest format --check .claude/hooks/` — 68 files already formatted
- [x] `mypy` clean on both touched source files
- [x] Pre-commit hooks (ruff-format, ruff-lint, mypy) all green at commit time

## Acceptance criteria (issue #467)

- [x] Hook gracefully no-ops on relabel shape — 3 dedicated relabel-skip tests
- [x] Hook still renders kickoff comment on initial add — `test_initial_add_without_remove_still_matches` + existing `happy_label_apply_explicit_issue` fixture untouched
- [x] Annunaki noise drops to near-zero on wave-tail relabel batches — parse-time filter prevents the log call entirely
- [x] Unit tests added for both relabel-skip and initial-add paths

## Edge case acknowledged (acceptable)

Rare manual case: someone adds `p3-wave-11` to an issue that already had `p3-wave-10` WITHOUT `--remove-label` in the same command. The filter doesn't catch this shape (no `--remove-label` to detect). If W11 isn't kicked off, the issue would still produce one `skip_no_scope` log entry. This is an order-of-magnitude smaller noise class than the carry-forward batch (single event vs. 36-event burst) and represents a real operator anomaly worth logging. Defense-in-depth via `kickoff_already_posted` covers the "issue already has a kickoff comment" subcase. The narrower filter is the right fit for the actual noise source.

## Tech Debt

None introduced. No TODOs, no helpers deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
