### PR TITLE
fix(hooks): auto_set_env_test skip pytest tokens in heredoc bodies (#564)

### DIFF
--- a/.claude/hooks/auto_set_env_test.py
+++ b/.claude/hooks/auto_set_env_test.py
@@ -122,6 +122,17 @@ _BODY_FLAG = re.compile(r"(?<![\w-])--body(?:-file)?(?=[\s=]|$)")
 # Test-runner detection: pytest OR `make test`.
 _TEST_RUNNER = re.compile(r"\bpytest\b|\bmake\s+test\b")
 
+# Heredoc operator: `<<` (optionally `<<-`) followed by an optionally
+# quoted delimiter word. The delimiter is captured so we can find its
+# terminating line. Examples matched:
+#     <<EOF        <<-EOF        << EOF
+#     <<'EOF'      <<"EOF"       <<-'EOF'
+# We do NOT match `<<<` (here-string) — that has no body lines, its
+# operand is on the same line and is handled by ordinary quote/word
+# scanning. The negative lookahead `(?!<)` after the second `<` excludes
+# the here-string form.
+_HEREDOC_OPEN = re.compile(r"<<(?!<)-?\s*(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\1")
+
 # The literal env-var we require.
 _ENV_TOKEN = re.compile(r"\bENVIRONMENT=test\b")
 
@@ -367,6 +378,74 @@ def _strip_quoted_regions(s: str) -> str:
     return "".join(out)
 
 
+def _strip_heredoc_bodies(command: str) -> str:
+    """Return `command` with heredoc *body* characters blanked to spaces,
+    preserving every newline and the total length so the result is a
+    positional mirror of the original.
+
+    Heredoc bodies are command *input data* (a commit message, an API
+    request payload), never a program invocation. The token `pytest` or
+    `make test` inside a heredoc body is therefore not a test runner —
+    blanking the body before the test-runner scan prevents the #564
+    false-positive (e.g. `git commit -F- <<'EOF'\\n...make test...\\nEOF`
+    or a `--input` payload built with a heredoc). It is the heredoc-body
+    sibling of `_strip_quoted_regions` (quoted-arg data) and the same
+    safety tradeoff: data passed to a command is not the command.
+
+    Length- and newline-preserving so callers can run the existing
+    quote-aware `_split_segments` on the blanked view and get segment
+    boundaries identical to the original command — the body lines become
+    runs of spaces between unchanged separators, so a real test
+    invocation OUTSIDE any heredoc still lands in its own segment at the
+    same index and can be rewritten against the original text.
+
+    Scope notes:
+        - The opening operator line (everything up to and including the
+          newline that ends the line bearing `<<DELIM`) is preserved, so
+          a real `pytest` on the *same line as* a heredoc redirect is not
+          masked.
+        - Quoted (`<<'EOF'`) and unquoted (`<<EOF`) delimiters are both
+          handled; the closing line must equal the delimiter exactly
+          after optional leading tabs (the `<<-` indent-strip form).
+        - A heredoc opened but never closed (no terminating delimiter
+          line) blanks to end-of-string — matching shell behaviour where
+          the rest of the input is the body.
+        - Multiple heredocs and heredocs not at end-of-command are
+          handled by resuming the scan after each closing delimiter.
+    """
+    lines = command.split("\n")
+    out_lines: list[str] = []
+    i = 0
+    n = len(lines)
+    while i < n:
+        line = lines[i]
+        out_lines.append(line)
+        # Find the LAST heredoc operator on this line (a line may open
+        # several: `cmd <<A <<B`; bash collects bodies in order, but for
+        # detection we only need to know a body region begins — using the
+        # last delimiter keeps the close-scan simple and conservative).
+        matches = list(_HEREDOC_OPEN.finditer(line))
+        if not matches:
+            i += 1
+            continue
+        delimiter = matches[-1].group(2)
+        # Blank body lines (preserving each as an all-space line of equal
+        # length) until we hit the closing delimiter line or run out.
+        i += 1
+        while i < n:
+            body = lines[i]
+            # `<<-` strips leading TABS from the closing delimiter; accept
+            # the closer with optional leading tabs regardless, since a
+            # plain `<<` body line equal to the delimiter also closes.
+            if body.lstrip("\t") == delimiter:
+                out_lines.append(body)
+                i += 1
+                break
+            out_lines.append(" " * len(body))
+            i += 1
+    return "\n".join(out_lines)
+
+
 def _prepend_env_to_segment(segment: str) -> str:
     """Return segment with `ENVIRONMENT=test ` inserted before its first
     real (non-env-assignment, non-whitespace) token.
@@ -470,19 +549,26 @@ def _rewrite_command(command: str) -> tuple[str, list[int]]:
     control-flow body — those are NOT rewritten (the splice would
     produce invalid shell), and the caller uses the list to emit the
     bail-with-diagnostic ALLOW path instead of a BLOCK.
+
+    Heredoc-aware (#564): test-segment detection and control-flow
+    bracketing run against a heredoc-body-blanked *view* of the command
+    (same length/boundaries as the original), so a `pytest` token inside
+    a heredoc body is never treated as a runner to splice onto. The
+    splice itself rewrites the ORIGINAL segment text — the view is a
+    detection mask only.
     """
     parts = _split_segments(command)
+    parts_view = _split_segments(_strip_heredoc_bodies(command))
     bail_indices: list[int] = []
     for i in range(0, len(parts), 2):
-        seg = parts[i]
-        if not _is_test_segment(seg):
+        if not _is_test_segment(parts_view[i]):
             continue
-        if _segment_has_env_in_leading_block(seg):
+        if _segment_has_env_in_leading_block(parts[i]):
             continue
-        if _is_control_flow_bracketed(parts, i):
+        if _is_control_flow_bracketed(parts_view, i):
             bail_indices.append(i)
             continue
-        parts[i] = _prepend_env_to_segment(seg)
+        parts[i] = _prepend_env_to_segment(parts[i])
     return "".join(parts), bail_indices
 
 
@@ -505,8 +591,20 @@ def check(input_data: dict) -> dict | None:
     if _has_body_flag(command):
         return None
 
+    # Detection view: blank heredoc bodies (command *input data*, never a
+    # program invocation) before the test-runner scan so a `pytest` /
+    # `make test` token inside a commit-message or --input heredoc does
+    # not register as a test segment (#564). The view is length- and
+    # newline-preserving, so its segment boundaries are identical to the
+    # original command's — `parts_view[i]` and `parts[i]` cover the same
+    # byte range. We detect on the view but check env-blocks / rewrite on
+    # the original (where the real ENVIRONMENT=test, if any, lives).
+    detection_view = _strip_heredoc_bodies(command)
     parts = _split_segments(command)
-    test_segment_indices = [i for i in range(0, len(parts), 2) if _is_test_segment(parts[i])]
+    parts_view = _split_segments(detection_view)
+    test_segment_indices = [
+        i for i in range(0, len(parts_view), 2) if _is_test_segment(parts_view[i])
+    ]
     if not test_segment_indices:
         return None
 
@@ -523,9 +621,12 @@ def check(input_data: dict) -> dict | None:
     needs_splice_block = False
     saw_control_flow_block = False
     for i in test_segment_indices:
+        # env-block lives in the ORIGINAL segment (a real ENVIRONMENT=test
+        # prefix); control-flow bracketing is detected on the heredoc-
+        # blanked VIEW so keywords inside a heredoc body don't count.
         if _segment_has_env_in_leading_block(parts[i]):
             continue
-        if _is_control_flow_bracketed(parts, i):
+        if _is_control_flow_bracketed(parts_view, i):
             saw_control_flow_block = True
             continue
         needs_splice_block = True

--- a/.claude/hooks/tests/test_auto_set_env_test.py
+++ b/.claude/hooks/tests/test_auto_set_env_test.py
@@ -860,6 +860,110 @@ class QuotedRegionTests(unittest.TestCase):
         self.assertNotIn("ENVIRONMENT=test grep", result["reason"])
 
 
+class HeredocBodyParserTests(unittest.TestCase):
+    """Pure-parser coverage for `_strip_heredoc_bodies` (#564).
+
+    The function blanks heredoc *body* characters to spaces while
+    preserving every newline and the total length, so a downstream
+    `_split_segments` on the blanked view yields segment boundaries
+    identical to the original command. These tests pin the blanking
+    behaviour directly, independent of the `check()` decision."""
+
+    def test_quoted_delimiter_body_blanked(self) -> None:
+        cmd = "git commit -F- <<'EOF'\nrun pytest\nEOF"
+        view = hook._strip_heredoc_bodies(cmd)
+        # Same length + newline positions (positional mirror).
+        self.assertEqual(len(view), len(cmd))
+        self.assertEqual(
+            [i for i, c in enumerate(view) if c == "\n"],
+            [i for i, c in enumerate(cmd) if c == "\n"],
+        )
+        # The body line `run pytest` is blanked; the opener + delimiter survive.
+        self.assertNotIn("pytest", view)
+        self.assertIn("<<'EOF'", view)
+        self.assertIn("EOF", view.splitlines()[-1])
+
+    def test_unquoted_delimiter_body_blanked(self) -> None:
+        cmd = "cat <<EOF\nmake test reminder\nEOF"
+        view = hook._strip_heredoc_bodies(cmd)
+        self.assertNotIn("make test", view)
+
+    def test_indent_strip_dash_delimiter_closes(self) -> None:
+        # `<<-` permits a tab-indented closing delimiter.
+        cmd = "cat <<-END\n\tpytest note\n\tEND"
+        view = hook._strip_heredoc_bodies(cmd)
+        self.assertNotIn("pytest", view)
+
+    def test_here_string_not_treated_as_heredoc(self) -> None:
+        # `<<<` is a here-string (operand on same line), NOT a body heredoc.
+        cmd = "pytest tests/ <<< 'payload pytest'"
+        view = hook._strip_heredoc_bodies(cmd)
+        # No body lines to blank → command returns unchanged.
+        self.assertEqual(view, cmd)
+
+    def test_real_command_after_heredoc_survives(self) -> None:
+        # A real pytest AFTER the closing delimiter is outside the body and
+        # must remain visible to the detector.
+        cmd = "git commit -F- <<'EOF'\nmsg pytest\nEOF\npytest tests/"
+        view = hook._strip_heredoc_bodies(cmd)
+        # The body `msg pytest` is gone but the trailing real `pytest` stays.
+        self.assertEqual(view.count("pytest"), 1)
+        self.assertTrue(view.rstrip().endswith("pytest tests/"))
+
+
+class HeredocBodyTests(unittest.TestCase):
+    """Negative-match coverage for the #564 over-match: a `pytest` /
+    `make test` token inside a heredoc *body* is command input data (a
+    commit message, an API `--input` payload), never a test invocation.
+    Heredoc-body sibling of `QuotedRegionTests` (quoted-arg data).
+
+    Allow: heredoc body mentioning a test runner must not fire.
+    Block: a real test invocation that merely co-occurs with a heredoc
+    (the runner lives OUTSIDE the body) must still block, with the splice
+    targeting the real token — never the heredoc body."""
+
+    def test_heredoc_commit_msg_with_pytest_allowed(self) -> None:
+        # #563 repro shape: `git commit` heredoc body mentioning pytest.
+        command = "git commit -F- <<'EOF'\nfix: pytest mirror over-match\nEOF"
+        result = hook.check(_bash(command))
+        self.assertIsNone(result, "pytest inside a commit-message heredoc must be allowed")
+
+    def test_heredoc_commit_msg_with_make_test_allowed(self) -> None:
+        command = "git commit -F- <<'EOF'\nremember to run make test later\nEOF"
+        result = hook.check(_bash(command))
+        self.assertIsNone(result, "make test inside a commit-message heredoc must be allowed")
+
+    def test_unquoted_heredoc_input_payload_allowed(self) -> None:
+        # #562 repro family: a heredoc-built request payload mentioning pytest.
+        command = 'some-tool --stdin <<EOF\n{"body": "runs pytest in CI"}\nEOF'
+        result = hook.check(_bash(command))
+        self.assertIsNone(result, "pytest inside a heredoc payload must be allowed")
+
+    def test_indent_strip_heredoc_body_allowed(self) -> None:
+        command = "cat <<-END\n\tpytest is mentioned here\n\tEND"
+        result = hook.check(_bash(command))
+        self.assertIsNone(result, "pytest inside a <<- indented heredoc body must be allowed")
+
+    def test_real_pytest_after_heredoc_still_blocks_targeted(self) -> None:
+        # The heredoc body mentions pytest (data) but a REAL pytest runs after
+        # the closing delimiter. Must block, splice on the real token only.
+        command = "git commit -F- <<'EOF'\nmsg pytest\nEOF\npytest tests/"
+        result = hook.check(_bash(command))
+        assert result is not None
+        self.assertEqual(result.get("decision"), "block")
+        self.assertIn("ENVIRONMENT=test pytest tests/", result["reason"])
+        # The heredoc body must not be touched by the rewrite.
+        self.assertNotIn("ENVIRONMENT=test msg", result["reason"])
+
+    def test_real_pytest_with_heredoc_input_blocks(self) -> None:
+        # pytest is the actual program; its config is fed via a heredoc that
+        # happens to mention `make test`. The real pytest must still block.
+        command = "pytest -c - tests/ <<'EOF'\n[pytest]\n# make test compatible\nEOF"
+        result = hook.check(_bash(command))
+        assert result is not None
+        self.assertEqual(result.get("decision"), "block")
+
+
 class SegmentClassCoverageManifestTests(unittest.TestCase):
     """Guard: this file must carry a `# segment-class: <Name>` marker for all
     six separator classes mandated by `hooks.md § 5a`. This is the in-suite


### PR DESCRIPTION
## Summary
`auto_set_env_test` scanned every shell segment of a Bash command for a `pytest` / `make test` token. A heredoc **body** — a commit message fed via `git commit -F-`, or a `--input`/payload built with a heredoc — is command *input data*, not a program invocation, yet its lines were treated as command text. A test-runner token in that body falsely registered as a test segment and the hook blocked, demanding an `ENVIRONMENT=test` prefix that makes no sense for a message body.

Two P3W13 instances were worked around by hand:
- **#562** — `pytest` in a PR-body payload (worked around by rewording prose).
- **#563** — `pytest` in a `git commit` heredoc message (worked around with `-F file`).

(This very PR's commit hit the bug live: the parent session's *installed* hook is the pre-fix version, so the commit message had to be staged via a written file instead of an inline heredoc.)

## Fix
Add `_strip_heredoc_bodies()` — the heredoc-body sibling of `_strip_quoted_regions`. It blanks heredoc body characters to spaces while **preserving every newline and the total length**, so the blanked "detection view" splits into segments whose boundaries are identical to the original command. Detection (`_is_test_segment`) and control-flow bracketing run on the **view**; env-block checks and the splice rewrite run on the **original** text (where a real `ENVIRONMENT=test`, if any, lives). A real test invocation *outside* any heredoc still lands in its own segment and blocks with a correctly-targeted suggestion.

**Scope:** quoted (`<<'EOF'`) and unquoted (`<<EOF`) delimiters, the `<<-` indent-strip closer, multiple/non-terminal heredocs, and an unclosed heredoc (blanks to EOS). The here-string form `<<<` is explicitly **not** a body heredoc (negative lookahead) — its operand is same-line data handled by ordinary quote scanning.

## Tests
+11 tests:
- `HeredocBodyTests` (6) — negative-match: commit-msg / `--input` / `<<-` heredoc bodies mentioning `pytest`/`make test` are allowed; a real `pytest` co-occurring with a heredoc still blocks with the splice on the real token only.
- `HeredocBodyParserTests` (5) — pure-parser: length/newline-preservation, quoted+unquoted+`<<-` delimiters, `<<<` left untouched, real command after heredoc survives.

All 6 mandated segment-class markers (`hooks.md § 5a`) remain present (the manifest-guard test passes). Full suite **91 passed** (was 80). `ruff format --check`, `ruff check`, and `mypy` all clean.

## Related Issues
Closes #564

## Review Checklist
- [ ] `_strip_heredoc_bodies` preserves length + newline positions (positional mirror invariant)
- [ ] real test invocation outside a heredoc still blocks with correctly-targeted splice
- [ ] `<<<` here-string is not mistaken for a body heredoc
- [ ] all 6 segment-class markers present (per `hooks.md § Mandatory Test Coverage for PreToolUse Segment Parsers`)

Co-Authored-By: Aino Virtanen <parametrization+Aino.Virtanen@gmail.com>
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
