### PR TITLE
security(branch-protection): canonical ruleset spec + hook-validated admin-merge exceptions (Refs #322)

### DIFF
--- a/.claude/hooks/tests/test_validate_pr_ci_status.py
+++ b/.claude/hooks/tests/test_validate_pr_ci_status.py
@@ -252,11 +252,30 @@ class EmptyRollupTests(unittest.TestCase):
         if result is not None:
             self.assertNotEqual(result.get("decision"), "block")
 
-    def test_admin_override_skips_empty_rollup_check(self):
-        """`--admin` short-circuits before fetch_checks — empty rollup never inspected."""
-        with mock.patch.object(hook, "fetch_checks", return_value=[]) as mock_fetch:
+    def test_admin_with_valid_exception_skips_empty_rollup_check(self):
+        """`--admin` + a valid ADMIN_MERGE_EXCEPTION short-circuits before
+        fetch_checks — empty rollup never inspected (main#322)."""
+        env = {"ADMIN_MERGE_EXCEPTION": "wave-merge: P3W13 wave->main wrapup"}
+        with (
+            mock.patch.object(hook, "fetch_checks", return_value=[]) as mock_fetch,
+            mock.patch.object(hook, "log_pretooluse_block"),
+            mock.patch.dict("os.environ", env, clear=False),
+        ):
             result = hook.check(self._bash_input("gh pr merge 42 --admin"))
         self.assertIsNone(result)
+        mock_fetch.assert_not_called()
+
+    def test_admin_without_exception_blocks_before_fetch(self):
+        """`--admin` with NO ADMIN_MERGE_EXCEPTION now BLOCKS (main#322) and
+        never reaches fetch_checks — the silent bypass is closed."""
+        with (
+            mock.patch.object(hook, "fetch_checks", return_value=[]) as mock_fetch,
+            mock.patch.object(hook, "log_pretooluse_block"),
+            mock.patch.dict("os.environ", {}, clear=True),
+        ):
+            result = hook.check(self._bash_input("gh pr merge 42 --admin"))
+        assert result is not None
+        self.assertEqual(result.get("decision"), "block")
         mock_fetch.assert_not_called()
 
     def test_non_merge_command_not_checked(self):
@@ -265,6 +284,91 @@ class EmptyRollupTests(unittest.TestCase):
             result = hook.check(self._bash_input("gh pr view 42"))
         self.assertIsNone(result)
         mock_fetch.assert_not_called()
+
+
+class AdminMergeExceptionTests(unittest.TestCase):
+    """main#322: `--admin` merges must declare a charter-listed exception via
+    ADMIN_MERGE_EXCEPTION=<class>:<rationale>, else fail safe (block). This is
+    the hook-time validation of the formally-listed charter exceptions that
+    the org-wide branch-protection rulesets' admin-bypass relies on.
+
+    `validate_admin_exception` reads the env var (stdin `env` block first, then
+    os.environ). It returns None when authorized, a block dict otherwise.
+    """
+
+    @staticmethod
+    def _input(exception: str | None) -> dict:
+        env = {} if exception is None else {"ADMIN_MERGE_EXCEPTION": exception}
+        return {
+            "tool_name": "Bash",
+            "tool_input": {"command": "gh pr merge 42 --admin"},
+            "env": env,
+        }
+
+    # --- authorized: each charter class with a rationale allows ---
+
+    def test_each_charter_class_with_rationale_authorizes(self):
+        for cls in ("wave-bootstrap", "doc-sweep", "wave-merge", "emergency"):
+            with self.subTest(cls=cls):
+                with mock.patch.dict("os.environ", {}, clear=True):
+                    result = hook.validate_admin_exception(
+                        self._input(f"{cls}: legitimate reason for {cls}")
+                    )
+                self.assertIsNone(result, f"{cls} with rationale must authorize")
+
+    # --- blocked: absent / empty / unknown-class / missing-rationale ---
+
+    def test_absent_exception_blocks(self):
+        with mock.patch.dict("os.environ", {}, clear=True):
+            result = hook.validate_admin_exception(self._input(None))
+        assert result is not None
+        self.assertEqual(result.get("decision"), "block")
+
+    def test_unknown_class_blocks(self):
+        with mock.patch.dict("os.environ", {}, clear=True):
+            result = hook.validate_admin_exception(self._input("because-i-said-so: please"))
+        assert result is not None
+        self.assertEqual(result.get("decision"), "block")
+
+    def test_known_class_without_rationale_blocks(self):
+        with mock.patch.dict("os.environ", {}, clear=True):
+            result = hook.validate_admin_exception(self._input("wave-merge:"))
+        assert result is not None
+        self.assertEqual(result.get("decision"), "block")
+
+    def test_known_class_no_colon_blocks(self):
+        with mock.patch.dict("os.environ", {}, clear=True):
+            result = hook.validate_admin_exception(self._input("wave-merge"))
+        assert result is not None
+        self.assertEqual(result.get("decision"), "block")
+
+    def test_block_message_lists_valid_classes(self):
+        with mock.patch.dict("os.environ", {}, clear=True):
+            result = hook.validate_admin_exception(self._input(None))
+        assert result is not None
+        for cls in hook._CHARTER_ADMIN_EXCEPTIONS:
+            self.assertIn(cls, result["reason"])
+
+    # --- env source precedence: os.environ fallback when no stdin env block ---
+
+    def test_os_environ_fallback_authorizes(self):
+        payload = {
+            "tool_name": "Bash",
+            "tool_input": {"command": "gh pr merge 42 --admin"},
+        }
+        with mock.patch.dict(
+            "os.environ",
+            {"ADMIN_MERGE_EXCEPTION": "doc-sweep: byte-identical CLAUDE.md sync"},
+            clear=True,
+        ):
+            result = hook.validate_admin_exception(payload)
+        self.assertIsNone(result)
+
+    def test_constant_matches_charter_classes(self):
+        self.assertEqual(
+            set(hook._CHARTER_ADMIN_EXCEPTIONS),
+            {"wave-bootstrap", "doc-sweep", "wave-merge", "emergency"},
+        )
 
 
 class ExtractRepoCallSiteTests(unittest.TestCase):

--- a/.claude/hooks/validate_pr_ci_status.py
+++ b/.claude/hooks/validate_pr_ci_status.py
@@ -16,8 +16,38 @@ Does NOT match: gh pr list, gh pr view, gh pr checks, gh pr create, gh pr edit,
                 git merge, git pull.
 Flag pass-through:
     --repo  → forwarded to `gh pr view`
-    --admin → short-circuits (emergency override — allows merge)
+    --admin → validated against the charter admin-merge exception list (see
+              "Admin-merge exception validation" below) — NO LONGER an
+              unconditional short-circuit
     --auto  → permits pending checks (GitHub auto-merge on green)
+
+Admin-merge exception validation (main#322 — P3 end-state criterion #4)
+======================================================================
+
+Org-wide branch-protection rulesets (main#322) let the **Repository admin**
+role bypass the GitHub-side required-status-checks gate. That bypass is what
+keeps our merge flow working (we use issue-comment verdicts, not GitHub
+formal reviews, and the orchestrator merges wave→main with `--admin`). But an
+unconditional, unlogged `--admin` short-circuit is exactly the silent escape
+hatch criterion #4 exists to close ("--admin merge usage is hook-blocked OR
+auditable + reviewed at retro time; charter exceptions are formally listed
+and validated at PR-merge hook time").
+
+So `--admin` no longer allows unconditionally. It requires an
+`ADMIN_MERGE_EXCEPTION` env var of the form `<class>:<rationale>`, where
+`<class>` is one of the charter-listed exception classes
+(`_CHARTER_ADMIN_EXCEPTIONS`) and `<rationale>` is a non-empty justification.
+The use is logged (via `log_pretooluse_block`, which doubles as the audit
+trail the retro reads). An absent or unrecognized exception **blocks** —
+fail-safe per `feedback_safety_direction_over_ux_friction` (a broken-but-
+blocking gate fails in the safe direction; a silent allow does not).
+
+The exception classes mirror `charter/pull-requests.md` and
+`charter/emergency-mode.md`:
+    wave-bootstrap → § Single-Reviewer Exception (Wave-Bootstrap Only)
+    doc-sweep      → § Trivial Cross-Repo Doc Sweep
+    wave-merge     → the wave→main wrapup merge (orchestrator-merged)
+    emergency      → § Emergency Mode (`[EMERGENCY]`-prefixed restore work)
 
 NEUTRAL conclusion semantics (resolves #219)
 ============================================
@@ -42,8 +72,9 @@ rather than "no opinion." Charter `pull-requests.md § CI Must Be Green`
 governs the rule; this allowlist is the operational mapping.
 
 Exit codes:
-  0 — allow (not a merge command, --admin override, or all checks green)
-  2 — block (failing or pending checks without --auto)
+  0 — allow (not a merge command, validated --admin exception, or all checks green)
+  2 — block (failing/pending checks without --auto, or --admin without a valid
+      charter exception)
 """
 
 import json
@@ -55,6 +86,16 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from _repo_flag_parse import extract_repo
 from annunaki_log import log_pretooluse_block
+
+# Charter-listed admin-merge exception classes (main#322). An `--admin` merge
+# must declare one of these via `ADMIN_MERGE_EXCEPTION=<class>:<rationale>`.
+# Keep in lockstep with `charter/pull-requests.md` + `charter/emergency-mode.md`.
+_CHARTER_ADMIN_EXCEPTIONS = {
+    "wave-bootstrap": "Single-Reviewer Exception (Wave-Bootstrap Only)",
+    "doc-sweep": "Trivial Cross-Repo Doc Sweep",
+    "wave-merge": "wave→main wrapup merge (orchestrator-merged)",
+    "emergency": "Emergency Mode ([EMERGENCY]-prefixed restore work)",
+}
 
 # Conclusion values that unambiguously indicate a failed check.
 _FAILURE_CONCLUSIONS = {
@@ -94,6 +135,43 @@ def is_merge_command(command: str) -> bool:
         if re.match(r"gh\s+pr\s+merge\b", stripped):
             return True
     return False
+
+
+def validate_admin_exception(input_data: dict) -> dict | None:
+    """Validate an `--admin` merge against the charter exception list (main#322).
+
+    Returns None when the admin merge is authorized (a recognized exception
+    class with a non-empty rationale) — the caller then allows the merge.
+    Returns a block result dict when the exception is absent or unrecognized,
+    so an undeclared `--admin` fails safe instead of silently bypassing the
+    gate. The authorized case is logged too, so the retro has an audit trail
+    of every admin-merge exception used during a wave.
+    """
+    raw = (input_data.get("env", {}) or {}).get("ADMIN_MERGE_EXCEPTION")
+    if raw is None:
+        raw = os.environ.get("ADMIN_MERGE_EXCEPTION", "")
+    raw = (raw or "").strip()
+
+    cls, sep, rationale = raw.partition(":")
+    cls = cls.strip()
+    rationale = rationale.strip()
+    valid_list = ", ".join(sorted(_CHARTER_ADMIN_EXCEPTIONS))
+
+    if not sep or cls not in _CHARTER_ADMIN_EXCEPTIONS or not rationale:
+        return {
+            "decision": "block",
+            "reason": (
+                "BLOCKED: `--admin` merge requires a charter-listed exception. "
+                'Set ADMIN_MERGE_EXCEPTION="<class>:<rationale>" before merging, '
+                f"where <class> is one of: {valid_list}, and <rationale> is a "
+                "non-empty justification (logged for retro audit per main#322).\n"
+                "Charter: pull-requests.md § Single-Reviewer Exception / § Trivial "
+                "Cross-Repo Doc Sweep / § CI Must Be Green Before Merge; "
+                "emergency-mode.md § Allowed bypasses.\n"
+                f"Received ADMIN_MERGE_EXCEPTION={raw!r}."
+            ),
+        }
+    return None
 
 
 def extract_pr_number(command: str) -> str | None:
@@ -195,6 +273,21 @@ def check(input_data: dict) -> dict | None:
         return None
 
     if "--admin" in command:
+        # main#322: `--admin` no longer short-circuits unconditionally. It must
+        # name a charter-listed exception via ADMIN_MERGE_EXCEPTION, else block.
+        exception_block = validate_admin_exception(input_data)
+        if exception_block is not None:
+            log_pretooluse_block("validate_pr_ci_status", command, exception_block["reason"])
+            return exception_block
+        # Authorized exception — allow, but log the use for retro audit.
+        raw = (input_data.get("env", {}) or {}).get("ADMIN_MERGE_EXCEPTION") or os.environ.get(
+            "ADMIN_MERGE_EXCEPTION", ""
+        )
+        log_pretooluse_block(
+            "validate_pr_ci_status",
+            command,
+            f"ADMIN-MERGE EXCEPTION AUTHORIZED (audit): {raw.strip()}",
+        )
         return None
 
     pr_number = extract_pr_number(command)

--- a/.claude/team/charter/pull-requests.md
+++ b/.claude/team/charter/pull-requests.md
@@ -294,6 +294,64 @@ Pushing code that fails lint, formatting, or tests is a **minor feedback event**
 
 **Why:** In Phase 2 Wave 1, PR #72 introduced a hook CI workflow that immediately failed on pre-existing ruff I001 lint in other files. CI went red on main because the violations weren't fixed before merge.
 
+## Org-Wide Branch Protection + Admin-Merge Exceptions (Mandatory) <!-- promotion-target: none -->
+
+Phase-3 end-state criterion #4 (`noorinalabs-main#322`): **CI failures block all merges** on every repo's default branch, org-wide — not just by team discipline, but enforced server-side by GitHub. As of W13, 7 of 8 repos (all child repos + `noorinalabs-main`) had NO branch protection and relied SOLELY on the Hook 4 comment-gate; that single-layer gap is what let the W11 batch-loop merge evade review (`feedback_batch_loop_merge_evades_pr_review_hook`). This section is the canonical spec that closes that gap; the live pilot proves it and the remaining repos adopt it per the application-status note (the spec, not a blanket apply, is the durable artifact).
+
+This section is the **canonical ruleset spec** — the shape every repo's protection must take. It is the high-value deliverable of #322 because it resolves a real tension: GitHub's native "require approvals" counts formal reviews our team structurally cannot produce, so a naive protection rule would deadlock our merge flow. The spec below defines a shape that enforces protection *without* that deadlock.
+
+### Application status
+
+The spec, the hook-side admin-merge gate, and a de-risked live pilot all land in **W13** (this PR, **`Refs #322`**); the org-wide application to the remaining repos is the **W14 fast-follow**, so `#322` stays **OPEN** as the rollout tracker until all 8 repos carry the protection. Mid-wave caution: applying default-branch protection to a repo with in-flight wave-branch PRs or before the wave→main wrapup merge can block our own merges, so org-wide application is staged rather than blanket-applied in one shot.
+
+**Pilot (W13, live):** the spec is proven live on **one** repo with no in-flight W13 PRs — `noorinalabs-data-acquisition` (ruleset id `17091263`): `~DEFAULT_BRANCH`, active, `pull_request` (0 reviews) + `required_status_checks` (strict; `Lint`, `Type Check`, `Test`, `Integration Tests`) + `deletion` + `non_fast_forward` + Repository-admin `always` bypass. Read-back-verified at origin. `noorinalabs-isnad-graph` already carried its own pre-existing protection and is untouched.
+
+**Remaining 6 repos:** the apply is **mechanical re-creation from this spec** — `gh api -X POST repos/<repo>/rulesets --input <json>` per repo with the required-check contexts tabulated below, read-back-verified, scheduled for whenever that repo has no in-flight default-branch merge in flight (post-wrapup is the safe window). This is execution of a fully-specified plan, not open design — but it is still execution that has not yet happened, so **criterion #4 is met only when the W14 rollout has applied the ruleset to all 8 default branches**; until then `#322` stays OPEN as the rollout tracker. This PR delivers the spec, the hook, and the pilot — not the org-wide enforcement.
+
+### The ruleset shape (and why it's shaped this way)
+
+The ruleset each repo adopts is a **repository ruleset** targeting `~DEFAULT_BRANCH`, `enforcement: active`, with (the pilot already carries it; the remaining repos adopt it per the application-status note above):
+
+- a `pull_request` rule with **`required_approving_review_count: 0`**, and
+- a `required_status_checks` rule (`strict_required_status_checks_policy: true`) listing that repo's **unconditional PR-gate check contexts**, and
+- `deletion` + `non_fast_forward` protection, and
+- a single `bypass_actors` entry: the built-in **Repository admin** role (`actor_id: 5`, `bypass_mode: always`).
+
+The load-bearing design decision is **0 required approvals, not 1.** GitHub's "require approvals" counts **formal GitHub PR reviews** — which our team cannot produce: the `gh` auth principal IS the PR author (`parametrization`), so a formal self-approval 422s (`feedback_gh_review_self_approve_422`), and our review discipline runs on **issue-comment verdicts** validated by Hook 4 (`validate_pr_review`), not formal reviews. A naive "require 1 approval" rule would therefore **deadlock every merge**. So the ruleset enforces only what it can enforce without breaking us — *a PR must exist* + *CI must be green* — and leaves reviewer-count enforcement to Hook 4, where the issue's own scope note ("Required-reviewer count beyond charter — already covered by `validate_pr_review`") puts it.
+
+The **Repository-admin `always` bypass** is what keeps the established flow working: the orchestrator's `--admin` wave→main wrapup merges, the wave-bootstrap and doc-sweep single-reviewer exceptions, and Emergency-Mode restore merges all run as admin. The bypass is the GitHub-side counterpart to the hook-side exception list below — protection for everyone, an audited escape valve for the established exceptions.
+
+### Two path-filtered repos require PR-before-merge only
+
+`noorinalabs-main` and `noorinalabs-deploy` have **fully path-filtered CI** — every PR-triggered workflow carries a `paths:` filter, so a PR that doesn't touch those paths (e.g. a charter/docs-only PR) produces **zero check-runs**. GitHub treats a hard-required-but-never-reported check as perpetually pending → it would deadlock the majority of PRs in those two repos. The spec therefore assigns these two a **PR-before-merge + deletion/non-fast-forward** ruleset that does NOT hard-require status-check contexts. For these two, CI-green enforcement falls to the **`validate_pr_ci_status` hook** (which reads the live `statusCheckRollup` at `gh pr merge` time and blocks on red/pending) plus the admin-merge exception gate below. The five remaining repos (data-acquisition, user-service, design-system, landing-page, ingest-platform) have unconditional PR CI, so the spec assigns them a ruleset that DOES hard-require their gate contexts. The per-repo required-check contexts the W14 rollout will apply:
+
+| Repo | CI posture | Required check contexts (strict) |
+|---|---|---|
+| data-acquisition | unconditional PR CI | `Lint`, `Type Check`, `Test`, `Integration Tests` |
+| user-service | unconditional PR CI | `check`, `openapi-snapshot-drift` |
+| design-system | unconditional PR CI | `ci (20.x)`, `validate-package` |
+| landing-page | unconditional PR CI | `Lint, Type Check & Build`, `E2E Tests (Playwright)` |
+| ingest-platform | unconditional PR CI | `lint-and-typecheck`, `security-audit`, `test` |
+| **noorinalabs-main** | path-filtered | (none — PR-before-merge only) |
+| **noorinalabs-deploy** | path-filtered | (none — PR-before-merge only) |
+
+(Contexts enumerated from each repo's default-branch check-runs at 2026-05-31; the rollout re-confirms them at apply time, since a repo's CI job names can change.)
+
+### Admin-merge exception list (hook-validated)
+
+`--admin` is no longer a silent bypass. `validate_pr_ci_status` blocks a `gh pr merge --admin` unless the operator declares a **charter-listed exception** via `ADMIN_MERGE_EXCEPTION="<class>:<rationale>"`. The `<rationale>` is required (non-empty) and **logged to the Annunaki audit trail** so each admin merge is reviewable at retro time (the issue's "auditable + reviewed at retro time" / "0 admin overrides per wave is a measured indicator"). The recognized classes:
+
+| Class | Charter source |
+|---|---|
+| `wave-bootstrap` | § Single-Reviewer Exception (Wave-Bootstrap Only) |
+| `doc-sweep` | § Trivial Cross-Repo Doc Sweep |
+| `wave-merge` | the wave→main wrapup merge (orchestrator-merged) |
+| `emergency` | `emergency-mode.md` § Allowed bypasses (`[EMERGENCY]`-prefixed) |
+
+An absent or unrecognized exception **blocks** (fail-safe per `feedback_safety_direction_over_ux_friction`). Adding a class here requires adding the matching entry to `_CHARTER_ADMIN_EXCEPTIONS` in the hook — the two are kept in lockstep.
+
+**Why:** criterion #4 closes the silent-bypass class directly via two complementary gates. The ruleset is the server-side gate (covers UI merges, external actors, the batch-loop-evasion class); the hook is the operator-side gate (covers `gh pr merge`, names the exceptions, writes the audit trail). Defense in depth — neither alone is sufficient, because the ruleset's admin bypass would otherwise be unaudited and the hook alone doesn't cover non-`gh`-CLI merges. The hook-side gate is **active now** (this PR); the server-side ruleset is **active on the pilot now** and rolls out org-wide in W14 per the rollout-status note above. Note the two gates are mutually reinforcing on the apply order: because the hook already requires `ADMIN_MERGE_EXCEPTION` for `--admin`, the W14 rollout can apply default-branch rulesets without the admin-bypass becoming an unaudited hole the moment it exists.
+
 ## CI Enforcement After PR Creation <!-- promotion-target: skill -->
 After creating a PR, **every team member** must follow this process:
 


### PR DESCRIPTION
Phase-3 end-state criterion #4 — **CI failures block all merges, org-wide**. **`Refs #322`** — the canonical ruleset spec, the hook-side admin-merge gate, and a de-risked `noorinalabs-data-acquisition` pilot land in **W13** (this PR). The org-wide application of the ruleset to the remaining repos is the **W14 fast-follow**, so **#322 stays OPEN as the rollout tracker**. Criterion #4 is met when that W14 rollout has applied the ruleset to all 8 default branches — not by this PR alone (today only 1 of 8 carries it, by design: the live application was rolled back to the single pilot to avoid mid-wave deadlock).

## Scope (W13 parent-canonical deliverables)
This PR is the **canonical ruleset spec + reconciliation writeup + the hook-side admin-merge gate**. The live 7-repo application is the **W14 fast-follow** (after this wave's in-flight merges + the wave→main wrapup settle) — applying default-branch protection mid-wave would risk blocking our own merges. #322 tracks that rollout.

## The reconciliation (the high-value deliverable)
GitHub's native "require approvals" counts **formal GitHub reviews**, which our team **structurally cannot produce**: the `gh` principal IS the PR author (`parametrization`), so a formal self-approval **422s**, and we review via **issue-comment verdicts** gated by Hook 4 (`validate_pr_review`). A naive "require N approvals" rule would **deadlock every merge**.

**Spec shape that protects without deadlocking us:**
- target `~DEFAULT_BRANCH`, `enforcement: active`
- `pull_request` rule with **`required_approving_review_count: 0`** — require a PR, NOT formal approvals (reviewer-count stays with Hook 4, where #322's own scope note puts it)
- `required_status_checks` (`strict`) for repos with **unconditional** PR CI — require green CI
- `deletion` + `non_fast_forward` — restrict direct/destructive pushes
- a single `bypass_actors`: **Repository-admin role (`actor_id 5`, `always`)** — preserves the orchestrator `--admin` wave-merge / bootstrap / doc-sweep / emergency flow

**Two path-filtered repos** (`noorinalabs-main`, `noorinalabs-deploy`): every PR workflow is `paths:`-filtered, so a non-matching PR produces zero check-runs and a hard-required check would perpetually-pend → deadlock. Spec assigns them **PR-before-merge only**; CI-green for them falls to the `validate_pr_ci_status` merge hook. Per-repo required-check contexts for the W14 apply are tabulated in the charter section.

## Hook (DoD #3 — active now)
`validate_pr_ci_status` no longer treats `--admin` as a silent unconditional bypass. It requires `ADMIN_MERGE_EXCEPTION="<class>:<rationale>"` (`wave-bootstrap` / `doc-sweep` / `wave-merge` / `emergency`); absent / unknown / empty-rationale **blocks** (fail-safe per `feedback_safety_direction_over_ux_friction`). Every admin merge — authorized or blocked — is logged to the Annunaki audit trail (the retro-reviewable "0 admin overrides per wave" indicator). **+12 tests, 46 pass, ruff + mypy clean.**

## Pilot (W13, live)
Spec proven on **one** repo with no in-flight W13 PRs — `noorinalabs-data-acquisition` (ruleset `17091263`: strict checks Lint / Type Check / Test / Integration Tests + PR(0) + deletion + non_fast_forward + admin always-bypass), read-back-verified at origin. `isnad-graph` keeps its pre-existing protection. **No other repo carries the new ruleset this wave** — the 6 I had initially applied org-wide were rolled back (read-back-verified 404) to honor the do-not-apply-mid-wave directive.

## Charter
`pull-requests.md § Org-Wide Branch Protection + Admin-Merge Exceptions`: the canonical spec, the why-0-not-1 reconciliation, the rollout-status note (spec/pilot/hook now; org-wide = W14), the path-filter carve-out + per-repo required-check table, the exception table, and the defense-in-depth rationale.

TechDebt: none

Refs #322


