### PR TITLE
tech-debt(annunaki_monitor): tighten SILENT_BOOLEAN_TEST_PATTERNS (3 gaps + micro-cleanup, #490, #481 follow-up)

### DIFF
--- a/.claude/hooks/annunaki_monitor.py
+++ b/.claude/hooks/annunaki_monitor.py
@@ -68,34 +68,64 @@ IGNORE_PATTERNS = [
     re.compile(r"error_log|error\.log|errorhandl", re.IGNORECASE),  # filenames
 ]
 
-# Silent-boolean-test idioms (#474): commands whose ONLY failure signal is a
-# non-zero exit code with empty stdout/stderr — by design, not an error.
-# After #473 closed the silent-failure blind spot, these idioms became noise.
-# Apply ONLY when matched_patterns is exactly ["exit_code=..."] (no stdout or
-# stderr pattern matched) — pattern matches always win, ignore-on-silent-exit
-# never suppresses a real error.
+# Silent-boolean-test idioms (#474, tightened #490): commands whose ONLY
+# failure signal is a non-zero exit code with empty stdout/stderr — by
+# design, not an error. After #473 closed the silent-failure blind spot,
+# these idioms became noise. Apply ONLY when matched_patterns is exactly
+# ["exit_code=..."] (no stdout or stderr pattern matched) — pattern
+# matches always win, ignore-on-silent-exit never suppresses a real error.
+#
+# #490 changes vs #474:
+#   - Removed `^\s*if\s+\[` and `^\s*if\s+\[\[` (gap #3): outer `if [` matched
+#     even when the body — a real deploy step — was the failing command, so
+#     silenced genuine failures. The `[ ... ]` regex still covers bare
+#     condition-only commands; if-bodies now log on their own merit.
+#   - Removed redundant `^\s*\[\[` (micro-cleanup): `^\s*\[` already matches
+#     `[[` (both start with `[`).
+#   - Extended grep regex to handle split-flag forms (`grep -E -q ...`) in
+#     addition to combined-flag forms (`grep -qE`, `grep -Eq`).
 SILENT_BOOLEAN_TEST_PATTERNS = [
-    re.compile(r"^\s*\["),  # POSIX `[ ... ]` test
-    re.compile(r"^\s*\[\["),  # Bash `[[ ... ]]` test
+    re.compile(r"^\s*\["),  # POSIX `[ ... ]` test (also matches `[[`)
     re.compile(r"^\s*test\b"),  # explicit `test` builtin
-    re.compile(r"\bgrep\s+-[a-zA-Z]*q"),  # grep -q (and -qE, -qi, etc.)
+    # grep with -q anywhere in the flag sequence: combined (-qE, -Eq, -qi)
+    # or split (-E -q, -i -q). Non-capturing repeated `-flags \s+` prefix
+    # allows any number of intermediate flag tokens before the -*q* terminal.
+    re.compile(r"\bgrep\s+(?:-[a-zA-Z]+\s+)*-[a-zA-Z]*q"),
     re.compile(r"^\s*(pgrep|pkill)\b"),  # process find/signal, exit 1 on no match
     re.compile(r"^\s*(which|command\s+-v)\b"),  # which/command -v not-found
-    re.compile(r"\bdiff\s+--quiet\b"),  # diff --quiet: exit 1 on differences
-    re.compile(r"\bgit\s+diff\s+--quiet\b"),  # git diff --quiet: same
-    re.compile(r"^\s*if\s+\["),  # `if [ ... ]; then ...; fi` whole-conditional
-    re.compile(r"^\s*if\s+\[\["),  # `if [[ ... ]]; then ...; fi`
+]
+
+# Idioms with exit-code-conditional skip (#490 gap #2): these tools use
+# exit_code as a SIGNAL channel where some codes are by-design and others
+# are real errors. Listed here as (pattern, by_design_codes) so the skip
+# only fires when the exit_code is in the by-design set. Any other exit
+# code falls through to LOG.
+#
+# `diff` and `git diff --quiet` exit-code semantics:
+#   0 — identical
+#   1 — files differ (by-design idiom; suppress)
+#   2 — trouble (couldn't open, permission denied, etc.; LOG)
+SILENT_BOOLEAN_TEST_PATTERNS_BY_EXIT_CODE = [
+    (re.compile(r"\bdiff\s+--quiet\b"), {1}),
+    (re.compile(r"\bgit\s+diff\s+--quiet\b"), {1}),
 ]
 
 
-def _is_silent_boolean_test(command: str) -> bool:
+def _is_silent_boolean_test(command: str, exit_code: int = 0) -> bool:
     """Return True if command matches a documented silent-boolean-test idiom.
 
     Caller must additionally verify that the ONLY failure signal is exit_code
     (no stdout/stderr pattern match) — pattern matches always take precedence.
+
+    For exit-code-conditional idioms (diff --quiet, git diff --quiet), the
+    skip only fires when exit_code is in the by-design set documented for
+    that tool. Any other non-zero code falls through to LOG.
     """
     for pattern in SILENT_BOOLEAN_TEST_PATTERNS:
         if pattern.search(command):
+            return True
+    for pattern, by_design_codes in SILENT_BOOLEAN_TEST_PATTERNS_BY_EXIT_CODE:
+        if pattern.search(command) and exit_code in by_design_codes:
             return True
     return False
 
@@ -180,7 +210,9 @@ def check(input_data: dict) -> dict | None:
     # boolean-test idioms whose failure branch is by-design. Stderr/stdout
     # pattern matches always win — a `[ -f x ]` that somehow emits a real
     # Traceback still logs.
-    if matched_patterns == [f"exit_code={exit_code}"] and _is_silent_boolean_test(command):
+    if matched_patterns == [f"exit_code={exit_code}"] and _is_silent_boolean_test(
+        command, exit_code
+    ):
         return None
 
     error_lines = _extract_error_lines(combined_output)

--- a/.claude/hooks/tests/test_annunaki_monitor.py
+++ b/.claude/hooks/tests/test_annunaki_monitor.py
@@ -261,15 +261,22 @@ class SilentBooleanTestIdiomTests(unittest.TestCase):
         result = am.check(_bash_event("git diff --quiet", exit_code=1))
         self.assertIsNone(result)
 
-    def test_if_bracket_conditional_silent_exit_not_logged(self):
-        """NEG: `if [ -f x ]; then ...; fi` whole conditional with exit-1
-        false-branch → no log."""
-        result = am.check(_bash_event("if [ -f /nonexistent ]; then echo yes; fi", exit_code=1))
+    def test_if_bracket_conditional_false_branch_exit_zero_not_logged(self):
+        """NEG: `if [ -f /nonexistent ]; then echo unreachable; fi` exits 0
+        (false branch, body skipped) → no log. The whole-`if` regex was
+        removed in #490 because it silenced body failures (gap #3); the
+        false-branch path is now handled by exit_code=0 not being an error,
+        not by idiom-skip."""
+        result = am.check(
+            _bash_event("if [ -f /nonexistent ]; then echo unreachable; fi", exit_code=0)
+        )
         self.assertIsNone(result)
 
-    def test_if_double_bracket_conditional_silent_exit_not_logged(self):
-        """NEG: `if [[ ... ]]; then ...; fi` shape → no log."""
-        result = am.check(_bash_event("if [[ -f /nonexistent ]]; then echo yes; fi", exit_code=1))
+    def test_if_double_bracket_conditional_false_branch_exit_zero_not_logged(self):
+        """NEG: same shape with `[[`. exit 0 → no log."""
+        result = am.check(
+            _bash_event("if [[ -f /nonexistent ]]; then echo unreachable; fi", exit_code=0)
+        )
         self.assertIsNone(result)
 
     # --- Precedence: pattern match wins over idiom-on-silent-exit ---
@@ -374,6 +381,113 @@ class AinoFollowupTests(unittest.TestCase):
         )
         self.assertIsNone(result, "_should_ignore must precede exit-code capture")
         self.assertFalse(self._errors_path.exists())
