### PR TITLE
fix(session-start): anchor REPO_ROOT to parent, degrade safely from a worktree (Refs #533)

### DIFF
--- a/.claude/skills/session-start/SKILL.md
+++ b/.claude/skills/session-start/SKILL.md
@@ -7,7 +7,7 @@ description: "MANDATORY first action in every session — runs full startup prot
 
 **This skill MUST be invoked as the FIRST action in every new session.** Do not respond to the user's message, do not read files, do not run any other tool — invoke `/session-start` first. The user's actual request is handled AFTER this completes.
 
-> Note: all repo paths in bash blocks below are rooted at `$REPO_ROOT` to avoid cwd drift when the skill is invoked from a worktree or child-repo subdirectory (#149).
+> Note: all repo paths in bash blocks below are rooted at `$REPO_ROOT` to avoid cwd drift when the skill is invoked from a worktree or child-repo subdirectory (#149). `$REPO_ROOT` is anchored to the **parent org repo** deterministically via the parent of `git rev-parse --git-common-dir` (not `--show-toplevel`, which resolves to a worktree if run from one) and verified against the parent marker `cross-repo-status.json` + `CLAUDE.md` (#533). Each bash block re-derives it, since Skill blocks run as independent shells.
 
 ## Instructions
 
@@ -29,7 +29,31 @@ and all 7 child repos, applying a **verify-merged-then-remove guard**:
   a manual decision — never auto-remove unmerged work.
 
 ```bash
-REPO_ROOT="$(git rev-parse --show-toplevel)"
+# Anchor REPO_ROOT to the PARENT org repo deterministically (#533). Using a
+# bare `git rev-parse --show-toplevel` resolves to a WORKTREE if /session-start
+# is ever invoked from one, which silently breaks child-repo discovery below
+# (the `$REPO_ROOT/$child/.git` probes find nothing). --git-common-dir points
+# at the MAIN repo's `.git` even from a linked worktree, so its parent is the
+# real org root in both the parent-checkout and run-from-worktree cases. We
+# then verify the parent marker (cross-repo-status.json + CLAUDE.md) and warn
+# loudly rather than silently skip children if it isn't found.
+resolve_repo_root() {
+  local common_dir candidate
+  common_dir="$(git rev-parse --git-common-dir 2>/dev/null)" || common_dir=""
+  if [ -n "$common_dir" ]; then
+    candidate="$(cd "$common_dir/.." 2>/dev/null && pwd)"
+  fi
+  if [ -z "$candidate" ]; then
+    candidate="$(git rev-parse --show-toplevel 2>/dev/null)"
+  fi
+  if [ -n "$candidate" ] && [ -f "$candidate/cross-repo-status.json" ] && [ -f "$candidate/CLAUDE.md" ]; then
+    printf '%s\n' "$candidate"; return 0
+  fi
+  printf 'WARN: parent-repo marker not found under %s — child-repo discovery may be incomplete. ' "${candidate:-<unresolved>}" >&2
+  printf 'Run /session-start from the parent main checkout (its mandated invocation path).\n' >&2
+  printf '%s\n' "${candidate:-$(pwd)}"; return 1
+}
+REPO_ROOT="$(resolve_repo_root)"
 
 # Parent repo + the 7 canonical child repos (CLAUDE.md Repository Map).
 REPOS=("$REPO_ROOT")
@@ -138,6 +162,11 @@ Run `/annunaki` to check the error monitor.
 Read the current project state:
 
 ```bash
+# Re-anchor REPO_ROOT (each Skill bash block is an independent shell — the
+# Step 0 value does not carry over). Same parent-anchor as Step 0 (#533):
+# parent of --git-common-dir resolves the org root even from a worktree.
+REPO_ROOT="$(cd "$(git rev-parse --git-common-dir 2>/dev/null)/.." 2>/dev/null && pwd)"
+[ -f "$REPO_ROOT/cross-repo-status.json" ] || REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
 cat "$REPO_ROOT/cross-repo-status.json"
 gh issue list --repo noorinalabs/noorinalabs-main --state open --limit 10 --json number,title,labels
 ```
@@ -155,6 +184,9 @@ If the report surfaces unexpected gaps between board view and open-issue counts 
 Read the tail of the feedback log:
 
 ```bash
+# Re-anchor REPO_ROOT to the parent (independent shell block — see Step 0 / #533).
+REPO_ROOT="$(cd "$(git rev-parse --git-common-dir 2>/dev/null)/.." 2>/dev/null && pwd)"
+[ -f "$REPO_ROOT/cross-repo-status.json" ] || REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
 tail -40 "$REPO_ROOT/.claude/team/feedback_log.md"
 ```
 


### PR DESCRIPTION
## fix(session-start): anchor REPO_ROOT to parent, degrade safely from a worktree

#528 cwd-anchor family. `/session-start` Step 0 used a bare `git rev-parse --show-toplevel` for `REPO_ROOT`; if invoked from a worktree that resolves to the worktree and child-repo discovery silently finds **0 children** (the `$REPO_ROOT/$child/.git` probes miss).

### Change
Anchor deterministically to the **parent org repo** via the parent of `git rev-parse --git-common-dir` (points at the main repo `.git` even from a linked worktree), with a `--show-toplevel` fallback, then **verify the parent marker** (`cross-repo-status.json` + `CLAUDE.md`). If the marker is absent (e.g. run from a child repo), warn loudly to stderr and keep the best candidate rather than silently skipping children — degrade safely, do not mis-anchor.

Steps 5 and 6 reference `$REPO_ROOT` in their own independent shell blocks where it was never actually defined (Skill blocks are separate shells); each re-anchors with the same compact parent-of-common-dir form.

### Verification
- **From a worktree**: REPO_ROOT now resolves to the parent and all **8 repos** (parent + 7 children) are discovered — was 0 children pre-fix.
- **From the parent checkout**: unchanged (8 repos).
- **From a child repo**: warns + does not mis-anchor.
- `bash -n` clean on the full Step 0 block.

Reviewers: Wanjiku + Santiago.

Refs #533
