### PR TITLE
fix(hooks): post_wave_kickoff_comment idempotency is wave-specific (#547)

### DIFF
--- a/.claude/hooks/fixtures/post_wave_kickoff_comment/cross_wave_carry_forward_not_skipped.json
+++ b/.claude/hooks/fixtures/post_wave_kickoff_comment/cross_wave_carry_forward_not_skipped.json
@@ -1,0 +1,21 @@
+{
+  "description": "Cross-wave carry-forward (#547): an issue carried from W12 to W13 already has a **Wave 12 Kickoff** comment. The bare --add-label p3-wave-13 must NOT be suppressed by the stale prior-wave heading — the hook posts a FRESH Wave 13 kickoff. Before the wave-specific regex fix this returned skip_idempotent (six such carry-forwards were silently skipped in the P3W13 kickoff).",
+  "command": "gh issue edit 136 --repo noorinalabs/noorinalabs-main --add-label \"p3-wave-13\"",
+  "status": {
+    "wave_13_meta_issue": 529,
+    "wave_13_scope": {
+      "tier_2_carry": [
+        {"id": "noorinalabs-main#136", "implementer": "Wanjiku Mwangi", "reviewer": "Aino Virtanen", "reviewer_2": "Santiago Ferreira", "priority": "carry-forward"}
+      ]
+    }
+  },
+  "existing_comments": [
+    {"body": "Requestor: Fatima Okonkwo\nRequestee: Wanjiku Mwangi\nRequestOrReplied: Request\n\n**Wave 12 Kickoff — Phase 3**\n\nThis issue is assigned to you for p3-wave-12."}
+  ],
+  "post_succeeds": true,
+  "expect_action": "post",
+  "expect_body_contains": [
+    "**Wave 13 Kickoff — Phase 3**",
+    "p3-wave-13"
+  ]
+}

--- a/.claude/hooks/post_wave_kickoff_comment.py
+++ b/.claude/hooks/post_wave_kickoff_comment.py
@@ -82,7 +82,36 @@ KICKOFF_REQUESTOR = "Fatima Okonkwo"
 # (`**Wave {M} Kickoff — Phase {N}**`). Used for idempotency check. The
 # emdash is the literal character in the template; we tolerate either
 # em-dash or regular hyphen-surrounded form in case of copy-paste drift.
+#
+# WAVE-SPECIFIC (#547): the wave number MUST be matched literally, not as
+# a bare `\d+`. A carry-forward issue (labeled `p3-wave-12`, then
+# relabeled `p3-wave-13`) carries its PRIOR wave's kickoff comment. A
+# wave-agnostic `Wave \d+ Kickoff` regex matched that stale comment and
+# made `kickoff_already_posted` return True, so the hook silently skipped
+# the NEW wave's kickoff (six W11/W12 carry-forwards skipped in the
+# P3W13 kickoff). `_kickoff_heading_re(wave_num)` builds a regex that
+# only matches the CURRENT wave's heading, so same-wave re-applies stay
+# idempotent while cross-wave carry-forwards get a fresh kickoff.
+#
+# The module-level `_KICKOFF_HEADING_RE` is retained as the wave-agnostic
+# fallback (`wave_num=None`) so a caller that genuinely wants "any
+# kickoff comment present" semantics keeps working; the hook's own
+# idempotency caller always passes the concrete current wave number.
 _KICKOFF_HEADING_RE = re.compile(r"\*\*Wave\s+\d+\s+Kickoff\s+[—-]\s+Phase\s+\d+\*\*")
+
+
+def _kickoff_heading_re(wave_num: int | None = None) -> re.Pattern[str]:
+    """Return the kickoff-heading regex for `wave_num`.
+
+    With a concrete `wave_num`, the wave digit is matched literally so a
+    prior wave's kickoff comment on a carry-forward issue does NOT count
+    as "already posted" for the new wave (#547). With `wave_num=None`,
+    returns the wave-agnostic `_KICKOFF_HEADING_RE` (matches any wave) —
+    the legacy fallback semantics.
+    """
+    if wave_num is None:
+        return _KICKOFF_HEADING_RE
+    return re.compile(rf"\*\*Wave\s+{wave_num}\s+Kickoff\s+[—-]\s+Phase\s+\d+\*\*")
 
 
 def _read_status() -> dict | None:
@@ -209,9 +238,17 @@ def render_kickoff_comment(row: dict, wave_num: int, phase_num: int, repo: str) 
     return "\n".join(lines)
 
 
-def kickoff_already_posted(repo: str, issue_number: str, fetch_comments=None) -> bool:
-    """Idempotency check: True if any existing comment body matches the
-    charter kickoff heading regex.
+def kickoff_already_posted(
+    repo: str, issue_number: str, wave_num: int | None = None, fetch_comments=None
+) -> bool:
+    """Idempotency check: True if an existing comment body matches the
+    kickoff heading regex for `wave_num`.
+
+    Wave-specific (#547): with a concrete `wave_num`, only a kickoff
+    comment for THAT wave counts — a carry-forward issue's prior-wave
+    kickoff comment no longer suppresses the new wave's kickoff. With
+    `wave_num=None` the legacy wave-agnostic match is used (any kickoff
+    heading counts).
 
     The `fetch_comments` callable defaults to a real `gh issue view` call;
     tests inject a mock. Returns False on any error fetching comments
@@ -225,9 +262,10 @@ def kickoff_already_posted(repo: str, issue_number: str, fetch_comments=None) ->
     if comments is None:
         return False
 
+    heading_re = _kickoff_heading_re(wave_num)
     for c in comments:
         body = c.get("body", "") if isinstance(c, dict) else ""
-        if _KICKOFF_HEADING_RE.search(body):
+        if heading_re.search(body):
             return True
     return False
 
@@ -383,8 +421,12 @@ def check(
         )
         return {"action": "skip_no_row", "repo": repo, "issue": issue_number}
 
-    # Idempotency: don't double-post.
-    if kickoff_already_posted(repo, issue_number, fetch_comments=comment_fetcher):
+    # Idempotency: don't double-post FOR THIS WAVE. Passing wave_num makes
+    # the heading match wave-specific so a carry-forward issue's prior-wave
+    # kickoff comment does not suppress the current wave's kickoff (#547).
+    if kickoff_already_posted(
+        repo, issue_number, wave_num=wave_num, fetch_comments=comment_fetcher
+    ):
         return {"action": "skip_idempotent", "repo": repo, "issue": issue_number}
 
     body = render_kickoff_comment(row, wave_num, phase_num, repo)

--- a/.claude/hooks/tests/test_post_wave_kickoff_comment.py
+++ b/.claude/hooks/tests/test_post_wave_kickoff_comment.py
@@ -393,6 +393,44 @@ class KickoffAlreadyPostedTests(unittest.TestCase):
 
         self.assertFalse(hook.kickoff_already_posted("x", "1", fetch_comments=fetch))
 
+    def test_wave_specific_same_wave_still_idempotent(self):
+        """#547: with wave_num=13, a Wave 13 comment still counts as posted."""
+
+        def fetch(r, n):
+            return [{"body": "**Wave 13 Kickoff — Phase 3**\n\nbody"}]
+
+        self.assertTrue(hook.kickoff_already_posted("x", "1", wave_num=13, fetch_comments=fetch))
+
+    def test_wave_specific_prior_wave_not_counted(self):
+        """#547 core fix: with wave_num=13, a stale Wave 12 carry-forward
+        kickoff comment does NOT count as the Wave 13 kickoff → not posted
+        yet, so the hook will post a fresh one."""
+
+        def fetch(r, n):
+            return [{"body": "**Wave 12 Kickoff — Phase 3**\n\nprior-wave body"}]
+
+        self.assertFalse(hook.kickoff_already_posted("x", "1", wave_num=13, fetch_comments=fetch))
+
+    def test_wave_specific_multi_digit_wave_not_substring_matched(self):
+        """#547 edge: wave_num=2 must not match a 'Wave 12 Kickoff' comment
+        (the literal-digit interpolation is `\\bWave 2 ` via \\s, but the
+        \\s+ boundary + the 'Kickoff' suffix prevent '12' from satisfying
+        'Wave 2 Kickoff'). Guards against a naive substring regex."""
+
+        def fetch(r, n):
+            return [{"body": "**Wave 12 Kickoff — Phase 3**"}]
+
+        self.assertFalse(hook.kickoff_already_posted("x", "1", wave_num=2, fetch_comments=fetch))
+
+    def test_wave_none_falls_back_to_wave_agnostic(self):
+        """#547: wave_num=None preserves legacy any-wave semantics — any
+        kickoff heading counts."""
+
+        def fetch(r, n):
+            return [{"body": "**Wave 7 Kickoff — Phase 2**"}]
+
+        self.assertTrue(hook.kickoff_already_posted("x", "1", wave_num=None, fetch_comments=fetch))
+
 
 class NonBashToolTests(unittest.TestCase):
     """tool_name != Bash → early return None."""


### PR DESCRIPTION
## Summary
`_KICKOFF_HEADING_RE` matched **any** wave number (`Wave \d+ Kickoff — Phase \d+`), so `kickoff_already_posted` returned `True` whenever an issue carried *any* prior kickoff comment. A carry-forward issue relabeled from one wave to the next (e.g. `p3-wave-12` → `p3-wave-13`) still bears its **prior** wave's kickoff comment, so the hook returned `skip_idempotent` and silently skipped the **new** wave's kickoff.

Six W11/W12 carry-forwards were skipped during the P3W13 kickoff (deploy#269/#245/#204/#193/#100, main#136) and had to be force-posted via an ad-hoc orchestrator workaround.

## Fix (per issue's suggested shape)
- Add `_kickoff_heading_re(wave_num)` — interpolates the wave number **literally** so only the current wave's heading counts.
- `kickoff_already_posted` gains a `wave_num` parameter; the hook's idempotency caller in `check()` passes the concrete current `wave_num` (already in scope from `parse_wave_label`).
- `_KICKOFF_HEADING_RE` is **kept** as the wave-agnostic fallback (`wave_num=None`) so any caller wanting any-wave semantics still works.

Result: same-wave re-applies stay idempotent; cross-wave carry-forwards get a fresh kickoff (implementer/reviewer assignments may have changed between waves).

## Tests
- **+1 fixture** `cross_wave_carry_forward_not_skipped.json` — an issue bearing a **Wave 12** kickoff, relabeled `p3-wave-13`, now POSTs a fresh **Wave 13** kickoff (asserts `expect_action: post` + body contains `**Wave 13 Kickoff — Phase 3**`), where it previously returned `skip_idempotent`.
- **+4 unit tests** on `kickoff_already_posted`: same-wave still idempotent; prior-wave not counted; `wave_num=2` does NOT substring-match a `Wave 12 Kickoff` comment; `wave_num=None` preserves legacy any-wave fallback.
- Existing `idempotent_re_apply.json` (W9 comment + W9 label → skip) now flows through the wave-specific path and still skips.

Suite **41 passed**. `ruff format --check`, `ruff check`, `mypy` all clean.

## Related Issues
Closes #547

## Review Checklist
- [ ] wave number is matched literally (no bare `\d+`) for the current wave
- [ ] `wave_num=None` fallback retains wave-agnostic semantics
- [ ] caller in `check()` passes the current `wave_num`
- [ ] cross-wave fixture asserts `post` (not `skip_idempotent`); same-wave still idempotent

Co-Authored-By: Aino Virtanen <parametrization+Aino.Virtanen@gmail.com>
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
