### PR TITLE
tech-debt(ci): extend lint/format/typecheck/smoke to .claude/lib/ + add pytest gate (#491)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           python-version: "3.12"
       - run: pip install ruff
-      - run: ruff check .claude/hooks/
+      - run: ruff check .claude/hooks/ .claude/lib/
 
   format:
     name: Ruff format check
@@ -39,7 +39,7 @@ jobs:
         with:
           python-version: "3.12"
       - run: pip install ruff
-      - run: ruff format --check .claude/hooks/
+      - run: ruff format --check .claude/hooks/ .claude/lib/
 
   typecheck:
     name: Mypy type check
@@ -50,7 +50,7 @@ jobs:
         with:
           python-version: "3.12"
       - run: pip install mypy
-      - run: mypy .claude/hooks/ --ignore-missing-imports --no-error-summary
+      - run: mypy .claude/hooks/ .claude/lib/ --ignore-missing-imports --no-error-summary
 
   smoke-test:
     name: Smoke test — hooks compile and exit cleanly
@@ -60,9 +60,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - name: Verify all hooks compile
+      - name: Verify all hooks and lib files compile
         run: |
-          for f in .claude/hooks/*.py; do
+          for f in .claude/hooks/*.py .claude/lib/*.py; do
             python3 -c "import py_compile; py_compile.compile('$f', doraise=True)"
           done
       - name: Verify hooks exit 0 on empty stdin
@@ -70,3 +70,17 @@ jobs:
           for f in .claude/hooks/*.py; do
             echo '{}' | python3 "$f" || true
           done
+
+  pytest:
+    name: Pytest — hooks and lib test suites
+    runs-on: ubuntu-latest
+    env:
+      ENVIRONMENT: test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install pytest
+      - name: Run hook and lib tests
+        run: pytest .claude/hooks/tests/ .claude/lib/tests/ -q

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ setup-hooks:
 	pre-commit install
 
 lint:
-	python3 -m ruff check .claude/hooks/
+	python3 -m ruff check .claude/hooks/ .claude/lib/
 
 format:
-	python3 -m ruff format .claude/hooks/
+	python3 -m ruff format .claude/hooks/ .claude/lib/


### PR DESCRIPTION
## Summary

- Extends lint, format, typecheck, and smoke-test jobs to cover `.claude/lib/` in addition to `.claude/hooks/`. Prior to this PR, a `.claude/lib/`-only change would trigger CI (via the paths filter added in #488) but all 4 jobs would no-op against the changed files.
- Adds a new `pytest` job running `.claude/hooks/tests/` and `.claude/lib/tests/` with `ENVIRONMENT: test` set at job level. There was no mechanical CI gate for the 882-test suite; test regressions were only caught by PR-author local discipline.
- Aligns `make lint` and `make format` targets to match the extended CI scope.

## CI duration impact

Expected impact: **+30–60s** from the new `pytest` job (local runtime ~1.4s for 882 tests; CI overhead dominates). The 4 extended jobs (lint/format/typecheck/smoke) add negligible time — they parallelize and the lib surface is small (1 file + 1 test file currently).

## Local verification

- `ruff check .claude/hooks/ .claude/lib/`: clean
- `ruff format --check .claude/hooks/ .claude/lib/`: clean (66 files formatted)
- `mypy .claude/hooks/ .claude/lib/ --ignore-missing-imports --no-error-summary`: 0 errors
- `ENVIRONMENT=test pytest .claude/hooks/tests/ .claude/lib/tests/ -q`: **882 passed, 19 subtests passed** (baseline before and after changes identical)

No mypy or ruff issues found in `.claude/lib/` at time of extension — no fixes needed.

## Files modified

- `.github/workflows/ci.yml` — 4 jobs extended + 1 new pytest job
- `Makefile` — lint/format targets extended to `.claude/lib/`

Closes #491

---

**Requestor:** Aino Virtanen
**Requestee:** Aino Virtanen
**RequestOrReplied:** N/A (author PR)
**TechDebt:** none