### PR TITLE
tech-debt(test): port CwdFallbackTests onto wave-11 (closes #506)

### DIFF
--- a/.claude/hooks/tests/test_validate_commit_identity.py
+++ b/.claude/hooks/tests/test_validate_commit_identity.py
@@ -1220,5 +1220,97 @@ class IndirectExecExtensionTests(unittest.TestCase):
         self.assertIn("eval", result["reason"])
 
 
+class CwdFallbackTests(unittest.TestCase):
+    """Issue #475 fix 1: when no literal `cd <path>` prefix is present, fall
+    back to the tool-call cwd for roster resolution. Lets operators commit
+    from within a child-repo worktree without composing a `cd` prefix."""
+
+    def test_cwd_fallback_loads_child_roster(self):
+        """`git -c user.name=<child-only-name> ... commit` from inside the
+        child worktree (no `cd` prefix) validates against the child roster."""
+        with tempfile.TemporaryDirectory() as td:
+            outer = Path(td)
+            _git_init(outer)
+            _write_roster(outer, {"Nadia": "nadia@example.com"})
+            child = outer / "child"
+            child.mkdir()
+            _git_init(child)
+            _write_roster(child, {"Alice": "alice@example.com"})
+
+            detected = hook._detect_target_roster("git commit -m 'x'", cwd=str(child))
+            self.assertIsNotNone(detected)
+            assert detected is not None
+            self.assertEqual(
+                detected,
+                {
+                    "Nadia": "nadia@example.com",
+                    "Alice": "alice@example.com",
+                },
+            )
+
+    def test_cwd_fallback_when_no_roster_returns_none(self):
+        """cwd has no roster.json → return None (caller uses local ROSTER)."""
+        with tempfile.TemporaryDirectory() as td:
+            empty = Path(td) / "no_roster"
+            empty.mkdir()
+            self.assertIsNone(hook._detect_target_roster("git commit -m 'x'", cwd=str(empty)))
+
+    def test_cd_prefix_wins_over_cwd_fallback(self):
+        """Explicit `cd <path>` in the command takes priority over cwd."""
+        with tempfile.TemporaryDirectory() as td:
+            outer = Path(td)
+            _git_init(outer)
+            cd_target = outer / "explicit"
+            cd_target.mkdir()
+            _git_init(cd_target)
+            _write_roster(cd_target, {"Explicit": "explicit@example.com"})
+
+            # Different repo for the cwd-fallback; should be ignored.
+            cwd_target = outer / "cwd_only"
+            cwd_target.mkdir()
+            _git_init(cwd_target)
+            _write_roster(cwd_target, {"FromCwd": "cwd@example.com"})
+
+            detected = hook._detect_target_roster(
+                f"cd {cd_target} && git commit -m 'x'",
+                cwd=str(cwd_target),
+            )
+            assert detected is not None
+            self.assertIn("Explicit", detected)
+            self.assertNotIn("FromCwd", detected)
+
+    def test_no_cd_no_cwd_returns_none(self):
+        """Regression: omitting both still returns None (existing contract)."""
+        self.assertIsNone(hook._detect_target_roster("git commit -m 'x'"))
+
+    def test_check_uses_cwd_fallback_to_accept_child_only_name(self):
+        """Integration: `check()` with a child-only roster name + cwd
+        pointing at the child repo (no `cd` prefix) → ALLOWED.
+
+        Previously this BLOCKED because `_detect_target_roster` returned
+        None without a cd prefix, the local ROSTER was used, and the
+        child-only name failed lookup. Fix 1 makes the cwd the fallback
+        anchor, restoring symmetry with the cd-prefix path.
+        """
+        with tempfile.TemporaryDirectory() as td:
+            outer = Path(td)
+            _git_init(outer)
+            _write_roster(outer, {"Nadia": "nadia@example.com"})
+            child = outer / "child"
+            child.mkdir()
+            _git_init(child)
+            _write_roster(child, {"Alice": "alice@example.com"})
+
+            cmd = 'git -c user.name="Alice" -c user.email="alice@example.com" commit -m "x"'
+            result = hook.check(
+                {
+                    "tool_name": "Bash",
+                    "tool_input": {"command": cmd},
+                    "cwd": str(child),
+                }
+            )
+            self.assertIsNone(result, f"expected allow, got block: {result}")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Follow-up to #505 — ports the third missing test class (`CwdFallbackTests`) from `origin/main` onto wave-11. Same gap shape as #499: the cwd-fallback hook logic merged cleanly into wave-11 via f707483, but its corresponding test class was not present on wave-11. Caught by Aino + Santiago in #505 review.

## What changed

Appended verbatim from `origin/main:.claude/hooks/tests/test_validate_commit_identity.py` (lines 893-983):

**`CwdFallbackTests`** — 5 methods covering issue #475 fix 1 (cwd-as-fallback anchor for roster resolution when no `cd <path>` prefix is present):

- `test_cwd_fallback_loads_child_roster` — child roster loaded from cwd
- `test_cwd_fallback_when_no_roster_returns_none` — empty cwd returns None
- `test_cd_prefix_wins_over_cwd_fallback` — explicit `cd` takes priority
- `test_no_cd_no_cwd_returns_none` — both omitted → None (existing contract)
- `test_check_uses_cwd_fallback_to_accept_child_only_name` — end-to-end allow path

All helpers (`_git_init`, `_write_roster`, `tempfile`, `Path`, `hook`) already imported on wave-11 — no new imports needed.

Untouched:
- `IndirectExecBypassTests` + `IndirectExecExtensionTests` (from #505)
- `HyphenatedNameFixtures` + `CrossRepoCommitIdentityFixtures` (from #459)
- `validate_commit_identity.py` hook (cwd-fallback logic was already on wave-11)

## Test Plan

- [x] `python3 -m pytest .claude/hooks/tests/test_validate_commit_identity.py` → **84 passed in 0.18s** (was 79 after #505, +5 here)
- [x] `python3 -c "import py_compile; py_compile.compile(...)"` → compiles OK
- [x] `ruff format --check .claude/hooks/` → 68 files already formatted
- [x] `ruff check .claude/hooks/` → All checks passed
- [x] Pre-commit hooks (ruff-format, ruff-lint, mypy) all passed

## Structured fields

Requestor: (TBD — orchestrator will assign reviewers)
Requestee: Wanjiku Mwangi
RequestOrReplied: New
TechDebt: none

Closes #506
