### PR TITLE
fix(hooks): auto_set_env_test recognize newline as statement separator (#537)

### DIFF
--- a/.claude/hooks/auto_set_env_test.py
+++ b/.claude/hooks/auto_set_env_test.py
@@ -14,9 +14,10 @@ Fires on:
 Matches (blocks if ENVIRONMENT=test missing on the test segment):
     Any Bash command containing a real test-runner invocation detected
     by the regexes `\\bpytest\\b` or `\\bmake\\s+test\\b`. The command is
-    split on shell separators (`&&`, `||`, `;`, `|`) into segments; each
-    test-bearing segment is checked independently for a leading
-    `ENVIRONMENT=test` env-block.
+    split on shell separators (`&&`, `||`, `;`, `|`, `\\n`) into segments;
+    each test-bearing segment is checked independently for a leading
+    `ENVIRONMENT=test` env-block. An unescaped newline acts as a statement
+    terminator equivalent to `;` (#537).
 
     Typical matched forms:
         pytest tests/
@@ -49,9 +50,10 @@ Detection order:
     1. Strip leading `VAR=value` tokens from the command for argv[0] check.
     2. If the next token is `gh`, ALLOW (return None).
     3. If the command contains `--body` or `--body-file`, ALLOW.
-    4. Split on `&&`/`||`/`;`/`|` into segments using a quote-aware
+    4. Split on `&&`/`||`/`;`/`|`/`\\n` into segments using a quote-aware
        state-machine scanner — separators inside `'...'`, `"..."`, or
-       `\\`-escaped positions are NOT recognised.
+       `\\`-escaped positions are NOT recognised. (A `\\`-then-newline
+       line-continuation is consumed by `in_escape` and so does NOT split.)
     5. For each segment containing `\\bpytest\\b` or `\\bmake\\s+test\\b`,
        require `\\bENVIRONMENT=test\\b` in that segment's leading env-block
        (subshell-aware: a segment that opens with `(` peeks inside the
@@ -184,7 +186,7 @@ def _has_body_flag(command: str) -> bool:
 
 
 def _split_segments(command: str) -> list[str]:
-    """Split command on `&&`/`||`/`;`/`|`, preserving separators as
+    """Split command on `&&`/`||`/`;`/`|`/`\\n`, preserving separators as
     alternating list entries: [seg0, sep0, seg1, sep1, ..., segN].
 
     Quote-aware (#478): separators inside `'...'`, `"..."`, or
@@ -283,6 +285,8 @@ def _match_separator_at(command: str, i: int) -> str | None:
         return ";"
     if command[i] == "|":
         return "|"
+    if command[i] == "\n":
+        return "\n"
     return None
 
 

--- a/.claude/hooks/tests/test_auto_set_env_test.py
+++ b/.claude/hooks/tests/test_auto_set_env_test.py
@@ -635,5 +635,81 @@ class ControlFlowHardBlockTests(unittest.TestCase):
         self.assertNotIn("; ENVIRONMENT=test do", result["reason"])
 
 
+class NewlineSeparatorTests(unittest.TestCase):
+    """Issue #537: an unescaped `\\n` between bash statements acts as a
+    statement terminator (equivalent to `;`). Pre-fix the separator
+    scanner only recognised `&&`/`||`/`;`/`|`, so multi-line scripts
+    where pytest is on its own line had the prior line glued onto the
+    pytest segment via `|`, producing mangled suggestions that prepended
+    ENVIRONMENT=test to the wrong token (e.g. `head -3` instead of
+    `pytest`)."""
+
+    def test_newline_separator_allows_when_env_on_pytest_line(self) -> None:
+        """NEG: multi-line script; env is in the pytest line's leading
+        env-block. The prior-line pipe (`awk ... | head -3`) does NOT
+        bleed into the pytest segment because `\\n` now splits. Allow."""
+        command = (
+            "cd /tmp\n"
+            "awk '/foo/' some.txt | head -3\n"
+            'echo "marker"\n'
+            "ENVIRONMENT=test uv run pytest -q"
+        )
+        result = hook.check(_bash(command))
+        self.assertIsNone(
+            result,
+            "newline must split segments so env on pytest line is recognised",
+        )
+
+    def test_newline_separator_blocks_when_env_missing_on_pytest_line(self) -> None:
+        """POS: multi-line script with pytest on its own line and no env.
+        Block, suggestion must prepend ENVIRONMENT=test IMMEDIATELY before
+        `uv run pytest` — NOT before `echo` or `cd` or `head`."""
+        command = 'cd /tmp\necho "marker"\nuv run pytest -q'
+        result = hook.check(_bash(command))
+        assert result is not None
+        self.assertEqual(result.get("decision"), "block")
+        self.assertIn("ENVIRONMENT=test uv run pytest -q", result["reason"])
+        # The splice must not land on the prior segments.
+        self.assertNotIn("ENVIRONMENT=test cd /tmp", result["reason"])
+        self.assertNotIn('ENVIRONMENT=test echo "marker"', result["reason"])
+
+    def test_newline_inside_single_quotes_not_a_separator(self) -> None:
+        """NEG: a literal newline character inside `'...'` must NOT be
+        recognised as a separator (quote-aware state machine stays
+        in-quote). `awk '/foo\\nbar/' file | pytest tests/` — the `\\n`
+        inside the awk pattern is data; the only real separator is the
+        `|`, splitting awk-segment | pytest-segment. Pytest segment
+        lacks env → block, splice on the pytest segment, NOT inside
+        the awk pattern.
+
+        Regression-guard so future refactors don't break the quote-
+        aware split."""
+        command = "awk '/foo\nbar/' file | pytest tests/"
+        result = hook.check(_bash(command))
+        assert result is not None
+        self.assertEqual(result.get("decision"), "block")
+        # Splice on pytest segment.
+        self.assertIn("ENVIRONMENT=test pytest tests/", result["reason"])
+        # Awk pattern must be preserved verbatim — no env inside the quoted region.
+        self.assertNotIn("ENVIRONMENT=testbar", result["reason"])
+        self.assertNotIn("'/fooENVIRONMENT=test", result["reason"])
+
+    def test_backslash_line_continuation_not_a_separator(self) -> None:
+        """POS: `ENVIRONMENT=test pytest a \\\n  b` — bash line-
+        continuation; the backslash escapes the newline so it does NOT
+        terminate the statement. The whole thing is one logical segment
+        with env+pytest+both args. Existing `in_escape` flag in
+        `_split_segments` handles this; the new newline-as-separator
+        branch must not bypass it.
+
+        Verifies: with env present on the (sole) segment, allow."""
+        command = "ENVIRONMENT=test pytest a \\\n  b"
+        result = hook.check(_bash(command))
+        self.assertIsNone(
+            result,
+            "backslash-newline line-continuation must not be treated as separator",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Adds `\n` to the set of recognised statement separators in
`auto_set_env_test._match_separator_at`. Multi-line bash scripts with
pytest on its own line no longer have prior-line pipes/separators bleed
into the pytest segment, so suggestions land on the correct token.

## Root cause

Per #537: an unescaped newline acts as a statement terminator in bash
(equivalent to `;`), but `_match_separator_at` only recognised
`&&`/`||`/`;`/`|`. A script like

```
awk '/foo/' some.txt | head -3
ENVIRONMENT=test uv run pytest -q
```

was split as TWO segments joined by the awk-line's `|`:
- seg0: `awk '/foo/' some.txt`
- seg1: `head -3\nENVIRONMENT=test uv run pytest -q`

Pytest landed in seg1 with leading token `head`, so the rewriter spliced
`ENVIRONMENT=test` before `head` — mangled.

## Diff scope

- `auto_set_env_test.py`: one branch added to `_match_separator_at`;
  three docstring touches (module + `_split_segments` + matched-list
  enumeration) to keep policy contract in sync.
- `tests/test_auto_set_env_test.py`: new `NewlineSeparatorTests` class
  with 4 cases (allow / block / quoted-newline-not-a-separator /
  backslash-line-continuation regression-guard).

No charter changes. Pre-existing `_split_segments` quote-aware and
`in_escape` state-machine handle the edge cases — the fix is additive.

## Verification

Local pytest run on the suite:

```
$ ENVIRONMENT=test uv run pytest .claude/hooks/tests/test_auto_set_env_test.py -q
.....................................................................    [100%]
69 passed in 0.10s
```

65 pre-existing tests still pass, 4 new tests pass. Ruff format-check
and lint clean on both modified files.

## Cross-reference

User reported as recurring ("I've seen this error pop up a few times").
Tracked as #537.

## Caveats

- The safe-direction discipline established in #478 is preserved — when
  the rewriter can't produce a clean suggestion (control-flow body),
  the hook still HARD BLOCKs with a diagnostic. Newline recognition
  doesn't open any new allow-with-log paths.
- Backslash-newline line-continuation continues to be consumed by the
  existing `in_escape` flag (verified by the new regression test).

Closes #537
TechDebt: none
