### PR TITLE
chore(coord): recover W11 wrapup status + gitignore worktrees/.bak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,12 @@ temp/
 .vscode/
 .idea/
 .hypothesis/
+
+# Worktrees — local-only isolation dirs, never tracked. Top-level .worktrees/
+# plus the .claude/worktrees/ convention path used by wave/agent isolation.
+.worktrees/
+.claude/worktrees/
+
+# Annunaki rotation backups — created by /annunaki-attack Step 1 before clearing
+# errors.jsonl. Historical-only; safe to age out locally, not for tracking.
+.claude/annunaki/errors.jsonl.bak.*

--- a/cross-repo-status.json
+++ b/cross-repo-status.json
@@ -2658,5 +2658,11 @@
         "status": "created"
       }
     }
-  }
+  },
+  "wave_11_final_pr_count": 86,
+  "wave_11_changes_requested_cycles": 16,
+  "wave_11_top_concentration_pct": 15,
+  "wave_11_wrapup_at": "2026-05-20T01:36:10Z",
+  "wave_11_carry_forward": ["noorinalabs-deploy#269","noorinalabs-deploy#245","noorinalabs-deploy#244","noorinalabs-deploy#204","noorinalabs-deploy#193","noorinalabs-deploy#156","noorinalabs-deploy#140","noorinalabs-deploy#100","noorinalabs-deploy#86","noorinalabs-deploy#45","noorinalabs-deploy#11","noorinalabs-main#136"],
+  "wave_11_close_blocked_by": "deploy#348 — .net/.org canonical-redirect entrypoint import must apply to prod before W11 closes (owner directive 2026-05-21)"
 }

--- a/ontology/checksums.json
+++ b/ontology/checksums.json
@@ -170,10 +170,10 @@
       "resolved_at": "2026-05-16T22:20:43.893664+00:00"
     },
     ".gitignore": {
-      "last_resolved": "99a48dfddef755ee0af95d7c44b8cc62d5b74a8cda39be8977e236538a4f1b35",
-      "last_tracked": "99a48dfddef755ee0af95d7c44b8cc62d5b74a8cda39be8977e236538a4f1b35",
-      "resolved_at": "2026-05-11T01:24:19.842478+00:00",
-      "tracked_at": "2026-05-11T01:24:19.842478+00:00"
+      "last_tracked": "78d915777b9d1fcb638d4f7185c73364db6cf6cd9cfe72d8030b37e617020bde",
+      "last_resolved": "78d915777b9d1fcb638d4f7185c73364db6cf6cd9cfe72d8030b37e617020bde",
+      "tracked_at": "2026-05-24T15:08:10.361465+00:00",
+      "resolved_at": "2026-05-24T15:08:46Z"
     },
     ".pre-commit-config.yaml": {
       "last_resolved": "e5cb514b9a22f37b80adb4d74896cef8e9d2768f0f42ae3f3a29001efd3ae615",
@@ -200,10 +200,10 @@
       "tracked_at": "2026-04-16T21:36:05.052302+00:00"
     },
     "cross-repo-status.json": {
-      "last_tracked": "8c73a1c24a34d92608c19fe7faa9fb2048fc6bd4d9f8325d36ae7d6e8dac2663",
-      "last_resolved": "8c73a1c24a34d92608c19fe7faa9fb2048fc6bd4d9f8325d36ae7d6e8dac2663",
-      "tracked_at": "2026-05-12T22:57:20.346557+00:00",
-      "resolved_at": "2026-05-13T03:21:08.894134+00:00"
+      "last_tracked": "b517daf1b57c5d972b4b758cc8a779627285f8f1ffeb39c7ac09d1125ca2f4ad",
+      "last_resolved": "b517daf1b57c5d972b4b758cc8a779627285f8f1ffeb39c7ac09d1125ca2f4ad",
+      "tracked_at": "2026-05-24T15:08:13.177664+00:00",
+      "resolved_at": "2026-05-24T15:08:46Z"
     },
     "dependencies.yml": {
       "last_resolved": "f4b53ffd3e1f81e055130ae2f53ff08ba9b5f651782434bbf3ac8b3eab4276e8",


### PR DESCRIPTION
## Summary

Recovers stranded P3W11 wrapup state and adds missing gitignore entries, after reconciling a diverged local `main`.

**Context:** local `main` had drifted 2-ahead / 35-behind `origin/main`. The 2 local commits were stale ontology/gitignore housekeeping (superseded by newer origin rebuilds); they were discarded by resetting `main` to `origin/main` (which carries the #522 wave-11 merge). One genuinely valuable artifact was stranded as an *uncommitted* edit on that diverged main — the W11 wrapup status block — and is recovered here.

## Changes

**`cross-repo-status.json`** — additive W11 wrapup keys (generated by `/wave-wrapup` on 2026-05-20, never committed):
- `wave_11_final_pr_count: 86`, `wave_11_changes_requested_cycles: 16`, `wave_11_top_concentration_pct: 15`
- `wave_11_wrapup_at: 2026-05-20T01:36:10Z`
- `wave_11_carry_forward`: 12 issues (11 deploy + main#136)
- `wave_11_close_blocked_by: deploy#348` — .net/.org canonical-redirect entrypoint import must apply to prod before W11 closes (owner directive 2026-05-21)
- `wave_11_active` intentionally left `true` — W11 is open-pending-close, not closed.

**`.gitignore`** — `.worktrees/`, `.claude/worktrees/` (local-only isolation dirs), and `.claude/annunaki/errors.jsonl.bak.*` (rotation backups; pattern was previously tracked only on the discarded local branch).

**`ontology/checksums.json`** — checksum-only resolution of the two files above (no entity/service changes).

## Test plan
- [x] `cross-repo-status.json` validates as JSON; 6 wrapup keys present
- [x] `git check-ignore` confirms `.worktrees/`, `.claude/worktrees/`, `errors.jsonl.bak.*` are ignored
- [x] ontology dirty count = 0 after resolution

Refs #447
