### PR TITLE
fix(enforce-ontology-context): anchor coordinator opener to exact line start (#471)

### DIFF
--- a/.claude/hooks/enforce_ontology_context.py
+++ b/.claude/hooks/enforce_ontology_context.py
@@ -55,9 +55,15 @@ ONTOLOGY_MARKERS = [
 
 # Canonical coordinator-class opener: `You are **{Name}**, {Role}[ for {repo}]`
 # where {Role} is one of the pure-coordination titles. Bold-markdown around
-# the name is optional. `re.MULTILINE` so the `^` anchor matches at the
-# start of any line — handles briefs that prepend a header (Ontology
-# Context block, task framing, etc.) before the "You are X, ..." opener.
+# the name is optional. The `(?:\A|\n)You are` anchor matches the opener only
+# when it sits at an EXACT line start (start of prompt, or immediately after a
+# newline) — no leading-whitespace tolerance. This still handles briefs that
+# prepend a header / task framing / role-card excerpt before the opener
+# (the opener line itself is at column 0; only the prepended content is above
+# it — see CoordinatorExemptHandlesPrependedHeader tests), while NOT exempting
+# a `You are X, Manager` line that appears INDENTED inside the prompt body
+# (4-space code blocks, YAML-indented examples). The old `^\s*` + re.MULTILINE
+# matched those indented lines and falsely exempted the spawn (#471).
 #
 # Title list is enumerative — see module docstring. Multi-word titles
 # precede single-word `Manager` alternation so the regex engine doesn't
@@ -65,7 +71,7 @@ ONTOLOGY_MARKERS = [
 # `Manager` requires position right after `, `, but the explicit ordering
 # documents the intent for future maintainers).
 COORDINATOR_ROLE_OPENER = re.compile(
-    r"^\s*You are\s+\*{0,2}[^,\n]+?\*{0,2},\s*"
+    r"(?:\A|\n)You are\s+\*{0,2}[^,\n]+?\*{0,2},\s*"
     r"(Pipeline\s+Manager"
     r"|Project\s+Lead"
     r"|Program\s+Director"
@@ -73,7 +79,7 @@ COORDINATOR_ROLE_OPENER = re.compile(
     r"|TPM"
     r"|Release\s+Coordinator"
     r"|Manager)\b",
-    re.IGNORECASE | re.MULTILINE,
+    re.IGNORECASE,
 )
 
 

--- a/.claude/hooks/tests/test_enforce_ontology_context.py
+++ b/.claude/hooks/tests/test_enforce_ontology_context.py
@@ -186,6 +186,49 @@ class CoordinatorExemptHandlesPrependedHeader(unittest.TestCase):
         self.assertIsNone(hook.check(_spawn(prompt)))
 
 
+class IndentedCoordinatorOpenerNotExempt(unittest.TestCase):
+    """The opener must sit at an EXACT line start to exempt. An indented
+    `You are X, Manager` line — inside a 4-space code block, a YAML-indented
+    example, or a blockquote — is NOT the coordinator's own opener; it's
+    prompt-body content. The old `^\\s*` + re.MULTILINE matched these and
+    falsely exempted implementer spawns. The `(?:\\A|\\n)You are` anchor
+    blocks them (#471). The opener tested here belongs to an Engineer spawn
+    with NO ontology context, so the correct outcome is a block."""
+
+    def test_four_space_indented_opener_not_exempt(self):
+        prompt = (
+            "You are **Mateo Salazar**, Engineer. Implement #123. Example brief shape:\n"
+            "    You are **Bereket Tadesse**, Manager for noorinalabs-deploy.\n"
+        )
+        result = hook.check(_spawn(prompt))
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+
+    def test_yaml_indented_opener_not_exempt(self):
+        prompt = (
+            "You are **Mateo Salazar**, Engineer. Implement #123. YAML example:\n"
+            "brief:\n"
+            "  opener: You are **Bereket Tadesse**, Manager for noorinalabs-deploy\n"
+        )
+        result = hook.check(_spawn(prompt))
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+
+    def test_blockquote_indented_opener_not_exempt(self):
+        # Defensive: a blockquote-prefixed opener (`> You are ...`) already
+        # wouldn't match a column-0 anchor; this pins that it stays blocked.
+        prompt = (
+            "You are **Mateo Salazar**, Engineer. Implement #123. Quoted brief:\n"
+            "> You are **Bereket Tadesse**, Manager for noorinalabs-deploy\n"
+        )
+        result = hook.check(_spawn(prompt))
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+
+
 class CheckIsCrashSafeOnMalformedInput(unittest.TestCase):
     """PreToolUse hooks that raise get surfaced to the user as
     block-with-error, which is worse than silently allowing a malformed


### PR DESCRIPTION
## Summary

`COORDINATOR_ROLE_OPENER` in `.claude/hooks/enforce_ontology_context.py` used `r"^\s*You are"` with `re.MULTILINE`. The `^\s*` indent tolerance combined with MULTILINE meant a whitespace-indented `You are X, <CoordRole>` line **anywhere** in a prompt body — a 4-space code block, a YAML-indented example — falsely exempted an implementer spawn from ontology-context enforcement.

## Change

Tighten the leading anchor to **`r"(?:\A|\n)You are"`**: match only at an exact line start (prompt start, or immediately after a newline), with no indent tolerance. The now-redundant `re.MULTILINE` flag is dropped (the `\n` alternative makes line-start matching explicit).

## Preserves PR #468

The `CoordinatorExemptHandlesPrependedHeader` test class (markdown header / task context / role-card excerpt prepended before the opener) is preserved: in all three shapes the **opener line itself is at column 0** — only the prepended content sits above it — so `(?:\A|\n)You are` still matches and those coordinators stay exempt. Verified: all 3 prepended-header tests pass unchanged.

## New tests

`IndentedCoordinatorOpenerNotExempt` pins the false-positive shapes that must NOT exempt (each is an Engineer spawn with no ontology context, so the correct outcome is a block):
- 4-space-indent `    You are X, Manager`
- YAML-indent `  opener: You are X, Manager`
- blockquote `> You are X, Manager` (defensive — already wouldn't match a column-0 anchor)

## Validation

- `ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/test_enforce_ontology_context.py -v` → **37 passed** (3 preserved prepended-header + 3 new indented-not-exempt + existing coverage).
- `ruff format --check` + `ruff check` clean on `.claude/hooks/`; pre-commit ruff/mypy passed.

## Tech debt

REMOVES — closes a silent enforcement-bypass hole (indented opener in prompt body slipping an implementer spawn past the ontology-context gate).

Closes #471
