### PR TITLE
tech-debt(charter+wave-kickoff): document coordinator-class ontology-context exemption (#470, #468 follow-up)

### DIFF
--- a/.claude/skills/wave-kickoff/SKILL.md
+++ b/.claude/skills/wave-kickoff/SKILL.md
@@ -334,7 +334,9 @@ If the wave has no meta-issue (rare; pre-#284 waves), skip this step.
 
 **(a) Orchestrator bakes librarian output into the spawn prompt** — `enforce_ontology_context.py` scans the Agent tool prompt for the literal heading `## Ontology Context` and **blocks** the spawn if absent.
 
-For each agent in the wave:
+**Coordinator-class exemption (#468):** the `## Ontology Context` bake is REQUIRED for implementer-class spawns and OPTIONAL for coordinator-class spawns (Manager, Pipeline Manager, Project Lead, Program Director, TPM / Technical Program Manager, Release Coordinator). The hook's `COORDINATOR_ROLE_OPENER` regex matches the canonical `You are **{Name}**, {Role}[ for {repo}]` opener and exempts these spawns from step (a). Step (b) below — instructing the agent to run `/ontology-librarian` themselves — still applies to coordinators that may Edit/Write, since Hook 15 fires independently at the Edit/Write surface.
+
+For each implementer in the wave:
 1. Identify the repos and code areas they'll modify
 2. Run the librarian with a descriptive query:
    ```

--- a/.claude/team/charter/agents.md
+++ b/.claude/team/charter/agents.md
@@ -256,7 +256,9 @@ The harness enforces **one team per orchestrator session** — `TeamCreate` fail
 
 ### Reviewer slate discipline (FIRST-LINE in every spawn prompt)
 
-> **Position-first rule (resolves [main#201](https://github.com/noorinalabs/noorinalabs-main/issues/201)).** The reviewer slate is the first decision the spawn prompt forces the orchestrator (or PD-via-spawn-request) to make — not buried mid-checklist where it gets back-filled after scope/branch/sequencing have already framed the assignment. Every spawn prompt template MUST place this section immediately after the identity / git-identity preamble and BEFORE the `## Ontology Context` section.
+> **Position-first rule (resolves [main#201](https://github.com/noorinalabs/noorinalabs-main/issues/201)).** The reviewer slate is the first decision the spawn prompt forces the orchestrator (or PD-via-spawn-request) to make — not buried mid-checklist where it gets back-filled after scope/branch/sequencing have already framed the assignment. Every spawn prompt template MUST place this section immediately after the identity / git-identity preamble and BEFORE the `## Ontology Context` section (when that section is present — see coordinator-class exemption note below).
+>
+> **Coordinator-class exemption (#468):** the `## Ontology Context` section is MANDATORY for implementer-class spawns and OPTIONAL for coordinator-class spawns (Manager, Pipeline Manager, Project Lead, Program Director, TPM / Technical Program Manager, Release Coordinator). Coordinators communicate primarily via SendMessage and rarely Edit/Write directly; `enforce_ontology_context.py` matches the canonical `You are **{Name}**, {Role}[ for {repo}]` opener and exempts these roles from the spawn-time Agent block. Hook 15 (`enforce_librarian_consulted.py`) still fires at the Edit/Write surface for the few coordinators that do edit. When a coordinator brief DOES include `## Ontology Context`, the position-first rule above continues to apply — the section retains its required location.
 >
 > **You MUST NOT name as reviewer:**
 > - The **manager of the implementer's repo** (manager-boundary rule — see `pull-requests.md` § Two-Reviewer Assignment, observed-and-corrected ≥4× across three managers in P2W10).
@@ -319,7 +321,7 @@ The harness enforces **one team per orchestrator session** — `TeamCreate` fail
 Every implementer spawn prompt MUST include, **in order**:
 
 1. **Reviewer slate** (first-line per § Reviewer slate discipline above) — both reviewers named, manager-boundary verified, valid-source check applied.
-2. **`## Ontology Context`** section (literal heading) with librarian output baked in — `enforce_ontology_context.py` scans for this heading and blocks the spawn if absent.
+2. **`## Ontology Context`** section (literal heading) with librarian output baked in — `enforce_ontology_context.py` scans for this heading and blocks the spawn if absent. **Coordinator-class spawns are exempt** (Manager, Pipeline Manager, Project Lead, Program Director, TPM / Technical Program Manager, Release Coordinator) per the carveout above and #468; the hook's `COORDINATOR_ROLE_OPENER` regex matches the canonical `You are **{Name}**, {Role}[ for {repo}]` opener and skips the block. This item remains MANDATORY for implementer-class spawns (Engineer, Tech Lead, Standards & Quality Lead, Security Engineer, Engineering Manager).
 3. **MANDATORY first-action** instruction to run `/ontology-librarian {topic}` in the spawned agent's own session — Hook 15 scans the agent's transcript independently and blocks Edit/Write otherwise.
 4. **Git identity** flags (`git -c user.name="..." -c user.email="parametrization+FirstName.LastName@gmail.com"`).
 5. **Branch name** matching `{FirstInitial}.{LastName}/{IIII}-{slug}` and **PR target** (typically `deployments/phase-{N}/wave-{M}`).

--- a/ontology/conventions.md
+++ b/ontology/conventions.md
@@ -166,6 +166,7 @@ Existing 3-digit ADRs are not merge-blockers; renames are mechanical and reversi
 | `block_gh_pr_review.py` | PreToolUse (Bash) | Block `gh pr review` (use comment-based reviews) |
 | `validate_review_comment_format.py` | PreToolUse (Bash) | Enforce review comment charter format |
 | `validate_wave_context.py` | PreToolUse (Agent) | Warn if agent spawned without wave context or ontology context in prompt |
+| `enforce_ontology_context.py` | PreToolUse (Agent) | Block worktree-isolated Agent spawns without `## Ontology Context` marker (or equivalent librarian-output markers) in the prompt. Coordinator-class spawns (Manager, Pipeline Manager, Project Lead, Program Director, TPM / Technical Program Manager, Release Coordinator) are exempt — the hook matches `COORDINATOR_ROLE_OPENER` against the canonical `You are **{Name}**, {Role}[ for {repo}]` opener and skips. Hook 15 (`enforce_librarian_consulted.py`) covers the Edit/Write surface for the few coordinators that do edit. PR #468 (issue #466) |
 | `block_shutdown_without_retro.py` | PreToolUse (SendMessage) | Block agent shutdown before retro |
 | `auto_add_issue_to_board.py` | PostToolUse (Bash) | Auto-add new issues to project board. Reads `tool_response.stdout` (with legacy `tool_output` fallback) per Claude Code PostToolUse contract — #453/#454 fix |
 | `post_wave_kickoff_comment.py` | PostToolUse (Bash) | Post charter-format kickoff comment when a `p{N}-wave-{M}` label is APPLIED |


### PR DESCRIPTION
Closes #470.

## Summary

PR #468 added a coordinator-class carveout to `enforce_ontology_context.py` — Manager / Pipeline Manager / Project Lead / Program Director / TPM / Technical Program Manager / Release Coordinator now skip the spawn-time Agent block via the `COORDINATOR_ROLE_OPENER` regex matching the canonical `You are **{Name}**, {Role}[ for {repo}]` opener. Three doc surfaces still asserted the `## Ontology Context` heading as universally required, and one self-noted #468 follow-up was outstanding.

Base: `deployments/phase-3/wave-11` (HEAD `cf8bf51` post-#485 merge — where the carveout actually lives; PR #468 has not yet propagated to main).

## Changes (4 surfaces, all doc-only)

### `.claude/team/charter/agents.md:259` (position-first rule blockquote)

Added a follow-up paragraph naming the coordinator-class exemption. The position-first rule itself continues to apply WHEN `## Ontology Context` is present (the section retains its required location); the carveout only affects whether the section is required at all.

### `.claude/team/charter/agents.md:322` (orchestrator-checklist-implementer item #2)

Appended one sentence noting coordinator-class spawns are exempt and listing the implementer-class roles that remain mandatory. Same wording style as item #2's original.

### `.claude/skills/wave-kickoff/SKILL.md:335` (§ 9 Ontology librarian — bake step (a))

Inserted the coordinator-class exemption callout between the (a) header and the "For each implementer in the wave" loop (which the edit also renames from "agent" to "implementer" to reflect the narrower scope). Step (b) — agent-side librarian invocation — explicitly continues to apply to coordinators that may Edit/Write, because Hook 15 fires independently at the Edit/Write surface.

### `ontology/conventions.md:168` (hooks table — #468 self-noted follow-up)

Added a new row for `enforce_ontology_context.py` between the existing `validate_wave_context.py` row (the older, warn-only hook covering the same surface) and `block_shutdown_without_retro.py`. The description names the coordinator-class roles and references both Hook 15 (which covers the Edit/Write surface) and the PR #468 / issue #466 provenance.

## Test plan

Doc-only — no code, no tests. Validated via:

- `grep -n "ontology" .claude/team/charter/agents.md` — anchors confirmed at lines 259 / 322 post-edit; rule reads coherent in context
- `grep -n "ontology" .claude/skills/wave-kickoff/SKILL.md` — anchor at 335 unchanged; new callout slots in cleanly
- `grep -nE "(enforce_|^\\| Hook)" ontology/conventions.md` — new row at line 169 in the right table position
- `git diff --stat HEAD` — 3 files, +8/-3 lines, no surprise changes
- Pre-commit hooks correctly skipped (ruff-format / ruff-lint / mypy all `no files to check`)

## Why this matters

`feedback_enforcement_hierarchy.md`: charter and skill text that lags hook behavior decays. Orchestrators reading the pre-update charter would either (low cost) waste cycles baking in unnecessary `## Ontology Context` headings on coordinator briefs, or (high cost) assume the heading is the ONLY enforcement and skip the agent-side librarian call for coordinator briefs — which Hook 15 still requires at the Edit/Write surface and would re-block them.

The 4 doc surfaces now match hook behavior post-#468.

## Tech Debt

None introduced. Closes one tech-debt item + completes one PR #468 self-noted follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
