### PR TITLE
tech-debt(hook): validate_commit_identity — extend indirect-exec detection to heredoc / eval / dash+ksh / extension-agnostic (#482)

### DIFF
--- a/.claude/hooks/tests/test_validate_commit_identity.py
+++ b/.claude/hooks/tests/test_validate_commit_identity.py
@@ -619,6 +619,277 @@ class IndirectExecBypassTests(unittest.TestCase):
         self.assertIn("indirect-exec", result["reason"])
 
 
+class IndirectExecExtensionTests(unittest.TestCase):
+    """Issue #482: extend indirect-exec detection from the original 4 shapes
+    (#475) to 5 more — heredoc, here-string, eval, dash/ksh -c (via the
+    widened `_INTERPRETERS` alternation), and extension-agnostic script
+    read (the highest-severity #482 change, since operators could trivially
+    rename a bypass script to circumvent the prior `.sh\\b` restriction).
+
+    Each new shape gets a paired BLOCK / ALLOW test to pin both halves of
+    the detection contract:
+      - BLOCK: inner payload contains git-commit-shape
+      - ALLOW: same wrapper shape but inner payload is innocent
+
+    All existing 46 tests in this file continue to pass — the extensions
+    are strictly additive to `_detect_indirect_commit`'s dispatcher.
+    """
+
+    @staticmethod
+    def _input(command: str, cwd: str | None = None) -> dict:
+        d: dict = {"tool_name": "Bash", "tool_input": {"command": command}}
+        if cwd is not None:
+            d["cwd"] = cwd
+        return d
+
+    def _assert_blocked_with_shape(self, result, shape_label: str) -> None:
+        """Assert the result is an indirect-exec block and the reason
+        contains the expected shape label (e.g. 'heredoc', 'here-string').
+        Also asserts the unified #475/#482 cite is present."""
+        self.assertIsNotNone(result, f"indirect-exec bypass must block ({shape_label})")
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+        self.assertIn("indirect-exec", result["reason"])
+        self.assertIn(shape_label, result["reason"])
+        # Both citations should be present in the unified post-#482 block message.
+        self.assertIn("#475", result["reason"])
+        self.assertIn("#482", result["reason"])
+
+    # --- heredoc shape -----------------------------------------------------
+
+    def test_bash_heredoc_with_git_commit_blocks(self):
+        """POS: `bash <<EOF\\ngit commit ...\\nEOF` — heredoc body fed as
+        stdin to a shell. Without #482 detection the outer tokenizer sees
+        only `['bash', '<<EOF', '...', 'EOF']`-style decomposition and
+        `_find_commit_segment` returns None → silent allow."""
+        cmd = 'bash <<EOF\ngit -c user.name="X" -c user.email="Y" commit -F /tmp/msg.txt\nEOF'
+        self._assert_blocked_with_shape(hook.check(self._input(cmd)), "heredoc")
+
+    def test_bash_heredoc_quoted_delim_with_git_commit_blocks(self):
+        """POS: `bash <<'EOF'...` — quoted-delim heredoc (no var expansion).
+        Same exec semantics; detector must match this variant too."""
+        cmd = 'bash <<\'EOF\'\ngit -c user.name="X" -c user.email="Y" commit -m z\nEOF'
+        self._assert_blocked_with_shape(hook.check(self._input(cmd)), "heredoc")
+
+    def test_bash_heredoc_dash_form_with_git_commit_blocks(self):
+        """POS: `bash <<-EOF...` — tab-stripping heredoc form."""
+        cmd = "bash <<-EOF\n\tgit -c user.name=X -c user.email=Y commit -m z\n\tEOF"
+        self._assert_blocked_with_shape(hook.check(self._input(cmd)), "heredoc")
+
+    def test_bash_heredoc_no_git_commit_allows(self):
+        """NEG: `bash <<EOF\\necho hi\\nEOF` — innocent heredoc body."""
+        cmd = "bash <<EOF\necho hello\nls -la\nEOF"
+        self.assertIsNone(hook.check(self._input(cmd)))
+
+    def test_cat_heredoc_mentioning_git_commit_allows(self):
+        """NEG: `cat <<EOF\\ngit commit is a phrase\\nEOF` — `cat` is NOT
+        a shell interpreter so the heredoc body is data, not code. Must
+        not false-block. This is the principal false-positive guard for
+        heredoc detection — prose containing 'git commit' inside a doc
+        being piped to `cat` (or `tee`, `bat`, etc.) is everywhere."""
+        cmd = "cat <<EOF > /tmp/doc.md\nHow to git commit:\ngit commit -m foo\nEOF"
+        self.assertIsNone(hook.check(self._input(cmd)))
+
+    # --- here-string shape -------------------------------------------------
+
+    def test_bash_herestring_with_git_commit_blocks(self):
+        """POS: `bash <<<'git commit ...'` — here-string body."""
+        cmd = "bash <<<'git -c user.name=X -c user.email=Y commit -m z'"
+        self._assert_blocked_with_shape(hook.check(self._input(cmd)), "here-string")
+
+    def test_bash_herestring_double_quoted_with_git_commit_blocks(self):
+        """POS: `bash <<<"..."` — double-quoted here-string."""
+        cmd = 'bash <<<"git -c user.name=X -c user.email=Y commit -m z"'
+        self._assert_blocked_with_shape(hook.check(self._input(cmd)), "here-string")
+
+    def test_bash_herestring_no_git_commit_allows(self):
+        """NEG: `bash <<<'echo hi'` — innocent here-string."""
+        self.assertIsNone(hook.check(self._input("bash <<<'echo hello'")))
+
+    def test_cat_herestring_mentioning_git_commit_allows(self):
+        """NEG: `cat <<<'git commit is a phrase'` — `cat` is not a shell;
+        body is data not code. Must not false-block."""
+        self.assertIsNone(hook.check(self._input("cat <<<'git commit is a phrase'")))
+
+    # --- eval shape --------------------------------------------------------
+
+    def test_eval_with_git_commit_blocks(self):
+        """POS: `eval 'git commit ...'` — shell builtin re-parses and
+        executes its argument. Outer tokenizer sees `eval` as argv[0]
+        and skips identity validation."""
+        cmd = "eval 'git -c user.name=X -c user.email=Y commit -m foo'"
+        self._assert_blocked_with_shape(hook.check(self._input(cmd)), "eval")
+
+    def test_eval_double_quoted_payload_blocks(self):
+        """POS: `eval "git commit ..."` — double-quoted payload form."""
+        cmd = 'eval "git -c user.name=X -c user.email=Y commit -m foo"'
+        self._assert_blocked_with_shape(hook.check(self._input(cmd)), "eval")
+
+    def test_eval_no_git_commit_allows(self):
+        """NEG: `eval 'echo hello'` — innocent eval."""
+        self.assertIsNone(hook.check(self._input("eval 'echo hello'")))
+
+    def test_eval_variable_substitution_documented_punt(self):
+        """NEG: `eval "$CMD"` — variable-substituted eval body. Documented
+        punt per the hook docstring: substitution happens at shell-runtime,
+        after the hook fires, so we can't inspect the actual command. Must
+        ALLOW (otherwise every legitimate `eval $cmd` use would false-block)."""
+        self.assertIsNone(hook.check(self._input('eval "$CMD"')))
+        self.assertIsNone(hook.check(self._input("eval $cmd")))
+
+    def test_eval_no_quotes_no_commit_allows(self):
+        """NEG: `eval echo hello` — bareword eval, no commit shape."""
+        self.assertIsNone(hook.check(self._input("eval echo hello")))
+
+    # --- dash / ksh extended interpreter alternation -----------------------
+
+    def test_dash_dash_c_with_git_commit_blocks(self):
+        """POS: `dash -c 'git commit ...'` — `dash` is a POSIX shell.
+        Pre-#482 `_INTERPRETERS` was `(?:bash|sh|zsh)` and missed dash;
+        #482 extended to `(?:bash|sh|zsh|dash|ksh)`."""
+        cmd = "dash -c 'git -c user.name=X -c user.email=Y commit -m z'"
+        self._assert_blocked_with_shape(hook.check(self._input(cmd)), "shell -c")
+
+    def test_ksh_dash_c_with_git_commit_blocks(self):
+        """POS: `ksh -c 'git commit ...'` — Korn shell, also POSIX."""
+        cmd = "ksh -c 'git -c user.name=X -c user.email=Y commit -m z'"
+        self._assert_blocked_with_shape(hook.check(self._input(cmd)), "shell -c")
+
+    def test_dash_dash_c_no_git_commit_allows(self):
+        """NEG: `dash -c 'ls -la'` — innocent dash invocation."""
+        self.assertIsNone(hook.check(self._input("dash -c 'ls -la'")))
+
+    def test_dash_piped_with_git_commit_blocks(self):
+        """POS: `printf '...' | dash` — pipe-to-shell with dash interpreter."""
+        cmd = "printf 'git -c user.name=X -c user.email=Y commit -m z\\n' | dash"
+        self._assert_blocked_with_shape(hook.check(self._input(cmd)), "printf/echo piped to shell")
+
+    def test_ksh_piped_with_git_commit_blocks(self):
+        """POS: `echo '...' | ksh` — same with ksh."""
+        cmd = "echo 'git -c user.name=X -c user.email=Y commit -m z' | ksh"
+        self._assert_blocked_with_shape(hook.check(self._input(cmd)), "printf/echo piped to shell")
+
+    # --- extension-agnostic script read (highest-severity #482 fix) -------
+
+    def test_bash_script_dot_bash_extension_blocks(self):
+        """POS: `bash /tmp/script.bash` — .bash extension was NOT covered
+        by the pre-#482 `\\.sh\\b` restriction. Now extension-agnostic,
+        any readable file under the 256 KiB cap is inspected."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".bash", delete=False, encoding="utf-8"
+        ) as f:
+            f.write('git -c user.name="X" -c user.email="Y" commit -F /tmp/msg.txt\n')
+            script_path = f.name
+        try:
+            self._assert_blocked_with_shape(
+                hook.check(self._input(f"bash {script_path}")),
+                "shell script",
+            )
+        finally:
+            Path(script_path).unlink(missing_ok=True)
+
+    def test_bash_script_extensionless_blocks(self):
+        """POS: `bash /tmp/script-no-ext` — completely extensionless. The
+        rename-bypass that was the highest-severity #482 concern: an
+        operator who knew the hook checked `.sh` could rename their
+        bypass script to `myscript` and slip through. Now blocked."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix="", delete=False, encoding="utf-8") as f:
+            f.write('git -c user.name="X" -c user.email="Y" commit -F /tmp/msg.txt\n')
+            script_path = f.name
+        try:
+            self._assert_blocked_with_shape(
+                hook.check(self._input(f"bash {script_path}")),
+                "shell script",
+            )
+        finally:
+            Path(script_path).unlink(missing_ok=True)
+
+    def test_bash_script_unusual_extension_blocks(self):
+        """POS: `bash /tmp/script.ksh` — unusual extension. Content read
+        is unconditional on extension; the cap + fail-open OSError discipline
+        is preserved from the prior `.sh\\b`-restricted detector."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".ksh", delete=False, encoding="utf-8"
+        ) as f:
+            f.write("git -c user.name=X -c user.email=Y commit -m z\n")
+            script_path = f.name
+        try:
+            self._assert_blocked_with_shape(
+                hook.check(self._input(f"bash {script_path}")),
+                "shell script",
+            )
+        finally:
+            Path(script_path).unlink(missing_ok=True)
+
+    def test_bash_extensionless_script_no_git_commit_allows(self):
+        """NEG: `bash /tmp/script` where content has NO git commit.
+        Detection should still try to read (extension-agnostic), find
+        nothing matching, and allow."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix="", delete=False, encoding="utf-8") as f:
+            f.write("#!/usr/bin/env bash\nls -la\necho done\n")
+            script_path = f.name
+        try:
+            self.assertIsNone(hook.check(self._input(f"bash {script_path}")))
+        finally:
+            Path(script_path).unlink(missing_ok=True)
+
+    def test_bash_script_dash_c_does_not_false_match_as_script(self):
+        """NEG/regression: `bash -c '...'` must continue to match as
+        `shell -c`, NOT as a script-path read. The script regex's leading
+        char class excludes `-`, so `-c` is correctly skipped."""
+        cmd = "bash -c 'git -c user.name=X -c user.email=Y commit -m foo'"
+        result = hook.check(self._input(cmd))
+        assert result is not None
+        # Should be matched by the shell -c detector, not the script detector
+        self.assertIn("shell -c", result["reason"])
+        # Should NOT have script-shape language in the reason
+        self.assertNotIn("shell script", result["reason"])
+
+    def test_bash_script_with_size_cap_still_protected(self):
+        """NEG (defensive): a script file >256 KiB is NOT inspected
+        (preserves the original #475 fail-open-on-large-file discipline).
+        If the script content contains a git commit shape but the file
+        exceeds the cap, the detector returns None and the rest of the
+        hook handles it normally (ALLOW since outer-command tokenizer
+        sees `bash <path>`, not git)."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".bash", delete=False, encoding="utf-8"
+        ) as f:
+            # Write >256 KiB of padding followed by git commit text
+            f.write("# padding\n" * 30000)  # ~300 KiB
+            f.write('git -c user.name="X" -c user.email="Y" commit -m z\n')
+            script_path = f.name
+        try:
+            self.assertIsNone(
+                hook.check(self._input(f"bash {script_path}")),
+                "files >256 KiB must not be inspected (preserves fail-open discipline)",
+            )
+        finally:
+            Path(script_path).unlink(missing_ok=True)
+
+    # --- cross-shape coherence --------------------------------------------
+
+    def test_unified_block_message_cites_both_issues(self):
+        """POS: the post-#482 block message MUST cite both #475 (original
+        4-shape work) AND #482 (5-shape extension) so operators landing
+        on the message can trace the full bypass surface."""
+        result = hook.check(self._input("eval 'git -c user.name=X commit -m z'"))
+        assert result is not None
+        self.assertIn("#475", result["reason"])
+        self.assertIn("#482", result["reason"])
+
+    def test_block_message_lists_new_shapes(self):
+        """POS: the wrapper-list in the block message MUST include the
+        new shape examples so the operator sees them inline. Helps prevent
+        operators from re-discovering bypass patterns by trial."""
+        result = hook.check(self._input("eval 'git -c user.name=X commit -m z'"))
+        assert result is not None
+        # New #482 shapes named in the unified message
+        self.assertIn("<<EOF", result["reason"])
+        self.assertIn("<<<", result["reason"])
+        self.assertIn("eval", result["reason"])
+
+
 class CwdFallbackTests(unittest.TestCase):
     """Issue #475 fix 1: when no literal `cd <path>` prefix is present, fall
     back to the tool-call cwd for roster resolution. Lets operators commit