+
+
+class IdiomTighteningTests(unittest.TestCase):
+    """#490 coverage: the 3 gaps + micro-cleanup Aisha surfaced on PR #481's
+    secondary review. Headline regression case is gap #3 — `if [ ... ]; then
+    real-failure; fi` must log the body's exit-1 failure, not be silenced."""
+
+    def setUp(self):
+        self._saved_env = {
+            "ENVIRONMENT": os.environ.pop("ENVIRONMENT", None),
+            "NOORIN_HOOK_TEST_MODE": os.environ.pop("NOORIN_HOOK_TEST_MODE", None),
+        }
+        am._seen_hashes.clear()
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self._errors_path = Path(self._tmpdir.name) / "errors.jsonl"
+        self._orig_monitor_file = am.ERRORS_FILE
+        self._orig_log_file = alog.ERRORS_FILE
+        am.ERRORS_FILE = self._errors_path
+        alog.ERRORS_FILE = self._errors_path
+
+    def tearDown(self):
+        am.ERRORS_FILE = self._orig_monitor_file
+        alog.ERRORS_FILE = self._orig_log_file
+        self._tmpdir.cleanup()
+        for k, v in self._saved_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    # --- Gap #1: split-flag grep -q forms ---
+
+    def test_grep_split_flag_dash_E_dash_q_silent_exit_not_logged(self):
+        """NEG (#490 gap #1): `grep -E -q pattern file` exit 1 silent → no
+        log. Split-flag form was missed by the combined-flag-only regex
+        before tightening."""
+        result = am.check(_bash_event("grep -E -q '^foo' /tmp/file.txt", exit_code=1))
+        self.assertIsNone(result, "split-flag `grep -E -q` must skip")
+
+    def test_grep_split_flag_dash_i_dash_q_silent_exit_not_logged(self):
+        """NEG (#490 gap #1): `grep -i -q pattern file` exit 1 silent → no
+        log. Order-independent."""
+        result = am.check(_bash_event("grep -i -q bar /tmp/file.txt", exit_code=1))
+        self.assertIsNone(result)
+
+    # --- Gap #2: diff --quiet exit_code discrimination ---
+
+    def test_diff_quiet_exit_2_trouble_logged(self):
+        """POS (#490 gap #2): `diff --quiet a b` exit 2 (couldn't open,
+        permission denied) → MUST log even with empty stderr. Exit 2 is
+        "trouble", not by-design differs-signal."""
+        result = am.check(_bash_event("diff --quiet /tmp/a /tmp/b", exit_code=2))
+        self.assertIsNotNone(result, "diff --quiet exit=2 trouble must log")
+        rec = _read_records(self._errors_path)[0]
+        self.assertEqual(rec["exit_code"], 2)
+        self.assertIn("exit_code=2", rec["matched_patterns"])
+
+    def test_git_diff_quiet_exit_2_trouble_logged(self):
+        """POS (#490 gap #2): git diff --quiet variant of the trouble exit
+        discrimination. Exit 2 → log."""
+        result = am.check(_bash_event("git diff --quiet", exit_code=2))
+        self.assertIsNotNone(result, "git diff --quiet exit=2 trouble must log")
+
+    def test_diff_quiet_exit_1_differs_still_skipped(self):
+        """NEG (#490 gap #2 regression guard): exit 1 (the by-design
+        differs-signal) → still skipped per #474. The fix narrows the skip
+        condition, doesn't broaden the log condition."""
+        result = am.check(_bash_event("diff --quiet /tmp/a /tmp/b", exit_code=1))
+        self.assertIsNone(result, "diff --quiet exit=1 differs is still by-design")
+
+    # --- Gap #3 HEADLINE: if [ ...; ]; then real-failure; fi must log ---
+
+    def test_if_bracket_with_failing_body_logged(self):
+        """POS (#490 gap #3 HEADLINE): `if [ -d /tmp ]; then false; fi`
+        exit 1 (body failed, condition was truthy) → MUST log. This was the
+        regression case — the old `^\\s*if\\s+\\[` regex matched the outer
+        `if [` and suppressed the real body failure."""
+        result = am.check(_bash_event("if [ -d /tmp ]; then false; fi", exit_code=1))
+        self.assertIsNotNone(
+            result, "if-conditional body failure must log; idiom-skip must not silence it"
+        )
+        rec = _read_records(self._errors_path)[0]
+        self.assertEqual(rec["exit_code"], 1)
+
+    def test_if_double_bracket_with_failing_body_logged(self):
+        """POS (#490 gap #3): `[[` variant of the headline case → log."""
+        result = am.check(_bash_event("if [[ -d /tmp ]]; then false; fi", exit_code=1))
+        self.assertIsNotNone(result)
+
+    def test_if_bracket_false_condition_exit_zero_skipped(self):
+        """NEG (#490 gap #3 invariant): false condition (exit 0 because
+        else-branch is empty / body not entered) → no log. Preserves the
+        existing "happy path of the false branch is silent" behavior."""
+        result = am.check(
+            _bash_event("if [ -d /nonexistent ]; then echo unreachable; fi", exit_code=0)
+        )
+        self.assertIsNone(result, "false-condition exit-0 stays silent")
+
+    # --- Micro-cleanup: redundant `^\s*\[\[` removal regression guard ---
+
+    def test_bash_double_bracket_still_skipped_after_dedup(self):
+        """NEG (#490 micro-cleanup regression guard): `[[ -f x ]]` exit 1
+        silent → no log. The line-79 `^\\s*\\[\\[` regex was removed because
+        `^\\s*\\[` already matches `[[` (both start with `[`). This test
+        confirms `[[` is still covered by the dedup'd list."""
+        result = am.check(_bash_event("[[ -f /nonexistent ]]", exit_code=1))
+        self.assertIsNone(result, "[[ idiom must still skip after dedup")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Follow-up to PR #481 (which closed #474). Aisha Idrissi's 2° verdict on #481 surfaced 3 gaps + 1 micro-cleanup in the new `SILENT_BOOLEAN_TEST_PATTERNS` idiom-skip logic.

