### PR TITLE
chore(coord): lift W11 close-blocker (deploy#348 resolved) + post-unblock scrub

### DIFF
--- a/cross-repo-status.json
+++ b/cross-repo-status.json
@@ -2664,5 +2664,19 @@
   "wave_11_top_concentration_pct": 15,
   "wave_11_wrapup_at": "2026-05-20T01:36:10Z",
   "wave_11_carry_forward": ["noorinalabs-deploy#269","noorinalabs-deploy#245","noorinalabs-deploy#244","noorinalabs-deploy#204","noorinalabs-deploy#193","noorinalabs-deploy#156","noorinalabs-deploy#140","noorinalabs-deploy#100","noorinalabs-deploy#86","noorinalabs-deploy#45","noorinalabs-deploy#11","noorinalabs-main#136"],
-  "wave_11_close_blocked_by": "deploy#348 — .net/.org canonical-redirect entrypoint import must apply to prod before W11 closes (owner directive 2026-05-21)"
+  "wave_11_close_blocker_resolved": {
+    "issue": "noorinalabs-deploy#348",
+    "resolved_at": "2026-05-24T16:18:00Z",
+    "via_prs": ["noorinalabs-deploy#349", "noorinalabs-deploy#350"],
+    "evidence": "terraform apply 0 added / 2 changed / 0 destroyed; live 301 verified noorinalabs.net + .org -> .com (path + query preserved)",
+    "supersedes": "wave_11_close_blocked_by (deploy#348, owner directive 2026-05-21)"
+  },
+  "wave_11_post_unblock_scrub_2026_05_24": {
+    "open_p3_wave_11_issues": 0,
+    "orphans_found": 0,
+    "carry_forward_verified": "12 issues, all labeled p3-wave-12 (stale p3-wave-3 removed from deploy#245)",
+    "phase3_labels_added": 13,
+    "td_ratio_actual": {"open": 93, "open_td": 34, "pct": 37},
+    "note": "W11 labeled scope fully closed. TD ratio 37% exceeds the post-W11 projection (30%); W12+W13 sweep confirmed needed. Formal /wave-retro + meta-issue #447 close deferred to a dedicated session (owner directive 2026-05-24)."
+  }
 }

--- a/ontology/checksums.json
+++ b/ontology/checksums.json
@@ -200,10 +200,10 @@
       "tracked_at": "2026-04-16T21:36:05.052302+00:00"
     },
     "cross-repo-status.json": {
-      "last_tracked": "b517daf1b57c5d972b4b758cc8a779627285f8f1ffeb39c7ac09d1125ca2f4ad",
-      "last_resolved": "b517daf1b57c5d972b4b758cc8a779627285f8f1ffeb39c7ac09d1125ca2f4ad",
-      "tracked_at": "2026-05-24T15:08:13.177664+00:00",
-      "resolved_at": "2026-05-24T15:08:46Z"
+      "last_tracked": "7437b04e89d209d8cf965c0ee119f1f2c013015d5ae804fbcf78350d0572397f",
+      "last_resolved": "7437b04e89d209d8cf965c0ee119f1f2c013015d5ae804fbcf78350d0572397f",
+      "tracked_at": "2026-05-24T16:45:28Z",
+      "resolved_at": "2026-05-24T16:45:28Z"
     },
     "dependencies.yml": {
       "last_resolved": "f4b53ffd3e1f81e055130ae2f53ff08ba9b5f651782434bbf3ac8b3eab4276e8",


### PR DESCRIPTION
## Summary

Lifts the P3W11 close-blocker now that **deploy#348 is resolved and live in production**, and records the post-unblock scrub.

## Changes (`cross-repo-status.json`)
- **`wave_11_close_blocked_by` → `wave_11_close_blocker_resolved`**: deploy#348 (.net/.org canonical-redirect entrypoint import) resolved via deploy#349 (import+adopt) + deploy#350 (expression fix). Apply: `0 added / 2 changed / 0 destroyed`; live `301` verified `.net`/`.org → .com` (path+query preserved).
- **`wave_11_post_unblock_scrub_2026_05_24`**: 0 open `p3-wave-11` issues; 0 orphans (audited merged-PR `Closes`-refs vs open issues); 12 carry-forwards verified on `p3-wave-12` (stale `p3-wave-3` removed from deploy#245); 13 `phase-3` labels added to untagged tech-debt; TD ratio actual **37%** (34/93) vs the 30% post-W11 projection → W12+W13 sweep confirmed needed.

`ontology/checksums.json`: checksum-only resolution for `cross-repo-status.json` (no entity changes).

## Deferred (owner directive 2026-05-24)
`wave_11_active` is intentionally left `true`. The formal `/wave-retro` + meta-issue #447 close are deferred to a dedicated session — this PR only lifts the blocker and records the scrub.

## Test plan
- [x] `cross-repo-status.json` valid JSON; `wave_11_close_blocked_by` removed, `wave_11_close_blocker_resolved` present
- [x] checksum entry matches file sha256
- [x] deploy#348 CLOSED with live-curl evidence

Refs #447
