### PR TITLE
tech-debt(#326): pin docs.yml actionlint installer to v1.7.12 + sha256 (Refs #578)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -159,11 +159,31 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Download and verify actionlint
+        env:
+          # Pinned: version + linux_amd64 tarball SHA256 from upstream's
+          # signed release manifest (actionlint_1.7.12_checksums.txt at
+          # https://github.com/rhysd/actionlint/releases/tag/v1.7.12).
+          # `sha256sum -c` aborts the job on mismatch — bytes-on-runner are
+          # exactly what was published at release time. Replaces the prior
+          # `curl|bash` of the unpinned download-actionlint.bash off `main`
+          # (#578): fetching+executing latest-of-main each run is a
+          # supply-chain gap and diverges from the pinned v1.7.12 the
+          # .pre-commit-config.yaml mirror already ships (#571).
+          ACTIONLINT_VERSION: 1.7.12
+          ACTIONLINT_SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
+        run: |
+          cd "$RUNNER_TEMP"
+          curl --fail --silent --show-error --location \
+            -o "actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          echo "${ACTIONLINT_SHA256}  actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" | sha256sum -c -
+          tar -xzf "actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" actionlint
+          install -m 0755 actionlint /usr/local/bin/actionlint
+          actionlint -version
       - name: Run actionlint on parent workflows
         # shellcheck is preinstalled on ubuntu-latest, so actionlint's embedded
         # shellcheck integration runs (per the actionlint-needs-shellcheck
         # discipline) rather than silently skipping.
-        run: |
-          bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
-          ./actionlint -color
+        run: actionlint -color
 


### PR DESCRIPTION
## What

Pin the parent `.github/workflows/docs.yml` actionlint installer to **v1.7.12 + SHA256 verify**, replacing the unpinned `curl|bash` of `download-actionlint.bash` off `main`.

Refs #578 (parent-template step; #578 stays open to track the 7-repo docs.yml propagation sweep).

## Why

The `Config — Workflow actionlint` job installed actionlint via:

```
bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
./actionlint -color
```

— an unpinned `main` ref with **no checksum**, fetching and executing the latest binary at run time. This is a supply-chain gap and diverges from the pinned `rhysd/actionlint v1.7.12` the `.pre-commit-config.yaml` mirror already ships (#571).

## How

Mirrors deploy's `lint-workflows.yml` canonical pinned+verified pattern: download the `v1.7.12` linux_amd64 tarball, `sha256sum -c` against the published hash (aborts on mismatch), install to `/usr/local/bin`, then lint. The shellcheck-on-ubuntu-latest note is preserved so actionlint's embedded shellcheck integration still runs.

The SHA256 `8aca8db9...a3d8` was **verified against upstream's published `actionlint_1.7.12_checksums.txt`** release manifest, not copied on trust.

## Scope

Parent docs.yml only (the canonical template). The 7-repo `docs.yml` propagation sweep is a separate follow-up tracked in #578.

## Validation

- `actionlint .github/workflows/docs.yml` → clean (shellcheck integration active locally; v1.7.7 local, CI uses pinned v1.7.12).
- YAML parses; `python3 .claude/lib/pre_commit_ci_sync.py . --ci ci.yml --ci docs.yml` → OK (no sync drift; the `actionlint` kind stays mirrored).
- Local pre-commit actionlint hook (v1.7.12 pin) passed on commit.

Refs #326 #327.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

