### PR TITLE
fix(hook): validate_review_comment_format — forward --repo to internal gh pr view (closes #503)

### DIFF
--- a/.claude/hooks/tests/test_validate_review_comment_format.py
+++ b/.claude/hooks/tests/test_validate_review_comment_format.py
@@ -348,25 +348,38 @@ class CheckIntegrationTests(unittest.TestCase):
         )
         self.assertIsNone(result)
 
-    def test_cross_repo_pr_comment_with_repo_flag(self):
-        """#302 input shape: `gh pr comment N --repo OWNER/REPO`.
+    def test_cross_repo_pr_comment_with_repo_flag_forwards_repo(self):
+        """Post-#503: `gh pr comment N --repo OWNER/REPO` now forwards --repo
+        to the internal `gh pr view` so the branch fetched is from the
+        commented-against repo, NOT cwd's default.
 
-        get_branch_name does NOT forward --repo (line 76 — `gh pr view N`
-        without --repo resolves from cwd). Pin current behavior: the hook
-        validates against the CURRENT repo's PR #N, not the cross-repo one.
-        If the local cwd has no matching PR, get_branch_name returns ""
-        and the hook warn-allows.
+        Pre-#503 this test pinned the BUG: the hook fetched the wrong PR's
+        branch when reviewer's cwd was a different repo, leading to the
+        Aino-rev-deploy#314 false-block. Post-#503 the hook reads `--repo`
+        from the user's command and passes it through.
         """
         cmd = (
             "gh pr comment 99 --repo noorinalabs/noorinalabs-deploy "
             '--body "Requestor: Aino Virtanen\nRequestee: Nadia Khoury\n'
             'RequestOrReplied: Approved\nTechDebt: none"'
         )
-        with mock.patch.object(hook, "get_branch_name", return_value=""):
+        captured_kwargs: dict = {}
+
+        def fake_get_branch(pr_number, repo=None):  # noqa: ARG001
+            captured_kwargs["repo"] = repo
+            # Return a deploy-side branch that does NOT match Aino's lastname
+            # so the swap heuristic does NOT fire — this is the cross-repo
+            # happy path the fix unblocks.
+            return "N.Hakim/0071-cloud-init-caddy-removal"
+
+        with mock.patch.object(hook, "get_branch_name", side_effect=fake_get_branch):
             result = hook.check(_bash_input(cmd))
-        # Empty branch name → warn-allow path
-        if result is not None:
-            self.assertEqual(result.get("decision"), "allow")
+        # The --repo value MUST be threaded into get_branch_name (the whole
+        # point of #503).
+        self.assertEqual(captured_kwargs.get("repo"), "noorinalabs/noorinalabs-deploy")
+        # And the verdict resolves as ALLOW because the fetched branch
+        # (N.Hakim/...) lastname doesn't collide with the Requestor (Virtanen).
+        self.assertIsNone(result)
 
     def test_markdown_bold_requestor_form(self):
         """Hook regex tolerates `**Requestor:**` markdown-bold prefix on the swap field.
@@ -407,6 +420,124 @@ class CheckIntegrationTests(unittest.TestCase):
         self.assertIsNotNone(result)
         assert result is not None
         self.assertEqual(result.get("decision"), "block")
