### PR TITLE
ci(P3W14): add actionlint mirror to .pre-commit-config.yaml (#571)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,22 @@ repos:
         files: ^\.claude/(hooks|lib)/.*\.py$
         exclude: ^\.claude/worktrees/
 
+  # actionlint mirrors the `Config — Workflow actionlint` CI job in
+  # .github/workflows/docs.yml (the sync-drift gate globs ALL workflow files,
+  # so a CI-enforced `actionlint` kind not mirrored here turns the gate red —
+  # #571). The upstream golang hook builds a pinned actionlint and already
+  # scopes to ^.github/workflows/. shellcheck MUST be on PATH so actionlint's
+  # embedded shellcheck integration runs rather than silently skipping
+  # (feedback_actionlint_needs_shellcheck) — CI gets this from ubuntu-latest's
+  # preinstalled shellcheck; locally, install shellcheck before committing.
+  # Pinned to v1.7.12 to match what CI's `download-actionlint.bash` (tracking
+  # the latest release off `main`) resolves to.
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
+    hooks:
+      - id: actionlint
+        name: actionlint
+
   # Heavier checks run at pre-push (mirror CI's mypy + pytest jobs). Running as
   # `local`/`system` hooks so we use the system tools and don't drift from
   # whatever CI pins.


### PR DESCRIPTION
## Summary
The `Pre-commit ⇄ CI sync-drift gate` (`.claude/lib/pre_commit_ci_sync.py`) globs **all** `.github/workflows/*.y*ml`. `docs.yml` ships the `Config — Workflow actionlint` job, so `actionlint` is a CI-enforced check kind. With no matching pre-commit hook, the gate reported CI-enforced-but-not-local drift and exited 1 — the sync-drift gate was **RED on main**.

This adds the upstream `rhysd/actionlint` golang pre-commit hook, pinned to **v1.7.12** (what CI's `download-actionlint.bash` off `main` resolves to). The hook already scopes to `^.github/workflows/` and uses shellcheck if present — matching the CI job's embedded-shellcheck behavior (`feedback_actionlint_needs_shellcheck`).

**Verification:** `python3 .claude/lib/pre_commit_ci_sync.py .` now exits **0** (was 1). `actionlint .github/workflows/*.yml` exits 0 on the existing workflows. Config parses as valid YAML; the hook env installed cleanly at commit time.

Config-only change — no Python under `.claude/{hooks,lib}` touched, so ruff/mypy/pytest surface is unaffected.

## Related Issues
Closes #571

## Review Checklist
- [ ] `rev: v1.7.12` is a real rhysd/actionlint release and matches CI's resolved version
- [ ] Hook scope `^.github/workflows/` matches the CI job's target
- [ ] shellcheck-on-PATH requirement documented in the config comment
- [ ] sync-drift gate exits 0 with this change

Co-Authored-By: Aino Virtanen <parametrization+Aino.Virtanen@gmail.com>
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
