### PR TITLE
tech-debt(hook): consolidate validate_pr_ci_status --repo parser via shared helper (closes #515)

### DIFF
--- a/.claude/hooks/tests/test_validate_pr_ci_status.py
+++ b/.claude/hooks/tests/test_validate_pr_ci_status.py
@@ -267,5 +267,44 @@ class EmptyRollupTests(unittest.TestCase):
         mock_fetch.assert_not_called()
 
 
+class ExtractRepoCallSiteTests(unittest.TestCase):
+    """Smoke coverage that `validate_pr_ci_status` exposes `extract_repo`
+    (re-exported from the shared `_repo_flag_parse` helper) and that the
+    canonical `gh pr merge --repo` happy path still resolves the same
+    value.
+
+    Comprehensive parser coverage (all 4 flag forms, tokenize / regex
+    fallback, malformed cases) lives in `test_repo_flag_parse.py` alongside
+    the helper. These tests pin the hook's import wiring so a future
+    refactor that drops the re-export trips here, not at runtime. Mirrors
+    `test_validate_pr_review.ExtractRepoCallSiteTests` from #516 and
+    `test_validate_review_comment_format.ExtractRepoCallSiteTests` from
+    #513.
+    """
+
+    def test_present_returns_value(self):
+        cmd = "gh pr merge 487 --repo noorinalabs/noorinalabs-deploy --squash"
+        self.assertEqual(
+            hook.extract_repo(cmd),
+            "noorinalabs/noorinalabs-deploy",
+        )
+
+    def test_absent_returns_none(self):
+        cmd = "gh pr merge 487 --squash"
+        self.assertIsNone(hook.extract_repo(cmd))
+
+    def test_equals_form_now_supported(self):
+        """`--repo=value` form is supported post-#515 (was the documented
+        latent #503-class gap in the original space-only inline parser —
+        sister consolidations #513, #516 fixed it for three hooks; #515
+        extends the fix to validate_pr_ci_status for the gh-pr-merge CI
+        gate code path)."""
+        cmd = "gh pr merge 487 --repo=noorinalabs/noorinalabs-deploy --squash"
+        self.assertEqual(
+            hook.extract_repo(cmd),
+            "noorinalabs/noorinalabs-deploy",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.claude/hooks/validate_pr_ci_status.py
+++ b/.claude/hooks/validate_pr_ci_status.py
@@ -53,6 +53,7 @@ import subprocess
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _repo_flag_parse import extract_repo
 from annunaki_log import log_pretooluse_block
 
 # Conclusion values that unambiguously indicate a failed check.
@@ -101,14 +102,6 @@ def extract_pr_number(command: str) -> str | None:
     if match:
         return match.group(1)
     match = re.search(r"/pull/(\d+)", command)
-    if match:
-        return match.group(1)
-    return None
-
-
-def extract_repo_from_command(command: str) -> str | None:
-    """Extract --repo value from gh pr merge command."""
-    match = re.search(r"--repo\s+(\S+)", command)
     if match:
         return match.group(1)
     return None
@@ -205,7 +198,7 @@ def check(input_data: dict) -> dict | None:
         return None
 
     pr_number = extract_pr_number(command)
-    repo = extract_repo_from_command(command)
+    repo = extract_repo(command)
     rollup = fetch_checks(pr_number, repo)
 
     pr_display = f"#{pr_number}" if pr_number else "(current branch)"


### PR DESCRIPTION
Closes #515

Fourth-hook consolidation in the `_repo_flag_parse` shared-helper family. Sibling to:
- #513 — helper introduction + `validate_labels.py` + `validate_review_comment_format.py` (closes #510)
- #516 — `validate_pr_review.py` (closes #514)

## Summary

Replace the inline single-form `re.search(r"--repo\s+(\S+)", command)` parser in `validate_pr_ci_status.py` with `from _repo_flag_parse import extract_repo`. The shared helper handles all four flag forms (`--repo X`, `--repo=X`, `-R X`, `-R=X`) — the previous inline parser only matched the canonical space form, so the other three silently fell back to cwd-default repo resolution. Same latent #503-class skew direction.

## Diff shape

- `.claude/hooks/validate_pr_ci_status.py`: −11/+2 lines (deletes the inline `extract_repo_from_command` helper, adds the import, rewires the call site).
- `.claude/hooks/tests/test_validate_pr_ci_status.py`: +39 lines (new `ExtractRepoCallSiteTests` class mirroring the smoke shape from #513 / #516).

## Base branch

This PR targets `main` (not `deployments/phase-3/wave-11`) for parity with #513 and #516 — the three sibling hook-consolidation PRs in this family. The wave-11 branch hasn't been merged-down from main since `f707483` (2026-05-18), which predates #513/#516, so the shared helper isn't reachable from there yet. Pre-spawn-verify-at-HEAD caught this before any worktree work; team-lead confirmed the `--base main` decision.

## Out of scope (deferred per #482 single-purpose-PR discipline)

`warn_ghcr_image.py:60-69` defines an `extract_repo_from_command` with genuinely different semantics — `-R` only, plus short-name post-processing via `.split("/")[-1]` for the GHCR image-name lookup table. Migrating it would require either call-site post-processing (cleaner) or keeping the inline parser (also fine). Either choice is defensible but unrelated to this consolidation; separate evaluation if filed.

## Acceptance verification

- [x] `validate_pr_ci_status.extract_repo_from_command` removed.
- [x] Inline `re.search(r"--repo\s+(\S+)", command)` regex gone from the hook.
- [x] All 34 pre-existing tests pass unchanged (behavior-preserving for the space-form path).
- [x] 3 new `ExtractRepoCallSiteTests` smoke tests pass (present-returns-value, absent-returns-none, equals-form-now-supported).
- [x] Acceptance grep `grep -rn 'extract_repo\|--repo\s' .claude/hooks/*.py | grep -v __pycache__ | grep -v _repo_flag_parse.py` shows only shared-helper imports and call sites across all migrated hooks, plus the documented genuinely-different `warn_ghcr_image.py:60-69`.
- [x] `uvx ruff@0.15.11 format --check` clean on both edited files.
- [x] `uvx ruff@0.15.11 check` clean on both edited files.
- [x] Pre-commit ruff-format + ruff-lint + mypy all green.

## Test plan

- [x] `ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/test_validate_pr_ci_status.py -v` → 37 passed, 19 subtests passed.
- [ ] CI green on PR.

Requestor: Wanjiku Mwangi
Requestee: TBD
RequestOrReplied: New
TechDebt: none