+
+
+class ExtractRepoFromCommandTests(unittest.TestCase):
+    """Coverage for the `--repo` flag extractor added in #503.
+
+    The hook now reads the user's `--repo OWNER/NAME` flag and forwards it
+    to the internal `gh pr view` so the branch fetched matches the repo the
+    user is commenting against (closes the #503 cross-repo skew).
+    """
+
+    def test_present_returns_value(self):
+        cmd = "gh pr comment 99 --repo noorinalabs/noorinalabs-deploy --body x"
+        self.assertEqual(
+            hook.extract_repo_from_command(cmd),
+            "noorinalabs/noorinalabs-deploy",
+        )
+
+    def test_absent_returns_none(self):
+        cmd = 'gh pr comment 99 --body "x"'
+        self.assertIsNone(hook.extract_repo_from_command(cmd))
+
+    def test_with_equals_form_not_supported(self):
+        """`--repo=value` form is not currently parsed (charter convention is
+        `--repo value`). Pin: returns None for the equals form so callers know
+        the limit if they ever try it.
+        """
+        cmd = "gh pr comment 99 --repo=noorinalabs/noorinalabs-deploy --body x"
+        # The `\S+` regex captures `--repo=noorinalabs/...` as the value if
+        # space-separated isn't found; with `--repo=` form it does NOT match
+        # the leading `--repo\s+` pattern. Result: None.
+        self.assertIsNone(hook.extract_repo_from_command(cmd))
+
+
+class CrossRepoRegressionTests(unittest.TestCase):
+    """Regression coverage for the P3W11 #503 cross-repo false-block.
+
+    Reproduces the exact Aino-rev-deploy#314 scenario: reviewer in
+    noorinalabs-main cwd posting a verdict on noorinalabs-deploy PR with
+    `--repo noorinalabs/noorinalabs-deploy`. Pre-fix the hook fetched main's
+    same-numbered PR (whose branch happened to also be `A.Virtanen/...`),
+    matched the lastname, and false-blocked. Post-fix the --repo flag is
+    forwarded and the correct (deploy-side) branch is fetched.
+    """
+
+    REPRO_COMMAND = (
+        "gh pr comment 314 --repo noorinalabs/noorinalabs-deploy "
+        '--body "Requestor: Aino Virtanen\nRequestee: Nurul Hakim\n'
+        'RequestOrReplied: Approved\nTechDebt: none"'
+    )
+
+    def test_503_repro_no_false_block_when_repo_forwarded(self):
+        """The exact Aino-rev-deploy#314 false-block scenario, post-fix.
+
+        Without --repo forwarding, get_branch_name would (in production) hit
+        main's PR #314 with `A.Virtanen/0300-w7-retro-charter` → match Aino's
+        lastname → false-block. With --repo forwarding it hits deploy's PR
+        #314 with `N.Hakim/0071-cloud-init-caddy-removal` → no lastname
+        collision → allow.
+
+        Verified by capturing the repo kwarg passed to get_branch_name and
+        asserting it equals what the user wrote.
+        """
+        captured_kwargs: dict = {}
+
+        def fake_get_branch(pr_number, repo=None):  # noqa: ARG001
+            captured_kwargs["repo"] = repo
+            # Simulate gh pr view returning the deploy-side branch when --repo
+            # is properly forwarded.
+            if repo == "noorinalabs/noorinalabs-deploy":
+                return "N.Hakim/0071-cloud-init-caddy-removal"
+            # The buggy path would have returned main's same-numbered PR.
+            return "A.Virtanen/0300-w7-retro-charter"
+
+        with mock.patch.object(hook, "get_branch_name", side_effect=fake_get_branch):
+            result = hook.check(_bash_input(self.REPRO_COMMAND))
+
+        # Post-fix: --repo MUST be forwarded.
+        self.assertEqual(captured_kwargs.get("repo"), "noorinalabs/noorinalabs-deploy")
+        # And the false-block MUST NOT fire (branch lastname = Hakim ≠ Virtanen).
+        self.assertIsNone(
+            result,
+            "Cross-repo verdict with --repo correctly forwarded should NOT block",
+        )
+
+    def test_same_repo_path_emits_fallback_warning_on_stderr(self):
+        """When --repo is absent, hook uses cwd-default but emits a stderr
+        breadcrumb so future cross-repo invocations missing --repo are
+        discoverable in transcripts. Pins the fallback log behavior.
+        """
+        cmd = (
+            "gh pr comment 42 "
+            '--body "Requestor: Nadia Khoury\nRequestee: Aino Virtanen\n'
+            'RequestOrReplied: Approved\nTechDebt: none"'
+        )
+        # Capture stderr around the hook call.
+        import io
+        from contextlib import redirect_stderr
+
+        captured_kwargs: dict = {}
+
+        def fake_get_branch(pr_number, repo=None):  # noqa: ARG001
+            captured_kwargs["repo"] = repo
+            return "A.Virtanen/0373-ruff-format"
+
+        stderr_buf = io.StringIO()
+        with (
+            mock.patch.object(hook, "get_branch_name", side_effect=fake_get_branch),
+            redirect_stderr(stderr_buf),
+        ):
+            hook.check(_bash_input(cmd))
+
+        # No --repo passed → fallback path; repo kwarg is None.
+        self.assertIsNone(captured_kwargs.get("repo"))
+        # Stderr breadcrumb names the hook + the #503 origin.
+        stderr_text = stderr_buf.getvalue()
+        self.assertIn("validate_review_comment_format", stderr_text)
+        self.assertIn("--repo", stderr_text)
+        self.assertIn("#503", stderr_text)
 
 
 if __name__ == "__main__":

