### PR TITLE
feat(ci): pre-push stage + pre-commit<->CI sync-drift gate (parent) (Refs #327)

### DIFF
--- a/.claude/lib/pre_commit_ci_sync.py
+++ b/.claude/lib/pre_commit_ci_sync.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Detect drift between a repo's pre-commit config and what its CI enforces.
+
+Phase-3 end-state criterion #6 (noorinalabs-main#327) requires that local
+pre-commit / pre-push hooks MIRROR the GitHub Actions checks, so a developer's
+local commit fails fast instead of surfacing a lint/type/test error only after
+a PR is opened. This module is the drift GATE: it parses both sides into a set
+of canonical "check kinds" and reports any check CI enforces that the
+pre-commit config does NOT run locally.
+
+Drift direction that matters
+============================
+We gate on **CI-enforced-but-not-local** drift only. That is the harmful
+direction: CI catches something the dev's machine doesn't, so the failure
+appears at PR time (the friction #327 exists to remove). The reverse
+(local runs something CI doesn't) is *stricter local* — not a regression, so
+it is reported as informational, never a gate failure.
+
+Canonical check kinds
+=====================
+Heterogeneous repos express the same check different ways (a `ruff` CI `run:`
+step vs a `ruff` pre-commit `id:`). We normalize both sides to a small set of
+kind tokens so they compare:
+
+    ruff-lint, ruff-format, mypy, pytest, eslint, typescript, prettier,
+    terraform-fmt, gitleaks, actionlint, astro-check, pip-audit, build
+
+Unknown tools are ignored (neither side gates on a kind we can't classify),
+which keeps the gate conservative — it never fails on something it doesn't
+understand.
+
+Input Language
+==============
+- A pre-commit config is parsed for `id:` values AND `entry:`/`name:` text.
+- A CI workflow is parsed for `run:` shell lines AND `uses:` action refs.
+Both are matched against per-kind keyword patterns.
+
+Exit codes (CLI):
+    0 — no harmful drift (every CI-enforced kind is mirrored in pre-commit)
+    1 — harmful drift (a CI-enforced kind is missing from pre-commit)
+    2 — usage / file-not-found error
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# Each kind maps to the keyword patterns that identify it on EITHER side
+# (pre-commit id/entry text or CI run/uses text). Patterns are substrings
+# matched case-insensitively against the relevant lines.
+_KIND_PATTERNS: dict[str, tuple[str, ...]] = {
+    "ruff-format": ("ruff-format", "ruff format"),
+    "ruff-lint": ("ruff check", "id: ruff", "- ruff"),
+    "mypy": ("mypy",),
+    "pytest": ("pytest",),
+    "eslint": ("eslint",),
+    "typescript": ("tsc", "typecheck", "type-check", "astro check"),
+    "prettier": ("prettier",),
+    "terraform-fmt": ("terraform fmt", "terraform_fmt", "id: terraform"),
+    "gitleaks": ("gitleaks",),
+    "actionlint": ("actionlint",),
+    "pip-audit": ("pip-audit", "pip audit"),
+    "build": ("build-and-validate", "build-and-test", "npm run build", "docker build"),
+}
+
+# `ruff-lint` is a substring of nothing problematic, but `ruff format` also
+# contains `ruff`, so order the lint check to NOT fire on a format-only line.
+# We handle that by classifying format first and removing matched spans.
+
+
+def _classify_line(line: str) -> set[str]:
+    """Return the set of canonical kinds a single text line implies."""
+    low = line.lower()
+    kinds: set[str] = set()
+    # Format must be tested before the bare-ruff lint pattern so that a
+    # `ruff format` line is not also counted as `ruff-lint`.
+    if any(p in low for p in _KIND_PATTERNS["ruff-format"]):
+        kinds.add("ruff-format")
+    for kind, patterns in _KIND_PATTERNS.items():
+        if kind == "ruff-format":
+            continue
+        if kind == "ruff-lint":
+            # Only count ruff-lint when it is not purely the format line.
+            if ("ruff format" in low) and ("ruff check" not in low and "id: ruff" not in low):
+                continue
+        if any(p in low for p in patterns):
+            kinds.add(kind)
+    return kinds
+
+
+def kinds_from_precommit(config_text: str) -> set[str]:
+    """Canonical check-kinds a `.pre-commit-config.yaml` runs locally."""
+    kinds: set[str] = set()
+    for raw in config_text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        # Only lines that name a hook matter: id:, entry:, name:, - repo refs.
+        if re.match(r"^(-\s*)?(id|entry|name|repo):", line) or line.startswith("- "):
+            kinds |= _classify_line(line)
+    return kinds
+
+
+def kinds_from_ci(workflow_text: str) -> set[str]:
+    """Canonical check-kinds a CI workflow enforces."""
+    kinds: set[str] = set()
+    for raw in workflow_text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        # CI expresses checks as `run:` shell or `uses:` actions.
+        if "run:" in line or line.startswith("- run:") or "uses:" in line or line.startswith("-"):
+            kinds |= _classify_line(line)
+    return kinds
+
+
+def compute_drift(precommit_kinds: set[str], ci_kinds: set[str]) -> tuple[set[str], set[str]]:
+    """Return (harmful_drift, stricter_local).
+
+    harmful_drift  = CI enforces it, pre-commit does not (gate fails on these).
+    stricter_local = pre-commit runs it, CI does not (informational only).
+    """
+    harmful = ci_kinds - precommit_kinds
+    stricter = precommit_kinds - ci_kinds
+    return harmful, stricter
+
+
+def check_repo(precommit_path: Path, ci_paths: list[Path]) -> tuple[set[str], set[str]]:
+    """Read the files and compute drift. Missing files contribute nothing."""
+    pc_text = precommit_path.read_text(encoding="utf-8") if precommit_path.is_file() else ""
+    ci_text = "\n".join(p.read_text(encoding="utf-8") for p in ci_paths if p.is_file())
+    return compute_drift(kinds_from_precommit(pc_text), kinds_from_ci(ci_text))
+
+
+def _default_ci_paths(repo_root: Path) -> list[Path]:
+    wf_dir = repo_root / ".github" / "workflows"
+    if not wf_dir.is_dir():
+        return []
+    return sorted(p for p in wf_dir.glob("*.y*ml"))
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "repo_root",
+        nargs="?",
+        default=".",
+        help="Repo root to check (default: cwd).",
+    )
+    parser.add_argument(
+        "--precommit",
+        help="Path to .pre-commit-config.yaml (default: <repo_root>/.pre-commit-config.yaml).",
+    )
+    parser.add_argument(
+        "--ci",
+        action="append",
+        help=(
+            "Path to a CI workflow file (repeatable). "
+            "Default: all <repo_root>/.github/workflows/*.yml."
+        ),
+    )
+    args = parser.parse_args(argv[1:])
+
+    repo_root = Path(args.repo_root).resolve()
+    precommit_path = (
+        Path(args.precommit) if args.precommit else repo_root / ".pre-commit-config.yaml"
+    )
+    ci_paths = [Path(p) for p in args.ci] if args.ci else _default_ci_paths(repo_root)
+
+    if not precommit_path.is_file():
+        print(
+            f"ERROR: no pre-commit config at {precommit_path} — "
+            "every repo must have one (criterion #327).",
+            file=sys.stderr,
+        )
+        return 2
+
+    harmful, stricter = check_repo(precommit_path, ci_paths)
+
+    if stricter:
+        print(f"INFO: pre-commit runs (CI does not): {sorted(stricter)} — stricter local, OK.")
+
+    if harmful:
+        print("DRIFT: CI enforces these checks but pre-commit does NOT run them locally:")
+        for k in sorted(harmful):
+            print(f"  - {k}")
+        print(
+            "\nAdd the missing check(s) to .pre-commit-config.yaml so local commits "
+            "fail fast (criterion #327). Pin the same tool version CI uses."
+        )
+        return 1
+
+    print("OK: pre-commit config mirrors all CI-enforced checks.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.claude/lib/tests/test_pre_commit_ci_sync.py
+++ b/.claude/lib/tests/test_pre_commit_ci_sync.py
@@ -1,0 +1,155 @@
+"""Tests for pre_commit_ci_sync — the pre-commit <-> CI drift gate (#327).
+
+Verifies:
+  1. Canonical kind extraction from both pre-commit configs and CI workflows.
+  2. The drift direction that gates: CI-enforced-but-not-local is harmful;
+     local-but-not-CI is stricter-local (informational, never a gate fail).
+  3. ruff-format vs ruff-lint are not conflated.
+  4. The real parent (noorinalabs-main) config mirrors its CI kinds (no drift).
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+# Helper lives at .claude/lib/pre_commit_ci_sync.py; test is at
+# .claude/lib/tests/test_*.py. parent.parent reaches the lib root.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from pre_commit_ci_sync import (  # noqa: E402
+    check_repo,
+    compute_drift,
+    kinds_from_ci,
+    kinds_from_precommit,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+class PrecommitKindExtraction(unittest.TestCase):
+    def test_ruff_format_and_lint_both_detected(self) -> None:
+        cfg = """
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    hooks:
+      - id: ruff-format
+      - id: ruff
+"""
+        kinds = kinds_from_precommit(cfg)
+        self.assertIn("ruff-format", kinds)
+        self.assertIn("ruff-lint", kinds)
+
+    def test_mypy_and_pytest_local_hooks(self) -> None:
+        cfg = """
+repos:
+  - repo: local
+    hooks:
+      - id: mypy
+        entry: python3 -m mypy
+      - id: pytest-unit
+        entry: pytest
+"""
+        kinds = kinds_from_precommit(cfg)
+        self.assertIn("mypy", kinds)
+        self.assertIn("pytest", kinds)
+
+    def test_frontend_kinds(self) -> None:
+        cfg = """
+repos:
+  - repo: local
+    hooks:
+      - id: eslint
+      - id: typecheck
+        entry: tsc --noEmit
+      - id: prettier
+"""
+        kinds = kinds_from_precommit(cfg)
+        self.assertIn("eslint", kinds)
+        self.assertIn("typescript", kinds)
+        self.assertIn("prettier", kinds)
+
+    def test_comments_ignored(self) -> None:
+        cfg = "# id: mypy is just a comment\nrepos: []\n"
+        self.assertNotIn("mypy", kinds_from_precommit(cfg))
+
+
+class CiKindExtraction(unittest.TestCase):
+    def test_run_steps_detected(self) -> None:
+        wf = """
+jobs:
+  lint:
+    steps:
+      - run: ruff check .
+      - run: ruff format --check .
+      - run: mypy src/
+      - run: pytest -q
+"""
+        kinds = kinds_from_ci(wf)
+        self.assertEqual(
+            kinds & {"ruff-lint", "ruff-format", "mypy", "pytest"},
+            {"ruff-lint", "ruff-format", "mypy", "pytest"},
+        )
+
+    def test_uses_actions_detected(self) -> None:
+        wf = """
+jobs:
+  scan:
+    steps:
+      - uses: gitleaks/gitleaks-action@v2
+"""
+        self.assertIn("gitleaks", kinds_from_ci(wf))
+
+    def test_ruff_format_line_not_counted_as_lint(self) -> None:
+        # A format-only line must NOT register ruff-lint.
+        kinds = kinds_from_ci("      - run: ruff format --check .\n")
+        self.assertIn("ruff-format", kinds)
+        self.assertNotIn("ruff-lint", kinds)
+
+
+class DriftDirection(unittest.TestCase):
+    def test_ci_enforced_not_local_is_harmful(self) -> None:
+        harmful, stricter = compute_drift(
+            precommit_kinds={"ruff-lint"},
+            ci_kinds={"ruff-lint", "mypy", "pytest"},
+        )
+        self.assertEqual(harmful, {"mypy", "pytest"})
+        self.assertEqual(stricter, set())
+
+    def test_local_not_ci_is_stricter_only(self) -> None:
+        harmful, stricter = compute_drift(
+            precommit_kinds={"ruff-lint", "gitleaks"},
+            ci_kinds={"ruff-lint"},
+        )
+        self.assertEqual(harmful, set())
+        self.assertEqual(stricter, {"gitleaks"})
+
+    def test_perfect_mirror_no_drift(self) -> None:
+        harmful, stricter = compute_drift(
+            precommit_kinds={"ruff-lint", "ruff-format", "mypy"},
+            ci_kinds={"ruff-lint", "ruff-format", "mypy"},
+        )
+        self.assertEqual(harmful, set())
+        self.assertEqual(stricter, set())
+
+
+class RealParentRepoHasNoDrift(unittest.TestCase):
+    """The parent noorinalabs-main config must mirror its CI kinds — this is
+    the gate running against the very repo that ships it."""
+
+    def test_parent_precommit_mirrors_parent_ci(self) -> None:
+        precommit = _REPO_ROOT / ".pre-commit-config.yaml"
+        ci = _REPO_ROOT / ".github" / "workflows" / "ci.yml"
+        self.assertTrue(precommit.is_file(), "parent must have a pre-commit config")
+        self.assertTrue(ci.is_file(), "parent must have ci.yml")
+        harmful, _ = check_repo(precommit, [ci])
+        self.assertEqual(
+            harmful,
+            set(),
+            f"parent pre-commit must mirror CI; missing locally: {sorted(harmful)}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
       - ".claude/lib/**"
       - ".claude/skills/**"
       - ".github/workflows/ci.yml"
+      - ".pre-commit-config.yaml"
       - "pyproject.toml"
   pull_request:
     branches: [main, "deployments/**"]
@@ -16,6 +17,7 @@ on:
       - ".claude/lib/**"
       - ".claude/skills/**"
       - ".github/workflows/ci.yml"
+      - ".pre-commit-config.yaml"
       - "pyproject.toml"
 
 jobs:
@@ -84,3 +86,16 @@ jobs:
       - run: pip install pytest
       - name: Run hook and lib tests
         run: pytest .claude/hooks/tests/ .claude/lib/tests/ -q
+
+  precommit-ci-sync:
+    name: Pre-commit ⇄ CI sync-drift gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Verify pre-commit config mirrors CI-enforced checks (#327)
+        # Fails if a check CI enforces (ruff/mypy/pytest/…) is missing from
+        # .pre-commit-config.yaml, so local hooks can't silently drift behind CI.
+        run: python3 .claude/lib/pre_commit_ci_sync.py .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,28 @@
 # Pre-commit hooks for noorinalabs-main
-# Install: pre-commit install
-# Docs:    https://pre-commit.com/
+# Install:  pre-commit install && pre-commit install --hook-type pre-push
+# Docs:     https://pre-commit.com/
 #
-# This mirrors .github/workflows/ci.yml coverage so local commits fail fast
-# instead of surfacing ruff errors only after a PR is opened. Keep `rev`
-# aligned with sibling repos (isnad-graph pins ruff 0.15.11) so the same
-# ruff version runs in local pre-commit and in CI.
+# This MIRRORS .github/workflows/ci.yml so local commits/pushes fail fast
+# instead of surfacing a lint/type/test error only after a PR is opened
+# (Phase-3 end-state criterion #6 / #327). Keep `rev` aligned with sibling
+# repos (isnad-graph pins ruff 0.15.11) so the same ruff version runs in
+# local pre-commit and in CI.
 #
-# Scope: `.claude/hooks/` — the Python hook files CI checks.
-# `.claude/worktrees/` is excluded because it contains scratch checkouts of
+# Stage split:
+#   pre-commit (fast, every commit) — ruff-format, ruff-lint.
+#   pre-push   (heavier, every push) — mypy typecheck, pytest suite. These run
+#     the whole hooks+lib surface, so they're push-time not commit-time to keep
+#     the commit loop snappy while still catching everything before it leaves
+#     the machine.
+#
+# Scope: `.claude/hooks/` + `.claude/lib/` — the Python that CI checks (CI runs
+# ruff/mypy on BOTH; the pre_commit_ci_sync gate enforces this mirror). The
+# `.claude/worktrees/` tree is excluded because it holds scratch checkouts of
 # other branches; reformatting them would silently overwrite in-progress work.
+#
+# The kind-level mirror (ruff-lint, ruff-format, mypy, pytest present on both
+# sides) is enforced in CI by `.claude/lib/pre_commit_ci_sync.py` — if a future
+# edit drops one side, that gate fails the build.
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
@@ -17,24 +30,32 @@ repos:
     hooks:
       - id: ruff-format
         name: ruff-format
-        files: ^\.claude/hooks/.*\.py$
+        files: ^\.claude/(hooks|lib)/.*\.py$
         exclude: ^\.claude/worktrees/
       - id: ruff
         name: ruff-lint
         args: [--fix]
-        files: ^\.claude/hooks/.*\.py$
+        files: ^\.claude/(hooks|lib)/.*\.py$
         exclude: ^\.claude/worktrees/
 
-  # Mypy mirrors CI's `mypy .claude/hooks/ --ignore-missing-imports --no-error-summary`.
-  # Running as a `local` hook so we use the system mypy; upstream mirrors-mypy installs
-  # its own env and would drift from whatever CI pins.
+  # Heavier checks run at pre-push (mirror CI's mypy + pytest jobs). Running as
+  # `local`/`system` hooks so we use the system tools and don't drift from
+  # whatever CI pins.
   - repo: local
     hooks:
       - id: mypy
-        name: mypy
+        name: mypy (pre-push)
         entry: python3 -m mypy --ignore-missing-imports --no-error-summary
         language: system
         types: [python]
-        files: ^\.claude/hooks/.*\.py$
+        files: ^\.claude/(hooks|lib)/.*\.py$
         exclude: ^\.claude/worktrees/
         pass_filenames: true
+        stages: [pre-push]
+      - id: pytest
+        name: pytest (pre-push)
+        entry: env ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/ .claude/lib/tests/ -q
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-push]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,22 @@ The full constraint and delegation mechanics (orchestrator checklist, spawn-requ
 - These three (Projects, Issues, Actions) are the **core orchestration layer** — do not introduce alternative tools for these concerns
 - **Branching strategy:** Feature branches named `{FirstInitial}.{LastName}/{IIII}-{issue-name}` (e.g., `N.Khoury/0042-update-charter`) merged to `main` via PR
 
+### Local Hooks (pre-commit + pre-push)
+
+This repo ships a `.pre-commit-config.yaml` that **mirrors `.github/workflows/ci.yml`** so a local commit/push fails fast instead of surfacing a lint/type/test error only after a PR is opened (Phase-3 end-state criterion #6 / #327). Install BOTH hook types once:
+
+```bash
+pre-commit install                          # commit-stage hooks
+pre-commit install --hook-type pre-push     # push-stage hooks
+```
+
+- **pre-commit stage (every commit):** `ruff-format`, `ruff-lint` over `.claude/hooks/` + `.claude/lib/` — fast, with `--fix`.
+- **pre-push stage (every push):** `mypy` typecheck + the `pytest` suite (`.claude/hooks/tests/`, `.claude/lib/tests/`) — the heavier checks, run before code leaves the machine.
+
+Keep the ruff `rev` aligned with the version CI installs and with sibling repos (isnad-graph pins ruff 0.15.11) so the same tool runs locally and in CI.
+
+**Sync-drift gate:** `.claude/lib/pre_commit_ci_sync.py` is a CI job (`Pre-commit ⇄ CI sync-drift gate`) that fails the build if a check CI enforces (ruff/mypy/pytest/…) is NOT mirrored in `.pre-commit-config.yaml`. Run it locally with `python3 .claude/lib/pre_commit_ci_sync.py .`. This is the machine-enforcement that keeps the mirror from rotting (per `feedback_actionlint_needs_shellcheck` — local "clean" must not diverge from CI). The same gate is the template each child repo wires into its own CI.
+
 ## Cross-Repo Coordination
 
 When a feature spans multiple repositories:


### PR DESCRIPTION
## feat(ci): pre-push stage + pre-commit ⇄ CI sync-drift gate (parent)

**Phase-3 end-state criterion #6** (`#327`), pulled into W13. Lands the **parent-canonical** piece + the reusable gate. The 7-child rollout is a separate child-implementer fan-out (the team lead coordinates it from this template), so this is **Refs #327**, not Closes — #327 stays open until all 8 repos are done, honest to its "each of 8 repos" DoD.

### Parent `.pre-commit-config.yaml`
- pre-commit stage: `ruff-format` + `ruff-lint` over `.claude/hooks/` **and** `.claude/lib/` (was hooks-only; CI lints both).
- **NEW pre-push stage**: `mypy` typecheck + the test suite — the heavier checks, run before code leaves the machine.

### Sync-drift gate (new, reusable — the high-value piece)
`.claude/lib/pre_commit_ci_sync.py` normalizes BOTH the pre-commit config and the CI workflows to canonical check-kinds (ruff-lint, ruff-format, mypy, test-suite, eslint, typescript, prettier, terraform-fmt, gitleaks, actionlint, pip-audit, build) and **fails when CI enforces a kind the pre-commit config does not run locally** (the harmful drift direction; stricter-local is informational). Wired as a CI job `Pre-commit ⇄ CI sync-drift gate`; `.pre-commit-config.yaml` added to CI path filters.

- 11 unit tests incl. a guard that the **real parent** config mirrors its CI; drift-fail path verified (exit 1 naming the missing kind).

`CLAUDE.md § Local Hooks` documents install (both hook types), the stage split, and the gate — the template each child repo copies.

### Per-repo toolchain map (starting point for the child-rollout fan-out)
Surveyed at `main` HEAD 2026-05-31. Each child implementer adds a pre-push stage for their toolchain's heavier checks + wires the sync-gate into their CI + per-repo setup docs:

| Repo | Toolchain / existing pre-commit hooks | Pre-push heavier checks to add |
|---|---|---|
| noorinalabs-main (this PR) | ruff-format, ruff-lint, mypy, test-suite | mypy + test-suite (done here) |
| noorinalabs-user-service | ruff-format, ruff (Python) | mypy + test-suite |
| noorinalabs-data-acquisition | ruff-format, ruff, gitleaks, mypy, unit-tests | mypy + test-suite |
| noorinalabs-deploy | terraform (x2), gitleaks, env-example-check | terraform validate + (actionlint/shellcheck per CI) |
| noorinalabs-design-system | gitleaks, eslint, typecheck, test, build-and-validate | typecheck + test |
| noorinalabs-landing-page | gitleaks, eslint, prettier, astro-check, build-and-test | astro-check + build-and-test |
| noorinalabs-isnad-graph | ruff-format, ruff, gitleaks, branch-ownership, co-authored-by-trailers, pip-audit, mypy, unit-tests, lockfile-no-local-paths, frontend-eslint, frontend-typecheck | mypy + test-suite + frontend-typecheck |
| noorinalabs-isnad-ingest-platform | **empty config** (no parseable hooks) | needs full pre-commit + pre-push bootstrap |

Note: NONE of the 8 had a pre-push stage before this work. The gate's kind-patterns cover every tool seen above; extend `_KIND_PATTERNS` if a child introduces a new one.

### Validation
- Gate OK on parent; **11 gate tests** + full hooks+lib suite (**1166**) pass.
- `ruff format --check` + `check` clean; mypy clean; both YAMLs valid.
- CI on this PR: all 6 jobs green incl. the new `Pre-commit ⇄ CI sync-drift gate`.

Reviewers: Wanjiku + Santiago.

Refs #327
