### PR TITLE
tech-debt(hook-lib): consolidate --repo parser into shared helper (closes #510)

### DIFF
--- a/.claude/hooks/_repo_flag_parse.py
+++ b/.claude/hooks/_repo_flag_parse.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Shared parser for `--repo OWNER/NAME` / `-R OWNER/NAME` extraction.
+
+Background
+==========
+
+Two PreToolUse hooks need to extract the `--repo` value from a `gh` bash
+command and forward it to internal `gh` subcalls:
+
+- `validate_labels.py` — forwards `--repo` to `gh label list` so we query
+  the same repo the user is creating the issue in.
+- `validate_review_comment_format.py` — forwards `--repo` to `gh pr view`
+  so the branch we fetch is from the SAME repo the user is commenting
+  against (#503 cross-repo skew fix, #509).
+
+Before this helper, the two hooks had divergent parsers:
+
+- `validate_labels.py:extract_repo` already handled ALL FOUR forms via
+  `(?:^|\\s)(?:--repo|-R)(?:=|\\s+)(\\S+)` with a tokenizer-first /
+  regex-fallback shape.
+- `validate_review_comment_format.py:extract_repo_from_command` (added in
+  #509) only handled the canonical `--repo <value>` space form via
+  `--repo\\s+(\\S+)`. Equals-form, `-R`, and `-R=` were silent fallthroughs
+  to cwd-default resolution — same failure direction as the #503 root
+  cause, just via alternate flag spellings.
+
+Issue #510 (filed during #509 review) asked for consolidation. This helper
+mirrors the `_shell_parse` / `_wave_label_parse` shared-helper pattern.
+
+Public API
+==========
+
+    extract_repo(command: str) -> str | None
+        Parse a bash command. Returns the `OWNER/NAME` value passed via any
+        of `--repo X`, `--repo=X`, `-R X`, `-R=X`, or None if no `--repo` /
+        `-R` flag is present.
+
+        Tokenizer-first via `_shell_parse.walk_flag_values`; falls back to
+        a conservative regex when shlex tokenization fails (e.g. command
+        contains a malformed quote). Both paths recognize all four forms.
+
+Design notes
+============
+
+- Returns the value string unchanged for direct pass-through to gh.
+- Returns None on absent flag AND on malformed flag (flag present but no
+  value); callers fail-open to cwd-default resolution + breadcrumb log.
+- `set` is used for `_REPO_FLAGS` to match `walk_flag_values`' expected
+  type (set membership lookup); the tuple-style sentinel used elsewhere
+  in the codebase would force a wrap inside `walk_flag_values`.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(os.path.abspath(__file__)).parent))
+
+from _shell_parse import (  # noqa: E402
+    tokenize,
+    walk_flag_values,
+)
+
+# Flags whose VALUE is a repo specifier (OWNER/REPO).
+_REPO_FLAGS = {"--repo", "-R"}
+
+# Regex covering all 4 surface forms when tokenize() fails:
+#   --repo X    --repo=X    -R X    -R=X
+# Anchored on a token boundary at the front so `--no-repo` etc. cannot
+# false-match. `(\\S+)` is greedy-to-whitespace; matches any non-whitespace
+# value form gh accepts (gh itself validates the OWNER/NAME shape).
+_REPO_FALLBACK_RE = re.compile(r"(?:^|\s)(?:--repo|-R)(?:=|\s+)(\S+)")
+
+
+def extract_repo(command: str) -> str | None:
+    """Extract the `--repo` / `-R` `OWNER/NAME` value, or None if absent."""
+    tokens = tokenize(command)
+    if tokens is None:
+        match = _REPO_FALLBACK_RE.search(command)
+        return match.group(1) if match else None
+    values = walk_flag_values(tokens, _REPO_FLAGS)
+    return values[0] if values else None

--- a/.claude/hooks/tests/test_repo_flag_parse.py
+++ b/.claude/hooks/tests/test_repo_flag_parse.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Tests for `_repo_flag_parse` shared helper.
+
+Consolidates `--repo` / `-R` extraction across `validate_labels.py` and
+`validate_review_comment_format.py`. Covers all four flag forms gh CLI
+accepts (space-form / equals-form × long / short) plus the regex
+fallback used when shlex tokenization fails on malformed input.
+
+Issue #510 origin: filed during #509 review when I noticed
+`validate_review_comment_format.extract_repo_from_command` recognized
+only `--repo X` while `validate_labels.extract_repo` already recognized
+all four forms — a latent #503-class regression risk (cross-repo block
+silently misfires through `--repo=` / `-R` flag spellings).
+
+Run: python3 -m pytest .claude/hooks/tests/test_repo_flag_parse.py -v
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_HOOKS_DIR = _HERE.parent
+sys.path.insert(0, str(_HOOKS_DIR))
+
+import _repo_flag_parse as parser  # noqa: E402
+
+
+class FourFormsTests(unittest.TestCase):
+    """All four `gh` flag forms must parse to the same OWNER/REPO value."""
+
+    EXPECTED = "noorinalabs/noorinalabs-deploy"
+
+    def test_long_space_form(self):
+        """`--repo OWNER/NAME` — charter convention; the dominant shape."""
+        cmd = f"gh pr comment 314 --repo {self.EXPECTED} --body x"
+        self.assertEqual(parser.extract_repo(cmd), self.EXPECTED)
+
+    def test_long_equals_form(self):
+        """`--repo=OWNER/NAME` — gh accepts this; pre-#510 the
+        review-comment hook silently fell back to cwd, recreating the
+        #503 cross-repo false-block."""
+        cmd = f"gh pr comment 314 --repo={self.EXPECTED} --body x"
+        self.assertEqual(parser.extract_repo(cmd), self.EXPECTED)
+
+    def test_short_space_form(self):
+        """`-R OWNER/NAME` — gh's documented short flag."""
+        cmd = f"gh pr comment 314 -R {self.EXPECTED} --body x"
+        self.assertEqual(parser.extract_repo(cmd), self.EXPECTED)
+
+    def test_short_equals_form(self):
+        """`-R=OWNER/NAME` — short flag + equals separator."""
+        cmd = f"gh pr comment 314 -R={self.EXPECTED} --body x"
+        self.assertEqual(parser.extract_repo(cmd), self.EXPECTED)
+
+
+class MixedWithOtherFlagsTests(unittest.TestCase):
+    """`--repo` co-existing with other flags must not false-match."""
+
+    def test_after_body_flag(self):
+        cmd = 'gh pr comment 99 --body "ok" --repo owner/repo'
+        self.assertEqual(parser.extract_repo(cmd), "owner/repo")
+
+    def test_before_label_flag(self):
+        cmd = "gh issue create --repo owner/repo --label bug --title t --body b"
+        self.assertEqual(parser.extract_repo(cmd), "owner/repo")
+
+    def test_no_repo_substring_in_other_flag_false_matches(self):
+        """A flag like `--no-repo` (or any unrelated long flag containing
+        `repo` substring) must NOT match. Anchoring on token boundary
+        prevents this — the test pins the protection."""
+        cmd = "gh foo --no-repo --bar baz"
+        self.assertIsNone(parser.extract_repo(cmd))
+
+    def test_repo_inside_quoted_body_does_not_match(self):
+        """A reviewer body containing the literal text `--repo` inside a
+        quoted comment must not be parsed as a real flag — tokenizer path
+        treats the quoted argument as a single opaque token, so the
+        token-walk sees `gh`, `pr`, `comment`, `99`, `--body`, `<one-token>`."""
+        cmd = 'gh pr comment 99 --body "discussed --repo owner/repo in #123"'
+        self.assertIsNone(parser.extract_repo(cmd))
+
+
+class AbsentAndMalformedTests(unittest.TestCase):
+    """`--repo` absent or malformed → None (callers fail-open)."""
+
+    def test_absent_returns_none(self):
+        cmd = "gh pr comment 99 --body x"
+        self.assertIsNone(parser.extract_repo(cmd))
+
+    def test_empty_string_returns_none(self):
+        self.assertIsNone(parser.extract_repo(""))
+
+    def test_trailing_flag_no_value_returns_none(self):
+        """`gh foo --repo` with nothing after → no capturable value.
+        gh itself would error; we just return None so the caller falls
+        back to cwd-default + breadcrumb log."""
+        cmd = "gh pr comment 99 --repo"
+        self.assertIsNone(parser.extract_repo(cmd))
+
+
+class RegexFallbackTests(unittest.TestCase):
+    """When `_shell_parse.tokenize` returns None (malformed shell), the
+    helper falls back to the conservative regex. Both paths must agree
+    on the four supported forms."""
+
+    @staticmethod
+    def _malformed(value_form: str) -> str:
+        """Build a command with an unbalanced quote so shlex fails, then
+        append the flag-under-test. The regex fallback must still find it."""
+        return f"echo 'unterminated && gh pr comment 99 {value_form} --body x"
+
+    def test_fallback_long_space(self):
+        cmd = self._malformed("--repo owner/repo")
+        self.assertEqual(parser.extract_repo(cmd), "owner/repo")
+
+    def test_fallback_long_equals(self):
+        cmd = self._malformed("--repo=owner/repo")
+        self.assertEqual(parser.extract_repo(cmd), "owner/repo")
+
+    def test_fallback_short_space(self):
+        cmd = self._malformed("-R owner/repo")
+        self.assertEqual(parser.extract_repo(cmd), "owner/repo")
+
+    def test_fallback_short_equals(self):
+        cmd = self._malformed("-R=owner/repo")
+        self.assertEqual(parser.extract_repo(cmd), "owner/repo")
+
+    def test_fallback_absent_returns_none(self):
+        cmd = self._malformed("--label bug")
+        self.assertIsNone(parser.extract_repo(cmd))
+
+
+class IssueOrigin503ReproTests(unittest.TestCase):
+    """Pin the exact #503 / #509 / #510 lineage shape on a real-world
+    cross-repo verdict-comment command. If a future regression silently
+    drops one of the alternate flag forms back to cwd-default, this
+    fixture surfaces it."""
+
+    def test_503_canonical_command_extracts_deploy_repo(self):
+        cmd = (
+            "gh pr comment 314 --repo noorinalabs/noorinalabs-deploy "
+            '--body "Requestor: Aino Virtanen\nRequestee: Nurul Hakim\n'
+            'RequestOrReplied: Approved\nTechDebt: none"'
+        )
+        self.assertEqual(parser.extract_repo(cmd), "noorinalabs/noorinalabs-deploy")
+
+    def test_503_with_equals_form_also_extracts(self):
+        """Post-#510: the equals-form variant of the same command also
+        resolves to the deploy repo (was returning None pre-#510 →
+        cross-repo block would silently misfire)."""
+        cmd = (
+            "gh pr comment 314 --repo=noorinalabs/noorinalabs-deploy "
+            '--body "Requestor: Aino Virtanen\nRequestee: Nurul Hakim\n'
+            'RequestOrReplied: Approved\nTechDebt: none"'
+        )
+        self.assertEqual(parser.extract_repo(cmd), "noorinalabs/noorinalabs-deploy")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/hooks/tests/test_validate_review_comment_format.py
+++ b/.claude/hooks/tests/test_validate_review_comment_format.py
@@ -422,35 +422,41 @@ class CheckIntegrationTests(unittest.TestCase):
         self.assertEqual(result.get("decision"), "block")
 
 