--- a/.claude/hooks/validate_commit_identity.py
+++ b/.claude/hooks/validate_commit_identity.py
@@ -22,14 +22,28 @@ cwd-fallback for cross-repo detection (#475 fix 1):
   every operator to compose a `cd` prefix when their shell cwd already names
   the right repo.
 
-Indirect-exec bypass detection (#475 fix 2):
+Indirect-exec bypass detection (#475 fix 2, extended in #482):
   PreToolUse hooks only see the literal Bash `command` parameter. Wrappers
-  like `printf '<git-commit-cmd>' | bash`, `bash -c '<git-commit-cmd>'`,
-  `bash <script-with-git-commit>`, and `bash <(echo '<git-commit-cmd>')`
-  hide the actual `git commit` from the outer-command tokenizer. The hook
-  now scans for these shapes and, if the payload looks like a git commit,
-  BLOCKS with a message pointing operators to the canonical shape. This
-  closes a silent bypass discovered in P3W11 PR #41 fixup.
+  that hide the actual `git commit` from the outer-command tokenizer are
+  detected pre-tokenize and BLOCKED. Original 4 shapes from #475:
+      printf '<git-commit-cmd>' | bash
+      bash -c '<git-commit-cmd>'
+      bash <script-with-git-commit>      (extension-restricted to *.sh)
+      bash <(echo '<git-commit-cmd>')
+
+  #482 follow-up adds 5 more, surfaced by Aisha + Petra convergent review:
+      bash <<EOF...git commit...EOF      (heredoc body)
+      bash <<<'git commit ...'           (here-string)
+      eval 'git commit ...'              (shell builtin)
+      dash|ksh -c '...'                  (extended _INTERPRETERS alternation)
+      bash <script.bash>                 (extension-agnostic; *.sh restriction removed)
+
+  The extension-agnostic script read is the highest-severity #482 change:
+  the prior `.sh` restriction was trivially circumvented by renaming the
+  bypass script. Now any token after `bash|sh|zsh|dash|ksh` that points to
+  a readable regular file (under the 256 KiB cap, fail-open on OSError)
+  has its content scanned for git-commit-shape. Token must not start with
+  a flag (`-c`, `-x`, etc.) to avoid colliding with the `-c` detector.
 
 Input Language
 ==============
@@ -192,8 +206,13 @@ def _detect_target_roster(command: str, *, cwd: str | None = None) -> dict[str, 
 #   only block when the readable content matches the git-commit shape;
 #   bare `bash some-script.sh` whose content is innocent is allowed.
 
-# Wrapper interpreters we recognise.
-_INTERPRETERS = r"(?:bash|sh|zsh)"
+# Wrapper interpreters we recognise. Extended for #482 to include `dash`
+# and `ksh` — both are POSIX shells that operators may use as `dash -c …`
+# / `ksh -c …` to bypass the original (bash|sh|zsh)-only alternation.
+# `mksh` and `pdksh` are deliberately excluded as a conservative bound;
+# they're rare in modern installs and can be added later if observed in
+# any bypass surface (see #482 acceptance bullet).
+_INTERPRETERS = r"(?:bash|sh|zsh|dash|ksh)"
 
 # printf/echo … | <interpreter>. Captures the printf/echo argument body.
 # Anchor on `printf` or `echo` at word boundary, allow any chars up to the
@@ -224,12 +243,61 @@ _PROCESS_SUB_RE = re.compile(
 )
 
 # <interpreter> <scriptpath> — the script path is whatever non-flag
-# non-redirect token follows. Restricted to tokens ending in `.sh` to
-# avoid false-positives on `bash -c '...'` (handled above) and `bash`
-# bare (interactive shell, no script). The path may be absolute or
-# relative; if relative we resolve against the hook's cwd.
+# non-redirect token follows. The prior `\.sh\b` extension restriction was
+# trivially circumvented by renaming the bypass script (`bash script.bash`
+# / `bash extensionless-script`) — see #482. Now extension-agnostic: any
+# token whose first char is not a flag (`-`), a redirect (`<>|;&`), or a
+# process-substitution opener (`(`) is treated as a candidate script path
+# and read for content inspection (subject to the 256 KiB cap + fail-open
+# OSError discipline in `_read_script_if_safe`).
+#
+# Disambiguation from the `-c` case: the leading character class `[^-…]`
+# rejects `bash -c '…'` because the first token char is `-`. The `bash`
+# bare-interactive form (no following token) has no match because the
+# `\s+(?P<path>…)` requires at least one whitespace + path char.
 _SCRIPT_INVOKE_RE = re.compile(
-    r"\b" + _INTERPRETERS + r"\s+(?P<path>[^\s|;&<>]+\.sh)\b",
+    r"\b" + _INTERPRETERS + r"\s+(?P<path>[^\s\-<>|;&(][^\s|;&<>]*)",
+)
+
+# <interpreter> <<DELIM ... DELIM  (heredoc body fed as stdin to a shell).
+# The heredoc body is read as commands by the shell — if it contains a
+# git-commit shape, it slips past the outer tokenizer. We must anchor on
+# `_INTERPRETERS` here; an unrelated `cat <<EOF\ngit commit …\nEOF` is
+# data-only (cat prints the body, does not exec it) and must not
+# false-block. Matches the four shell heredoc opener variants:
+# `<<DELIM`, `<<'DELIM'`, `<<"DELIM"`, `<<-DELIM`.
+#
+# Note: this regex INTENTIONALLY does not share machinery with
+# `_shell_parse.strip_heredocs` — the latter removes heredoc bodies for
+# the standard parser path so prose containing "git commit" inside a cat
+# heredoc doesn't false-match. Here we want the OPPOSITE: extract the
+# body specifically when the heredoc target IS a shell interpreter, so
+# we can scan it for hidden git commits.
+_HEREDOC_RE = re.compile(
+    r"\b" + _INTERPRETERS + r"\b[^\n]*?<<-?\s*['\"]?(?P<delim>\w+)['\"]?[^\n]*\n"
+    r"(?P<payload>.*?)\n\t*(?P=delim)\b",
+    re.DOTALL,
+)
+
+# <interpreter> <<<'<payload>' (here-string). The body is fed as a single
+# stdin line — same exec semantics as a heredoc for our purposes. Anchor
+# on `_INTERPRETERS` for the same reason as heredoc.
+_HERESTRING_RE = re.compile(
+    r"\b" + _INTERPRETERS + r"\s+<<<\s*(?P<payload>(?P<q>['\"]).*?(?P=q)|\S+)",
+    re.DOTALL,
+)
+
+# eval '<payload>' — shell builtin that re-parses + executes its argument
+# string. Captures the argument up to the closing matching quote OR (for
+# unquoted forms) up to the next shell segment separator. Documented
+# punts: variable-substituted eval strings (`eval "$cmd"`) are NOT
+# inspected because the substitution happens at shell-runtime, after the
+# hook fires; multi-segment eval bodies (`eval 'git status; git commit'`)
+# are matched as a single payload but the inner-payload regex correctly
+# bounds the `git` … `commit` bridge to a single segment via `[^;&|]`.
+_EVAL_RE = re.compile(
+    r"\beval\s+(?P<payload>(?P<q>['\"]).*?(?P=q)|\S+)",
+    re.DOTALL,
 )
 
 # Inner-payload commit-shape: looser than the outer `_COMMIT_FALLBACK_RE`
@@ -296,10 +364,17 @@ def _detect_indirect_commit(command: str, *, cwd: str | None = None) -> str | No
     commit, or None when no wrapper-with-commit shape is matched.
 
     Shapes checked, in order:
-      1. printf/echo … | bash|sh|zsh
-      2. bash|sh|zsh -c '<payload>'
-      3. bash|sh|zsh <(…)  (process substitution)
-      4. bash|sh|zsh <script.sh>  (reads the script content)
+      1. printf/echo … | bash|sh|zsh|dash|ksh
+      2. bash|sh|zsh|dash|ksh -c '<payload>'
+      3. bash|sh|zsh|dash|ksh <(…)  (process substitution)
+      4. bash|sh|zsh|dash|ksh <<DELIM ... DELIM  (heredoc body, #482)
+      5. bash|sh|zsh|dash|ksh <<<'<payload>'  (here-string, #482)
+      6. eval '<payload>'  (shell builtin, #482)
+      7. bash|sh|zsh|dash|ksh <scriptpath>  (extension-agnostic, #482)
+
+    The script-path check is LAST because it requires disk I/O — all
+    pattern-only checks run first to short-circuit common cases without
+    hitting the filesystem.
     """
     for m in _PIPE_TO_SHELL_RE.finditer(command):
         if _payload_looks_like_commit(m.group("payload")):
@@ -313,6 +388,20 @@ def _detect_indirect_commit(command: str, *, cwd: str | None = None) -> str | No
     for m in _PROCESS_SUB_RE.finditer(command):
         if _payload_looks_like_commit(m.group("payload")):
             return "process substitution"
+
+    for m in _HEREDOC_RE.finditer(command):
+        if _payload_looks_like_commit(m.group("payload")):
+            return "heredoc"
+
+    for m in _HERESTRING_RE.finditer(command):
+        payload = _strip_outer_quotes(m.group("payload"))
+        if _payload_looks_like_commit(payload):
+            return "here-string"
+
+    for m in _EVAL_RE.finditer(command):
+        payload = _strip_outer_quotes(m.group("payload"))
+        if _payload_looks_like_commit(payload):
+            return "eval"
 
     for m in _SCRIPT_INVOKE_RE.finditer(command):
         content = _read_script_if_safe(m.group("path"), cwd)
@@ -398,7 +487,8 @@ def check(input_data: dict) -> dict | None:
                 "carrying a hidden `git commit`. Commit-identity validation "
                 "only sees the outer Bash command, so wrappers like "
                 "`printf '...' | bash`, `bash -c '...'`, `bash <script>`, "
-                "and `bash <(...)` would let an unvalidated commit through.\n\n"
+                "`bash <(...)`, `bash <<EOF...EOF`, `bash <<<'...'`, and "
+                "`eval '...'` would let an unvalidated commit through.\n\n"
                 "Run the git command directly so the hook can inspect the "
                 "identity flags:\n"
                 '  git -c user.name="Your Name" -c user.email="..." \\\n'
@@ -406,7 +496,7 @@ def check(input_data: dict) -> dict | None:
                 "If you need a different working directory, prefix with "
                 "`cd <path> && git -c ... commit ...` (canonical cross-repo "
                 "shape).\n\n"
-                "See issue #475 for the full bypass surface and rationale."
+                "See issues #475 and #482 for the full bypass surface and rationale."
             ),
         }
         log_pretooluse_block("validate_commit_identity", command, result["reason"])


### PR DESCRIPTION
Requestor: Aino Virtanen
Requestee: Aino Virtanen
RequestOrReplied:
TechDebt: None

Closes #482.

## Summary

Direct follow-up to PR #479 (which closed #475). Aisha + Petra's convergent review of #479 surfaced 5 additional indirect-exec bypass shapes I explicitly punted in #475's scope. This PR closes all 5 with extensions to `_detect_indirect_commit` — no breaking changes, strictly additive.

The highest-severity gap was the script extension restriction (`\.sh\b`) — operator-discoverable via the hook docstring and trivially circumvented by renaming the bypass script. Now extension-agnostic.

## Shapes added

| # | Shape | Detector |
|---|---|---|
| 1 | `bash <<EOF\ngit commit ...\nEOF` | new `_HEREDOC_RE` (4 opener variants) |
| 2 | `bash <<<'git commit ...'` | new `_HERESTRING_RE` |
| 3 | `eval 'git commit ...'` | new `_EVAL_RE` |
| 4 | `dash -c '...'` / `ksh -c '...'` | `_INTERPRETERS` widened to `(?:bash\|sh\|zsh\|dash\|ksh)` |
| 5 | `bash script.bash` / `bash <extensionless>` | `_SCRIPT_INVOKE_RE` relaxed extension; content read at any extension |

The `_INTERPRETERS` widening (#4) automatically extends the 4 pre-existing detectors plus the 2 new heredoc/here-string detectors — `printf '...' | dash`, `dash <(...)`, `ksh <script>` etc. all now match.

## Why the heredoc detector is anchored on `_INTERPRETERS`

`cat <<EOF\ngit commit is a phrase\nEOF` is data-only — cat prints the body, does not execute it. Without the `_INTERPRETERS` anchor we'd false-block every documentation heredoc mentioning git commit. The detector specifically requires the heredoc target to be a known shell interpreter. Same anchor discipline for `_HERESTRING_RE`.

`_EVAL_RE` deliberately does NOT anchor on `_INTERPRETERS` — `eval` is a shell builtin available regardless of which shell is invoking the command.

## Documented punts (recorded inline at regex comments)

- **Variable-substituted eval** (`eval "$cmd"`): substitution happens at shell-runtime, after the hook fires. Cannot inspect. Test `test_eval_variable_substitution_documented_punt` pins ALLOW.
- **`mksh`/`pdksh`**: excluded from `_INTERPRETERS` as conservative bound — rare in modern installs, easy to extend later if observed in any bypass surface.
- **Nested process substitution with parens** (`bash <($(echo git) commit)`): existing #475 limitation; the surrounding context almost always triggers one of the other detectors anyway.

## Test plan

- [x] **27 new tests** in `IndirectExecExtensionTests` class. All BLOCK/ALLOW pairs explicit; helper `_assert_blocked_with_shape(result, shape_label)` validates both the indirect-exec gate AND the specific shape attribution in the block message.
- [x] **Acceptance bullet coverage from #482**:
  - `bash <<EOF\ngit commit ...\nEOF` → BLOCKED naming "heredoc" — `test_bash_heredoc_with_git_commit_blocks` (+ 2 sibling tests for `<<'EOF'` and `<<-EOF` variants)
  - `bash <<<'git commit ...'` → BLOCKED naming "here-string" — `test_bash_herestring_with_git_commit_blocks` (+ double-quoted variant)
  - `eval 'git commit -c user.name=X commit -m foo'` → BLOCKED naming "eval" — `test_eval_with_git_commit_blocks`
  - `eval 'echo hello'` → ALLOWED — `test_eval_no_git_commit_allows`
  - `dash -c 'git commit ...'` → BLOCKED naming "shell -c" — `test_dash_dash_c_with_git_commit_blocks`
  - `ksh -c 'git commit ...'` → BLOCKED naming "shell -c" — `test_ksh_dash_c_with_git_commit_blocks`
  - `bash script.bash` (containing git commit) → BLOCKED naming "shell script" — `test_bash_script_dot_bash_extension_blocks`
  - `bash extensionless-script` (containing git commit) → BLOCKED — `test_bash_script_extensionless_blocks`
- [x] **Defensive coverage** beyond acceptance: cat-heredoc-mentioning-commit ALLOWED (false-positive guard), cat-herestring-mentioning-commit ALLOWED, `bash -c` does NOT false-match as script-path (regression guard for the `-` exclusion in script regex), 256 KiB cap preserved (fail-open on large scripts), unified block message cites both #475 + #482 and lists new shapes inline.
- [x] **All existing 46 tests continue to pass** — strictly additive change to detector dispatcher.
- [x] **Full hooks suite**: 856 passed across `.claude/hooks/tests/` — no sibling-hook regression.
- [x] **256 KiB cap + fail-open OSError discipline preserved** — verified by `test_bash_script_with_size_cap_still_protected`.

```
$ ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/test_validate_commit_identity.py
  73 passed in 0.15s   (46 pre-existing + 27 new)

$ ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/
  856 passed in 1.37s

$ uvx ruff@latest check .claude/hooks/      → All checks passed!
$ uvx ruff@latest format --check .claude/hooks/ → 64 files already formatted
```

## Coordination notes

- Charter `pull-requests.md` § Origin > Local Clone followed for review reference.
- Charter `state-claims.md` § Refresh State Before Claim followed (read-back-verified labels + project board membership before PR close).
- Per memory `feedback_techdebt_literal_line_not_section`, the bare `TechDebt: None` literal line at the top of this PR body is what Hook 4 parses; no `## Tech Debt` markdown section.
- Per memory `feedback_heredoc_in_git_commit`, commit message was written to `/tmp/commit-msg-aino-482.txt` via Write tool and passed via `-F` (not heredoc inline).
- Per memory `feedback_actionlint_needs_shellcheck`: no workflow changes in this PR; `actionlint`/`shellcheck` are both on PATH and verified at session start but not exercised here.

## Related

- `feedback_consumer_against_in_flight_upstream` does NOT apply — this PR has no upstream dependency; #475's PR #479 already merged.
- The cross-domain `env`-wrapper bypass I flagged on PR #483's review (commented on #482 as drift evidence) is NOT closed by this PR. The Aisha+Petra original scope of #482 covers 5 shapes; the env-wrapper finding is row 6 added later via comment. Should be picked up as a follow-up issue or rolled into a Phase B sweep. Mentioned here so the reviewer sees the full open surface and doesn't expect this PR to close the env-wrapper too.
