### PR TITLE
tech-debt(hook15): subprocess-based shell/Python hash parity test (#175)

### DIFF
--- a/.claude/hooks/tests/test_enforce_librarian_consulted.py
+++ b/.claude/hooks/tests/test_enforce_librarian_consulted.py
@@ -528,6 +528,85 @@ class SentinelFallbackTests(unittest.TestCase):
         expected = hashlib.sha1((sample + "\n").encode("utf-8")).hexdigest()[:16]
         self.assertEqual(hook._cwd_sentinel_hash(sample), expected)
 
+    def test_cwd_hash_matches_actual_shell_subprocess(self) -> None:
+        """Parity guard #2 (#175): run the EXACT shell pipeline from the
+        ontology-librarian SKILL.md step 0 in an isolated cwd and assert
+        the resulting hash matches `_cwd_sentinel_hash`.
+
+        The pre-#175 `test_cwd_hash_matches_shell_pwd_sha1sum` re-implemented
+        the algorithm in Python (`hashlib.sha1((sample + "\\n").encode(...))`)
+        — if `sha1sum` itself were to drift, or if a shell-platform quirk
+        produced different bytes, the pure-Python test would not notice.
+        This test actually invokes `/bin/sh -c 'pwd | sha1sum | cut -c1-16'`
+        in a `tmp_path` cwd and compares the produced filename hash against
+        `_cwd_sentinel_hash(str(tmp_path))`.
+        """
+        import subprocess
+
+        with tempfile.TemporaryDirectory(
+            prefix="hook15_parity_", dir=os.path.expanduser("~")
+        ) as tmp_cwd:
+            shell_output = subprocess.run(
+                ["/bin/sh", "-c", "pwd | sha1sum | cut -c1-16"],
+                cwd=tmp_cwd,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            shell_hash = shell_output.stdout.strip()
+            python_hash = hook._cwd_sentinel_hash(tmp_cwd)
+            self.assertEqual(
+                shell_hash,
+                python_hash,
+                f"shell `pwd | sha1sum | cut -c1-16` ({shell_hash!r}) must "
+                f"match `_cwd_sentinel_hash({tmp_cwd!r})` ({python_hash!r}); "
+                "if these diverge the librarian skill's sentinel will never "
+                "be found by the hook and the #169 race re-opens silently.",
+            )
+
+    def test_skill_md_uses_expected_shell_pipeline(self) -> None:
+        """Bonus parity guard (#175): the test_cwd_hash_matches_actual_shell_subprocess
+        test above hard-codes `pwd | sha1sum | cut -c1-16` as the pipeline
+        under test. If a future edit to SKILL.md changes the pipeline (e.g.,
+        to `realpath | sha1sum | cut -c1-16`, or a different cut width, or
+        a `printf '%s' "$(pwd)"` variant that strips the trailing newline),
+        the subprocess test would still pass against the OLD pipeline while
+        the skill writes sentinels under a DIFFERENT hash — silently
+        re-opening the #169 race.
+
+        This test asserts the literal pipeline still appears in SKILL.md as
+        the sentinel-write step. Failure means EITHER:
+          1. SKILL.md was edited and the pipeline changed — update both the
+             skill AND the parity test deliberately, OR
+          2. SKILL.md was renamed/moved — update this test's path.
+        """
+        skill_md_path = (
+            Path(__file__).resolve().parent.parent.parent
+            / "skills"
+            / "ontology-librarian"
+            / "SKILL.md"
+        )
+        self.assertTrue(
+            skill_md_path.is_file(),
+            f"SKILL.md not at expected path {skill_md_path}; if moved, "
+            "update this test's path resolution.",
+        )
+        skill_md = skill_md_path.read_text(encoding="utf-8")
+        # Literal substring search — if the skill stops using this exact
+        # pipeline the test fails loudly. The trailing newline in `pwd`
+        # output (consumed by sha1sum) is the load-bearing detail that
+        # `_cwd_sentinel_hash`'s `+ "\n"` mirrors.
+        self.assertIn(
+            "pwd | sha1sum | cut -c1-16",
+            skill_md,
+            "ontology-librarian SKILL.md no longer contains the canonical "
+            "`pwd | sha1sum | cut -c1-16` sentinel-write pipeline. If this "
+            "was an intentional change, update `_cwd_sentinel_hash` in "
+            "`_consultation_sentinel.py` to match the new shell algorithm "
+            "AND update `test_cwd_hash_matches_actual_shell_subprocess` "
+            "above to invoke the new pipeline.",
+        )
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
Closes #175.

## Summary

Adds two new parity-guard tests to `test_enforce_librarian_consulted.py` so that drift in the librarian skill's shell pipeline OR in `sha1sum` itself surfaces as a test failure (currently passes silently and re-opens the #169 transcript-flush race).

## Background

The sentinel-fallback design relies on two paths producing byte-identical hashes:

1. **Skill side** (shell, in `SKILL.md` step 0): `HASH=$(pwd | sha1sum | cut -c1-16)`
2. **Hook side** (Python, in `_consultation_sentinel.cwd_sentinel_hash`): `hashlib.sha1((abspath(cwd) + "\n").encode("utf-8")).hexdigest()[:16]`

The trailing `"\n"` in the Python form mirrors the trailing newline that `pwd` emits before `sha1sum` consumes it. If these drift, the skill writes the sentinel under a hash the hook never looks up — the fallback silently no-ops and the #169 race re-opens.

The pre-existing `test_cwd_hash_matches_shell_pwd_sha1sum` re-implements the algorithm in pure Python:

```python
sample = "/home/parameterization/code/noorinalabs-main"
expected = hashlib.sha1((sample + "\n").encode("utf-8")).hexdigest()[:16]
self.assertEqual(hook._cwd_sentinel_hash(sample), expected)
```

This catches Python-side drift in `_cwd_sentinel_hash` but does NOT catch:

1. `sha1sum` behavior drift (unlikely but possible)
2. Shell-platform quirks producing different bytes
3. The ontology-librarian `SKILL.md` changing its shell pipeline (e.g., to `realpath`, a different cut width, or `printf '%s' "$(pwd)"` that strips the trailing newline)

## New tests

### 1. `test_cwd_hash_matches_actual_shell_subprocess`

Invokes the actual shell pipeline via `subprocess.run` in an isolated `tmp_path` cwd and compares the output against `_cwd_sentinel_hash`. Catches drift classes 1 & 2.

```python
shell_output = subprocess.run(
    ["/bin/sh", "-c", "pwd | sha1sum | cut -c1-16"],
    cwd=tmp_cwd, capture_output=True, text=True, check=True,
)
self.assertEqual(shell_output.stdout.strip(), hook._cwd_sentinel_hash(tmp_cwd))
```

Tmp cwd created under `~` (not under repo) so the test doesn't pollute the worktree's `.claude/.consulted/` tree and doesn't trip the Hook 15 sentinel-write that fires on librarian-skill invocations.

### 2. `test_skill_md_uses_expected_shell_pipeline` (bonus, per issue body)

Reads `.claude/skills/ontology-librarian/SKILL.md` and asserts the literal `pwd | sha1sum | cut -c1-16` substring still appears. Catches drift class 3. Failure message explicitly directs the maintainer to update BOTH the skill AND the subprocess test deliberately:

> ontology-librarian SKILL.md no longer contains the canonical `pwd | sha1sum | cut -c1-16` sentinel-write pipeline. If this was an intentional change, update `_cwd_sentinel_hash` in `_consultation_sentinel.py` to match the new shell algorithm AND update `test_cwd_hash_matches_actual_shell_subprocess` above to invoke the new pipeline.

Used literal-substring check rather than regex because the substring is short, distinctive, and operates as a load-bearing-line guard (sibling pattern to `feedback_techdebt_literal_line_not_section` — match the canonical artifact form, don't paraphrase).

## Test plan

- [x] 29 prior tests still pass (no regressions in `AllowListTests`, `NonMatchedToolTests`, `BlockingTests`, `AllowWithLibrarianTests`, `FailOpenTests`, `SignalDetectionTests`, `SentinelFallbackTests`)
- [x] 2 new tests in `SentinelFallbackTests` — both green
- [x] Full hooks suite: 823 passed, no regressions
- [x] `uvx ruff check .claude/hooks/` — All checks passed
- [x] `uvx ruff format --check .claude/hooks/` — 64 files already formatted

### Local run

```
$ ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/test_enforce_librarian_consulted.py -v
============================== 31 passed in 0.10s ==============================

$ ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/
============================= 823 passed in 1.34s ==============================
```

## Tech Debt

None introduced. PR adds defensive coverage against a documented silent-failure mode (issue #169 lineage). No helper deferred, no TODO planted.
