### PR TITLE
fix(hooks): validate_pr_review hard-blocks batch-loop variable merges (#567)

### DIFF
--- a/.claude/hooks/tests/test_validate_pr_review.py
+++ b/.claude/hooks/tests/test_validate_pr_review.py
@@ -1521,5 +1521,166 @@ class ResolveRosterDirsTests(unittest.TestCase):
             hook._resolve_roster_dirs("noorinalabs/noorinalabs-nonexistent-xyz")
 
 
+class BatchLoopMergeDetectorTests(unittest.TestCase):
+    """#567: `is_variable_pr_merge_in_loop` detects a `gh pr merge <var>` inside
+    a for/while/until loop — the shape that fail-opens the 2-reviewer gate
+    (memory `feedback_batch_loop_merge_evades_pr_review_hook`).
+
+    Six parser classes per charter `hooks.md § 5a` segment-parser coverage:
+    newline-separated loop, quoted-var arg, `${}`-form, literal-still-passes,
+    while-loop, nested-loop. Plus the body-mention false-positive guard."""
+
+    def test_for_loop_quoted_var_blocked(self):
+        # parser-class: quoted-var
+        self.assertTrue(
+            hook.is_variable_pr_merge_in_loop(
+                'for pr in 48 49 50; do gh pr merge "$pr" --repo o/r --merge; done'
+            )
+        )
+
+    def test_for_loop_bare_var_blocked(self):
+        self.assertTrue(
+            hook.is_variable_pr_merge_in_loop("for pr in 48 49; do gh pr merge $pr --merge; done")
+        )
+
+    def test_brace_form_var_blocked(self):
+        # parser-class: ${}-form
+        self.assertTrue(
+            hook.is_variable_pr_merge_in_loop('for pr in 1 2; do gh pr merge "${pr}" --merge; done')
+        )
+
+    def test_while_loop_blocked(self):
+        # parser-class: while-loop
+        self.assertTrue(
+            hook.is_variable_pr_merge_in_loop("while read pr; do gh pr merge ${pr} --merge; done")
+        )
+
+    def test_until_loop_blocked(self):
+        self.assertTrue(
+            hook.is_variable_pr_merge_in_loop('until [ -z "$pr" ]; do gh pr merge $pr; done')
+        )
+
+    def test_newline_separated_loop_blocked(self):
+        # parser-class: newline
+        self.assertTrue(
+            hook.is_variable_pr_merge_in_loop(
+                'for pr in 48 49\ndo\n  gh pr merge "$pr" --merge\ndone'
+            )
+        )
+
+    def test_nested_loop_blocked(self):
+        # parser-class: nested-loop
+        self.assertTrue(
+            hook.is_variable_pr_merge_in_loop(
+                'for r in a b; do\n  for pr in 1 2; do gh pr merge "$pr" --merge; done\ndone'
+            )
+        )
+
+    def test_literal_merge_not_blocked(self):
+        # parser-class: literal-still-passes — a literal PR number is untouched
+        # by the guard (its number parses and the normal gate runs).
+        self.assertFalse(hook.is_variable_pr_merge_in_loop("gh pr merge 54 --repo o/r --merge"))
+
+    def test_literal_loop_not_blocked(self):
+        # A loop iterating LITERAL merges (no shell variable) is not the
+        # fail-open shape — each merge parses a literal number.
+        self.assertFalse(
+            hook.is_variable_pr_merge_in_loop("for n in 1; do gh pr merge 54 --merge; done")
+        )
+
+    def test_var_merge_outside_loop_not_blocked(self):
+        # Out of scope for #567: a one-off variable merge with no loop.
+        self.assertFalse(hook.is_variable_pr_merge_in_loop('gh pr merge "$PR" --merge'))
+
+    def test_loop_text_in_body_not_blocked(self):
+        # False-positive guard: a `--body` payload that merely MENTIONS the
+        # loop-merge shape (quoted prose) must NOT be detected. The real
+        # command is `gh pr create`, not a merge.
+        self.assertFalse(
+            hook.is_variable_pr_merge_in_loop(
+                'gh pr create --body "for pr in 1; do gh pr merge $pr; done"'
+            )
+        )
+
+    def test_non_merge_loop_not_blocked(self):
+        # A loop that runs some other gh command is irrelevant to the gate.
+        self.assertFalse(
+            hook.is_variable_pr_merge_in_loop('for pr in 1 2; do gh pr view "$pr"; done')
+        )
+
+
+class BatchLoopMergeEndToEndTests(unittest.TestCase):
+    """#567 end-to-end: check() HARD BLOCKS a batch-loop variable merge, and a
+    literal merge still flows to the normal 2-reviewer gate unchanged."""
+
+    @staticmethod
+    def _input(command: str) -> dict:
+        return {"tool_name": "Bash", "tool_input": {"command": command}}
+
+    def test_loop_var_merge_hard_blocked(self):
+        # The guard returns BEFORE get_pr_data; patch it to a sentinel that
+        # would NOT itself block, so a passing test proves the LOOP guard
+        # (not the downstream gate) produced the block.
+        with mock.patch.object(hook, "get_pr_data", return_value=None):
+            result = hook.check(
+                self._input('for pr in 48 49 50; do gh pr merge "$pr" --merge; done')
+            )
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result.get("decision"), "block")
+        self.assertIn("Batch-loop", result["reason"])
+        self.assertIn("one pr per call", result["reason"].lower())
+
+    def test_loop_var_merge_with_admin_still_overrides(self):
+        # --admin is the emergency override and bypasses the loop guard too.
+        result = hook.check(
+            self._input('for pr in 1 2; do gh pr merge "$pr" --admin --merge; done')
+        )
+        self.assertIsNone(result, "--admin must bypass the batch-loop guard")
+
+    def test_literal_merge_unaffected_by_loop_guard(self):
+        # A bare literal merge is NOT loop-shaped; it reaches the normal gate.
+        # With 2 distinct approved reviewers it allows (proves the guard did
+        # not interfere with the literal path).
+        review_result = hook.CommentReviewResult()
+        review_result.reviewers = {"aino virtanen", "nadia khoury"}
+        pr_data = {
+            "author": "parametrization",
+            "number": 100,
+            "reviews": [],
+            "headRefName": "L.Pham/0001-fix",
+            "labels": [],
+        }
+        with (
+            mock.patch.object(hook, "get_pr_data", return_value=pr_data),
+            mock.patch.object(hook, "check_comment_reviews", return_value=review_result),
+        ):
+            result = hook.check(self._input("gh pr merge 100 --merge"))
+        self.assertIsNone(result, "literal 2-approved merge must still pass the gate")
+
+
+class StripQuotedRunsKeepVarArgsTests(unittest.TestCase):
+    """#567 pure-parser: `_strip_quoted_runs_keep_var_args` drops quoted prose
+    but unwraps a lone `"$var"` arg to its bare form."""
+
+    def test_lone_double_quoted_var_unwrapped(self):
+        out = hook._strip_quoted_runs_keep_var_args('gh pr merge "$pr" --merge')
+        self.assertIn("$pr", out)
+        self.assertNotIn('"', out)
+
+    def test_brace_lone_var_unwrapped(self):
+        out = hook._strip_quoted_runs_keep_var_args('gh pr merge "${pr}" --merge')
+        self.assertIn("${pr}", out)
+
+    def test_prose_double_quoted_run_dropped(self):
+        out = hook._strip_quoted_runs_keep_var_args('gh pr create --body "do gh pr merge $pr"')
+        # The body content (including its inner merge mention) is removed.
+        self.assertNotIn("merge $pr", out)
+
+    def test_single_quoted_run_dropped(self):
+        out = hook._strip_quoted_runs_keep_var_args("echo 'for pr in 1; do gh pr merge $pr; done'")
+        self.assertNotIn("gh pr merge", out)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.claude/hooks/validate_pr_review.py
+++ b/.claude/hooks/validate_pr_review.py
@@ -19,6 +19,15 @@ Input Language:
                the PR in the repo the user named, not the cwd-resolved repo.
     --admin  → short-circuits (emergency override — allows merge).
 
