### PR TITLE
ontology: add encryption_at_rest: SSE-B2 to state_backend (#501)

### DIFF
--- a/ontology/repos/deploy.yaml
+++ b/ontology/repos/deploy.yaml
@@ -24,7 +24,7 @@ terraform_modules:
         path: terraform/hetzner/envs/prod/
         server: { name: noorinalabs-prod, type: CPX41, location: ash, image: ubuntu-24.04 }
         state_key: hetzner/prod.tfstate
-    state_backend: { type: s3, bucket: noorinalabs-terraform-state, endpoint: backblaze-b2, region: us-east-005 }
+    state_backend: { type: s3, bucket: noorinalabs-terraform-state, endpoint: backblaze-b2, region: us-east-005, encryption_at_rest: SSE-B2 }
     firewall_rules: [SSH/22, HTTP/80, HTTPS/443]
     outputs_per_env: [env, server_name, server_ip, server_ipv6, ssh_target, labels, server_status]
     notes:

--- a/ontology/services.yaml
+++ b/ontology/services.yaml
@@ -318,6 +318,7 @@ infrastructure:
   state_backend:
     type: Backblaze B2 (S3-compatible)
     bucket: noorinalabs-terraform-state
+    encryption_at_rest: SSE-B2  # enabled 2026-04-30 per noorinalabs-deploy#172
     used_by: [terraform/hetzner, terraform/cloudflare]
 
   container_registry:


### PR DESCRIPTION
## Summary
Add `encryption_at_rest: SSE-B2` field on the `state_backend` ontology entry — SSE-B2 was toggled on 2026-04-30 per `noorinalabs-deploy#172`. Mirrors into both the top-level `services.yaml` entry and the `repos/deploy.yaml` inline entry.

## Changes
- `ontology/services.yaml` — `state_backend` entry: +`encryption_at_rest: SSE-B2` field (with inline date/source comment)
- `ontology/repos/deploy.yaml` — `state_backend` inline entry: +`encryption_at_rest: SSE-B2` key

## Context
Closing the spillover from `noorinalabs-deploy#195` (closed as already-resolved 2026-05-18 — deploy repo had no stale refs and no ontology mirror; only the parent-repo SSE-B2 field remained).

Closes #501