**Gap #1** — split-flag `grep -E -q`: extend the grep regex to `\bgrep\s+(?:-[a-zA-Z]+\s+)*-[a-zA-Z]*q`. Combined-flag (`-qE`, `-Eq`, `-qi`) still matches; split-flag (`-E -q`, `-i -q`) now also matches. *Under-skip direction — was logging by-design noise.*

**Gap #2** — `diff --quiet` exit=2 trouble: split into a new `SILENT_BOOLEAN_TEST_PATTERNS_BY_EXIT_CODE` list of `(pattern, by_design_codes)` tuples. `diff --quiet` / `git diff --quiet` only skip on exit_code=1 (the documented differs-signal); exit 2 (trouble — file-open failure, permission denied) now logs even with empty stderr. *Over-skip direction — was silencing real errors.*

**Gap #3 HEADLINE** — `if [ -d /target ]; then real-failure; fi`: remove `^\s*if\s+\[` and `^\s*if\s+\[\[` from `SILENT_BOOLEAN_TEST_PATTERNS` (option a from issue body). The outer `if [` regex matched even when the body — a real deploy step — was the failing command, silencing genuine failures. The existing `^\s*\[` regex still covers bare condition-only commands. Body failures now log on their own merit.

**Micro-cleanup** — `^\s*\[\[` removed (`^\s*\[` already matches `[[` since both start with `[`; the OR-loop short-circuits on the first match).