--- a/.claude/hooks/validate_review_comment_format.py
+++ b/.claude/hooks/validate_review_comment_format.py
@@ -79,6 +79,28 @@ def extract_pr_number(command: str) -> str | None:
     return None
 
 
+def extract_repo_from_command(command: str) -> str | None:
+    """Extract --repo value from a gh command.
+
+    The hook's internal `gh pr view` (see `get_branch_name`) must target the
+    SAME repository the user is commenting against; otherwise gh's default
+    cwd-based resolution picks the wrong repo and the branch fetched is from
+    an unrelated PR with the same number. That cross-repo skew was the
+    P3W11-#503 false-positive: reviewer in `noorinalabs-main` cwd posting
+    on `noorinalabs/noorinalabs-deploy#314` with `--repo noorinalabs/noorinalabs-deploy`
+    had the hook silently fetch main's #314 (`A.Virtanen/0300-w7-retro-charter`),
+    matched the lastname, and false-blocked.
+
+    Matches the canonical `--repo <owner>/<name>` form. Returns the value
+    string unchanged for direct pass-through to gh; returns None if the flag
+    is absent.
+    """
+    match = re.search(r"--repo\s+(\S+)", command)
+    if match:
+        return match.group(1)
+    return None
+
+
 def extract_comment_body(command: str) -> str | None:
     """Extract the comment body from the gh pr comment command.
 
@@ -107,11 +129,22 @@ def extract_comment_body(command: str) -> str | None:
     return None
 
 
-def get_branch_name(pr_number: str) -> str | None:
-    """Fetch the head branch name for a PR."""
+def get_branch_name(pr_number: str, repo: str | None = None) -> str | None:
+    """Fetch the head branch name for a PR.
+
+    When `repo` (a `<owner>/<name>` string parsed from the user's `gh pr comment
+    --repo` flag) is supplied, it is forwarded as `--repo <repo>` so the gh
+    invocation targets the SAME repo the user is commenting against. Without
+    that pass-through, gh's default repo resolution is cwd-based and a
+    cross-repo invocation (reviewer in repo A's cwd posting on repo B's PR)
+    silently returns the wrong PR's branch — the #503 cross-repo false-block.
+    """
+    cmd = ["gh", "pr", "view", pr_number, "--json", "headRefName"]
+    if repo:
+        cmd.extend(["--repo", repo])
     try:
         result = subprocess.run(
-            ["gh", "pr", "view", pr_number, "--json", "headRefName"],
+            cmd,
             capture_output=True,
             text=True,
             timeout=15,
@@ -236,7 +269,22 @@ def check(input_data: dict) -> dict | None:
             ),
         }
 
-    branch_name = get_branch_name(pr_number)
+    # Forward the user's --repo flag to the internal gh pr view so the branch
+    # we fetch is from the SAME repo the user is commenting against. Closes
+    # the #503 cross-repo skew: reviewer in repo-A cwd posting on repo-B PR.
+    repo = extract_repo_from_command(command)
+    if not repo:
+        # Same-repo path — gh's cwd-based default resolution is used. Emit a
+        # stderr breadcrumb so a future cross-repo invocation that omits
+        # --repo is discoverable in transcripts, and the brittle cwd-dependence
+        # of the same-repo path is not silent.
+        print(
+            "validate_review_comment_format: --repo flag absent on gh pr comment; "
+            "falling back to cwd-default repo resolution for internal gh pr view. "
+            "Cross-repo invocations MUST pass --repo to avoid the #503 swap-block.",
+            file=sys.stderr,
+        )
+    branch_name = get_branch_name(pr_number, repo=repo)
     if not branch_name:
         return {
             "decision": "allow",


### PR DESCRIPTION
## Summary

Fixes P3W11 #503 — `validate_review_comment_format` was calling `gh pr view <N>` WITHOUT `--repo`, so when a reviewer in repo-A's cwd posted a verdict on repo-B's PR with `--repo`, gh's cwd-default repo resolution silently picked the wrong PR. The Aino-rev-deploy#314 false-block was the trigger: hook fetched main's PR #314 (`A.Virtanen/0300-w7-retro-charter`) instead of deploy's #314 (`N.Hakim/0071-...`), lastname matched the reviewer (Virtanen), swap heuristic fired.

Pure lastname coincidence — other cross-repo reviewers from main cwd this session (Nino, Lucas, Aisha, Nurul) were just lucky their lastnames didn't collide with main's same-numbered PR.

Closes #503

## What changed

`.claude/hooks/validate_review_comment_format.py`

- New `extract_repo_from_command(command)` parses `--repo OWNER/NAME` from the Bash command (same shape as the parser already in `validate_pr_review.py`).
- `get_branch_name(pr_number, repo=None)` accepts and forwards `--repo` when present.
- `check()` extracts repo from the user's command and threads it through to `get_branch_name`.
- When `--repo` is absent (same-repo path), emit a stderr breadcrumb naming the hook + `--repo` + `#503` so future cross-repo invocations that omit `--repo` are discoverable in transcripts (no silent same-repo dependence on cwd discipline).

`.claude/hooks/tests/test_validate_review_comment_format.py`

- New `ExtractRepoFromCommandTests` × 3 — `present_returns_value`, `absent_returns_none`, `with_equals_form_not_supported` (pins the current parser limit).
- New `CrossRepoRegressionTests`:
  - `test_503_repro_no_false_block_when_repo_forwarded` — exact Aino-rev-deploy#314 reproduction. Captures the repo kwarg passed to `get_branch_name` and verifies the fix forwards `noorinalabs/noorinalabs-deploy`. With the fix, the branch returned is `N.Hakim/0071-...` (no lastname collision) and the verdict allows.
  - `test_same_repo_path_emits_fallback_warning_on_stderr` — captures stderr around `check()` and asserts the breadcrumb mentions the hook name, `--repo`, and `#503`.
- Updated `test_cross_repo_pr_comment_with_repo_flag_forwards_repo` — pre-fix this test pinned the BUG behavior (hook ignored `--repo`, fell back to cwd). Post-fix it pins the correct forwarding behavior, including the kwarg capture and the allow verdict.

## Test Plan

- [x] `ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/test_validate_review_comment_format.py -v` → **47 passed in 0.08s** (38 pre-existing + 5 new + 1 reworked + 3 helper coverage)
- [x] Full hook suite — `pytest .claude/hooks/tests/` → **887 passed in 1.29s** (was 882 → +5)
- [x] `uvx ruff format --check .claude/hooks/` → 64 files already formatted
- [x] `uvx ruff check .claude/hooks/` → All checks passed
- [x] Pre-commit (ruff-format / ruff-lint / mypy) all passed on commit

## Failure-direction note

Pre-fix failure was **safe-but-noisy** — false-positive block, reviewer worked around by cd'ing into the target repo's worktree. Per `feedback_safety_direction_over_ux_friction.md` this is the right safe-direction default for an unfixable bug, but it forced operational friction. Post-fix the hook validates against the same repo the user is commenting on, no workaround needed.

---

Requestor: (TBD — orchestrator will assign reviewers)
Requestee: Aino Virtanen
RequestOrReplied: New
TechDebt: none
