### PR TITLE
fix(no_worktree_self_delete): recover invocation cwd to catch cd-into-worktree self-delete (Refs #535)

### DIFF
--- a/.claude/hooks/no_worktree_self_delete.py
+++ b/.claude/hooks/no_worktree_self_delete.py
@@ -25,10 +25,15 @@ Matches (one or more segments in the command, split on &&, ||, ;, |):
     - Global git options `-C <dir>` and `-c key=value` are skipped.
     - Short-option flags on `worktree remove` (`-f`, `--force`) are skipped.
     - `<path>` is the first non-flag argument after `remove`.
-    - A `cd <somewhere>` earlier in the compound command does NOT neutralize
-      the check: cd's inside the command string are plans the shell has not
-      yet executed, so the tool-call's actual cwd (from `input_data["cwd"]`
-      or `os.getcwd()`) is what matters.
+    - A leading `cd <dir>` IS honored when it names an absolute directory
+      that exists on disk (#535): the cwd used for the ancestry check is the
+      last such `cd` target (last-cd-wins via `resolve_invocation_cwd`),
+      because that is where the shell will be when `git worktree remove`
+      actually runs. `cd /safe && git worktree remove <wt>` therefore ALLOWS
+      (shell moves out first) while `cd <wt> && git worktree remove <wt>`
+      BLOCKS (the self-delete). A `cd <nonexistent>` is ignored — recovery
+      falls back to the stdin `cwd`, so the guard never relaxes on a path
+      that isn't there.
 
 Does NOT match:
     git worktree list            (no `remove` subcommand)
@@ -77,6 +82,7 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _shell_parse import resolve_invocation_cwd  # noqa: E402
 from annunaki_log import log_pretooluse_block  # noqa: E402
 
 # Shell operators that separate command segments. We split on these to reach
@@ -263,19 +269,23 @@ def check(input_data: dict) -> dict | None:
             # Cheap pre-filter — most Bash calls don't touch worktree remove.
             return None
 
-        # Caller-reported cwd wins; fall back to ours. Hook input carries the
-        # shell's actual cwd at tool-call time.
+        # Recover the cwd the shell will actually be in when `git worktree
+        # remove` runs (#535). resolve_invocation_cwd applies last-cd-wins
+        # recovery: it returns the target of the last `cd <absolute-existing
+        # -dir>` in the command, else the stdin `cwd`, else os.getcwd().
         #
-        # NOTE: this hook deliberately does NOT adopt the #521
-        # `resolve_invocation_cwd` cd-target recovery used by the gh-pr-create
-        # hooks. Here a leading `cd` changes the SAFETY semantics rather than
-        # just repo identity: `cd /safe && git worktree remove /worktree` is
-        # safe (shell moves out first) while `cd /worktree && remove /worktree`
-        # is the self-delete. Folding the cd target into cwd would change the
-        # block/allow verdict, which is a distinct behavioral decision from the
-        # cwd-anchor sweep — see the docstring "cd plans not yet executed"
-        # note. Left as-is intentionally; tracked separately if revisited.
-        cwd = input_data.get("cwd") or os.getcwd()
+        # Unlike the gh-pr-create hooks — which adopt recovery to fix repo
+        # IDENTITY — here recovery fixes the block/allow SAFETY verdict, and it
+        # makes it MORE correct in BOTH directions:
+        #   cd <wt> && git worktree remove <wt>   → resolves to <wt>  → BLOCK
+        #       (this is the #173 self-delete the pre-#535 stdin-cwd read MISSED
+        #        when the harness cwd was anchored at the parent, not <wt>).
+        #   cd /safe && git worktree remove <wt>  → resolves to /safe → ALLOW
+        #       (the shell moves out of <wt> first; not a self-delete).
+        # The recovery only honors an absolute cd target that EXISTS on disk;
+        # a `cd <nonexistent>` falls back to the stdin cwd, so we never relax
+        # the guard on the strength of a directory that isn't there.
+        cwd = resolve_invocation_cwd(input_data)
 
         for segment in _SEGMENT_SPLIT_RE.split(command):
             target = _extract_worktree_remove_path(segment)

--- a/.claude/hooks/tests/test_no_worktree_self_delete.py
+++ b/.claude/hooks/tests/test_no_worktree_self_delete.py
@@ -9,6 +9,7 @@ Run: python3 -m pytest .claude/hooks/tests/test_no_worktree_self_delete.py -v
 
 from __future__ import annotations
 
+import os
 import sys
 import tempfile
 import unittest
@@ -88,14 +89,17 @@ class SelfDeleteBlocks(unittest.TestCase):
             assert result is not None
             self.assertEqual(result["decision"], "block")
 
-    def test_chained_cd_then_remove_still_blocks(self) -> None:
-        """POS: a `cd` earlier in the command is a PLAN, not yet executed.
+    def test_chained_cd_to_nonexistent_then_remove_still_blocks(self) -> None:
+        """POS: `cd /safe && remove <wt>` where `/safe` does NOT exist on disk.
 
-        The tool-call's actual cwd is what matters at PreToolUse time —
-        shell hasn't run the cd yet when the hook fires.
+        Post-#535 the hook honors a leading `cd`, but ONLY when the target is
+        an absolute directory that exists. A `cd <nonexistent>` is ignored and
+        cwd recovery falls back to the stdin cwd (the worktree) — so this is
+        still the self-delete and must block. This guards the "don't relax the
+        guard on a path that isn't there" invariant.
         """
         with _WorktreeFixture() as f:
-            cmd = f"cd /safe && git worktree remove {f.wt_a}"
+            cmd = f"cd /nonexistent-{os.getpid()} && git worktree remove {f.wt_a}"
             result = hook.check(_bash(cmd, cwd=str(f.wt_a)))
             assert result is not None
             self.assertEqual(result["decision"], "block")
@@ -167,6 +171,108 @@ class SafeInvocationsAllow(unittest.TestCase):
             sibling.mkdir()
             result = hook.check(_bash(f"git worktree remove {target}", cwd=str(sibling)))
             self.assertIsNone(result)
+
+
+class CdRecoverySafetyMatrix(unittest.TestCase):
+    """#535 safety matrix — last-cd-wins cwd recovery changes the block/allow
+    SAFETY verdict (not just repo identity), so it gets its own dedicated
+    test surface. Each case pins a (command, stdin-cwd) → (block|allow) cell.
+
+    The motivating bug: a worktree subagent runs `cd <wt> && git worktree
+    remove <wt>` but the harness stdin `cwd` is anchored at the PARENT, so the
+    pre-#535 stdin-cwd read saw the parent (safe-looking) and FAILED OPEN on a
+    real self-delete (#173 / #534 follow-up). Recovery resolves the post-cd
+    cwd and catches it.
+    """
+
+    # --- improvement cases: recovery now CATCHES self-deletes the old
+    #     stdin-cwd read missed (harness cwd anchored at parent) ---
+
+    def test_cd_into_target_then_remove_blocks_even_when_stdin_cwd_is_parent(
+        self,
+    ) -> None:
+        """POS: `cd <wt_a> && remove <wt_a>` with stdin cwd at the PARENT.
+
+        This is the exact worktree-subagent footgun: the old hook read the
+        parent cwd and allowed; recovery resolves to <wt_a> and blocks."""
+        with _WorktreeFixture() as f:
+            cmd = f"cd {f.wt_a} && git worktree remove {f.wt_a}"
+            result = hook.check(_bash(cmd, cwd=str(f.parent)))
+            assert result is not None, "cd-into-target self-delete must block"
+            self.assertEqual(result["decision"], "block")
+
+    def test_cd_into_subdir_then_remove_blocks_from_parent(self) -> None:
+        """POS: `cd <wt_a/sub> && remove <wt_a>` with stdin cwd at parent —
+        cwd recovers to a descendant of the target → block."""
+        with _WorktreeFixture() as f:
+            cmd = f"cd {f.wt_a_sub} && git worktree remove {f.wt_a}"
+            result = hook.check(_bash(cmd, cwd=str(f.parent)))
+            assert result is not None
+            self.assertEqual(result["decision"], "block")
+
+    # --- correctness cases: recovery now ALLOWS safe removes the old
+    #     stdin-cwd read false-blocked (shell cd's OUT before removing) ---
+
+    def test_cd_to_safe_then_remove_allows_even_when_stdin_cwd_is_target(
+        self,
+    ) -> None:
+        """NEG: `cd <safe-existing> && remove <wt_a>` with stdin cwd at
+        <wt_a>. The shell moves OUT of <wt_a> first, so this is NOT a
+        self-delete — recovery resolves to <safe> and allows. Pre-#535 this
+        false-blocked on the stdin cwd."""
+        with _WorktreeFixture() as f:
+            cmd = f"cd {f.parent} && git worktree remove {f.wt_a}"
+            result = hook.check(_bash(cmd, cwd=str(f.wt_a)))
+            self.assertIsNone(result, "cd-out-then-remove is safe; must allow")
+
+    def test_cd_to_sibling_worktree_then_remove_allows(self) -> None:
+        """NEG: `cd <wt_b> && remove <wt_a>` — cd to a sibling worktree, then
+        remove the other; safe, allow."""
+        with _WorktreeFixture() as f:
+            cmd = f"cd {f.wt_b} && git worktree remove {f.wt_a}"
+            result = hook.check(_bash(cmd, cwd=str(f.wt_a)))
+            self.assertIsNone(result)
+
+    # --- last-cd-wins ordering ---
+
+    def test_last_cd_wins_safe_then_unsafe_blocks(self) -> None:
+        """POS: `cd <safe> && cd <wt_a> && remove <wt_a>` — the LAST cd lands
+        inside the target, so it is a self-delete → block."""
+        with _WorktreeFixture() as f:
+            cmd = f"cd {f.parent} && cd {f.wt_a} && git worktree remove {f.wt_a}"
+            result = hook.check(_bash(cmd, cwd=str(f.parent)))
+            assert result is not None
+            self.assertEqual(result["decision"], "block")
+
+    def test_last_cd_wins_unsafe_then_safe_allows(self) -> None:
+        """NEG: `cd <wt_a> && cd <safe> && remove <wt_a>` — the LAST cd moves
+        out of the target, so the remove is safe → allow."""
+        with _WorktreeFixture() as f:
+            cmd = f"cd {f.wt_a} && cd {f.parent} && git worktree remove {f.wt_a}"
+            result = hook.check(_bash(cmd, cwd=str(f.wt_a)))
+            self.assertIsNone(result)
+
+    # --- recovery must not RELAX the guard on a path that isn't there ---
+
+    def test_cd_to_nonexistent_falls_back_to_stdin_cwd_and_blocks(self) -> None:
+        """POS: `cd <nonexistent> && remove <wt_a>` with stdin cwd at <wt_a>.
+        The nonexistent cd target is ignored; recovery falls back to the stdin
+        cwd (inside the target) → block. Recovery never relaxes on an absent
+        directory."""
+        with _WorktreeFixture() as f:
+            cmd = f"cd /nope-{os.getpid()} && git worktree remove {f.wt_a}"
+            result = hook.check(_bash(cmd, cwd=str(f.wt_a)))
+            assert result is not None
+            self.assertEqual(result["decision"], "block")
+
+    def test_no_cd_bare_remove_uses_stdin_cwd_blocks(self) -> None:
+        """POS: bare `git worktree remove <wt_a>` with no cd — stdin cwd
+        (inside target) is used directly → block. Confirms the no-cd path is
+        unchanged by recovery."""
+        with _WorktreeFixture() as f:
+            result = hook.check(_bash(f"git worktree remove {f.wt_a}", cwd=str(f.wt_a)))
+            assert result is not None
+            self.assertEqual(result["decision"], "block")
 
 
 class NonMatchingCommandsAllow(unittest.TestCase):


### PR DESCRIPTION
## fix(no_worktree_self_delete): recover invocation cwd to catch cd-into-worktree self-delete

#534/#528 follow-up. The hook read the stdin cwd as-is, so for a worktree subagent `cd <wt> && git worktree remove <wt>` (harness cwd anchored at the parent) **failed open** on the #173 self-delete.

### Change
Adopt the #534 `resolve_invocation_cwd` primitive (last-cd-wins recovery). The ancestry check now runs against the cwd the shell will actually be in when `git worktree remove` runs:
- `cd <wt> && git worktree remove <wt>` → resolves to `<wt>` → **BLOCK** (the self-delete the old read missed)
- `cd /safe && git worktree remove <wt>` → resolves to `/safe` → **ALLOW** (shell moves out first; correct)

Recovery only honors an absolute cd target that **exists on disk**; `cd <nonexistent>` falls back to the stdin cwd, so the guard never relaxes on a path that is not there.

### Safety test matrix (per issue — block/allow verdict surface)
New `CdRecoverySafetyMatrix` (8 cells): cd-into-target-from-parent blocks; cd-into-subdir blocks; cd-out-then-remove allows; cd-to-sibling allows; last-cd-wins both orderings (safe→unsafe blocks, unsafe→safe allows); cd-nonexistent falls back and blocks; bare-remove path unchanged. The prior `cd /safe`-literal test was retargeted to a nonexistent-path case and re-documented.

### Validation
- `test_no_worktree_self_delete.py`: 31 pass
- Full hook + lib suite: 1137 pass
- `uvx ruff@0.6.9 format --check .claude/hooks/` + `check` clean

Docstrings updated to replace the prior "cd is a plan not yet executed; left as-is intentionally" note with the new last-cd-wins semantics. Reviewers: Wanjiku + Santiago.

Refs #535
