### PR TITLE
ci(detection): include .claude/lib/** in workflow paths filter (#464)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, "deployments/**"]
     paths:
       - ".claude/hooks/**"
+      - ".claude/lib/**"
       - ".claude/skills/**"
       - ".github/workflows/ci.yml"
       - "pyproject.toml"
@@ -12,6 +13,7 @@ on:
     branches: [main, "deployments/**"]
     paths:
       - ".claude/hooks/**"
+      - ".claude/lib/**"
       - ".claude/skills/**"
       - ".github/workflows/ci.yml"
       - "pyproject.toml"


### PR DESCRIPTION
Closes #464.

## Summary

`.github/workflows/ci.yml` `on.push.paths` + `on.pull_request.paths` filters omit `.claude/lib/**`, so PRs that change only files under that directory silently skip ALL 4 CI gates (Ruff lint, Ruff format check, Mypy, Smoke test). PR #460 (Wanjiku's upsert_status_keys regression-cover) was the live surface — two-file change under `.claude/lib/`, zero check-runs. This PR adds `.claude/lib/**` to both paths lists.

## Change (two lines)

```diff
   push:
     branches: [main, "deployments/**"]
     paths:
       - ".claude/hooks/**"
+      - ".claude/lib/**"
       - ".claude/skills/**"
       - ".github/workflows/ci.yml"
       - "pyproject.toml"
   pull_request:
     branches: [main, "deployments/**"]
     paths:
       - ".claude/hooks/**"
+      - ".claude/lib/**"
       - ".claude/skills/**"
       - ".github/workflows/ci.yml"
       - "pyproject.toml"
```

Alpha-sorted insertion, matching the existing style. No job changes.

## Why this matters

PR-author-level discipline ("I ran lint locally") is not a substitute for a mechanical gate the team can rely on. When the upsert helper graduated from `.claude/skills/wave-scope/` to `.claude/lib/` (per main#292), the path filter wasn't extended. Every `.claude/lib/`-only PR since has been ungated.

## Charter consideration (acceptance bullet 3 of #464)

`.claude/team/charter/**` is 12 markdown files, 0 Python. NOT added to the filter — adding it would fire CI on charter-only PRs but all 4 jobs would no-op (nothing under `.claude/hooks/` changed). Issue body already flagged this as "probably out-of-scope".

## Test plan

- [x] `actionlint .github/workflows/ci.yml` → exit 0 (shellcheck + actionlint both on PATH per `feedback_actionlint_needs_shellcheck`)
- [x] Diff is exactly the +2 lines, alpha-sorted to match existing pattern
- [ ] Post-merge validation (per issue acceptance bullet 2): observe CI fires on `.claude/lib/`-only PRs. This PR's own CI run is the first natural test — the diff IS a `.github/workflows/ci.yml` change so the `paths` filter SHOULD trigger CI on this PR; verify all 4 check-runs land green before merging.

## Out of scope (filed as follow-up, NOT in this PR)

The CI jobs themselves still only scan `.claude/hooks/` — `ruff check .claude/hooks/`, `mypy .claude/hooks/`, `for f in .claude/hooks/*.py`. After this fix, CI WILL FIRE on `.claude/lib/`-only changes but the 4 jobs will pass even if `.claude/lib/` itself has lint/format/type errors, because the jobs don't look there.

This is a real but separate concern — issue #464's explicit "Out of scope" notes "Adding new gates (e.g., pytest collection) — that's a separate scope decision". Will file as a sweep follow-up so the gap is tracked without conflating two distinct fixes in one PR.

(Surfaced incidentally: Makefile `lint`/`format` targets also only target `.claude/hooks/`. Same class of gap, same follow-up scope.)

## Tech Debt

None introduced. The job-coverage gap (jobs targeting only `.claude/hooks/`) is a real but pre-existing concern that pre-dates this PR; will be filed as its own follow-up issue per the issue body's out-of-scope guidance.