+  Batch-loop guard (#567): a `gh pr merge <shell-var>` inside a
+  for/while/until loop (e.g. `for pr in 48 49; do gh pr merge "$pr" …; done`)
+  is HARD BLOCKED. The literal-PR parse cannot resolve a loop variable, so the
+  gate would fail-open and merge every iteration unverified (observed P3W11 +
+  P3W13). The operator is told to run one literal merge per call so each PR is
+  gate-checked. `--admin` still overrides; a literal `gh pr merge 54` is
+  unaffected. Conservative DECIDE-tier shape (no conditional-allow) per
+  `feedback_safety_direction_over_ux_friction`.
+
 Charter-format review comments (canonical per `pull-requests.md` § Comment-Based Reviews,
 resolves #233):
 
@@ -129,6 +138,101 @@ def extract_pr_number(command: str) -> str | None:
         return match.group(1)
     # gh pr merge with no number (current branch PR)
     return None
+
+
+# A `gh pr merge` whose PR-number argument is a shell variable rather than a
+# literal: `$pr` or `${pr}` (the surrounding double-quotes of a `"$pr"` arg are
+# normalized away by `_strip_quoted_runs_keep_var_args` before this matches).
+# The lookahead lets the arg end at whitespace, a shell terminator, or EOS.
+_GH_MERGE_VAR_PR = re.compile(
+    r"\bgh\s+pr\s+merge\s+"  # the merge verb
+    r"\$\{?[A-Za-z_][A-Za-z0-9_]*\}?"  # $pr | ${pr}
+    r"(?=\s|;|&|\||$)"  # arg ends at whitespace, a shell terminator, or EOS
+)
+
+# A shell loop construct: a `for`/`while`/`until` opener token paired with a
+# `do` body keyword. Requiring BOTH (not just `for`) keeps the detector
+# conservative — a bare `for` in a flag value won't trip it on its own.
+_LOOP_OPENER = re.compile(r"\b(?:for|while|until)\b")
+_LOOP_BODY = re.compile(r"(?:^|[\s;])do(?:[\s;]|$)")
+
+
+def _strip_quoted_runs_keep_var_args(command: str) -> str:
+    """Return `command` with quoted regions removed, EXCEPT a quoted region
+    that is exactly a single variable reference (`"$pr"` / `"${pr}"`), which
+    is unwrapped to its bare `$pr` / `${pr}` form.
+
+    Why: the loop-merge detector must (a) NOT see a `gh pr merge $pr` that
+    lives inside a `--body "..."` payload (quoted argument data — strip it),
+    yet (b) STILL see the real arg in `gh pr merge "$pr"` where only the
+    variable itself is quoted (unwrap it). Shell semantics agree: double
+    quotes around a lone variable are removed and the variable remains the
+    program's argument, whereas a quoted run of prose is one opaque arg.
+
+    Single-quoted runs are always opaque data (no expansion) and are removed
+    wholesale. Double-quoted runs are unwrapped to the inner text ONLY when
+    the inner text is a lone variable reference; otherwise removed.
+    """
+    out: list[str] = []
+    i = 0
+    n = len(command)
+    while i < n:
+        ch = command[i]
+        if ch == "'":
+            # Single-quoted run: opaque, drop through the closing quote.
+            j = command.find("'", i + 1)
+            if j == -1:
+                break  # unbalanced — stop; raw-string fallback handles it
+            i = j + 1
+            continue
+        if ch == '"':
+            j = command.find('"', i + 1)
+            if j == -1:
+                break  # unbalanced
+            inner = command[i + 1 : j]
+            # Keep a lone-variable double-quoted arg as the bare variable.
+            if re.fullmatch(r"\$\{?[A-Za-z_][A-Za-z0-9_]*\}?", inner):
+                out.append(inner)
+            i = j + 1
+            continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
+def is_variable_pr_merge_in_loop(command: str) -> bool:
+    """True if `command` runs `gh pr merge <shell-var>` inside a for/while/until
+    loop — the batch-loop merge shape that fail-opens the 2-reviewer gate
+    (#567, memory `feedback_batch_loop_merge_evades_pr_review_hook`).
+
+    The gate parses a LITERAL PR number from `gh pr merge <N>` to fetch that
+    PR's reviews. When the PR number is a loop variable (`$pr`), the literal
+    parse returns None, `get_pr_data(None)` resolves the cwd branch's PR (or
+    nothing), and the merge fail-opens — the gate is silently disabled for
+    every iteration. Both observed instances (P3W11 wave→main 4-merge loop,
+    P3W13 ingest 6-PR loop) merged with the gate effectively off.
+
+    Conservative DECIDE-tier design (per #567 + `feedback_safety_direction_
+    over_ux_friction`): we HARD BLOCK the variable-PR-in-loop shape outright.
+    We do NOT attempt to enumerate loop values and gate-verify each — that is
+    the explicitly-deferred conditional-allow path. A literal
+    `gh pr merge 54` is untouched (its PR number parses, the gate runs).
+
+    Detection requires BOTH, evaluated on a quote-normalized view of the
+    command (quoted prose stripped, a lone `"$pr"` arg unwrapped — see
+    `_strip_quoted_runs_keep_var_args`) so a `--body "... for … do gh pr
+    merge $pr … done"` payload that merely MENTIONS the shape is not matched:
+      1. a `gh pr merge` whose PR-number arg is a shell variable
+         (`$pr` / `${pr}` / `"$pr"` / `"${pr}"`), AND
+      2. a loop construct (`for`/`while`/`until` opener + a `do` body keyword).
+    Requiring the loop keyword pair avoids blocking a one-off
+    `gh pr merge "$PR"` typed outside any loop (out of scope for #567, and
+    rare) — only the batch-loop shape the gate actually fail-opens on.
+    """
+    view = _strip_quoted_runs_keep_var_args(command)
+    if not _GH_MERGE_VAR_PR.search(view):
+        return False
+    return bool(_LOOP_OPENER.search(view) and _LOOP_BODY.search(view))
 
 
 def get_pr_data(pr_number: str | None, repo: str | None = None) -> dict | None:
@@ -666,10 +770,50 @@ def check(input_data: dict) -> dict | None:
 
     command = input_data.get("tool_input", {}).get("command", "")
 
-    if not is_merge_command(command):
+    # `--admin` is the emergency override — it bypasses the whole gate
+    # (including the batch-loop guard below), matching the existing
+    # short-circuit semantics. Checked first so an explicit admin override
+    # is honored even for the loop shape.
+    if "--admin" in command:
         return None
 
-    if "--admin" in command:
+    # Batch-loop merge guard (#567): a `gh pr merge $pr` inside a for/while
+    # loop fail-opens the 2-reviewer gate (the literal-PR parse can't resolve
+    # the loop variable, so get_pr_data falls back to the cwd branch and the
+    # gate is silently disabled per iteration). HARD BLOCK and instruct
+    # one-literal-merge-per-call so the gate stays active — fail in the safe
+    # direction (`feedback_safety_direction_over_ux_friction`).
+    #
+    # This runs BEFORE the `is_merge_command` early-return below ON PURPOSE:
+    # `is_merge_command` splits on `&&`/`;`/`|` and checks each segment's
+    # FIRST token for `gh pr merge`. In a loop the merge segment leads with
+    # the `do` keyword (`do gh pr merge "$pr"`), so `is_merge_command`
+    # returns False and `check()` would early-exit — re-opening the exact
+    # fail-open hole this guard closes. Detecting the loop shape here is the
+    # only placement that fires on it.
+    if is_variable_pr_merge_in_loop(command):
+        result = {
+            "decision": "block",
+            "reason": (
+                "Batch-loop `gh pr merge` with a shell-variable PR number "
+                '(e.g. `for pr in 48 49 50; do gh pr merge "$pr" ...; done`) is '
+                "BLOCKED. The 2-reviewer gate parses a LITERAL PR number to fetch "
+                "that PR's reviews; a loop variable cannot be resolved at parse "
+                "time, so the gate fail-opens and the merge proceeds UNVERIFIED "
+                "(this happened twice — P3W11 and P3W13). Merge one PR per call "
+                "with a literal number so the gate verifies each PR:\n"
+                "  gh pr merge 48 --repo <owner/repo> --merge\n"
+                "  gh pr merge 49 --repo <owner/repo> --merge\n"
+                "Run them as separate commands (not a loop). Each literal merge "
+                "is checked for two distinct Approved reviewers individually."
+            ),
+        }
+        log_pretooluse_block("validate_pr_review", command, result["reason"])
+        return result
+
+    # Not the loop shape — only a plain `gh pr merge <N>` invocation is gated
+    # below. Anything else (gh pr list/view/create, git merge, …) is allowed.
+    if not is_merge_command(command):
         return None
 
     pr_number = extract_pr_number(command)


### PR DESCRIPTION
## Summary
The 2-reviewer gate parses a **literal** PR number from `gh pr merge <N>` to fetch that PR's reviews. When the PR number is a shell **loop variable** —

```bash
for pr in 48 49 50; do gh pr merge "$pr" --repo ... --merge; done
```

— the literal parse returns `None`, `get_pr_data(None)` falls back to the cwd branch's PR, and the gate **fail-opens**: every iteration merges unverified. This fired twice (P3W11 wave→main 4-merge loop with 0 reviews; P3W13 ingest 6-PR loop), caught only post-hoc in #927.

## Fix (DECIDE-tier — conservative block only)
Add `is_variable_pr_merge_in_loop(command)` and **HARD BLOCK** in `check()` before the fail-open path. Per the issue and `feedback_safety_direction_over_ux_friction`, this is the conservative block — **no** conditional-allow / loop-value-enumeration. The operator is told to run one literal merge per call so each PR is gate-checked individually.

Detection requires **both**: a `gh pr merge` with a shell-variable arg (`$pr` / `${pr}` / `"$pr"` / `"${pr}"`) **and** a loop construct (`for`/`while`/`until` opener + a `do` body keyword).

**Placement** (important): the guard runs **before** the `is_merge_command` early-return on purpose — `is_merge_command` checks each `;`-split segment's *first* token for `gh pr merge`, but in a loop the merge segment leads with the `do` keyword, so it returns False and `check()` would early-exit, re-opening the exact hole. `--admin` still overrides (checked first); a literal `gh pr merge 54` is untouched (its number parses, the normal gate runs).

**Quote-awareness**: `_strip_quoted_runs_keep_var_args` removes quoted prose so a `--body "... do gh pr merge $pr ... done"` payload that merely *mentions* the shape is NOT blocked, while unwrapping a lone `"$pr"` arg to its bare form so the real quoted-var merge IS detected (mirrors shell: quotes around a lone variable are removed, the variable stays an arg).

## Tests (+19)
- **`BatchLoopMergeDetectorTests`** — the 6 parser classes per `hooks.md § 5a` (newline, quoted-var, `${}`-form, literal-still-passes, while-loop, nested-loop) + until-loop, literal-loop, var-outside-loop, **body-mention false-positive**, non-merge-loop.
- **`BatchLoopMergeEndToEndTests`** — `check()` hard-blocks the loop-var merge; `--admin` overrides; a literal 2-approved merge still passes the gate (guard doesn't interfere).
- **`StripQuotedRunsKeepVarArgsTests`** (4) — pure-parser: lone-var unwrap, brace-var unwrap, prose-run drop, single-quoted-run drop.

Full `validate_pr_review` suite **122 passed** (was 103). `ruff format --check`, `ruff check`, `mypy` clean.

> Note: one unrelated test (`test_ontology_tracker.py::...worktrees_segment_not_substring_false_match`) fails **only** when run from inside a `.claude/worktrees/` checkout (its `REPO_ROOT` path itself contains `worktrees`). It passes from the canonical checkout and in CI; it does not touch any file in this PR.

## Related Issues
Closes #567

## Review Checklist
- [ ] guard runs before `is_merge_command` early-return (loop merge segment leads with `do`)
- [ ] `--admin` still overrides; literal `gh pr merge 54` unaffected
- [ ] body-mention (`gh pr create --body "...loop..."`) is NOT a false positive
- [ ] real quoted-var `"$pr"` IS detected; conservative block only (no conditional-allow)
- [ ] all 6 parser classes present per `hooks.md § Mandatory Test Coverage for PreToolUse Segment Parsers`

Co-Authored-By: Aino Virtanen <parametrization+Aino.Virtanen@gmail.com>
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
