### PR TITLE
feat(wave-wrapup): gate wave close on successful staging promotion (Refs #325)

### DIFF
--- a/.claude/skills/wave-wrapup/SKILL.md
+++ b/.claude/skills/wave-wrapup/SKILL.md
@@ -224,6 +224,8 @@ This step mirrors `/wave-retro` Step 6.5 by design — the same check fires from
 
 **Tech-debt created:** {count} new issues
 
+**Staging promotion:** {success | failure | deferred (criterion #1 not yet live) | overridden: <rationale>} {run URL if any}
+
 **Documentation:** {docs updated | docs need update | no doc changes}
 
 **Worktrees cleaned:** {count}
@@ -401,6 +403,89 @@ export STRANDING_OVERRIDE_RATIONALE="P3W7 work descoped post-#339 audit; \
 ```
 
 The override is intentionally noisy: rationale is required (no empty string), logged to the wrapup report, and persisted to `cross-repo-status.json` under `wave_{M}_stranding_override` so subsequent /wave-retro and audit passes can surface it.
+
+### 11.6. Staging-promotion gate (Phase-3 end-state criterion #3)
+
+A wave is **not closeable until its merged code has been promoted to staging green**. This is the wrapup-time enforcement of Phase-3 end-state criterion #3 (`main#325`) and the charter rule `pull-requests.md § Wave-Wrapup Staging-Promotion Gate`. It runs AFTER the Step 11.5 reachability-to-main gate (code must be on main before it can be promoted to staging) and BEFORE the ontology rebuild.
+
+The canonical staging deploy is `noorinalabs-deploy/.github/workflows/deploy-stg.yml`. The gate inspects the latest run; blocks on red; **defers** (does not fail) when staging does not yet exist — criterion #3 is blocked by criterion #1 (live staging). An explicit rationale env var overrides a red/absent run.
+
+```bash
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+STATUS="$REPO_ROOT/cross-repo-status.json"
+UPSERT="$REPO_ROOT/.claude/lib/upsert_status_keys.py"
+STG_WORKFLOW="deploy-stg.yml"
+DEPLOY_REPO="noorinalabs/noorinalabs-deploy"
+
+# Fetch the latest deploy-stg.yml run. Empty result = staging not live yet.
+STG_RUN=$(gh run list --repo "$DEPLOY_REPO" --workflow "$STG_WORKFLOW" \
+  --limit 1 --json databaseId,status,conclusion,url,headSha \
+  --jq '.[0] // empty' 2>/dev/null || true)
+
+if [ -z "$STG_RUN" ]; then
+  # Criterion #1 not satisfied — defer, do NOT hard-fail. Logged, not silent.
+  STG_RESULT="deferred"
+  STG_URL=""
+  echo "staging-promotion gate DEFERRED — criterion #1 (live staging) not yet satisfied"
+  echo "  (no $STG_WORKFLOW run history in $DEPLOY_REPO). Gate auto-activates once staging is live."
+else
+  STG_STATUS=$(echo "$STG_RUN" | jq -r .status)
+  STG_CONCLUSION=$(echo "$STG_RUN" | jq -r .conclusion)
+  STG_URL=$(echo "$STG_RUN" | jq -r .url)
+
+  if [ "$STG_STATUS" != "completed" ]; then
+    echo "staging deploy still in progress ($STG_STATUS) — re-run /wave-wrapup once $STG_URL completes,"
+    echo "or set STG_PROMOTION_OVERRIDE_RATIONALE to close anyway."
+    STG_CONCLUSION="in_progress"
+  fi
+
+  if [ "$STG_CONCLUSION" = "success" ]; then
+    STG_RESULT="success"
+    echo "staging promotion GREEN — $STG_URL"
+  elif [ -n "${STG_PROMOTION_OVERRIDE_RATIONALE:-}" ]; then
+    STG_RESULT="overridden"
+    echo "staging promotion NOT green ($STG_CONCLUSION) — OVERRIDDEN:"
+    echo "  $STG_PROMOTION_OVERRIDE_RATIONALE"
+  else
+    echo "════════════════════════════════════════════════════════════"
+    echo "BLOCKED: /wave-wrapup cannot close wave {M} — staging promotion is $STG_CONCLUSION."
+    echo "  Latest $STG_WORKFLOW run: $STG_URL"
+    echo "Fix-forward options:"
+    echo "  (a) Fix the regression and re-trigger the staging deploy, then re-run /wave-wrapup."
+    echo "  (b) Re-dispatch deploy-stg.yml manually:"
+    echo "      gh workflow run $STG_WORKFLOW --repo $DEPLOY_REPO"
+    echo "  (c) If a red/absent staging run is INTENTIONALLY acceptable (staging infra"
+    echo "      mid-migration, meta-only wave with no deployable surface), set"
+    echo "      STG_PROMOTION_OVERRIDE_RATIONALE=\"<explicit reason>\" before re-invoking."
+    echo "════════════════════════════════════════════════════════════"
+    exit 1
+  fi
+fi
+
+# Persist the result for /wave-retro Step 2.5 + audit passes. Compact-inline
+# preserved via upsert_status_keys.py (NOT jq>tmp>mv — see main#332).
+python3 "$UPSERT" "$STATUS" \
+    "wave_{M}_stg_promotion=\"${STG_RESULT}\"" \
+    "wave_{M}_stg_promotion_url=\"${STG_URL}\""
+[ "$STG_RESULT" = "overridden" ] && python3 "$UPSERT" "$STATUS" \
+    "wave_{M}_stg_promotion_override_rationale=\"${STG_PROMOTION_OVERRIDE_RATIONALE}\""
+
+# Read-back verify (feedback_gh_pr_edit_silent_noop family).
+jq -r --arg m "{M}" '"wave_" + $m + "_stg_promotion = " + (.["wave_" + $m + "_stg_promotion"] | tostring)' "$STATUS"
+```
+
+**Override mechanism** (when a red/absent staging run is acceptable):
+
+```bash
+# Only use when staging green is genuinely not achievable/applicable for this wave
+# (staging infra mid-migration, meta-only wave with no deployable surface).
+export STG_PROMOTION_OVERRIDE_RATIONALE="W13 is charter/skill-meta only; no service \
+  image changed, so no staging deploy is produced. Gate overridden, criterion #3 \
+  unaffected (no deployable surface to promote)."
+# Re-invoke /wave-wrapup — the gate logs the rationale, persists it, and proceeds.
+```
+
+Include the staging-promotion result (`success`/`failure`/`deferred`/`overridden`) and the run URL in the Step 10 final wave report. `/wave-retro` records it in the wave history row alongside PR count and admin overrides.
 
 ### 12. Ontology rebuild
 

--- a/.claude/team/charter/pull-requests.md
+++ b/.claude/team/charter/pull-requests.md
@@ -229,6 +229,26 @@ At the **end of a wave or phase**, the Manager creates a PR from the deployments
 
 The **user reviews and merges** this PR. Do not proceed to the next phase until the user has merged.
 
+## Wave-Wrapup Staging-Promotion Gate (Mandatory) <!-- promotion-target: skill -->
+
+A wave is **not closeable** until its merged code has been promoted to **staging green**. This is Phase-3 end-state criterion #3 (`noorinalabs-main#325`): "/wave-wrapup requires successful stg promotion as a wave-completion criterion." The gate is the wrapup-time enforcement counterpart of the same liveness contract the deploy track exists to satisfy — code that merged to main but never reached a green staging deploy is the deploy-track analogue of the stranded-wave-branch pattern (§ the reachability gate in `/wave-wrapup` Step 11.5).
+
+### The gate
+
+`/wave-wrapup` Step 11.6 (immediately after the Step 11.5 reachability-to-main gate) verifies that the staging deploy is green for the wave's merged code:
+
+1. **Workflow:** the canonical staging deploy is `noorinalabs-deploy/.github/workflows/deploy-stg.yml` (triggered by service-repo `repository_dispatch` fan-in on push, or `workflow_dispatch` for a manual redeploy). The gate inspects the latest `deploy-stg.yml` run reachable for the wave's merged commits.
+2. **Block on red:** if the latest staging run concluded `failure`/`cancelled`/`timed_out`, the wave is NOT closeable. The operator fixes-forward (re-trigger the deploy, fix the regression) before re-invoking `/wave-wrapup`.
+3. **Dependency-aware deferral (criterion #1):** criterion #3 is **blocked by criterion #1** (staging must exist). Until a live staging environment + `deploy-stg.yml` run history exist, the gate reports `staging-promotion gate DEFERRED — criterion #1 (live staging) not yet satisfied` and proceeds. This deferral is itself logged (so it is visible, not silent) and disappears automatically once staging is live. The gate must NOT hard-fail every wrapup before staging exists.
+4. **Override (when red is acceptable):** an explicit `STG_PROMOTION_OVERRIDE_RATIONALE="<reason>"` env var lets the operator close a wave despite a red/absent staging run (e.g. staging infra is mid-migration, the wave is meta-only with no deployable surface). Rationale is required (no empty string), logged to the wrapup report, and persisted — mirroring the Step 11.5 `STRANDING_OVERRIDE_RATIONALE` mechanism.
+5. **Persistence + retro hand-off:** the staging-promotion result (`success` / `failure` / `deferred` / `overridden`) is written to `cross-repo-status.json` as `wave_{M}_stg_promotion` via the shared `upsert_status_keys.py` helper, alongside the run URL. `/wave-retro` records the stg-promotion result in the wave history row next to PR count and admin overrides.
+
+### Why a gate, not a checklist
+
+A "remember to check staging" checklist item is opt-in and decays (`feedback_enforcement_hierarchy`: "Charter rules without enforcement decay"). Encoding the gate in the `/wave-wrapup` skill with a hard block (and a noisy, rationale-required override) makes staging-green a contractual wave-completion condition — the deploy track's whole purpose per Phase-3 end-state.
+
+<!-- Promoted from memory: feedback_enforcement_hierarchy (hook>skill>charter — gate-over-checklist) — codifies Phase-3 end-state criterion #3 (issue #325, deploy-track-alongside Proposal B ratified 2026-05-31). Skill-tier enforcement lands in /wave-wrapup Step 11.6; a hook MAY further enforce at invocation time (follow-up). -->
+
 ## PR Template <!-- promotion-target: none -->
 ```bash
 git push -u origin <branch-name>


### PR DESCRIPTION
## feat(wave-wrapup): gate wave close on successful staging promotion

**Phase-3 end-state criterion #3** (`#325`): a wave is not closeable until its merged code has been promoted to **staging green**.

### `/wave-wrapup` Step 11.6 (new)
Runs after Step 11.5 (reachability-to-main) and before ontology rebuild. Inspects the latest `deploy-stg.yml` run in `noorinalabs-deploy`:
- **Blocks** (exit 1) on a red staging run, with fix-forward guidance (re-trigger, re-dispatch, or override).
- **Defers** (does NOT hard-fail) when no `deploy-stg.yml` run history exists — criterion #3 is **blocked by criterion #1** (live staging). The deferral is logged, not silent, and auto-activates once staging is live. This keeps every pre-staging wrapup from hard-failing.
- **Override**: `STG_PROMOTION_OVERRIDE_RATIONALE="<reason>"` closes despite red/absent (mirrors the Step 11.5 `STRANDING_OVERRIDE` mechanism — rationale required, logged, persisted).
- **Persists** `wave_{M}_stg_promotion` + `_url` to `cross-repo-status.json` via the shared `upsert_status_keys.py` helper (compact-inline preserved per `main#332`).

Result is surfaced in the Step 10 wave report and handed to `/wave-retro` for the wave history row.

### Charter
`pull-requests.md § Wave-Wrapup Staging-Promotion Gate (Mandatory)` documents the gate, dependency-aware deferral, override, and persistence.

### Validation
- wave-wrapup skill tests pass (7).
- `upsert_status_keys.py` verified with string values on a canonical-format fixture (top-level placement, JSON-valid, siblings preserved).
- Gate branch logic dry-run covers defer / pass / block / override.

Reviewers: Bereket + Wanjiku (verdicts posted separately).

Refs #325
