### PR TITLE
charter(hooks): mandatory 6-class test coverage for segment parsers (Refs #543)

### DIFF
--- a/.claude/hooks/tests/test_auto_set_env_test.py
+++ b/.claude/hooks/tests/test_auto_set_env_test.py
@@ -636,6 +636,7 @@ class ControlFlowHardBlockTests(unittest.TestCase):
 
 
 class NewlineSeparatorTests(unittest.TestCase):
+    # segment-class: Newline
     """Issue #537: an unescaped `\\n` between bash statements acts as a
     statement terminator (equivalent to `;`). Pre-fix the separator
     scanner only recognised `&&`/`||`/`;`/`|`, so multi-line scripts
@@ -708,6 +709,181 @@ class NewlineSeparatorTests(unittest.TestCase):
         self.assertIsNone(
             result,
             "backslash-newline line-continuation must not be treated as separator",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Canonical six-class segment-parser coverage matrix.
+#
+# Per `charter/hooks.md` § Hook Authorship Requirements § 5a (Mandatory Test
+# Coverage for PreToolUse Segment Parsers, issue #543), every hook that splits
+# a bash command on shell separators MUST carry allow + block coverage for ALL
+# SIX separator classes. The five classes above (ChainedCommandTests,
+# NewlineSeparatorTests, SubshellAwareTests, ControlFlowHardBlockTests,
+# QuoteAwareSplittingTests) already exercise these shapes under their original
+# feature-named classes; the classes below are the canonical-named, self-
+# contained reference implementation the charter section points to. Each
+# carries a `# segment-class: <Name>` marker so a future grep-based CI gate
+# (out of scope for #543, deferred follow-up) can assert all six are present.
+# ---------------------------------------------------------------------------
+
+
+class StandardSeparatorTests(unittest.TestCase):
+    # segment-class: Standard
+    """`&&` / `||` / `;` / `|` — the four standard statement separators.
+
+    Allow: env present on the pytest segment of an `&&` chain.
+    Block: env missing; suggestion lands on the pytest token of a `;` chain,
+    not the leading `cd`."""
+
+    def test_standard_separator_allows_when_env_on_pytest_segment(self) -> None:
+        result = hook.check(_bash("cd /path && ENVIRONMENT=test pytest tests/"))
+        self.assertIsNone(result, "env on the pytest segment of an && chain must allow")
+
+    def test_standard_separator_blocks_with_correctly_targeted_suggestion(
+        self,
+    ) -> None:
+        result = hook.check(_bash("cd /path ; pytest tests/"))
+        assert result is not None
+        self.assertEqual(result.get("decision"), "block")
+        # Splice on the pytest segment, NOT the leading cd.
+        self.assertIn("ENVIRONMENT=test pytest tests/", result["reason"])
+        self.assertNotIn("ENVIRONMENT=test cd /path", result["reason"])
+
+
+class SubshellTests(unittest.TestCase):
+    # segment-class: Subshell
+    """`(cmd1; cmd2)` — a leading `(` opens a subshell; the env-block is
+    recognised inside the parens.
+
+    Allow: `(ENVIRONMENT=test pytest tests/)`.
+    Block: `(pytest tests/)`; suggestion splices the env inside the parens,
+    immediately before pytest."""
+
+    def test_subshell_allows_when_env_inside_parens(self) -> None:
+        result = hook.check(_bash("(ENVIRONMENT=test pytest tests/)"))
+        self.assertIsNone(result, "env inside the subshell parens must be recognised")
+
+    def test_subshell_blocks_with_inside_splice(self) -> None:
+        result = hook.check(_bash("(pytest tests/)"))
+        assert result is not None
+        self.assertEqual(result.get("decision"), "block")
+        self.assertIn("(ENVIRONMENT=test pytest tests/)", result["reason"])
+
+
+class ControlFlowBodyTests(unittest.TestCase):
+    # segment-class: ControlFlowBody
+    """`for x in ...; do pytest ...; done` — pytest inside a control-flow body
+    where a clean env splice is impossible. Per § Hook 4 / #478 the hook HARD
+    BLOCKS with an operator-readable diagnostic rather than allow-with-log
+    (which would silently bypass the protection). The hook does NOT peek into
+    the do-body for an existing env-block — even env-already-inside hard-blocks
+    (see `ControlFlowHardBlockTests.test_for_with_env_inside_do_body_*`), so
+    the meaningful "allow" for this class is a control-flow loop that carries
+    NO test runner at all (the hook correctly does not fire).
+
+    Allow: a control-flow loop with no pytest/make-test — hook does not fire.
+    Block: pytest in the body, env missing — HARD-BLOCK diagnostic naming the
+    construct."""
+
+    def test_control_flow_body_allows_when_no_test_runner_in_body(self) -> None:
+        result = hook.check(_bash("for d in a b; do echo $d; done"))
+        self.assertIsNone(
+            result,
+            "a control-flow loop with no test runner must not fire the hook",
+        )
+
+    def test_control_flow_body_hard_blocks_with_diagnostic(self) -> None:
+        result = hook.check(_bash("for d in a b; do pytest $d; done"))
+        assert result is not None
+        self.assertEqual(result.get("decision"), "block")
+        # The diagnostic names the control-flow construct rather than emitting
+        # an invalid keyword-spliced suggestion.
+        self.assertIn("control-flow", result["reason"].lower())
+
+
+class LineContinuationTests(unittest.TestCase):
+    # segment-class: LineContinuation
+    """`cmd \\<newline>  arg` — a backslash-escaped newline is a line
+    continuation, NOT a statement separator. The whole thing is one logical
+    segment; the `in_escape` flag in `_split_segments` must consume it.
+
+    Allow: env present on the (sole) continued pytest segment.
+    Block: env missing on the continued pytest segment; suggestion stays on
+    pytest and does not split at the continuation."""
+
+    def test_line_continuation_allows_when_env_present(self) -> None:
+        command = "ENVIRONMENT=test pytest a \\\n  b"
+        result = hook.check(_bash(command))
+        self.assertIsNone(
+            result,
+            "backslash-newline continuation must not split; env present allows",
+        )
+
+    def test_line_continuation_blocks_with_pytest_targeted_suggestion(
+        self,
+    ) -> None:
+        command = "pytest a \\\n  b"
+        result = hook.check(_bash(command))
+        assert result is not None
+        self.assertEqual(result.get("decision"), "block")
+        # Env splices onto the single continued segment, before pytest.
+        self.assertIn("ENVIRONMENT=test pytest a", result["reason"])
+
+
+class QuotedRegionTests(unittest.TestCase):
+    # segment-class: QuotedRegion
+    """Separators inside `'...'` or `"..."` are data, not splits — the quote-
+    aware state machine stays in-quote.
+
+    Allow: a quoted separator does not produce a spurious env-less pytest
+    segment when the real pytest segment already carries env.
+    Block: a real pytest segment alongside a quoted `&&` blocks, with the
+    splice landing on the real pytest token, not inside the quoted region."""
+
+    def test_quoted_separator_does_not_spuriously_block(self) -> None:
+        # The `&&` lives inside the single-quoted grep pattern; the only real
+        # command is the env-prefixed pytest.
+        command = "ENVIRONMENT=test pytest -k 'a && b'"
+        result = hook.check(_bash(command))
+        self.assertIsNone(result, "a quoted `&&` is data and must not split the segment")
+
+    def test_quoted_region_blocks_with_real_pytest_targeted(self) -> None:
+        # Quoted `&&` is data; the real separator is the `;`. The pytest
+        # segment lacks env → block, splice on the real pytest token.
+        command = "grep 'x && y' f ; pytest tests/"
+        result = hook.check(_bash(command))
+        assert result is not None
+        self.assertEqual(result.get("decision"), "block")
+        self.assertIn("ENVIRONMENT=test pytest tests/", result["reason"])
+        # The quoted region must be preserved verbatim.
+        self.assertNotIn("ENVIRONMENT=test grep", result["reason"])
+
+
+class SegmentClassCoverageManifestTests(unittest.TestCase):
+    """Guard: this file must carry a `# segment-class: <Name>` marker for all
+    six separator classes mandated by `hooks.md § 5a`. This is the in-suite
+    stand-in for the deferred grep-based CI gate — if a future refactor drops
+    one of the canonical classes, this test fails loudly."""
+
+    REQUIRED_MARKERS = (
+        "Standard",
+        "Newline",
+        "Subshell",
+        "ControlFlowBody",
+        "LineContinuation",
+        "QuotedRegion",
+    )
+
+    def test_all_six_segment_class_markers_present(self) -> None:
+        source = Path(__file__).read_text(encoding="utf-8")
+        missing = [
+            name for name in self.REQUIRED_MARKERS if f"# segment-class: {name}" not in source
+        ]
+        self.assertEqual(
+            missing,
+            [],
+            f"missing segment-class markers (per hooks.md § 5a): {missing}",
         )
 
 

--- a/.claude/team/charter/hooks.md
+++ b/.claude/team/charter/hooks.md
@@ -358,6 +358,34 @@ Every hook with input parsing MUST have test fixtures covering all known input s
 
 **Dispatcher-style children (no committed `.claude/hooks/`):** Children that delegate all hook execution to the parent canonical via `settings.json` are exempt from per-child fixture requirements. Coverage obligations are fulfilled by the parent's test suite. A child is classified as dispatcher-style when `gh api repos/<owner>/<repo>/git/trees/<head_sha>?recursive=1` returns 0 entries under `.claude/hooks/`. Design-system and landing-page (post-W5) are the canonical exemplars.
 
+#### 5a. Mandatory Test Coverage for PreToolUse Segment Parsers
+
+This is a **specialization of §5** for the narrow class of hooks that split a bash command on shell separators into segments (e.g. `auto_set_env_test.py` splits on `&&`/`||`/`;`/`|`/`\n` to check each test-bearing segment independently). Any such **segment-parser** hook MUST carry test coverage for ALL SIX separator classes — not just the ones the original feature happened to exercise.
+
+| Class | Example | Test-class-name convention |
+|---|---|---|
+| Standard separators | `cmd1 && cmd2`, `cmd1 \|\| cmd2`, `cmd1; cmd2`, `cmd1 \| cmd2` | `StandardSeparatorTests` |
+| Newline | `cmd1\ncmd2` (multi-line script) | `NewlineSeparatorTests` |
+| Subshell | `(cmd1; cmd2)` | `SubshellTests` |
+| Control-flow body | `for x in ...; do cmd; done` | `ControlFlowBodyTests` |
+| Line-continuation | `cmd \`<br>`  arg` (backslash-newline) | `LineContinuationTests` |
+| Quoted regions | `'sep && inside'`, `"sep \| inside"` | `QuotedRegionTests` |
+
+Each class MUST include at minimum:
+
+- One **allow** case — the segment correctly receives the env-block / hook-condition and the hook passes.
+- One **block-with-correctly-targeted-suggestion** case — the segment is missing the env / hook-condition, the hook blocks, AND the suggestion lands on the right token (not a neighbouring segment). For the control-flow class where a clean splice is impossible, the block case asserts the HARD-BLOCK diagnostic path instead (per §Hook 4 / #478). Because that hook deliberately does NOT peek into the loop body for an existing env-block (even env-already-inside hard-blocks, so the operator edits manually), the control-flow "allow" case is a control-flow construct that carries no test runner at all — the hook correctly does not fire.
+
+The canonical reference implementation is `.claude/hooks/tests/test_auto_set_env_test.py`. The convention-named classes there carry a `# segment-class: <Standard|Newline|Subshell|ControlFlowBody|LineContinuation|QuotedRegion>` marker comment so a future grep-based CI gate (out of scope here, follow-up) can assert all six are present.
+
+**Why charter, not a code-review checklist:** a checklist is opt-in and decays (`feedback_enforcement_hierarchy`: "Charter rules without enforcement decay"). The `auto_set_env_test` hook shipped quote-aware (#478) and control-flow-aware detection but had NO coverage for newline-as-separator; the gap surfaced as repeated operator friction ("I've seen this error a few times") before #537 was filed and fixed in #538. Encoding the six-class matrix as a contract makes the NEXT segment-parser hook add all six from the start, rather than discovering each gap at runtime.
+
+**Spawn-brief line for hook PRs:** reviewer-class and implementer-class spawn briefs for any segment-parser hook PR MUST include the line: *"ensure all 6 segment-class tests present (per `hooks.md § Mandatory Test Coverage for PreToolUse Segment Parsers`)."*
+
+**Out of scope (follow-ups):** a grep-based CI gate asserting the six convention class-names; backfilling the six classes for *other* existing hooks (they have at least partial coverage already; a separate sweep); coverage requirements for non-segment-parser PreToolUse hooks (different signal pattern — §3 negative-match coverage already governs those).
+
+<!-- Promoted from memory: feedback_safety_direction_over_ux_friction (control-flow safety-direction precedent #478) — codifies P3W12 retro § Proposed Process Changes #2 (issue #543), newline precedent #537/#538. Charter-tier only (no hook); CI-gate enforcement is a deferred follow-up. -->
+
 ### 6. Promotion Provenance Phrasing
 
 Every hook's charter entry includes a provenance block describing where the hook came from. The `/promotion-audit` skill's `find_already_promoted` parser scans these blocks to decide which memories / charter rules / skill patterns have already landed as hooks. Ambiguous phrasing defeats the parser (false-negatives produce noisy AUTO classifications; false-positives produce noisy ALREADY-PROMOTED classifications). Three required parts:
@@ -382,7 +410,7 @@ Every hook MUST have exactly one backward-claim sentence. The parser's `_PROVENA
 
 **Rationale:** PR #155 added the reactive `_FORWARD_REFERENCE_MARKERS` filter to handle Hook 15's own provenance block — which had narrative referencing a future skill mixed in with the backward citation. The filter is the runtime safety net; this guidance is the preempt-at-author-time fix that reduces future filter-edits. Sibling of #393 (HTML-marker convention) — this section catalogues the parse keys; the authoritative shape-selection rule (when to use HTML-comment vs. bold-prose) lives at [`charter/skills.md` § Promotion Pipeline Marker Convention](skills.md#promotion-pipeline-marker-convention).
 
-**Enforcement:** The Standards & Quality Lead (Aino) verifies these requirements during hook PR review. A hook missing any of the six requirements must not be approved.
+**Enforcement:** The Standards & Quality Lead (Aino) verifies these requirements during hook PR review. A hook missing any of the six requirements must not be approved. For segment-parser hooks specifically, §5a's six-class test matrix is part of that verification.
 
 ## Hook Audit Protocol
 


### PR DESCRIPTION
## charter(hooks): mandatory test coverage for PreToolUse segment parsers (6 classes)

Adds `hooks.md § Hook Authorship Requirements § 5a` requiring every segment-parser hook (one that splits bash on shell separators) to carry **allow + block** coverage for all six separator classes:

| Class | Convention |
|---|---|
| Standard separators | `StandardSeparatorTests` |
| Newline | `NewlineSeparatorTests` |
| Subshell | `SubshellTests` |
| Control-flow body | `ControlFlowBodyTests` |
| Line-continuation | `LineContinuationTests` |
| Quoted regions | `QuotedRegionTests` |

### Reference implementation
`.claude/hooks/tests/test_auto_set_env_test.py` gains canonical-named classes for each (allow + block-with-correctly-targeted-suggestion), each carrying a `# segment-class: <Name>` marker. `SegmentClassCoverageManifestTests` asserts all six markers are present (in-suite stand-in for the deferred grep-based CI gate). LineContinuation previously had only an allow case — block case added.

Control-flow note: the hook hard-blocks even when env is already inside the loop body (it does not peek), so the meaningful control-flow *allow* case is a loop with no test runner. Charter wording + test aligned to that real behavior.

### Validation
- 80 tests pass (`ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/test_auto_set_env_test.py`)
- `uvx ruff@0.6.9 format --check .claude/hooks/` + `check` clean

Cross-references #478 (control-flow precedent) and #537/#538 (newline precedent). Reviewers: Wanjiku + Santiago (verdicts posted separately).

Refs #543