-class ExtractRepoFromCommandTests(unittest.TestCase):
-    """Coverage for the `--repo` flag extractor added in #503.
+class ExtractRepoCallSiteTests(unittest.TestCase):
+    """Smoke coverage that `validate_review_comment_format` exposes
+    `extract_repo` (re-exported from the shared `_repo_flag_parse` helper)
+    and that the canonical happy path still resolves the same value.
 
-    The hook now reads the user's `--repo OWNER/NAME` flag and forwards it
-    to the internal `gh pr view` so the branch fetched matches the repo the
-    user is commenting against (closes the #503 cross-repo skew).
+    Comprehensive parser coverage (all 4 flag forms, tokenize / regex
+    fallback, malformed cases) lives in `test_repo_flag_parse.py` alongside
+    the helper. These tests pin the hook's import wiring so a future
+    refactor that drops the re-export trips here, not at runtime.
     """
 
     def test_present_returns_value(self):
         cmd = "gh pr comment 99 --repo noorinalabs/noorinalabs-deploy --body x"
         self.assertEqual(
-            hook.extract_repo_from_command(cmd),
+            hook.extract_repo(cmd),
             "noorinalabs/noorinalabs-deploy",
         )
 
     def test_absent_returns_none(self):
         cmd = 'gh pr comment 99 --body "x"'
-        self.assertIsNone(hook.extract_repo_from_command(cmd))
+        self.assertIsNone(hook.extract_repo(cmd))
 
-    def test_with_equals_form_not_supported(self):
-        """`--repo=value` form is not currently parsed (charter convention is
-        `--repo value`). Pin: returns None for the equals form so callers know
-        the limit if they ever try it.
+    def test_equals_form_now_supported(self):
+        """`--repo=value` form is supported post-#510 (was a documented
+        gap in the original #509 implementation — see issue body for the
+        latent #503-class regression risk via alternate flag forms).
+        Pre-#510 this returned None (pinned by
+        `test_with_equals_form_not_supported`); post-#510 it returns the
+        value, closing the parser inconsistency with `validate_labels.py`.
         """
         cmd = "gh pr comment 99 --repo=noorinalabs/noorinalabs-deploy --body x"
-        # The `\S+` regex captures `--repo=noorinalabs/...` as the value if
-        # space-separated isn't found; with `--repo=` form it does NOT match
-        # the leading `--repo\s+` pattern. Result: None.
-        self.assertIsNone(hook.extract_repo_from_command(cmd))
+        self.assertEqual(
+            hook.extract_repo(cmd),
+            "noorinalabs/noorinalabs-deploy",
+        )
 
 
 class CrossRepoRegressionTests(unittest.TestCase):

--- a/.claude/hooks/validate_labels.py
+++ b/.claude/hooks/validate_labels.py
@@ -40,6 +40,7 @@ import subprocess
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _repo_flag_parse import extract_repo  # noqa: E402
 from _shell_parse import (  # noqa: E402
     is_gh_subcommand,
     tokenize,
@@ -49,9 +50,6 @@ from annunaki_log import log_pretooluse_block  # noqa: E402
 
 # Flags whose VALUE is a label list (comma-separated allowed by gh).
 _LABEL_FLAGS = {"--label", "-l"}
-
-# Flags whose VALUE is a repo specifier (OWNER/REPO).
-_REPO_FLAGS = {"--repo", "-R"}
 
 
 def get_existing_labels(repo: str | None = None) -> set[str]:
@@ -111,16 +109,6 @@ def extract_labels(command: str) -> list[str]:
             if label:
                 labels.append(label)
     return labels
-
-
-def extract_repo(command: str) -> str | None:
-    """Extract the --repo / -R OWNER/REPO value from the command, if any."""
-    tokens = tokenize(command)
-    if tokens is None:
-        match = re.search(r"(?:^|\s)(?:--repo|-R)(?:=|\s+)(\S+)", command)
-        return match.group(1) if match else None
-    values = walk_flag_values(tokens, _REPO_FLAGS)
-    return values[0] if values else None
 
 
 def check(input_data: dict) -> dict | None:

--- a/.claude/hooks/validate_review_comment_format.py
+++ b/.claude/hooks/validate_review_comment_format.py
@@ -54,6 +54,7 @@ import subprocess
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _repo_flag_parse import extract_repo
 from annunaki_log import log_pretooluse_block
 
 
@@ -74,28 +75,6 @@ def extract_pr_number(command: str) -> str | None:
     if match:
         return match.group(1)
     match = re.search(r"/pull/(\d+)", command)
-    if match:
-        return match.group(1)
-    return None
-
-
-def extract_repo_from_command(command: str) -> str | None:
-    """Extract --repo value from a gh command.
-
-    The hook's internal `gh pr view` (see `get_branch_name`) must target the
-    SAME repository the user is commenting against; otherwise gh's default
-    cwd-based resolution picks the wrong repo and the branch fetched is from
-    an unrelated PR with the same number. That cross-repo skew was the
-    P3W11-#503 false-positive: reviewer in `noorinalabs-main` cwd posting
-    on `noorinalabs/noorinalabs-deploy#314` with `--repo noorinalabs/noorinalabs-deploy`
-    had the hook silently fetch main's #314 (`A.Virtanen/0300-w7-retro-charter`),
-    matched the lastname, and false-blocked.
-
-    Matches the canonical `--repo <owner>/<name>` form. Returns the value
-    string unchanged for direct pass-through to gh; returns None if the flag
-    is absent.
-    """
-    match = re.search(r"--repo\s+(\S+)", command)
     if match:
         return match.group(1)
     return None
@@ -272,7 +251,7 @@ def check(input_data: dict) -> dict | None:
     # Forward the user's --repo flag to the internal gh pr view so the branch
     # we fetch is from the SAME repo the user is commenting against. Closes
     # the #503 cross-repo skew: reviewer in repo-A cwd posting on repo-B PR.
-    repo = extract_repo_from_command(command)
+    repo = extract_repo(command)
     if not repo:
         # Same-repo path — gh's cwd-based default resolution is used. Emit a
         # stderr breadcrumb so a future cross-repo invocation that omits


### PR DESCRIPTION
## Summary

Consolidates the divergent `--repo` parsers across `validate_labels.py` (handled all 4 gh flag forms via `_shell_parse`-backed tokenize+regex) and `validate_review_comment_format.py` (#509 added a single-form `--repo\s+(\S+)` parser). Both hooks now import `extract_repo` from a shared `_repo_flag_parse.py` helper, closing the latent #503-class regression risk via `--repo=` / `-R` / `-R=` flag spellings.

I filed #510 during my review of #509 (https://github.com/noorinalabs/noorinalabs-main/pull/509#issuecomment-4483472298) — so this PR implements the exact follow-up I proposed.

## Why `.claude/hooks/_repo_flag_parse.py` (not `.claude/lib/`)?

The brief asked me to choose deliberately. `.claude/lib/` exists and has its own pytest gate (#496), but `_shell_parse.py` and `_wave_label_parse.py` — the cited precedent in the #510 issue body — both live in `.claude/hooks/`. The new helper imports `tokenize` and `walk_flag_values` from `_shell_parse`; placing it in `.claude/lib/` would require sys.path tricks to reach a hooks/-side dependency. Same-dir colocation matches the immediate precedent and avoids cross-dir import brittleness. Migrating all three shared parsers (`_shell_parse`, `_wave_label_parse`, `_repo_flag_parse`) into `.claude/lib/` is a separate larger refactor, out of scope here.

## What changed

**New:**
- `.claude/hooks/_repo_flag_parse.py` — `extract_repo(command) -> str | None` with tokenize-first + regex-fallback; recognizes `--repo X`, `--repo=X`, `-R X`, `-R=X`.
- `.claude/hooks/tests/test_repo_flag_parse.py` — 17 tests across 5 classes (FourForms / MixedWithOtherFlags / AbsentAndMalformed / RegexFallback / IssueOrigin503Repro).

**Refactored:**
- `validate_labels.py` — drops inline `extract_repo` + the now-unused `_REPO_FLAGS` constant; imports from helper. All other `_shell_parse` imports preserved (still used by `extract_labels` + `check`).
- `validate_review_comment_format.py` — drops `extract_repo_from_command` (Aino's #509 single-form parser); imports `extract_repo` from helper; renames the one call site.
- `test_validate_review_comment_format.py` — renames `ExtractRepoFromCommandTests` → `ExtractRepoCallSiteTests` (now smoke-only — the heavy parser coverage moved to `test_repo_flag_parse.py`); inverts the previously-pinning `test_with_equals_form_not_supported` → `test_equals_form_now_supported` with a docstring documenting the inversion + latent-#503 risk rationale.

## Test Plan

- [x] `python3 -m pytest .claude/hooks/tests/ .claude/lib/tests/` → **914 passed in 1.32s** (matches main baseline + 17 new from `test_repo_flag_parse.py`)
- [x] `python3 -m pytest .claude/hooks/tests/test_repo_flag_parse.py .claude/hooks/tests/test_validate_labels.py .claude/hooks/tests/test_validate_review_comment_format.py` → **98 passed**
- [x] `ruff format --check .claude/hooks/ .claude/lib/` → 68 files already formatted
- [x] `ruff check .claude/hooks/ .claude/lib/` → All checks passed
- [x] Pre-commit hooks (ruff-format, ruff-lint, mypy) all passed

## Structured fields

Requestor: (TBD)
Requestee: Wanjiku Mwangi
RequestOrReplied: New
TechDebt: none

Closes #510
