### PR TITLE
tech-debt(hook): auto_set_env_test — shell-syntax-aware parsing (#478)

### DIFF
--- a/.claude/hooks/auto_set_env_test.py
+++ b/.claude/hooks/auto_set_env_test.py
@@ -26,6 +26,7 @@ Matches (blocks if ENVIRONMENT=test missing on the test segment):
         DEBUG=1 pytest tests/                  (env prefix preserved)
         cd /path && pytest tests/              (chain — env must be on pytest segment)
         pytest tests/ && pytest tests-other/   (chain — env required on BOTH segments)
+        (ENVIRONMENT=test pytest tests/)       (subshell — env recognised inside parens)
 
 Does NOT match (short-circuit skips — #114 fix):
     1. Command whose effective argv[0] is `gh` — `gh` is a GitHub API
@@ -48,10 +49,18 @@ Detection order:
     1. Strip leading `VAR=value` tokens from the command for argv[0] check.
     2. If the next token is `gh`, ALLOW (return None).
     3. If the command contains `--body` or `--body-file`, ALLOW.
-    4. Split on `&&`/`||`/`;`/`|` into segments.
+    4. Split on `&&`/`||`/`;`/`|` into segments using a quote-aware
+       state-machine scanner — separators inside `'...'`, `"..."`, or
+       `\\`-escaped positions are NOT recognised.
     5. For each segment containing `\\bpytest\\b` or `\\bmake\\s+test\\b`,
-       require `\\bENVIRONMENT=test\\b` in that segment's leading env-block;
-       else BLOCK with a per-segment-rewritten suggestion.
+       require `\\bENVIRONMENT=test\\b` in that segment's leading env-block
+       (subshell-aware: a segment that opens with `(` peeks inside the
+       parens for the env-block); else BLOCK with a per-segment-rewritten
+       suggestion, EXCEPT when the test segment is the body of a
+       control-flow construct (`for|while|until|if ... ; do pytest ...`)
+       where splicing env between `;` and `do` would produce invalid
+       shell — there we ALLOW with an operator-readable diagnostic
+       logged via annunaki_log rather than emit a mangled suggestion.
 
 Per-segment env-block check (the #476 silent-bypass fix):
     `ENVIRONMENT=test cd /x && pytest tests/` does NOT pass — even though
@@ -59,12 +68,33 @@ Per-segment env-block check (the #476 silent-bypass fix):
     on the pytest segment. Shell semantics apply env assignments only to
     the immediately-following program in the same segment.
 
+Shell-syntax-awareness scope (#478):
+    The state-machine split handles single quotes, double quotes, and
+    backslash-escapes at the top level. It does NOT recurse into
+    `$(...)` or backtick command substitutions — separators inside
+    `$(... && ...)` will still split, which is acceptable because the
+    inner command would only fire if the substitution were executed and
+    the segment scan would catch any pytest invocation regardless.
+    Subshell-recognition is one-deep: `(((pytest)))` is correctly
+    parsed; nested-with-other-content edge cases bail to the
+    control-flow allow-with-diagnostic path on the side of NOT mangling.
+
+Decision on subshell + control-flow coverage (#478):
+    Both are handled in this PR, NOT punted. Once the state machine is
+    in place for quote-awareness (case #1), subshell detection is a
+    leading-`(` peek and control-flow detection is a sibling-segment
+    keyword check — both cheap. Splitting into separate commits would
+    risk leaving the hook in a half-fixed state where mangled
+    suggestions still ship for cases #2 and #3.
+
 Exit codes:
     0 — allow (not a Bash tool, or skip condition met, or every test
-        segment already has ENVIRONMENT=test in its leading env-block)
-    2 — block (at least one test segment is missing ENVIRONMENT=test)
+        segment already has ENVIRONMENT=test in its leading env-block,
+        or test segment is inside a control-flow body — see #478)
+    2 — block (at least one test segment is missing ENVIRONMENT=test
+        and we can produce a syntactically-valid corrected suggestion)
 
-Enforcement artifact for: noorinalabs/noorinalabs-main#114, #476
+Enforcement artifact for: noorinalabs/noorinalabs-main#114, #476, #478
 """
 
 import json
@@ -83,17 +113,19 @@ _ENV_ASSIGN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=\S*\s+")
 # `--body=x`, and `--body-file path`.
 _BODY_FLAG = re.compile(r"(?<![\w-])--body(?:-file)?(?=[\s=]|$)")
 
-# Shell separators we split on. Order matters in the alternation: longer
-# tokens first so `&&` isn't mis-split as two `|`s by the `|` alternative.
-# Captured group preserves the separator in the split output so we can
-# splice segments back together with original glue.
-_SEPARATORS = re.compile(r"(\s*(?:&&|\|\||;|\|)\s*)")
-
 # Test-runner detection: pytest OR `make test`.
 _TEST_RUNNER = re.compile(r"\bpytest\b|\bmake\s+test\b")
 
 # The literal env-var we require.
 _ENV_TOKEN = re.compile(r"\bENVIRONMENT=test\b")
+
+# Shell control-flow keywords that appear as standalone tokens between
+# segment separators. When a test-bearing segment is bracketed by these,
+# splicing `ENVIRONMENT=test` between the separator and the next program
+# produces invalid shell (e.g. `for f in a; ENVIRONMENT=test do pytest`).
+# Used by the bail-with-diagnostic path in `_rewrite_command` (#478).
+_CONTROL_FLOW_OPENERS = frozenset({"for", "while", "until", "if", "case"})
+_CONTROL_FLOW_BODY_KEYWORDS = frozenset({"do", "done", "then", "else", "elif", "fi", "esac", "in"})
 
 
 def _strip_leading_env(command: str) -> str:
@@ -151,11 +183,103 @@ def _split_segments(command: str) -> list[str]:
     """Split command on `&&`/`||`/`;`/`|`, preserving separators as
     alternating list entries: [seg0, sep0, seg1, sep1, ..., segN].
 
+    Quote-aware (#478): separators inside `'...'`, `"..."`, or
+    `\\`-escaped positions are NOT recognised. The previous regex-only
+    implementation tripped on `git log --grep='fix && pytest'` by
+    treating the `&&` inside the grep pattern as a real separator and
+    classifying the quoted `pytest` token as a test-runner invocation.
+
     The result always has odd length: segments at even indices, separators
     at odd indices. A command with no separators returns a single-element
-    list [command].
+    list [command]. Surrounding whitespace around separators is preserved
+    in the separator entry so segments + separators concat back to the
+    original command byte-for-byte.
+
+    State machine:
+        - quote_char: None | "'" | '"'  (current quoting context)
+        - in_escape:  True after a `\\` outside single quotes (POSIX rule)
+        - Separators only fire when quote_char is None.
+        - Inside `'...'` backslashes are literal (POSIX); inside `"..."`
+          they escape `$` `` ` `` `"` `\\`. We treat `\\` as a generic
+          escape outside single quotes — close enough for the hook's
+          purpose, which is to avoid mis-splitting on quoted operators.
     """
-    return _SEPARATORS.split(command)
+    parts: list[str] = []
+    buf: list[str] = []
+    quote_char: str | None = None
+    in_escape = False
+    i = 0
+    n = len(command)
+    while i < n:
+        ch = command[i]
+        if in_escape:
+            buf.append(ch)
+            in_escape = False
+            i += 1
+            continue
+        if quote_char is not None:
+            if ch == "\\" and quote_char == '"':
+                buf.append(ch)
+                in_escape = True
+                i += 1
+                continue
+            buf.append(ch)
+            if ch == quote_char:
+                quote_char = None
+            i += 1
+            continue
+        # Unquoted context.
+        if ch == "\\":
+            buf.append(ch)
+            in_escape = True
+            i += 1
+            continue
+        if ch in ("'", '"'):
+            buf.append(ch)
+            quote_char = ch
+            i += 1
+            continue
+        # Separator detection — only fires outside quotes.
+        sep = _match_separator_at(command, i)
+        if sep is not None:
+            # Look back over the buffer to find the trailing whitespace
+            # that belongs to the separator group, mirroring the old
+            # regex `\s*(...)\s*` capture.
+            seg = "".join(buf)
+            trailing_ws_len = len(seg) - len(seg.rstrip())
+            parts.append(seg[: len(seg) - trailing_ws_len])
+            ws_before = seg[len(seg) - trailing_ws_len :]
+            j = i + len(sep)
+            ws_after_len = 0
+            while j < n and command[j] in (" ", "\t"):
+                ws_after_len += 1
+                j += 1
+            parts.append(ws_before + sep + command[i + len(sep) : i + len(sep) + ws_after_len])
+            buf = []
+            i = j
+            continue
+        buf.append(ch)
+        i += 1
+    parts.append("".join(buf))
+    return parts
+
+
+def _match_separator_at(command: str, i: int) -> str | None:
+    """Return the longest separator token at position `i`, or None.
+
+    Order is significant: `&&` and `||` must be matched before single
+    `&`/`|` would (we don't recognise bare `&`, but `||` must match
+    before `|`).
+    """
+    if command.startswith("&&", i):
+        return "&&"
+    if command.startswith("||", i):
+        return "||"
+    if command[i] == ";":
+        return ";"
+    if command[i] == "|":
+        return "|"
+    return None
 
 
 def _segment_has_env_in_leading_block(segment: str) -> bool:
@@ -165,15 +289,74 @@ def _segment_has_env_in_leading_block(segment: str) -> bool:
     start of the segment (after stripping surrounding whitespace). This
     is the only position where a shell env assignment applies to the
     segment's program.
+
+    Subshell-aware (#478): if the segment opens with `(`, peek inside
+    the parens at the leading env-block of the subshell contents. This
+    handles `(ENVIRONMENT=test pytest tests/)` — the env is on the
+    correct (sub-)segment's program. We strip the leading `(` and any
+    interior whitespace before re-checking; we do NOT need to find the
+    closing `)` because the env-block check only cares about leading
+    tokens. Nested subshells (`((ENVIRONMENT=test pytest))`) are handled
+    by recursion.
     """
     stripped = segment.lstrip()
+    if stripped.startswith("("):
+        # Strip one layer of subshell parens + interior whitespace, then
+        # recurse. This lets the env-block check see through one or more
+        # nested subshells uniformly.
+        return _segment_has_env_in_leading_block(stripped[1:])
     consumed = stripped[: len(stripped) - len(_strip_leading_env(stripped))]
     return bool(_ENV_TOKEN.search(consumed))
 
 
 def _is_test_segment(segment: str) -> bool:
-    """True if segment contains pytest or `make test` as a real invocation."""
-    return bool(_TEST_RUNNER.search(segment))
+    """True if segment contains pytest or `make test` as a real invocation.
+
+    Quote-aware (#478): a `pytest` token inside `'...'` or `"..."`
+    quoting is NOT a test-runner invocation — it's argument data. The
+    `_split_segments` quote-aware tokenizer already protects against
+    quoted separators triggering bogus segment splits, but a single
+    segment can still contain a quoted `pytest` substring (e.g.
+    `git log --grep='fix pytest'` with no separators at all). This
+    function strips quoted regions before applying the test-runner
+    regex.
+    """
+    return bool(_TEST_RUNNER.search(_strip_quoted_regions(segment)))
+
+
+def _strip_quoted_regions(s: str) -> str:
+    """Return `s` with single-quoted and double-quoted regions replaced
+    by empty strings. Backslash-escapes outside single quotes consume
+    their following char.
+
+    Used by `_is_test_segment` to avoid false-positive matches on
+    `pytest` / `make test` text that appears inside argument quoting.
+    """
+    out: list[str] = []
+    quote_char: str | None = None
+    in_escape = False
+    for ch in s:
+        if in_escape:
+            in_escape = False
+            if quote_char is None:
+                out.append(ch)
+            continue
+        if quote_char is not None:
+            if ch == "\\" and quote_char == '"':
+                in_escape = True
+                continue
+            if ch == quote_char:
+                quote_char = None
+            continue
+        if ch == "\\":
+            in_escape = True
+            out.append(ch)
+            continue
+        if ch in ("'", '"'):
+            quote_char = ch
+            continue
+        out.append(ch)
+    return "".join(out)
 
 
 def _prepend_env_to_segment(segment: str) -> str:
@@ -184,23 +367,111 @@ def _prepend_env_to_segment(segment: str) -> str:
     `DEBUG=1 ENVIRONMENT=test pytest`) and preserves the segment's
     leading whitespace exactly so splicing back into the chain doesn't
     re-shape the original command's formatting.
+
+    Subshell-aware (#478): if segment opens with `(`, the env is
+    inserted INSIDE the parens (after the opening `(` and any interior
+    whitespace). This produces `(ENVIRONMENT=test pytest)` rather than
+    the syntactically-incorrect `ENVIRONMENT=test (pytest)`.
     """
     leading_ws_len = len(segment) - len(segment.lstrip())
     leading_ws = segment[:leading_ws_len]
     body = segment[leading_ws_len:]
+    if body.startswith("("):
+        # Insert inside the subshell. Find the run of whitespace after
+        # the `(` so the env sits flush against the first real token.
+        inner = body[1:]
+        inner_ws_len = len(inner) - len(inner.lstrip())
+        inner_after_ws = inner[inner_ws_len:]
+        # Recurse the env-prepend onto the inner so DEBUG=1 etc. is
+        # preserved inside the subshell.
+        inner_with_env = _prepend_env_to_segment(inner_after_ws)
+        return f"{leading_ws}({inner[:inner_ws_len]}{inner_with_env}"
     body_after_env = _strip_leading_env(body)
     env_block = body[: len(body) - len(body_after_env)]
     return f"{leading_ws}{env_block}ENVIRONMENT=test {body_after_env}"
 
 
-def _rewrite_command(command: str) -> str:
-    """Splice ENVIRONMENT=test onto each test-bearing segment that lacks it."""
+def _is_control_flow_bracketed(parts: list[str], idx: int) -> bool:
+    """True if the segment at `parts[idx]` is part of a shell control-
+    flow construct where splicing `ENVIRONMENT=test` at the segment's
+    leading position would produce invalid shell.
+
+    Three invalid shapes we're guarding against:
+
+    1. **Body-keyword leading segment** —
+       `for f in a b; do pytest $f; done`
+       Splicing onto the `do pytest $f` segment yields
+       `; ENVIRONMENT=test do pytest $f` which is invalid (the `do`
+       keyword must immediately follow the separator).
+
+    2. **Opener-keyword leading segment** (this segment) —
+       `while pytest --quick; do echo ok; done`
+       The leading token is `while` (a control-flow opener); env
+       assignments can only precede simple commands, not compound
+       commands. Splicing yields `ENVIRONMENT=test while pytest ...`
+       which is invalid.
+
+    3. **Body-segment of a prior opener** —
+       `for f in a b; do pytest $f; done`
+       The test segment (`do pytest $f`) follows an opener segment
+       (`for f in a b`). Even after stripping the `do` keyword the
+       splice can't be placed safely without re-tokenising the body.
+
+    Detection:
+       - Segment-leading token is a body keyword (`do`/`then`/...) → bail
+       - Segment-leading token is an opener keyword (`for`/`while`/...) → bail
+       - A PRIOR segment leads with an opener and no closer (`done`/`fi`/...)
+         has intervened → segment is inside a body → bail
+
+    Per the docstring decision (#478), bail means ALLOW with annunaki
+    diagnostic rather than emit a mangled suggestion. The opener-segment
+    case (#2) could in principle be handled by splicing inside the
+    compound (`while ENVIRONMENT=test pytest --quick`) but that requires
+    a token-level rewrite — out of scope for this PR per the design
+    decision recorded in the docstring.
+    """
+    seg = parts[idx].lstrip()
+    first_token = seg.split(None, 1)[0] if seg else ""
+    if first_token in _CONTROL_FLOW_BODY_KEYWORDS:
+        return True
+    if first_token in _CONTROL_FLOW_OPENERS:
+        return True
+    # Look backwards through prior segments for a control-flow opener.
+    # If we find one before another opener-or-body-closing keyword
+    # interrupts the run, treat the current segment as inside its body.
+    for j in range(idx - 2, -1, -2):
+        prior = parts[j].lstrip()
+        prior_first = prior.split(None, 1)[0] if prior else ""
+        if prior_first in _CONTROL_FLOW_OPENERS:
+            return True
+        if prior_first in ("done", "fi", "esac"):
+            # Closer of a previous construct — current segment is OUTSIDE.
+            return False
+    return False
+
+
+def _rewrite_command(command: str) -> tuple[str, list[int]]:
+    """Splice ENVIRONMENT=test onto each test-bearing segment that lacks it.
+
+    Returns (rewritten_command, control_flow_bail_indices). The bail
+    indices are segment positions where the test segment is inside a
+    control-flow body — those are NOT rewritten (the splice would
+    produce invalid shell), and the caller uses the list to emit the
+    bail-with-diagnostic ALLOW path instead of a BLOCK.
+    """
     parts = _split_segments(command)
+    bail_indices: list[int] = []
     for i in range(0, len(parts), 2):
         seg = parts[i]
-        if _is_test_segment(seg) and not _segment_has_env_in_leading_block(seg):
-            parts[i] = _prepend_env_to_segment(seg)
-    return "".join(parts)
+        if not _is_test_segment(seg):
+            continue
+        if _segment_has_env_in_leading_block(seg):
+            continue
+        if _is_control_flow_bracketed(parts, i):
+            bail_indices.append(i)
+            continue
+        parts[i] = _prepend_env_to_segment(seg)
+    return "".join(parts), bail_indices
 
 
 def check(input_data: dict) -> dict | None:
@@ -223,14 +494,57 @@ def check(input_data: dict) -> dict | None:
         return None
 
     parts = _split_segments(command)
-    test_segments = [parts[i] for i in range(0, len(parts), 2) if _is_test_segment(parts[i])]
-    if not test_segments:
+    test_segment_indices = [i for i in range(0, len(parts), 2) if _is_test_segment(parts[i])]
+    if not test_segment_indices:
         return None
 
-    if all(_segment_has_env_in_leading_block(seg) for seg in test_segments):
-        return None
+    # Per-segment env-block + control-flow + subshell evaluation.
+    # Three buckets:
+    #   - satisfied: env-prefixed, no action needed
+    #   - control-flow bail: can't splice without invalid shell → ALLOW + log
+    #   - missing-env: real block, splice produces valid suggestion
+    needs_block = False
+    saw_control_flow_bail = False
+    for i in test_segment_indices:
+        if _segment_has_env_in_leading_block(parts[i]):
+            continue
+        if _is_control_flow_bracketed(parts, i):
+            saw_control_flow_bail = True
+            continue
+        needs_block = True
+    if needs_block:
+        rewritten, _ = _rewrite_command(command)
+        return {
+            "decision": "block",
+            "reason": (
+                "ENVIRONMENT=test is required for test commands but was not found in "
+                "the leading env-block of each test-bearing segment. Shell env "
+                "assignments only apply to the immediately-following program in the "
+                "same segment, so chains like `cd /x && pytest` need the env on the "
+                "pytest segment, not at the start of the whole command. Suggested "
+                "command:\n"
+                f"  {rewritten}"
+            ),
+        }
+    if saw_control_flow_bail:
+        # Every offending test segment is inside a control-flow body.
+        # See #478: erroring on the side of NOT mangling — emit a
+        # operator-readable diagnostic via annunaki_log and ALLOW.
+        return {
+            "decision": "allow_with_log",
+            "reason": (
+                "auto_set_env_test: test-bearing segment is inside a shell "
+                "control-flow construct (for/while/until/if). Cannot safely "
+                "splice ENVIRONMENT=test between the separator and the "
+                "control-flow keyword without producing invalid shell. "
+                "Allowing the command — operator must set ENVIRONMENT=test "
+                "in the body manually if the test runner needs it. "
+                f"Command: {command}"
+            ),
+        }
+    return None
 
-    rewritten = _rewrite_command(command)
+    rewritten, _ = _rewrite_command(command)
     return {
         "decision": "block",
         "reason": (
@@ -262,6 +576,19 @@ def main() -> None:
             tool_name="Bash",
         )
         sys.exit(2)
+    if result and result.get("decision") == "allow_with_log":
+        # Control-flow body bail (#478): log the diagnostic via annunaki
+        # but exit 0 so the operator's command runs. Stderr is suppressed
+        # to keep ALLOW paths quiet at the terminal — annunaki captures
+        # the diagnostic for post-hoc review.
+        command = input_data.get("tool_input", {}).get("command", "")
+        log_pretooluse_block(
+            "auto_set_env_test",
+            command,
+            result["reason"],
+            tool_name="Bash",
+        )
+        sys.exit(0)
     sys.exit(0)
 
 

--- a/.claude/hooks/auto_set_env_test.py
+++ b/.claude/hooks/auto_set_env_test.py
@@ -56,11 +56,14 @@ Detection order:
        require `\\bENVIRONMENT=test\\b` in that segment's leading env-block
        (subshell-aware: a segment that opens with `(` peeks inside the
        parens for the env-block); else BLOCK with a per-segment-rewritten
-       suggestion, EXCEPT when the test segment is the body of a
-       control-flow construct (`for|while|until|if ... ; do pytest ...`)
-       where splicing env between `;` and `do` would produce invalid
-       shell — there we ALLOW with an operator-readable diagnostic
-       logged via annunaki_log rather than emit a mangled suggestion.
+       suggestion. When the test segment is inside a shell control-flow
+       construct (`for|while|until|if ... ; do pytest ...`) where
+       splicing would produce invalid shell, HARD BLOCK with an
+       operator-readable diagnostic that names the construct and offers
+       both inline-env (`do ENVIRONMENT=test pytest`) and pull-out
+       (`ENVIRONMENT=test pytest a b`) alternatives. Allow-with-log
+       would silently bypass the protection (#420 prod-data-wipe class),
+       so we trade UX friction for safety.
 
 Per-segment env-block check (the #476 silent-bypass fix):
     `ENVIRONMENT=test cd /x && pytest tests/` does NOT pass — even though
@@ -76,8 +79,9 @@ Shell-syntax-awareness scope (#478):
     inner command would only fire if the substitution were executed and
     the segment scan would catch any pytest invocation regardless.
     Subshell-recognition is one-deep: `(((pytest)))` is correctly
-    parsed; nested-with-other-content edge cases bail to the
-    control-flow allow-with-diagnostic path on the side of NOT mangling.
+    parsed; nested-with-other-content edge cases fall through to the
+    control-flow HARD BLOCK path with manual-edit diagnostic rather
+    than emit a mangled suggestion.
 
 Decision on subshell + control-flow coverage (#478):
     Both are handled in this PR, NOT punted. Once the state machine is
@@ -89,10 +93,10 @@ Decision on subshell + control-flow coverage (#478):
 
 Exit codes:
     0 — allow (not a Bash tool, or skip condition met, or every test
-        segment already has ENVIRONMENT=test in its leading env-block,
-        or test segment is inside a control-flow body — see #478)
-    2 — block (at least one test segment is missing ENVIRONMENT=test
-        and we can produce a syntactically-valid corrected suggestion)
+        segment already has ENVIRONMENT=test in its leading env-block)
+    2 — block (at least one test segment is missing ENVIRONMENT=test,
+        whether splice-able with a corrected suggestion or inside a
+        control-flow body that requires a manual edit per the diagnostic)
 
 Enforcement artifact for: noorinalabs/noorinalabs-main#114, #476, #478
 """
@@ -423,12 +427,16 @@ def _is_control_flow_bracketed(parts: list[str], idx: int) -> bool:
        - A PRIOR segment leads with an opener and no closer (`done`/`fi`/...)
          has intervened → segment is inside a body → bail
 
-    Per the docstring decision (#478), bail means ALLOW with annunaki
-    diagnostic rather than emit a mangled suggestion. The opener-segment
-    case (#2) could in principle be handled by splicing inside the
-    compound (`while ENVIRONMENT=test pytest --quick`) but that requires
-    a token-level rewrite — out of scope for this PR per the design
-    decision recorded in the docstring.
+    Per the hook docstring decision (#478), control-flow detection
+    triggers a HARD BLOCK with operator-readable diagnostic — never an
+    allow-with-log. Allow-with-log would silently bypass the very
+    protection this hook exists for (the #420 prod-data-wipe class).
+    The diagnostic names the construct family and offers both inline-env
+    and pull-out alternatives; operator picks the right shape and
+    re-issues the command. The opener-segment case (#2) could in
+    principle be handled by splicing inside the compound (`while
+    ENVIRONMENT=test pytest --quick`) but that requires a token-level
+    rewrite — out of scope for this PR.
     """
     seg = parts[idx].lstrip()
     first_token = seg.split(None, 1)[0] if seg else ""
@@ -501,53 +509,28 @@ def check(input_data: dict) -> dict | None:
     # Per-segment env-block + control-flow + subshell evaluation.
     # Three buckets:
     #   - satisfied: env-prefixed, no action needed
-    #   - control-flow bail: can't splice without invalid shell → ALLOW + log
-    #   - missing-env: real block, splice produces valid suggestion
-    needs_block = False
-    saw_control_flow_bail = False
+    #   - control-flow: can't splice cleanly → HARD BLOCK + diagnostic
+    #     (safety direction: never silently allow a pytest run without
+    #     ENVIRONMENT=test even when our rewriter can't produce a valid
+    #     suggestion — #478 hard-block discipline. Allow-with-log would
+    #     bypass the very protection this hook exists for, exactly the
+    #     #420 prod-data-wipe class of failure.)
+    #   - missing-env splice-able: BLOCK with corrected-command suggestion
+    needs_splice_block = False
+    saw_control_flow_block = False
     for i in test_segment_indices:
         if _segment_has_env_in_leading_block(parts[i]):
             continue
         if _is_control_flow_bracketed(parts, i):
-            saw_control_flow_bail = True
+            saw_control_flow_block = True
             continue
-        needs_block = True
-    if needs_block:
+        needs_splice_block = True
+    if needs_splice_block:
         rewritten, _ = _rewrite_command(command)
-        return {
-            "decision": "block",
-            "reason": (
-                "ENVIRONMENT=test is required for test commands but was not found in "
-                "the leading env-block of each test-bearing segment. Shell env "
-                "assignments only apply to the immediately-following program in the "
-                "same segment, so chains like `cd /x && pytest` need the env on the "
-                "pytest segment, not at the start of the whole command. Suggested "
-                "command:\n"
-                f"  {rewritten}"
-            ),
-        }
-    if saw_control_flow_bail:
-        # Every offending test segment is inside a control-flow body.
-        # See #478: erroring on the side of NOT mangling — emit a
-        # operator-readable diagnostic via annunaki_log and ALLOW.
-        return {
-            "decision": "allow_with_log",
-            "reason": (
-                "auto_set_env_test: test-bearing segment is inside a shell "
-                "control-flow construct (for/while/until/if). Cannot safely "
-                "splice ENVIRONMENT=test between the separator and the "
-                "control-flow keyword without producing invalid shell. "
-                "Allowing the command — operator must set ENVIRONMENT=test "
-                "in the body manually if the test runner needs it. "
-                f"Command: {command}"
-            ),
-        }
-    return None
-
-    rewritten, _ = _rewrite_command(command)
-    return {
-        "decision": "block",
-        "reason": (
+        # If the same command also has a control-flow segment we
+        # couldn't rewrite cleanly, surface BOTH so the operator
+        # understands the suggestion may not cover every test segment.
+        reason = (
             "ENVIRONMENT=test is required for test commands but was not found in "
             "the leading env-block of each test-bearing segment. Shell env "
             "assignments only apply to the immediately-following program in the "
@@ -555,8 +538,37 @@ def check(input_data: dict) -> dict | None:
             "pytest segment, not at the start of the whole command. Suggested "
             "command:\n"
             f"  {rewritten}"
-        ),
-    }
+        )
+        if saw_control_flow_block:
+            reason += (
+                "\n\nNote: at least one pytest invocation is inside a shell "
+                "control-flow construct (for/while/until/if) that "
+                "auto_set_env_test cannot safely rewrite. Add ENVIRONMENT=test "
+                "manually inside the body for those segments."
+            )
+        return {"decision": "block", "reason": reason}
+    if saw_control_flow_block:
+        # Every offending test segment is inside a control-flow body.
+        # HARD BLOCK with operator-readable diagnostic — splicing would
+        # produce invalid shell, but allowing would silently bypass the
+        # hook's purpose (#420-class silent-prod-write). Trade UX
+        # friction for safety. Diagnostic names the construct family
+        # and offers both inline-env and pull-out alternatives.
+        return {
+            "decision": "block",
+            "reason": (
+                "pytest detected inside a shell control-flow body "
+                "(for/while/until/if) that auto_set_env_test cannot safely "
+                "rewrite — splicing ENVIRONMENT=test between the separator "
+                "and a control-flow keyword would produce invalid shell. "
+                "Add ENVIRONMENT=test manually inside the body. Example:\n"
+                "  for f in a b; do ENVIRONMENT=test pytest $f; done\n"
+                "Or pull the loop variable outside:\n"
+                "  ENVIRONMENT=test pytest a b\n"
+                f"Original command: {command}"
+            ),
+        }
+    return None
 
 
 def main() -> None:
@@ -576,19 +588,6 @@ def main() -> None:
             tool_name="Bash",
         )
         sys.exit(2)
-    if result and result.get("decision") == "allow_with_log":
-        # Control-flow body bail (#478): log the diagnostic via annunaki
-        # but exit 0 so the operator's command runs. Stderr is suppressed
-        # to keep ALLOW paths quiet at the terminal — annunaki captures
-        # the diagnostic for post-hoc review.
-        command = input_data.get("tool_input", {}).get("command", "")
-        log_pretooluse_block(
-            "auto_set_env_test",
-            command,
-            result["reason"],
-            tool_name="Bash",
-        )
-        sys.exit(0)
     sys.exit(0)
 
 

--- a/.claude/hooks/tests/test_auto_set_env_test.py
+++ b/.claude/hooks/tests/test_auto_set_env_test.py
@@ -540,69 +540,70 @@ class SubshellAwareTests(unittest.TestCase):
         self.assertIsNone(result)
 
 
-class ControlFlowBailTests(unittest.TestCase):
+class ControlFlowHardBlockTests(unittest.TestCase):
     """Issue #478 case 3: `for/while/until/if ... ; do pytest ; done` —
-    the test segment is the BODY of a control-flow construct. Pre-fix
-    the splice would insert env between `;` and `do` producing invalid
-    shell. Post-fix: detect the control-flow context and emit an
-    operator-readable diagnostic + ALLOW rather than mangle. Errors on
-    the side of NOT producing broken suggestions.
+    the test segment is inside a control-flow construct where splicing
+    `ENVIRONMENT=test` between the separator and the control-flow
+    keyword would produce invalid shell.
 
-    Per the design decision recorded in the hook docstring (#478):
-    `allow_with_log` is preferred over `block` when no valid splice
-    exists — operator gets a clear annunaki diagnostic instead of a
-    suggestion they can't apply."""
+    Per design decision (#478): HARD BLOCK with operator-readable
+    diagnostic — never allow-with-log. Allow-with-log would silently
+    bypass the very protection this hook exists for (the #420 prod-
+    data-wipe class of failure). The diagnostic names the construct
+    family and offers both inline-env (`do ENVIRONMENT=test pytest`)
+    and pull-out (`ENVIRONMENT=test pytest a b`) alternatives so the
+    operator picks the right shape and re-issues."""
 
-    def test_for_do_pytest_done_allows_with_log(self) -> None:
+    def test_for_do_pytest_done_hard_blocks_with_diagnostic(self) -> None:
         """POS: `for f in a b; do pytest $f; done` — splice between `;`
-        and `do` would produce invalid shell. Allow with diagnostic
-        rather than emit a mangled suggestion."""
+        and `do` would produce invalid shell. HARD BLOCK with manual-
+        edit diagnostic; operator picks inline-env or pull-out."""
         result = hook.check(_bash("for f in a b; do pytest $f; done"))
         assert result is not None
-        self.assertEqual(result.get("decision"), "allow_with_log")
+        self.assertEqual(result.get("decision"), "block")
+        # Diagnostic must name the construct family.
         self.assertIn("control-flow", result["reason"].lower())
-        # Annunaki diagnostic should include the offending command for
-        # operator review.
-        self.assertIn("for f in a b", result["reason"])
+        # Diagnostic must show both alternatives.
+        self.assertIn("for f in a b; do ENVIRONMENT=test pytest", result["reason"])
+        self.assertIn("ENVIRONMENT=test pytest a b", result["reason"])
+        # Diagnostic must include the original command for operator review.
+        self.assertIn("for f in a b; do pytest $f; done", result["reason"])
 
-    def test_while_pytest_condition_allows_with_log(self) -> None:
+    def test_while_pytest_condition_hard_blocks(self) -> None:
         """POS: `while pytest --quick; do echo ok; done` — segment-
         leading token is `while` (a control-flow opener). Env
         assignments can only precede SIMPLE commands, not compound
         commands, so splicing `ENVIRONMENT=test while pytest ...` would
-        be invalid shell. Bail with diagnostic. (A token-level rewrite
-        could splice inside the compound — `while ENVIRONMENT=test
-        pytest ...` — but that's out of scope for this PR; design
-        decision recorded in hook docstring.)"""
+        be invalid shell. HARD BLOCK with diagnostic."""
         result = hook.check(_bash("while pytest --quick; do echo ok; done"))
         assert result is not None
-        self.assertEqual(result.get("decision"), "allow_with_log")
+        self.assertEqual(result.get("decision"), "block")
+        self.assertIn("control-flow", result["reason"].lower())
 
-    def test_if_pytest_condition_allows_with_log(self) -> None:
+    def test_if_pytest_condition_hard_blocks(self) -> None:
         """POS: `if pytest --smoke; then echo go; fi` — same shape as
         the while-condition: segment-leading token is `if` (opener
-        keyword). Splice would be invalid (env can't precede compound
-        commands). Bail with diagnostic."""
+        keyword). Splice would be invalid. HARD BLOCK with diagnostic."""
         result = hook.check(_bash("if pytest --smoke; then echo go; fi"))
         assert result is not None
-        self.assertEqual(result.get("decision"), "allow_with_log")
+        self.assertEqual(result.get("decision"), "block")
+        self.assertIn("control-flow", result["reason"].lower())
 
-    def test_for_with_env_inside_do_body_allowed(self) -> None:
-        """NEG: `for f in a b; do ENVIRONMENT=test pytest $f; done` —
-        env IS in the leading env-block of the `do pytest` segment
-        (after stripping the `do` keyword? No — `do` is the leading
-        token, not an env assignment). The current implementation
-        treats this as bail-with-log because `do` is the first token
-        regardless of what follows. Operator can confirm env is in the
-        body by reading the annunaki diagnostic; not blocking is the
-        safe behavior."""
+    def test_for_with_env_inside_do_body_hard_blocks(self) -> None:
+        """POS-fall-through: `for f in a b; do ENVIRONMENT=test pytest $f; done`
+        — env IS correctly placed in the body, but body-segment leading
+        token is `do` (not the env assignment), so the env-block check
+        misses it and the control-flow detector fires. Treated as HARD
+        BLOCK to preserve the safety invariant: any test segment we
+        can't analyze cleanly gets blocked, not allowed.
+
+        Known false-positive — operator can work around by moving env
+        outside the loop (`ENVIRONMENT=test pytest a b`). Documented
+        in PR body caveats; future refinement could strip control-flow
+        keywords before re-checking the env-block."""
         result = hook.check(_bash("for f in a b; do ENVIRONMENT=test pytest $f; done"))
-        # Annotated POS-fall-through: current implementation surfaces
-        # this as allow_with_log because the body-segment leading token
-        # is `do`, not `ENVIRONMENT=test`. Future refinement could
-        # strip control-flow keywords before re-checking the env-block.
         assert result is not None
-        self.assertEqual(result.get("decision"), "allow_with_log")
+        self.assertEqual(result.get("decision"), "block")
 
     def test_normal_pytest_after_control_flow_close_still_blocks(self) -> None:
         """POS: `for f in a b; do echo $f; done; pytest tests/` —
@@ -614,19 +615,23 @@ class ControlFlowBailTests(unittest.TestCase):
         self.assertEqual(result.get("decision"), "block")
         self.assertIn("done; ENVIRONMENT=test pytest tests/", result["reason"])
 
-    def test_mixed_control_flow_bail_and_real_block_prefers_block(self) -> None:
+    def test_mixed_control_flow_and_real_block_combined_message(self) -> None:
         """POS: `for f in a b; do pytest $f; done && pytest other/` —
-        first pytest is inside control-flow (bail), second is a normal
-        chain segment (splice-able). Behavior: BLOCK takes precedence
-        — operator gets a suggestion for the fixable segment and the
-        broken-suggestion case is naturally avoided by the bail-aware
-        rewrite returning unchanged for the for-body segment."""
+        first pytest is inside control-flow, second is a normal chain
+        segment. Both block; the suggestion fixes the splice-able
+        segment AND appends a note that the control-flow segment
+        needs manual edit. Splice does NOT mangle the for-body
+        (no broken `; ENVIRONMENT=test do`)."""
         result = hook.check(_bash("for f in a b; do pytest $f; done && pytest other/"))
         assert result is not None
         self.assertEqual(result.get("decision"), "block")
-        # The trailing pytest gets the splice; the for-body pytest is
-        # left alone in the suggestion (no broken `; ENVIRONMENT=test do`).
+        # Splice-able segment gets the fix.
         self.assertIn("&& ENVIRONMENT=test pytest other/", result["reason"])
+        # Control-flow segment is preserved verbatim (no mangle).
+        self.assertNotIn("; ENVIRONMENT=test do", result["reason"])
+        # Combined-message note alerts the operator to the control-flow segment.
+        self.assertIn("control-flow", result["reason"].lower())
+        self.assertIn("manually", result["reason"].lower())
         self.assertNotIn("; ENVIRONMENT=test do", result["reason"])
 
 

--- a/.claude/hooks/tests/test_auto_set_env_test.py
+++ b/.claude/hooks/tests/test_auto_set_env_test.py
@@ -414,5 +414,221 @@ class ShortCircuitWithChainsTests(unittest.TestCase):
         self.assertIsNone(result)
 
 
+class QuoteAwareSplittingTests(unittest.TestCase):
+    """Issue #478 case 1: quoted `&&`/`||`/`;`/`|` and quoted `pytest`
+    tokens must NOT trigger segment-splitting or test-runner detection.
+
+    Pre-fix: the regex split treated quoted separators as real and
+    quoted pytest substrings as real invocations, producing both
+    false-positive blocks and mangled suggestions that inserted env
+    into the middle of a quoted string."""
+
+    def test_quoted_amp_amp_inside_grep_pattern(self) -> None:
+        """NEG: `git log --grep='fix && pytest' && echo done` — the
+        inner `&&` is inside a single-quoted grep pattern; the `pytest`
+        inside it is argument data, not a runner invocation. The OUTER
+        `&& echo done` is the only real separator, and the only segment
+        is `git log --grep=...` (no real pytest) + `echo done`. Allow.
+
+        This is the case 1 repro from #478 — pre-fix the hook blocked
+        with a mangled suggestion that inserted env inside the grep
+        pattern."""
+        result = hook.check(_bash("git log --grep='fix && pytest' && echo done"))
+        self.assertIsNone(
+            result,
+            "quoted && inside grep pattern must not split, "
+            "quoted pytest must not trigger test-runner detection",
+        )
+
+    def test_quoted_double_quoted_pytest_alone(self) -> None:
+        """NEG: `echo "running pytest"` — pytest entirely inside double
+        quotes is a string literal, not a runner invocation."""
+        result = hook.check(_bash('echo "running pytest"'))
+        self.assertIsNone(result)
+
+    def test_quoted_separator_does_not_split(self) -> None:
+        """NEG: `printf '%s' 'a;b|c&&d' ; pytest tests/` — quoted
+        separators inside printf args must not split; the trailing
+        real `;` does split, and the trailing real pytest segment
+        triggers a block. Confirms the quote-state machine correctly
+        re-enters unquoted state after the closing quote."""
+        result = hook.check(_bash("printf '%s' 'a;b|c&&d' ; pytest tests/"))
+        assert result is not None
+        self.assertEqual(result.get("decision"), "block")
+        # Splice should land on the trailing pytest segment, not inside
+        # the quoted printf arg.
+        self.assertIn("ENVIRONMENT=test pytest tests/", result["reason"])
+        self.assertNotIn("ENVIRONMENT=testa;b", result["reason"])
+
+    def test_backslash_escape_outside_quotes_protects_separator(self) -> None:
+        """POS: `echo a \\&\\& pytest` — the escape protects the `&`
+        from being recognised as part of `&&` (verifying the state
+        machine's `in_escape` branch). So the whole string is ONE
+        segment containing both `echo` and the literal `pytest` token.
+        Because `pytest` IS in the segment (not inside quotes), it's
+        flagged as a test invocation and blocked. This is the
+        safe-direction over-block — operator can manually quote the
+        `pytest` if it's data. Test pins the splice destination: env
+        goes at the segment start (before `echo`), not somewhere
+        absurd inside the escaped sequence."""
+        result = hook.check(_bash(r"echo a \&\& pytest"))
+        assert result is not None
+        self.assertEqual(result.get("decision"), "block")
+        # Splice prepends env to the single-segment command.
+        self.assertIn(r"ENVIRONMENT=test echo a \&\& pytest", result["reason"])
+
+    def test_quoted_pytest_with_real_pytest_in_other_segment(self) -> None:
+        """POS: `echo "pytest is great" && pytest tests/` — the quoted
+        pytest is data, the unquoted one is a real invocation. Block,
+        suggestion places env on the real pytest segment ONLY."""
+        result = hook.check(_bash('echo "pytest is great" && pytest tests/'))
+        assert result is not None
+        self.assertEqual(result.get("decision"), "block")
+        self.assertIn(
+            'echo "pytest is great" && ENVIRONMENT=test pytest tests/',
+            result["reason"],
+        )
+
+
+class SubshellAwareTests(unittest.TestCase):
+    """Issue #478 case 2: `(ENVIRONMENT=test pytest tests/)` — the env
+    block is inside a subshell. Pre-fix the detector looked at the
+    segment's leading tokens (which started with `(`) and missed the
+    interior env-block, false-positive-blocking."""
+
+    def test_subshell_with_env_inside_allowed(self) -> None:
+        """NEG: `(ENVIRONMENT=test pytest tests/)` — env is on the
+        correct (sub-)segment's program. Allow."""
+        result = hook.check(_bash("(ENVIRONMENT=test pytest tests/)"))
+        self.assertIsNone(result, "env inside subshell must be recognised")
+
+    def test_subshell_without_env_blocks_with_inside_splice(self) -> None:
+        """POS: `(pytest tests/)` — env missing inside subshell. Block,
+        suggestion places env INSIDE the parens (not before them)."""
+        result = hook.check(_bash("(pytest tests/)"))
+        assert result is not None
+        self.assertEqual(result.get("decision"), "block")
+        self.assertIn("(ENVIRONMENT=test pytest tests/)", result["reason"])
+
+    def test_subshell_with_debug_prefix_inside_allowed(self) -> None:
+        """NEG: `(DEBUG=1 ENVIRONMENT=test pytest tests/)` — env-block
+        inside subshell still allowed when ENVIRONMENT=test is one of
+        the leading assignments."""
+        result = hook.check(_bash("(DEBUG=1 ENVIRONMENT=test pytest tests/)"))
+        self.assertIsNone(result)
+
+    def test_subshell_splice_preserves_debug_prefix(self) -> None:
+        """POS: `(DEBUG=1 pytest tests/)` — env missing, splice inside
+        subshell preserves existing DEBUG=1."""
+        result = hook.check(_bash("(DEBUG=1 pytest tests/)"))
+        assert result is not None
+        self.assertEqual(result.get("decision"), "block")
+        self.assertIn("(DEBUG=1 ENVIRONMENT=test pytest tests/)", result["reason"])
+
+    def test_chained_subshell_segment(self) -> None:
+        """POS: `cd /path && (pytest tests/)` — chain with subshell as
+        the test segment; splice into subshell, leave cd alone."""
+        result = hook.check(_bash("cd /path && (pytest tests/)"))
+        assert result is not None
+        self.assertEqual(result.get("decision"), "block")
+        self.assertIn("cd /path && (ENVIRONMENT=test pytest tests/)", result["reason"])
+
+    def test_chained_subshell_with_env_inside_allowed(self) -> None:
+        """NEG: `cd /path && (ENVIRONMENT=test pytest tests/)` — env on
+        the correct (sub-)segment's program. Allow."""
+        result = hook.check(_bash("cd /path && (ENVIRONMENT=test pytest tests/)"))
+        self.assertIsNone(result)
+
+
+class ControlFlowBailTests(unittest.TestCase):
+    """Issue #478 case 3: `for/while/until/if ... ; do pytest ; done` —
+    the test segment is the BODY of a control-flow construct. Pre-fix
+    the splice would insert env between `;` and `do` producing invalid
+    shell. Post-fix: detect the control-flow context and emit an
+    operator-readable diagnostic + ALLOW rather than mangle. Errors on
+    the side of NOT producing broken suggestions.
+
+    Per the design decision recorded in the hook docstring (#478):
+    `allow_with_log` is preferred over `block` when no valid splice
+    exists — operator gets a clear annunaki diagnostic instead of a
+    suggestion they can't apply."""
+
+    def test_for_do_pytest_done_allows_with_log(self) -> None:
+        """POS: `for f in a b; do pytest $f; done` — splice between `;`
+        and `do` would produce invalid shell. Allow with diagnostic
+        rather than emit a mangled suggestion."""
+        result = hook.check(_bash("for f in a b; do pytest $f; done"))
+        assert result is not None
+        self.assertEqual(result.get("decision"), "allow_with_log")
+        self.assertIn("control-flow", result["reason"].lower())
+        # Annunaki diagnostic should include the offending command for
+        # operator review.
+        self.assertIn("for f in a b", result["reason"])
+
+    def test_while_pytest_condition_allows_with_log(self) -> None:
+        """POS: `while pytest --quick; do echo ok; done` — segment-
+        leading token is `while` (a control-flow opener). Env
+        assignments can only precede SIMPLE commands, not compound
+        commands, so splicing `ENVIRONMENT=test while pytest ...` would
+        be invalid shell. Bail with diagnostic. (A token-level rewrite
+        could splice inside the compound — `while ENVIRONMENT=test
+        pytest ...` — but that's out of scope for this PR; design
+        decision recorded in hook docstring.)"""
+        result = hook.check(_bash("while pytest --quick; do echo ok; done"))
+        assert result is not None
+        self.assertEqual(result.get("decision"), "allow_with_log")
+
+    def test_if_pytest_condition_allows_with_log(self) -> None:
+        """POS: `if pytest --smoke; then echo go; fi` — same shape as
+        the while-condition: segment-leading token is `if` (opener
+        keyword). Splice would be invalid (env can't precede compound
+        commands). Bail with diagnostic."""
+        result = hook.check(_bash("if pytest --smoke; then echo go; fi"))
+        assert result is not None
+        self.assertEqual(result.get("decision"), "allow_with_log")
+
+    def test_for_with_env_inside_do_body_allowed(self) -> None:
+        """NEG: `for f in a b; do ENVIRONMENT=test pytest $f; done` —
+        env IS in the leading env-block of the `do pytest` segment
+        (after stripping the `do` keyword? No — `do` is the leading
+        token, not an env assignment). The current implementation
+        treats this as bail-with-log because `do` is the first token
+        regardless of what follows. Operator can confirm env is in the
+        body by reading the annunaki diagnostic; not blocking is the
+        safe behavior."""
+        result = hook.check(_bash("for f in a b; do ENVIRONMENT=test pytest $f; done"))
+        # Annotated POS-fall-through: current implementation surfaces
+        # this as allow_with_log because the body-segment leading token
+        # is `do`, not `ENVIRONMENT=test`. Future refinement could
+        # strip control-flow keywords before re-checking the env-block.
+        assert result is not None
+        self.assertEqual(result.get("decision"), "allow_with_log")
+
+    def test_normal_pytest_after_control_flow_close_still_blocks(self) -> None:
+        """POS: `for f in a b; do echo $f; done; pytest tests/` —
+        control-flow construct closes with `done`, then a normal
+        pytest segment follows. The trailing pytest is NOT inside the
+        control-flow body and the splice IS safe there."""
+        result = hook.check(_bash("for f in a b; do echo $f; done; pytest tests/"))
+        assert result is not None
+        self.assertEqual(result.get("decision"), "block")
+        self.assertIn("done; ENVIRONMENT=test pytest tests/", result["reason"])
+
+    def test_mixed_control_flow_bail_and_real_block_prefers_block(self) -> None:
+        """POS: `for f in a b; do pytest $f; done && pytest other/` —
+        first pytest is inside control-flow (bail), second is a normal
+        chain segment (splice-able). Behavior: BLOCK takes precedence
+        — operator gets a suggestion for the fixable segment and the
+        broken-suggestion case is naturally avoided by the bail-aware
+        rewrite returning unchanged for the for-body segment."""
+        result = hook.check(_bash("for f in a b; do pytest $f; done && pytest other/"))
+        assert result is not None
+        self.assertEqual(result.get("decision"), "block")
+        # The trailing pytest gets the splice; the for-body pytest is
+        # left alone in the suggestion (no broken `; ENVIRONMENT=test do`).
+        self.assertIn("&& ENVIRONMENT=test pytest other/", result["reason"])
+        self.assertNotIn("; ENVIRONMENT=test do", result["reason"])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Requestor: Weronika Zielinska
Requestee: Weronika Zielinska
RequestOrReplied: (blank)
TechDebt: none
Closes #478

## Summary

Three shell-syntax-awareness fixes to `auto_set_env_test` hook, all rooted in the same `_split_segments` regex-unawareness limitation. Follow-up to #477 (closed #476).

| Case | Pre-fix | Post-fix |
|---|---|---|
| 1. Quoted `&&`/`pytest` inside arg strings | False-positive split + mangled suggestion that inserts env inside the quoted region | Quote-aware state machine; quoted separators don't split, quoted `pytest` substrings don't trigger detection |
| 2. `(ENVIRONMENT=test pytest)` subshell | False-positive block — segment leading token is `(`, env-block check misses interior | Subshell-aware env-block check peeks inside parens; splice INSIDE parens when needed |
| 3. `for f in a b; do pytest $f; done` control-flow body | Block with syntactically-invalid suggestion (`for f in a b; ENVIRONMENT=test do pytest`) | **HARD BLOCK** with operator-readable diagnostic naming the construct (for/while/if) and showing both inline-env and pull-out alternatives |

## Design decision (recorded in hook docstring)

Subshell + control-flow handled in this PR, NOT punted. Once the state machine is in place for quote-awareness (case #1), both case #2 (subshell-aware env detection via leading-`(` peek) and case #3 (control-flow detection + hard block) are cheap additions. Splitting into separate commits would risk leaving the hook in a half-fixed state where mangled suggestions still ship for cases #2 and #3.

## Why option 3 (hand-rolled state machine) over option 1 (shlex)

Overrode the issue body's recommendation after reading the actual code:

- `shlex.split` discards separator positions AND whitespace. The existing `_SEPARATORS` regex uses a capturing group specifically to splice segments back into the original command with byte-exact glue. Switching to shlex would mean rebuilding the entire splice pipeline.
- `shlex` doesn't recognise `&&`/`||` as separators by default. Would still need post-process for separator detection.
- Net effect: option 1 (shlex) actually requires MORE code than option 3 (hand-rolled). Option 3 also preserves the hook codebase's dependency-free style (option 2 — bashlex — adds a runtime dep).

## Case #3 hard-block design (per team-lead direction)

Initial implementation used `allow_with_log` for the control-flow case. Flipped to **HARD BLOCK** per team-lead correction:

> Allow-with-log says "we detected pytest, we know the env is missing, but we can't rewrite cleanly so we'll allow it" — that's silently bypassing the very protection. Failure direction matters more than UX friction here.

The mangled-suggestion failure is bad in the SAFE direction (operator doesn't run the command). Allow-with-log is bad in the UNSAFE direction (operator runs pytest without `ENVIRONMENT=test`, the exact #420 prod-data-wipe class this hook protects against).

Diagnostic format:
```
pytest detected inside a shell control-flow body (for/while/until/if)
that auto_set_env_test cannot safely rewrite — splicing ENVIRONMENT=test
between the separator and a control-flow keyword would produce invalid
shell. Add ENVIRONMENT=test manually inside the body. Example:
  for f in a b; do ENVIRONMENT=test pytest $f; done
Or pull the loop variable outside:
  ENVIRONMENT=test pytest a b
Original command: <command>
```

**Combined case** — `for f in a b; do pytest $f; done && pytest other/` (control-flow + splice-able): suggestion fixes the splice-able segment AND appends a note pointing at the control-flow segment for manual edit. Splice does NOT mangle the for-body.

Detected control-flow shapes:
- Segment leading with opener keyword (`for`/`while`/`until`/`if`/`case`)
- Segment leading with body keyword (`do`/`then`/`done`/`fi`/`else`/`elif`/`esac`/`in`)
- Segment in the body of a PRIOR opener (backward scan, stops at `done`/`fi`/`esac` closer)

## Scope NOT covered (caveats explicit)

- `$(...)` and backtick command substitutions — separators inside still split. Acceptable because the inner command only fires if the substitution executes, and any pytest invocation inside would be re-caught by the segment scan.
- `for f in a b; do ENVIRONMENT=test pytest $f; done` (env CORRECTLY placed in body) is BLOCKED as a known false-positive — body-segment leading token is `do`, not the env assignment, so the env-block check misses it and the control-flow detector fires. Trade for the safety invariant: any test segment we can't analyze cleanly is blocked, not allowed. Operator workaround: move env outside the loop (`ENVIRONMENT=test pytest a b`). Future refinement could strip control-flow keywords before re-checking the env-block.
- Token-level rewrite of `while pytest --quick` opener segment to `while ENVIRONMENT=test pytest --quick` (which IS valid shell). Currently HARD BLOCKS with diagnostic instead. Could be a future refinement if operator feedback shows the block is too restrictive.

## Acceptance criteria (from #478)

- [x] Test: `git log --grep='fix && pytest' && echo done` — quote-recognized, suggestion does NOT mangle the quoted segment (`QuoteAwareSplittingTests::test_quoted_amp_amp_inside_grep_pattern`)
- [x] Test: `(ENVIRONMENT=test pytest tests/)` — subshell-aware → allowed (`SubshellAwareTests::test_subshell_with_env_inside_allowed`)
- [x] Test: `for f in a b; do pytest $f; done` — **HARD BLOCK** with operator-readable diagnostic naming the construct and showing both alternatives (`ControlFlowHardBlockTests::test_for_do_pytest_done_hard_blocks_with_diagnostic`)
- [x] Test: `while pytest --quick; do echo ok; done` and `if pytest --smoke; then echo go; fi` — both HARD BLOCK with diagnostic
- [x] All 48 existing tests in `.claude/hooks/tests/test_auto_set_env_test.py` continue to pass
- [x] Decision recorded in PR body + hook docstring

## Test results

- 65 total tests (48 existing + 17 new); all pass.
- 846 total hooks tests pass — no regressions in adjacent hooks.
- `ruff format --check` + `ruff check` clean; pre-commit hooks pass.

## Test plan

- [x] All 65 unit tests pass: `ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/test_auto_set_env_test.py -v`
- [x] Full hooks suite passes: `ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/ -q`
- [x] Ruff format + lint clean
- [ ] Post-merge: smoke test `(ENVIRONMENT=test pytest)` subshell form in a real session — should be allowed without prompt
- [ ] Post-merge: smoke test `git log --grep='fix && pytest'` — should be allowed without prompt
- [ ] Post-merge: smoke test `for f in a b; do pytest $f; done` — should HARD BLOCK with manual-edit diagnostic (no silent run)
