### PR TITLE
tech-debt(hook): consolidate validate_pr_review --repo parser via shared helper (closes #514)

### DIFF
--- a/.claude/hooks/tests/test_validate_pr_review.py
+++ b/.claude/hooks/tests/test_validate_pr_review.py
@@ -1253,5 +1253,42 @@ class ProseFalseMatchRegressionTests(_CheckCommentReviewsHarness):
         self.assertEqual(result.reviewers, {"wanjiku mwangi"})
 
 
+class ExtractRepoCallSiteTests(unittest.TestCase):
+    """Smoke coverage that `validate_pr_review` exposes `extract_repo`
+    (re-exported from the shared `_repo_flag_parse` helper) and that the
+    canonical `gh pr merge --repo` happy path still resolves the same
+    value.
+
+    Comprehensive parser coverage (all 4 flag forms, tokenize / regex
+    fallback, malformed cases) lives in `test_repo_flag_parse.py` alongside
+    the helper. These tests pin the hook's import wiring so a future
+    refactor that drops the re-export trips here, not at runtime. Mirrors
+    `test_validate_review_comment_format.ExtractRepoCallSiteTests` from
+    #513.
+    """
+
+    def test_present_returns_value(self):
+        cmd = "gh pr merge 487 --repo noorinalabs/noorinalabs-deploy --squash"
+        self.assertEqual(
+            hook.extract_repo(cmd),
+            "noorinalabs/noorinalabs-deploy",
+        )
+
+    def test_absent_returns_none(self):
+        cmd = "gh pr merge 487 --squash"
+        self.assertIsNone(hook.extract_repo(cmd))
+
+    def test_equals_form_now_supported(self):
+        """`--repo=value` form is supported post-#514 (was the documented
+        latent #503-class gap in the original #509 implementation — sister
+        consolidation #510 fixed it for two hooks via #513, #514 extends
+        the fix to validate_pr_review for the gh-pr-merge code path)."""
+        cmd = "gh pr merge 487 --repo=noorinalabs/noorinalabs-deploy --squash"
+        self.assertEqual(
+            hook.extract_repo(cmd),
+            "noorinalabs/noorinalabs-deploy",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.claude/hooks/validate_branch_freshness.py
+++ b/.claude/hooks/validate_branch_freshness.py
@@ -71,6 +71,7 @@ import subprocess
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _repo_flag_parse import extract_repo  # noqa: E402
 from _shell_parse import (  # noqa: E402
     first_flag_value,
     is_gh_subcommand,
@@ -81,7 +82,6 @@ from annunaki_log import log_pretooluse_block  # noqa: E402
 
 _BASE_FLAGS = {"--base", "-B"}
 _HEAD_FLAGS = {"--head", "-H"}
-_REPO_FLAGS = {"--repo", "-R"}
 
 # Match an OWNER/REPO suffix on a git remote URL. Handles:
 #   git@github.com:owner/repo.git
@@ -102,11 +102,6 @@ def extract_head(command: str) -> str | None:
     if raw and ":" in raw:
         return raw.split(":", 1)[1]
     return raw
-
-
-def extract_repo(command: str) -> str | None:
-    """Extract --repo / -R OWNER/REPO value, if any."""
-    return first_flag_value(command, _REPO_FLAGS)
 
 
 def is_branch_fresh_local(base: str, cwd: str | None = None) -> bool:

--- a/.claude/hooks/validate_pr_review.py
+++ b/.claude/hooks/validate_pr_review.py
@@ -83,6 +83,7 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _repo_flag_parse import extract_repo
 from annunaki_log import log_pretooluse_block
 
 # Charter-enforcer role prefixes for the Single-Reviewer Exception. Derived
@@ -127,14 +128,6 @@ def extract_pr_number(command: str) -> str | None:
     if match:
         return match.group(1)
     # gh pr merge with no number (current branch PR)
-    return None
-
-
-def extract_repo_from_command(command: str) -> str | None:
-    """Extract --repo value from gh pr merge command."""
-    match = re.search(r"--repo\s+(\S+)", command)
-    if match:
-        return match.group(1)
     return None
 
 
@@ -584,7 +577,7 @@ def check(input_data: dict) -> dict | None:
         return None
 
     pr_number = extract_pr_number(command)
-    repo = extract_repo_from_command(command)
+    repo = extract_repo(command)
     pr_data = get_pr_data(pr_number, repo=repo)
 
     if pr_data is None:


### PR DESCRIPTION
## Summary

Extends #513's `_repo_flag_parse.extract_repo` consolidation to the third hook: `validate_pr_review.extract_repo_from_command` (the `gh pr merge` code path). Closes the same latent #503-class risk class for the `gh pr merge` surface that #510 closed for the `gh issue create` + `gh pr comment` surfaces.

Bundles the optional `validate_branch_freshness.py` DRY cleanup per #514's issue body — that hook's `extract_repo` already wraps `_shell_parse.first_flag_value` semantically equivalently to the shared helper, so the migration is pure consolidation.

## What changed

- **`validate_pr_review.py`** — import `extract_repo` from `_repo_flag_parse`; drop the inline `extract_repo_from_command` single-form regex; rename the call site.
- **`validate_branch_freshness.py`** — import `extract_repo` from `_repo_flag_parse`; drop the local `extract_repo` wrapper + its `_REPO_FLAGS` constant. Existing test fixtures call `hook.extract_repo` and pass unchanged via re-export.
- **`tests/test_validate_pr_review.py`** — add `ExtractRepoCallSiteTests` (3 smoke tests) mirroring `tests/test_validate_review_comment_format.py:ExtractRepoCallSiteTests` from #513. Pins import wiring so a future refactor that drops the re-export trips here, not at runtime.

Comprehensive 4-form parser coverage continues to live in `tests/test_repo_flag_parse.py` (the helper's own tests). Not duplicated here.

## Acceptance grep proof

Issue #514 acceptance criterion:

```
grep -rn 'extract_repo\|--repo\s' .claude/hooks/*.py | grep -v __pycache__ | grep -v _repo_flag_parse.py
```

Post-PR output (15 lines, all expected):

```
.claude/hooks/validate_branch_freshness.py:74:from _repo_flag_parse import extract_repo  # noqa: E402
.claude/hooks/validate_branch_freshness.py:225:    repo = extract_repo(command)
.claude/hooks/validate_labels.py:43:from _repo_flag_parse import extract_repo  # noqa: E402
.claude/hooks/validate_labels.py:134:    repo = extract_repo(command)
.claude/hooks/validate_pr_ci_status.py:109:def extract_repo_from_command(command: str) -> str | None:
.claude/hooks/validate_pr_ci_status.py:111:    match = re.search(r"--repo\s+(\S+)", command)
.claude/hooks/validate_pr_ci_status.py:208:    repo = extract_repo_from_command(command)
.claude/hooks/validate_wave_label_evidence.py:170:def _extract_repo_for_path(path: str, default_repo: str) -> tuple[str, str]:
.claude/hooks/validate_wave_label_evidence.py:243:        repo, inner_path = _extract_repo_for_path(path, repo_default)
.claude/hooks/validate_review_comment_format.py:57:from _repo_flag_parse import extract_repo
.claude/hooks/validate_review_comment_format.py:254:    repo = extract_repo(command)
.claude/hooks/warn_ghcr_image.py:60:def extract_repo_from_command(command: str) -> str | None:
.claude/hooks/warn_ghcr_image.py:87:    repo = extract_repo_from_command(command)
.claude/hooks/validate_pr_review.py:86:from _repo_flag_parse import extract_repo
.claude/hooks/validate_pr_review.py:580:    repo = extract_repo(command)
```

Three categories visible:

1. **Shared-helper consumers (clean post-PR)** — `validate_labels`, `validate_review_comment_format`, `validate_branch_freshness`, `validate_pr_review`. Each shows the import line + a single call site. Correct.

2. **`validate_wave_label_evidence._extract_repo_for_path`** — different function (signature `(path, default_repo)`, parses repo from a relative path not a CLI flag). Not in scope for `--repo`-flag consolidation. Correctly NOT touched.

3. **Two remaining inline `extract_repo_from_command` definitions** discovered during this audit:
   - `validate_pr_ci_status.py:109-111` — **same exact single-form shape** as #514 just removed. Same latent #503-class risk. Filed as follow-up #515 for separate small PR with the same acceptance pattern (out of #514's scope per issue text).
   - `warn_ghcr_image.py:60-69` — **genuinely different semantics**: only handles `-R`, applies `.split("/")[-1]` post-processing to return a short repo name for the GHCR image lookup table. NOT a drop-in candidate for `_repo_flag_parse.extract_repo`. Documented in #515.

#514's acceptance text says "ZERO inline parser defs". Strict reading leaves the two extras visible; #515 closes the `validate_pr_ci_status.py` half cleanly, and `warn_ghcr_image.py` deserves a separate evaluation (call-site short-name post-processing reconciliation). Flagged for explicit reviewer awareness rather than smuggled into this PR.

## Test Plan

- [x] `ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/ .claude/lib/tests/` → **933 passed in 1.33s**. No regression vs main.
- [x] Focused: `ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/test_validate_pr_review.py .claude/hooks/tests/test_validate_branch_freshness.py .claude/hooks/tests/test_repo_flag_parse.py .claude/hooks/tests/test_validate_labels.py .claude/hooks/tests/test_validate_review_comment_format.py` → **226 passed in 0.33s**.
- [x] `ruff format --check .claude/hooks/ .claude/lib/` → 68 files already formatted.
- [x] `ruff check .claude/hooks/ .claude/lib/` → All checks passed.
- [x] Pre-commit hooks (ruff-format, ruff-lint, mypy) all passed.

Closes #514

---

Requestor: (TBD — orchestrator will assign reviewers)
Requestee: Wanjiku Mwangi
RequestOrReplied: New
TechDebt: #515