## Test plan

- [x] `grep -E -q pattern file` exit=1, no stderr → SKIP (`test_grep_split_flag_dash_E_dash_q_silent_exit_not_logged`)
- [x] `grep -i -q pattern file` exit=1, no stderr → SKIP (`test_grep_split_flag_dash_i_dash_q_silent_exit_not_logged`)
- [x] `diff --quiet a b` exit=2, no stderr → LOG (`test_diff_quiet_exit_2_trouble_logged`)
- [x] `git diff --quiet` exit=2, no stderr → LOG (`test_git_diff_quiet_exit_2_trouble_logged`)
- [x] `diff --quiet a b` exit=1, no stderr → SKIP (`test_diff_quiet_exit_1_differs_still_skipped` — preserved)
- [x] `if [ -d /tmp ]; then false; fi` exit=1, no stderr → LOG (`test_if_bracket_with_failing_body_logged` — HEADLINE)
- [x] `if [[ -d /tmp ]]; then false; fi` exit=1, no stderr → LOG (`test_if_double_bracket_with_failing_body_logged`)
- [x] `if [ -d /nonexistent ]; then echo unreachable; fi` exit=0 → SKIP (`test_if_bracket_false_condition_exit_zero_skipped`)
- [x] `[[ -f /nonexistent ]]` exit=1, no stderr → SKIP (`test_bash_double_bracket_still_skipped_after_dedup` — micro-cleanup regression guard)
- [x] **37 tests pass total** (was 28 — added 9 new in `IdiomTighteningTests`)
- [x] `uvx ruff check` + `uvx ruff format --check` on both files: clean
- [x] Pre-commit hooks (ruff-format, ruff-lint, mypy): passed

## Test-update note

2 existing tests from #481 were UPDATED, not preserved:
- `test_if_bracket_conditional_silent_exit_not_logged` → `test_if_bracket_conditional_false_branch_exit_zero_not_logged`
- `test_if_double_bracket_conditional_silent_exit_not_logged` → `test_if_double_bracket_conditional_false_branch_exit_zero_not_logged`

The original tests asserted the OLD whole-`if` suppression behavior — exactly the bug #490 fixes. Preserving them would re-assert the regression. The updated tests cover the preserved-behavior invariant from the acceptance criteria ("false-condition path; existing behavior preserved"), reframed around exit_code=0 instead of the (now-removed) whole-`if` suppression path.

Requestor: Lucas Ferreira
Requestee: Lucas Ferreira
RequestOrReplied:
TechDebt: none
Closes #490
