### PR TITLE
fix(hooks): coordinated cwd-anchor pass — tracker .worktrees skip + gh-pr-create cwd recovery (closes #525 #521)

### DIFF
--- a/.claude/hooks/_shell_parse.py
+++ b/.claude/hooks/_shell_parse.py
@@ -92,6 +92,21 @@ Public API
         want to operate on the *user's* cwd (not the hook's parent process
         cwd) should use this to anchor `subprocess.run(..., cwd=...)`.
 
+    resolve_invocation_cwd(input_data) -> str
+        Like resolve_tool_cwd, but FIRST tries to recover the directory the
+        command actually runs in by extracting a leading `cd <dir>` segment
+        from the Bash command string. This closes the #521 residual: for a
+        worktree subagent the harness `cwd` field is captured at agent-spawn
+        time (the orchestrator's dir), NOT the subagent's dir after it has
+        `cd`'d into its worktree, and subsequent `cd` calls do not propagate
+        back to the hook's view of `cwd`. When the triggering command is
+        `cd /path/to/worktree && gh pr create ...`, the cd target is the
+        only in-band signal that recovers the real repo. Falls back to
+        resolve_tool_cwd (stdin cwd → os.getcwd()) when no leading `cd`
+        is present. Only absolute existing directories are honored; relative
+        cd targets are ambiguous (they'd be relative to the already-wrong
+        stdin cwd) so they are ignored.
+
     is_shutdown_request_message(message) -> bool
         True only if `message` is a structured shutdown_request JSON
         (dict-form OR str-form parseable to a dict with type==
@@ -443,6 +458,57 @@ def resolve_tool_cwd(input_data: dict) -> str:
     if cwd and isinstance(cwd, str):
         return cwd
     return os.getcwd()
+
+
+def extract_leading_cd_target(command: str) -> str | None:
+    """Return the directory of the last `cd <dir>` that precedes other work.
+
+    Walks the command's pipeline segments (see iter_command_segments) and
+    records the target of every `cd <dir>` segment, returning the last one.
+    Only honors a single-argument absolute `cd` target — relative targets
+    are ambiguous because they'd resolve against the (wrong) stdin cwd, and
+    multi-arg `cd` (e.g. `cd -P x`) is rare enough to skip rather than
+    mis-parse.
+
+    Returns None when the command does not tokenize, has no `cd`, or the
+    cd target is not an absolute path. The caller is responsible for
+    checking the path actually exists.
+
+    This is the in-band recovery signal for the worktree-subagent cwd-anchor
+    bug (#521): `cd /worktree && gh pr create` carries the real cwd in the
+    command itself even though the harness `cwd` field points at the
+    orchestrator's spawn-time directory.
+    """
+    tokens = tokenize(command)
+    if tokens is None:
+        return None
+    target: str | None = None
+    for segment in iter_command_segments(tokens):
+        if len(segment) == 2 and segment[0] == "cd" and segment[1].startswith("/"):
+            target = segment[1]
+    return target
+
+
+def resolve_invocation_cwd(input_data: dict) -> str:
+    """Resolve the directory the triggering command actually runs in.
+
+    Priority:
+      1. An absolute, existing `cd <dir>` target extracted from the command
+         string (recovers a worktree subagent's real cwd — #521).
+      2. resolve_tool_cwd(input_data) — stdin `cwd` then os.getcwd().
+
+    Use this (rather than resolve_tool_cwd) for any hook that derives repo
+    IDENTITY from cwd — i.e. anything that runs `git remote get-url origin`
+    or `git rev-parse` to decide which GitHub repo a command targets. The
+    plain resolve_tool_cwd is fine for hooks that only need *a* git context
+    and don't care about cross-repo misattribution.
+    """
+    command = input_data.get("tool_input", {}).get("command", "")
+    if isinstance(command, str) and command:
+        cd_target = extract_leading_cd_target(command)
+        if cd_target and os.path.isdir(cd_target):
+            return cd_target
+    return resolve_tool_cwd(input_data)
 
 
 def is_shutdown_request_message(message) -> bool:

--- a/.claude/hooks/no_worktree_self_delete.py
+++ b/.claude/hooks/no_worktree_self_delete.py
@@ -265,6 +265,16 @@ def check(input_data: dict) -> dict | None:
 
         # Caller-reported cwd wins; fall back to ours. Hook input carries the
         # shell's actual cwd at tool-call time.
+        #
+        # NOTE: this hook deliberately does NOT adopt the #521
+        # `resolve_invocation_cwd` cd-target recovery used by the gh-pr-create
+        # hooks. Here a leading `cd` changes the SAFETY semantics rather than
+        # just repo identity: `cd /safe && git worktree remove /worktree` is
+        # safe (shell moves out first) while `cd /worktree && remove /worktree`
+        # is the self-delete. Folding the cd target into cwd would change the
+        # block/allow verdict, which is a distinct behavioral decision from the
+        # cwd-anchor sweep — see the docstring "cd plans not yet executed"
+        # note. Left as-is intentionally; tracked separately if revisited.
         cwd = input_data.get("cwd") or os.getcwd()
 
         for segment in _SEGMENT_SPLIT_RE.split(command):

--- a/.claude/hooks/ontology_tracker.py
+++ b/.claude/hooks/ontology_tracker.py
@@ -17,16 +17,24 @@ Path filtering (issue #143):
     * Substring SKIP_PATTERNS (e.g. ``__pycache__/``, ``.git/``).
     * Paths beginning with ``/tmp/`` — ephemeral scratch (e.g. issue-body
       staging files).
-    * Paths containing ``.claude/worktrees/`` — ephemeral worktree copies.
-      The canonical entry for the underlying file is updated whenever the
-      file is next Edit/Written directly on the main checkout (this is a
-      PostToolUse hook on tool calls, NOT a git post-merge hook, so a
-      squash-merge of a worktree-only PR does not by itself update the
-      tracker — the next direct Edit on main does). Skipping worktree
-      paths is still the right call: it prevents accumulation of stale
-      paths in ``checksums.json`` after worktrees are removed, and the
-      slight latency in the canonical entry's ``last_tracked`` is
-      acceptable noise-vs-signal trade.
+    * Paths under any ``.worktrees`` directory — ephemeral worktree copies.
+      Two conventions are both gitignored (#523) and both skipped: the
+      historical ``.claude/worktrees/`` path and the top-level
+      ``.worktrees/`` path used by current wave/agent isolation. A worktree
+      path enters this hook when an Edit/Write happens inside a worktree and
+      the hook (anchored on the orchestrator cwd) records the worktree-
+      relative path — e.g. ``.worktrees/deploy-0348-aisha/...`` or a
+      child-repo file seen through a sibling worktree. These never resolve
+      (``last_resolved: ""``) and once aborted a ``git merge --ff-only``
+      during W11 close-out (#525). The canonical entry for the underlying
+      file is updated whenever the file is next Edit/Written directly on the
+      main checkout (this is a PostToolUse hook on tool calls, NOT a git
+      post-merge hook, so a squash-merge of a worktree-only PR does not by
+      itself update the tracker — the next direct Edit on main does).
+      Skipping worktree paths is still the right call: it prevents
+      accumulation of stale paths in ``checksums.json`` after worktrees are
+      removed, and the slight latency in the canonical entry's
+      ``last_tracked`` is acceptable noise-vs-signal trade.
     * Paths outside the repo tree — anything not under ``REPO_ROOT`` after
       resolution (e.g. user auto-memory files at
       ``/home/.../.claude/projects/.../memory/*.md``). The ontology only
@@ -73,16 +81,48 @@ SKIP_PATTERNS = [
 # Path prefixes: skip if the resolved file path starts with any of these.
 SKIP_PREFIXES = ("/tmp/",)
 
+# Directory names that mark a worktree-isolation tree. Any path with one of
+# these as a path COMPONENT is an ephemeral worktree copy and must not be
+# tracked into the parent checksums (#523 gitignored both; #525). Segment
+# matching (not substring) so a legitimate file like ``notes.worktrees.md``
+# is not skipped, while ``.worktrees/deploy-0348/x`` and
+# ``.claude/worktrees/foo/x`` both are.
+WORKTREE_DIR_NAMES = frozenset({".worktrees", "worktrees"})
+
+
+def _is_worktree_path(file_path: str) -> bool:
+    """True if any path component marks a worktree-isolation tree.
+
+    Checks the raw path components (both the as-given and, when it differs,
+    the resolved form) so that a relative worktree path recorded under the
+    orchestrator cwd (``.worktrees/...``) is caught even before resolution.
+    The ``worktrees`` bare name is only treated as a marker when its parent
+    component is ``.claude`` — i.e. the historical ``.claude/worktrees/``
+    convention — to avoid skipping an unrelated dir merely named
+    ``worktrees``.
+    """
+    parts = Path(file_path).parts
+    for i, part in enumerate(parts):
+        if part == ".worktrees":
+            return True
+        if part == "worktrees" and i > 0 and parts[i - 1] == ".claude":
+            return True
+    return False
+
 
 def _should_skip(file_path: str) -> bool:
     """Return True if this file should not be tracked.
 
-    Filters in order: substring patterns, /tmp/ prefix, then out-of-repo
-    paths. See module docstring for the rationale behind each rule.
+    Filters in order: substring patterns, worktree path components, /tmp/
+    prefix, then out-of-repo paths. See module docstring for the rationale
+    behind each rule.
     """
     for pattern in SKIP_PATTERNS:
         if pattern in file_path:
             return True
+
+    if _is_worktree_path(file_path):
+        return True
 
     try:
         resolved = Path(file_path).resolve()

--- a/.claude/hooks/tests/test_ontology_tracker.py
+++ b/.claude/hooks/tests/test_ontology_tracker.py
@@ -120,6 +120,52 @@ class ShouldSkipPositiveTests(unittest.TestCase):
         self.assertFalse(hook._should_skip(path))
 
 
+class ShouldSkipTopLevelWorktreesTests(unittest.TestCase):
+    """#525: top-level `.worktrees/` paths must be skipped.
+
+    The change-tracker anchors on the orchestrator cwd; an Edit inside a
+    worktree gets recorded as a worktree-relative path like
+    ``.worktrees/deploy-0348-aisha/...``. Pre-#525 only ``.claude/worktrees/``
+    was skipped, so the top-level convention (gitignored as of #523) polluted
+    the parent ``checksums.json`` with entries that never resolve and once
+    aborted a ``git merge --ff-only``.
+    """
+
+    def test_relative_top_level_worktrees_path_is_skipped(self):
+        """The exact #525 evidence shape — a worktree-relative path."""
+        self.assertTrue(
+            hook._should_skip(".worktrees/deploy-0348-aisha/terraform/cloudflare/variables.tf")
+        )
+
+    def test_relative_top_level_worktrees_status_file_is_skipped(self):
+        self.assertTrue(hook._should_skip(".worktrees/main-w11-unblock/cross-repo-status.json"))
+
+    def test_absolute_top_level_worktrees_path_is_skipped(self):
+        wt = str(hook.REPO_ROOT / ".worktrees" / "0528-cwd-anchor" / "ontology" / "domain.yaml")
+        self.assertTrue(hook._should_skip(wt))
+
+    def test_worktrees_segment_not_substring_false_match(self):
+        """A file merely NAMED with a worktrees substring is NOT skipped.
+
+        Segment-matching (not substring) guards against skipping a real
+        source file like ``notes.worktrees.md`` — only a path COMPONENT of
+        ``.worktrees`` triggers the skip.
+        """
+        # Place it under REPO_ROOT so the out-of-repo filter doesn't fire.
+        legit = str(hook.REPO_ROOT / "docs" / "notes.worktrees.md")
+        self.assertFalse(hook._is_worktree_path(legit))
+
+    def test_claude_worktrees_still_skipped_via_segment(self):
+        """The historical convention is also caught by the segment check."""
+        self.assertTrue(
+            hook._is_worktree_path(".claude/worktrees/A.Virtanen-0143/ontology/services.yaml")
+        )
+
+    def test_bare_worktrees_dir_without_claude_parent_not_skipped(self):
+        """A dir literally named ``worktrees`` but NOT under ``.claude`` is fine."""
+        self.assertFalse(hook._is_worktree_path("src/worktrees/helper.py"))
+
+
 class ShouldSkipExistingFiltersTests(unittest.TestCase):
     """Regression — pre-existing SKIP_PATTERNS keep working."""
 

--- a/.claude/hooks/tests/test_shell_parse.py
+++ b/.claude/hooks/tests/test_shell_parse.py
@@ -379,5 +379,76 @@ class IsShutdownRequestMessageTests(unittest.TestCase):
         self.assertFalse(sp.is_shutdown_request_message(None))
 
 
+class ExtractLeadingCdTargetTests(unittest.TestCase):
+    """#521: recover a worktree subagent's real cwd from a leading `cd`."""
+
+    def test_simple_cd_and_gh(self):
+        self.assertEqual(
+            sp.extract_leading_cd_target("cd /home/u/wt && gh pr create"),
+            "/home/u/wt",
+        )
+
+    def test_no_cd_returns_none(self):
+        self.assertIsNone(sp.extract_leading_cd_target("gh pr create --title t"))
+
+    def test_relative_cd_ignored(self):
+        """Relative cd targets are ambiguous (relative to the wrong stdin cwd)."""
+        self.assertIsNone(sp.extract_leading_cd_target("cd subdir && gh pr create"))
+
+    def test_last_absolute_cd_wins(self):
+        self.assertEqual(
+            sp.extract_leading_cd_target("cd /a && cd /b && gh pr create"),
+            "/b",
+        )
+
+    def test_cd_inside_quoted_body_is_not_a_segment(self):
+        """A `cd` mention inside a flag value must not be treated as a real cd."""
+        cmd = 'gh pr create --body "first cd /ghost then build"'
+        self.assertIsNone(sp.extract_leading_cd_target(cmd))
+
+    def test_multi_arg_cd_ignored(self):
+        """`cd -P /x` is a 3-token segment — skipped rather than mis-parsed."""
+        self.assertIsNone(sp.extract_leading_cd_target("cd -P /x && gh pr create"))
+
+    def test_unparseable_command_returns_none(self):
+        self.assertIsNone(sp.extract_leading_cd_target('cd /x && echo "unbalanced'))
+
+
+class ResolveInvocationCwdTests(unittest.TestCase):
+    """#521: invocation-cwd resolution prefers an existing `cd` target."""
+
+    def test_existing_cd_target_wins_over_stdin_cwd(self):
+        # The cwd field is the (wrong) orchestrator dir; the cd target is the
+        # subagent's real worktree. An existing absolute cd target wins.
+        real_dir = str(Path(__file__).resolve().parent)  # guaranteed to exist
+        input_data = {
+            "tool_input": {"command": f"cd {real_dir} && gh pr create"},
+            "cwd": "/some/orchestrator/dir",
+        }
+        self.assertEqual(sp.resolve_invocation_cwd(input_data), real_dir)
+
+    def test_nonexistent_cd_target_falls_back_to_stdin_cwd(self):
+        input_data = {
+            "tool_input": {"command": "cd /no/such/dir/here && gh pr create"},
+            "cwd": "/orchestrator",
+        }
+        self.assertEqual(sp.resolve_invocation_cwd(input_data), "/orchestrator")
+
+    def test_no_cd_falls_back_to_stdin_cwd(self):
+        input_data = {
+            "tool_input": {"command": "gh pr create"},
+            "cwd": "/orchestrator",
+        }
+        self.assertEqual(sp.resolve_invocation_cwd(input_data), "/orchestrator")
+
+    def test_no_cd_no_cwd_falls_back_to_getcwd(self):
+        input_data = {"tool_input": {"command": "gh pr create"}}
+        self.assertEqual(sp.resolve_invocation_cwd(input_data), os.getcwd())
+
+    def test_missing_command_falls_back_to_stdin_cwd(self):
+        input_data = {"tool_input": {}, "cwd": "/orchestrator"}
+        self.assertEqual(sp.resolve_invocation_cwd(input_data), "/orchestrator")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.claude/hooks/tests/test_validate_branch_freshness.py
+++ b/.claude/hooks/tests/test_validate_branch_freshness.py
@@ -384,5 +384,116 @@ class CwdHandlingTests(unittest.TestCase):
         self.assertEqual(captured.get("cwd"), "/tmp/worktree-bar")
 
 
+class Issue521CwdRecoveryTests(unittest.TestCase):
+    """#521: worktree-subagent cwd recovery + GH_REPO env fast-path.
+
+    The harness `cwd` field is the orchestrator's spawn-time dir, NOT the
+    subagent's worktree. The fix recovers the real cwd from a leading `cd`
+    in the command (resolve_invocation_cwd) and consults GH_REPO first.
+    """
+
+    @staticmethod
+    def _input(command: str, cwd: str) -> dict:
+        return {
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+            "cwd": cwd,
+        }
+
+    def test_cd_target_recovers_child_repo_cwd(self):
+        """`cd /worktree && gh pr create` resolves repo from the cd target,
+        not the (wrong) orchestrator stdin cwd.
+        """
+        import tempfile
+
+        captured: dict[str, object] = {}
+
+        def fake_resolve(cwd):
+            captured["cwd"] = cwd
+            return "noorinalabs/noorinalabs-deploy"
+
+        with tempfile.TemporaryDirectory() as worktree:
+            cmd = f"cd {worktree} && gh pr create --title t"
+            with (
+                mock.patch.dict("os.environ", {}, clear=True),
+                mock.patch.object(hook, "_resolve_implicit_repo", side_effect=fake_resolve),
+                mock.patch.object(hook, "_current_branch", return_value="A.Idrissi/0242-x"),
+                mock.patch.object(hook, "is_branch_fresh_remote", return_value=True) as remote,
+                mock.patch.object(hook, "is_branch_fresh_local") as local,
+            ):
+                result = hook.check(
+                    self._input(cmd, cwd="/home/parameterization/code/noorinalabs-main")
+                )
+            # The implicit-repo resolver saw the worktree, not the parent cwd.
+            self.assertEqual(captured.get("cwd"), worktree)
+            self.assertIsNone(result)
+            remote.assert_called_once_with(
+                "noorinalabs/noorinalabs-deploy", "main", "A.Idrissi/0242-x"
+            )
+            local.assert_not_called()
+
+    def test_repro_for_issue_521(self):
+        """Exact #521 repro: orchestrator cwd in parent, worktree targets child.
+
+        Pre-fix: `_resolve_implicit_repo` ran in the parent cwd → resolved
+        `noorinalabs/noorinalabs-main` and false-blocked on the parent's
+        wave branch. Post-fix: cd-target recovery resolves the child repo.
+        """
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as worktree:
+            cmd = f"cd {worktree} && gh pr create --title t --body-file /tmp/x.txt"
+
+            def repo_by_cwd(cwd):
+                # Parent cwd → main (the bug); worktree cwd → deploy (the fix).
+                if cwd == worktree:
+                    return "noorinalabs/noorinalabs-deploy"
+                return "noorinalabs/noorinalabs-main"
+
+            with (
+                mock.patch.dict("os.environ", {}, clear=True),
+                mock.patch.object(hook, "_resolve_implicit_repo", side_effect=repo_by_cwd),
+                mock.patch.object(hook, "_current_branch", return_value="A.Idrissi/0242-x"),
+                mock.patch.object(hook, "is_branch_fresh_remote", return_value=True) as remote,
+            ):
+                result = hook.check(
+                    self._input(cmd, cwd="/home/parameterization/code/noorinalabs-main")
+                )
+            self.assertIsNone(result, "#521: child-repo PR-create must not block on parent cwd")
+            remote.assert_called_once_with(
+                "noorinalabs/noorinalabs-deploy", "main", "A.Idrissi/0242-x"
+            )
+
+    def test_gh_repo_env_takes_priority(self):
+        """GH_REPO env var resolves the implicit repo before any cwd walk."""
+        with (
+            mock.patch.dict("os.environ", {"GH_REPO": "noorinalabs/noorinalabs-deploy"}),
+            mock.patch.object(hook, "_resolve_implicit_repo") as resolve_mock,
+            mock.patch.object(hook, "_current_branch", return_value="feat-x"),
+            mock.patch.object(hook, "is_branch_fresh_remote", return_value=True) as remote,
+        ):
+            result = hook.check(self._input("gh pr create", cwd="/anywhere"))
+        self.assertIsNone(result)
+        # GH_REPO short-circuits the cwd-based resolver entirely.
+        resolve_mock.assert_not_called()
+        remote.assert_called_once_with("noorinalabs/noorinalabs-deploy", "main", "feat-x")
+
+    def test_gh_repo_host_qualified_form(self):
+        with mock.patch.dict("os.environ", {"GH_REPO": "github.com/owner/repo"}):
+            self.assertEqual(hook._repo_from_env(), "owner/repo")
+
+    def test_gh_repo_plain_owner_repo_form(self):
+        with mock.patch.dict("os.environ", {"GH_REPO": "owner/repo"}):
+            self.assertEqual(hook._repo_from_env(), "owner/repo")
+
+    def test_gh_repo_empty_returns_none(self):
+        with mock.patch.dict("os.environ", {"GH_REPO": ""}):
+            self.assertIsNone(hook._repo_from_env())
+
+    def test_gh_repo_unset_returns_none(self):
+        with mock.patch.dict("os.environ", {}, clear=True):
+            self.assertIsNone(hook._repo_from_env())
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.claude/hooks/tests/test_validate_workflow_paths_coverage.py
+++ b/.claude/hooks/tests/test_validate_workflow_paths_coverage.py
@@ -545,5 +545,89 @@ class CheckEndToEndTests(unittest.TestCase):
         self.assertIn("db-migrate.yml", result["reason"])
 
 
+class CwdAnchorResolutionTests(unittest.TestCase):
+    """#521 cwd-anchor sweep: repo/head resolution must use the invocation cwd.
+
+    Pre-fix `_resolve_repo` / `_resolve_head` ran `git` with NO `cwd=`, so a
+    worktree subagent's `gh pr create` resolved the hook's parent-process
+    repo/branch. The fix threads `resolve_invocation_cwd` through both.
+    """
+
+    @staticmethod
+    def _input(command: str, cwd: str) -> dict:
+        return {"tool_name": "Bash", "tool_input": {"command": command}, "cwd": cwd}
+
+    def test_resolve_repo_anchors_git_on_cwd(self):
+        captured: dict[str, object] = {}
+
+        class _R:
+            returncode = 0
+            stdout = "git@github.com:noorinalabs/noorinalabs-deploy.git\n"
+
+        def fake_run(args, **kwargs):
+            captured["cwd"] = kwargs.get("cwd")
+            return _R()
+
+        with (
+            mock.patch.dict("os.environ", {}, clear=True),
+            mock.patch.object(hook.subprocess, "run", side_effect=fake_run),
+        ):
+            repo = hook._resolve_repo("gh pr create", cwd="/worktree/x")
+        self.assertEqual(repo, "noorinalabs/noorinalabs-deploy")
+        self.assertEqual(captured.get("cwd"), "/worktree/x")
+
+    def test_resolve_repo_gh_repo_env_priority(self):
+        with mock.patch.dict("os.environ", {"GH_REPO": "noorinalabs/noorinalabs-deploy"}):
+            with mock.patch.object(hook.subprocess, "run") as run_mock:
+                repo = hook._resolve_repo("gh pr create", cwd="/worktree/x")
+        self.assertEqual(repo, "noorinalabs/noorinalabs-deploy")
+        run_mock.assert_not_called()
+
+    def test_resolve_head_anchors_git_on_cwd(self):
+        captured: dict[str, object] = {}
+
+        class _R:
+            returncode = 0
+            stdout = "A.Idrissi/0242-promote\n"
+
+        def fake_run(args, **kwargs):
+            captured["cwd"] = kwargs.get("cwd")
+            return _R()
+
+        with mock.patch.object(hook.subprocess, "run", side_effect=fake_run):
+            head = hook._resolve_head("gh pr create", cwd="/worktree/x")
+        self.assertEqual(head, "A.Idrissi/0242-promote")
+        self.assertEqual(captured.get("cwd"), "/worktree/x")
+
+    def test_check_threads_recovered_cwd_into_resolvers(self):
+        """End-to-end: `cd /worktree && gh pr create` → resolvers see worktree."""
+        import tempfile
+
+        captured: dict[str, object] = {}
+
+        def fake_repo(command, cwd=None):
+            captured["repo_cwd"] = cwd
+            return "noorinalabs/noorinalabs-deploy"
+
+        def fake_head(command, cwd=None):
+            captured["head_cwd"] = cwd
+            return "feat-x"
+
+        with tempfile.TemporaryDirectory() as worktree:
+            cmd = f"cd {worktree} && gh pr create --base main"
+            with (
+                mock.patch.object(hook, "_resolve_repo", side_effect=fake_repo),
+                mock.patch.object(hook, "_resolve_head", side_effect=fake_head),
+                # No workflow files in diff → allow (keeps the test focused on cwd).
+                mock.patch.object(hook, "_list_pr_diff_files", return_value=["src/app.py"]),
+            ):
+                result = hook.check(
+                    self._input(cmd, cwd="/home/parameterization/code/noorinalabs-main")
+                )
+            self.assertIsNone(result)
+            self.assertEqual(captured.get("repo_cwd"), worktree)
+            self.assertEqual(captured.get("head_cwd"), worktree)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.claude/hooks/validate_branch_freshness.py
+++ b/.claude/hooks/validate_branch_freshness.py
@@ -57,6 +57,19 @@ Implicit-repo resolution (#227):
   get-url origin` and extracts `OWNER/REPO` from common github URL forms.
   Returns None on any parse failure → falls back to the legacy local check.
 
+Worktree-subagent cwd recovery (#521):
+  The #227 implementation anchored on `resolve_tool_cwd`, i.e. the harness
+  stdin `cwd` field. For a worktree subagent that field is captured at
+  agent-spawn time and points at the ORCHESTRATOR's directory, not the
+  subagent's worktree after it `cd`'d in — so `_resolve_implicit_repo`
+  resolved the PARENT repo (`noorinalabs/noorinalabs-main`) and false-blocked
+  child-repo `gh pr create` on the parent's stale branch. The workaround was
+  passing `--repo` explicitly. The fix here: resolve the invocation cwd via
+  `resolve_invocation_cwd`, which recovers the real cwd from a leading
+  `cd /worktree && gh pr create` in the command string, plus a `GH_REPO`
+  env-var fast-path (gh's own canonical repo override). Both are consulted
+  before the (possibly-wrong) stdin cwd. See `_shell_parse` for the chain.
+
 Exit codes:
   0 -- allow (not the matched command, branch is up to date, or check could not run)
   2 -- block (branch is behind base)
@@ -75,7 +88,7 @@ from _repo_flag_parse import extract_repo  # noqa: E402
 from _shell_parse import (  # noqa: E402
     first_flag_value,
     is_gh_subcommand,
-    resolve_tool_cwd,
+    resolve_invocation_cwd,
     tokenize,
 )
 from annunaki_log import log_pretooluse_block  # noqa: E402
@@ -128,6 +141,27 @@ def is_branch_fresh_local(base: str, cwd: str | None = None) -> bool:
         return result.returncode == 0
     except (subprocess.TimeoutExpired, FileNotFoundError):
         return True
+
+
+def _repo_from_env() -> str | None:
+    """Return a valid OWNER/REPO from the `GH_REPO` env var, or None.
+
+    `gh` itself honors `GH_REPO` as the implicit repo when `--repo` is
+    omitted, so when the harness or a subagent has it set it is the most
+    authoritative implicit target — more reliable than cwd resolution for a
+    worktree subagent (#521). Validated against the same slug shape gh
+    accepts (OWNER/REPO, optionally HOST/OWNER/REPO).
+    """
+    raw = (os.environ.get("GH_REPO") or "").strip()
+    if not raw:
+        return None
+    parts = raw.split("/")
+    if len(parts) == 2 and all(parts):
+        return raw
+    # HOST/OWNER/REPO form — gh accepts a host-qualified slug.
+    if len(parts) == 3 and all(parts):
+        return "/".join(parts[1:])
+    return None
 
 
 def _resolve_implicit_repo(cwd: str | None) -> str | None:
@@ -220,7 +254,7 @@ def check(input_data: dict) -> dict | None:
         if not re.search(r"\bgh\s+pr\s+create\b", command):
             return None
 
-    cwd = resolve_tool_cwd(input_data)
+    cwd = resolve_invocation_cwd(input_data)
     base = extract_base(command)
     repo = extract_repo(command)
     head = extract_head(command)
@@ -237,9 +271,13 @@ def check(input_data: dict) -> dict | None:
         rebase_hint = f"Rebase the head branch onto {target} on the target repo."
     else:
         # No --repo: prefer the implicit-repo API path when we can resolve
-        # the cwd's `origin` to a github slug (#227 — cross-cwd misattribution
-        # protection). Fall back to the local-cwd path if not on github.
-        implicit_repo = _resolve_implicit_repo(cwd)
+        # the target repo. Resolution order (#227 cross-cwd misattribution
+        # protection, extended for #521 worktree-subagent cwd recovery):
+        #   1. GH_REPO env var — gh's own canonical implicit-repo override.
+        #   2. The invocation cwd's `origin` remote (cwd already recovered
+        #      from a leading `cd` by resolve_invocation_cwd above).
+        # Fall back to the local-cwd path if neither yields a github slug.
+        implicit_repo = _repo_from_env() or _resolve_implicit_repo(cwd)
         if implicit_repo:
             implicit_head = head or _current_branch(cwd)
             if not implicit_head:

--- a/.claude/hooks/validate_workflow_paths_coverage.py
+++ b/.claude/hooks/validate_workflow_paths_coverage.py
@@ -100,6 +100,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from _shell_parse import (  # noqa: E402
     find_gh_subcommand,
     iter_command_segments,
+    resolve_invocation_cwd,
     strip_heredocs,
     tokenize,
 )
@@ -332,17 +333,31 @@ def _path_matches_any_glob(path: str, globs: set[str]) -> bool:
 # --- Repo / branch resolution ----------------------------------------------
 
 
-def _resolve_repo(command: str) -> str | None:
-    """Return OWNER/REPO from --repo flag, or from cwd's git remote."""
+def _resolve_repo(command: str, cwd: str | None = None) -> str | None:
+    """Return OWNER/REPO from --repo flag, or from `cwd`'s git remote.
+
+    `cwd` anchors `git remote get-url origin` so a worktree subagent's
+    `gh pr create` resolves ITS repo, not the hook's parent-process repo
+    (#521). Falls back to a `GH_REPO` env-var fast-path before cwd
+    resolution — gh's own canonical implicit-repo override.
+    """
     explicit = _extract_flag(command, "repo")
     if explicit:
         return explicit
+    env_repo = (os.environ.get("GH_REPO") or "").strip()
+    if env_repo:
+        parts = env_repo.split("/")
+        if len(parts) == 2 and all(parts):
+            return env_repo
+        if len(parts) == 3 and all(parts):  # HOST/OWNER/REPO
+            return "/".join(parts[1:])
     try:
         result = subprocess.run(
             ["git", "remote", "get-url", "origin"],
             capture_output=True,
             text=True,
             timeout=10,
+            cwd=cwd,
         )
     except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
         return None
@@ -359,7 +374,12 @@ def _resolve_base(command: str) -> str:
     return _extract_flag(command, "base") or "main"
 
 
-def _resolve_head(command: str) -> str | None:
+def _resolve_head(command: str, cwd: str | None = None) -> str | None:
+    """Return --head value, or the current branch in `cwd`.
+
+    `cwd` anchors `git rev-parse --abbrev-ref HEAD` so a worktree subagent
+    reads ITS branch, not the hook's parent-process branch (#521).
+    """
     explicit = _extract_flag(command, "head")
     if explicit:
         # Strip OWNER: prefix on cross-fork PRs.
@@ -372,6 +392,7 @@ def _resolve_head(command: str) -> str | None:
             capture_output=True,
             text=True,
             timeout=10,
+            cwd=cwd,
         )
     except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
         return None
@@ -495,9 +516,10 @@ def check(input_data: dict) -> dict | None:
     if not _is_gh_pr_gate_command(command):
         return None
 
-    repo = _resolve_repo(command)
+    cwd = resolve_invocation_cwd(input_data)
+    repo = _resolve_repo(command, cwd=cwd)
     base = _resolve_base(command)
-    head = _resolve_head(command)
+    head = _resolve_head(command, cwd=cwd)
     if not repo or not head:
         # Cannot determine PR scope → fail open. We don't block on our own
         # inability to resolve the args.


### PR DESCRIPTION
## Summary

A single coordinated cwd-anchor pass across `.claude/hooks/*.py`, landing the two residual cwd-anchor symptoms as one set rather than whack-a-mole (the explicit epic #528 mandate).

## Part A — #525: change-tracker records `.worktrees/` paths into parent checksums

`ontology_tracker` skipped `.claude/worktrees/` but not the top-level `.worktrees/` convention (gitignored as of #523). Worktree-relative paths like `.worktrees/deploy-0348-aisha/...` leaked into the parent `ontology/checksums.json`, never resolved (`last_resolved: ""`), and once aborted a `git merge --ff-only` during W11 close-out (hit 2×).

**Fix:** new path-COMPONENT-aware `_is_worktree_path` skip catching both `.worktrees` and `.claude/worktrees` — segment-matched, not substring, so a legit file like `notes.worktrees.md` still tracks.

## Part B — #521: validate_branch_freshness false-blocks child-repo PR-create

`#144`/`#227` (PR #248) already anchored the hook's subprocesses on `cwd`. The residual was the **source** of that cwd: the harness stdin `cwd` is the orchestrator's spawn-time dir, not the subagent's worktree after `cd`. So `_resolve_implicit_repo` resolved `noorinalabs-main` and blocked child-repo `gh pr create` on the parent's branch (workaround was explicit `--repo`).

**Fix:** shared `extract_leading_cd_target` + `resolve_invocation_cwd` in `_shell_parse`, recovering the real cwd from a leading `cd /worktree && gh pr create`, plus a `GH_REPO` env fast-path (gh's own canonical implicit-repo override). Both consulted before the (poisoned) stdin cwd.

## Part C — cross-hook audit (the "single pass")

`grep -rn "cwd" .claude/hooks/*.py` enumerated every cwd-consuming hook. Dispositions:

| Hook | Verdict |
|------|---------|
| `validate_branch_freshness` | **FIXED** (#521) |
| `validate_workflow_paths_coverage` | **FIXED** — `_resolve_repo`/`_resolve_head` ran git with no `cwd=` at all (parent-process repo/branch); same gh-pr-create trigger. Threaded `resolve_invocation_cwd` + `GH_REPO`. |
| `ontology_tracker` | **FIXED** (#525) |
| `no_worktree_self_delete` | **Audited, left as-is** (comment added). A leading `cd` here changes SAFETY semantics, not just repo identity (`cd /safe && remove /wt` is safe; `cd /wt && remove /wt` is self-delete) — adopting recovery would alter block/allow verdicts. Distinct decision, out of scope for the cwd-anchor sweep. |
| `validate_commit_identity` | **Ruled out** — already recovers cwd via its own `cd`-prefix extractor (#475); functionally correct. |
| `session_handoff` | **Ruled out** — parent-repo-scoped by design (defaults to `REPO_ROOT`). |
| `enforce_librarian_consulted` / `_consultation_sentinel` | **Ruled out** — cwd-keyed sentinel written by the skill in the same cwd the hook reads; consistent keying (#169/#176). |
| `validate_labels` / `validate_review_comment_format` / `validate_pr_review` / `_repo_flag_parse` | **Ruled out** — `--repo`-flag-based with fail-open to gh's cwd-default; no `git remote get-url` repo-identity walk to misanchor. |

## Tests (acceptance)

- `_shell_parse`: `ExtractLeadingCdTargetTests`, `ResolveInvocationCwdTests`
- `validate_branch_freshness`: `Issue521CwdRecoveryTests` (incl. `test_repro_for_issue_521` — parent stdin cwd + child-repo cd-target → routes to child)
- `validate_workflow_paths_coverage`: `CwdAnchorResolutionTests`
- `ontology_tracker`: `ShouldSkipTopLevelWorktreesTests` (incl. exact #525 evidence shapes + segment-vs-substring guard)

**Full suite: 1111 passed.** `ruff check` / `ruff format --check` clean; `mypy` clean.

## Tech debt

This PR **removes** tech-debt — the cwd-anchor residuals in the `gh pr create` gate hooks and the worktree-path pollution in the change-tracker.

Closes #525
Closes #521
Advances #528

🤖 Generated with [Claude Code](https://claude.com/claude-code)
