### PR TITLE
fix(session-start): Step 0 prunes child-repo worktrees with verify-merged guard (#526)

### DIFF
--- a/.claude/hooks/session_start.py
+++ b/.claude/hooks/session_start.py
@@ -90,10 +90,12 @@ def main() -> None:
         "",
     ]
 
-    # Step 0: Worktree cleanup
-    lines.append("STEP 0 — WORKTREE CLEANUP:")
-    lines.append("  Run: git worktree prune && git worktree list")
-    lines.append("  Remove any stale worktrees under .claude/worktrees/")
+    # Step 0: Worktree cleanup (parent + child repos, per #526)
+    lines.append("STEP 0 — WORKTREE CLEANUP (parent + child repos):")
+    lines.append("  Run the Step 0 block in skills/session-start/SKILL.md.")
+    lines.append("  It prunes the parent AND all 7 child repos, auto-removing")
+    lines.append("  only worktrees merged into origin/main and FLAGGING locked")
+    lines.append("  or unmerged ones for a manual decision (never auto-removed).")
     lines.append("")
 
     # Step 1: Team cleanup (unique to noorinalabs-main)

--- a/.claude/skills/session-start/SKILL.md
+++ b/.claude/skills/session-start/SKILL.md
@@ -13,15 +13,82 @@ description: "MANDATORY first action in every session — runs full startup prot
 
 Execute all 7 steps below. Steps that are independent of each other SHOULD run in parallel. Present results in a single concise status table at the end.
 
-### Step 0 — Worktree cleanup
+### Step 0 — Worktree cleanup (parent + child repos)
+
+Worktrees accumulate in BOTH the parent repo and every child repo (under
+`<child>/.claude/worktrees/`, `<child>/.worktrees/`, and sometimes `/tmp/`).
+Prior to #526, Step 0 only cleaned the parent — on 2026-05-24 ~33 stale
+child-repo worktrees were found uncaught. The block below iterates the parent
+and all 7 child repos, applying a **verify-merged-then-remove guard**:
+
+- **Auto-remove** a worktree only when its HEAD is an ancestor of that repo's
+  `origin/main` (i.e. the branch is fully merged). Safe to drop.
+- **FLAG (list, do not remove)** any worktree that is NOT verified-merged
+  (work in flight, superseded, or closed-issue cases) and any **locked**
+  worktree (e.g. the `/tmp/hotfix-user-service` lock case). Surface these for
+  a manual decision — never auto-remove unmerged work.
 
 ```bash
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-git -C "$REPO_ROOT" worktree prune
-git -C "$REPO_ROOT" worktree list
+
+# Parent repo + the 7 canonical child repos (CLAUDE.md Repository Map).
+REPOS=("$REPO_ROOT")
+for child in \
+  noorinalabs-isnad-graph \
+  noorinalabs-user-service \
+  noorinalabs-deploy \
+  noorinalabs-design-system \
+  noorinalabs-data-acquisition \
+  noorinalabs-isnad-ingest-platform \
+  noorinalabs-landing-page; do
+  [ -d "$REPO_ROOT/$child/.git" ] && REPOS+=("$REPO_ROOT/$child")
+done
+
+FLAGGED=()
+for repo in "${REPOS[@]}"; do
+  git -C "$repo" worktree prune
+  # Refresh remote tip so the merged-ancestor test is accurate.
+  git -C "$repo" fetch --quiet origin main 2>/dev/null || true
+  main_repo="$(git -C "$repo" rev-parse --show-toplevel)"
+
+  # Walk worktrees in porcelain form. Records are blank-line separated;
+  # fields we care about: worktree <path>, HEAD <sha>, locked [<reason>].
+  wt="" head="" locked=0
+  while IFS= read -r line; do
+    case "$line" in
+      "worktree "*) wt="${line#worktree }"; head=""; locked=0 ;;
+      "HEAD "*)     head="${line#HEAD }" ;;
+      "locked"*)    locked=1 ;;
+      "")  # end of a record — evaluate it
+        [ -z "$wt" ] && continue
+        if [ "$wt" = "$main_repo" ]; then wt=""; continue; fi  # skip main checkout
+        if [ "$locked" -eq 1 ]; then
+          FLAGGED+=("LOCKED  $repo :: $wt")
+        elif [ -n "$head" ] && git -C "$repo" merge-base --is-ancestor "$head" origin/main 2>/dev/null; then
+          echo "removing merged worktree: $wt"
+          git -C "$repo" worktree remove "$wt" 2>/dev/null \
+            || git -C "$repo" worktree remove --force "$wt" 2>/dev/null \
+            || FLAGGED+=("REMOVE-FAILED  $repo :: $wt")
+        else
+          FLAGGED+=("UNMERGED  $repo :: $wt (HEAD ${head:-?})")
+        fi
+        wt="" ;;
+    esac
+  done < <(git -C "$repo" worktree list --porcelain; echo)
+done
+
+echo "--- remaining worktrees (parent + children) ---"
+for repo in "${REPOS[@]}"; do git -C "$repo" worktree list; done
+
+if [ "${#FLAGGED[@]}" -gt 0 ]; then
+  echo "--- FLAGGED for manual decision (NOT removed) ---"
+  printf '%s\n' "${FLAGGED[@]}"
+fi
 ```
 
-Verify only the main repo root is listed. Remove any stale worktrees.
+Report how many merged worktrees were auto-removed and surface the FLAGGED
+list (locked + unmerged) to the user for a manual call. Do not force-remove a
+FLAGGED worktree without explicit confirmation.
 
 ### Step 1 — Team cleanup
 


### PR DESCRIPTION
## Summary

`/session-start` Step 0 only pruned the **parent** repo's worktrees. Child-repo worktrees (under `<child>/.claude/worktrees/`, `<child>/.worktrees/`, and `/tmp/`) accumulated indefinitely — ~33 stale ones were found manually on 2026-05-24 (isnad-graph ~19, user-service 5 incl. a locked `/tmp/hotfix-user-service`, data-acquisition 4, design-system 5), none caught by the skill.

## Change

Step 0 now iterates the parent **plus the 7 canonical child repos** (CLAUDE.md Repository Map) using `git worktree list --porcelain`, with a **verify-merged-then-remove guard** mirroring the manual 2026-05-24 procedure:

- **Auto-remove** a worktree only when its HEAD is an ancestor of that repo's `origin/main` (fully merged). 28 were auto-removable on 2026-05-24.
- **FLAG** (list, never auto-remove) any **unmerged** or **locked** worktree — e.g. the `/tmp/hotfix-user-service` lock case — for a manual decision. 5 were superseded/closed-issue cases.

The fix lives in `.claude/skills/session-start/SKILL.md` (the bash the orchestrator runs). `.claude/hooks/session_start.py` is text-directive only (it does not execute cleanup), so its Step 0 prose is updated to point at the SKILL.md block and describe the guard — keeping hook and skill in sync.

## Validation

- Step 0 bash block: `bash -n` syntax OK + `shellcheck -s bash` clean.
- Dry-run from the real main checkout: 8 repos detected; in-flight worktrees correctly FLAGGED (unmerged), parent main checkout skipped, merged ones marked for removal.
- `ruff format --check` + `ruff check` clean on `.claude/hooks/`; pre-commit ruff/mypy passed.

## Tech debt

REMOVES process-debt: eliminates the recurring manual child-repo worktree sweep that was being done by hand.

Closes #526
Advances #528 (epic closes after the #525/#521 cwd-anchor PR also lands)
