### PR TITLE
tech-debt(#327): sync-gate build-kind + multi-line run scanning (Refs #576 #577)

### DIFF
--- a/.claude/lib/pre_commit_ci_sync.py
+++ b/.claude/lib/pre_commit_ci_sync.py
@@ -51,6 +51,22 @@ from pathlib import Path
 # Each kind maps to the keyword patterns that identify it on EITHER side
 # (pre-commit id/entry text or CI run/uses text). Patterns are substrings
 # matched case-insensitively against the relevant lines.
+#
+# `build` matches only real build-QUALITY GATES — a job whose purpose is to
+# fail the PR if the project does not build/compile (`build-and-validate`,
+# `build-and-test`, `npm run build`). It deliberately does NOT match bare
+# `docker build` / `docker buildx`: those are runtime image-MOVING (retag,
+# promote, publish to a registry, cold-rebuild dry-runs, digest resolution),
+# which is the deploy/publish job itself, not a quality gate a local
+# pre-commit hook could mirror. A bare `docker build` substring also matches
+# `docker buildx`, so a repo that uses buildx at runtime (deploy, the
+# image-publishing CI in isnad-graph / ingest-platform) would otherwise see a
+# permanent un-mirrorable `build` kind and the drift gate could never exit 0
+# (#576). If a repo ever adds a genuine docker-build-as-quality-gate, name
+# that job `build-and-validate` / `build-and-test` (or add an explicit
+# pattern) so it is mirror-tracked. Tightening lifted verbatim from the
+# deploy-rollout form (deploy#391, A.Idrissi) and canonicalized here so all
+# vendored child copies converge.
 _KIND_PATTERNS: dict[str, tuple[str, ...]] = {
     "ruff-format": ("ruff-format", "ruff format"),
     "ruff-lint": ("ruff check", "id: ruff", "- ruff"),
@@ -63,7 +79,7 @@ _KIND_PATTERNS: dict[str, tuple[str, ...]] = {
     "gitleaks": ("gitleaks",),
     "actionlint": ("actionlint",),
     "pip-audit": ("pip-audit", "pip audit"),
-    "build": ("build-and-validate", "build-and-test", "npm run build", "docker build"),
+    "build": ("build-and-validate", "build-and-test", "npm run build"),
 }
 
 # `ruff-lint` is a substring of nothing problematic, but `ruff format` also
@@ -104,16 +120,64 @@ def kinds_from_precommit(config_text: str) -> set[str]:
     return kinds
 
 
+# A `run:` (or `- run:`) key opening a YAML block scalar (`|`, `>`, plus the
+# chomping/indentation indicators `-`/`+`/digits, e.g. `|-`, `>2`). The body
+# of such a block is one or more MORE-indented continuation lines that carry
+# the actual shell — tools invoked there (`uv run pip-audit`, a multi-line
+# `ruff check` / `mypy` / `pytest`) must be classified too, else the gate has
+# a blind spot (#577).
+_RUN_BLOCK_OPEN_RE = re.compile(r"^(?P<indent>\s*)-?\s*run:\s*[|>][+\-0-9]*\s*$")
+
+
 def kinds_from_ci(workflow_text: str) -> set[str]:
-    """Canonical check-kinds a CI workflow enforces."""
+    """Canonical check-kinds a CI workflow enforces.
+
+    Classifies the line that names a `run:`/`uses:` step AND — for a
+    multi-line `run: |` / `run: >` block scalar — every continuation line in
+    that block's body (#577). Without the block-scan a tool invoked only on a
+    continuation line (e.g. `security-audit`'s `uv run pip-audit` under
+    `run: |`) is invisible to the classifier, so the drift gate silently fails
+    to require it be mirrored. The block ends at the first line whose
+    indentation is less-than-or-equal-to the `run:` key's own indent (a
+    sibling key or list item), matching YAML block-scalar scoping.
+    """
     kinds: set[str] = set()
+    run_block_indent: int | None = None
     for raw in workflow_text.splitlines():
-        line = raw.strip()
-        if not line or line.startswith("#"):
+        stripped = raw.strip()
+
+        # Inside a multi-line run: block — classify body lines until the block
+        # closes (dedent to <= the run: key indent). Blank lines stay in the
+        # block (YAML block scalars permit interior blank lines).
+        if run_block_indent is not None:
+            if stripped:
+                line_indent = len(raw) - len(raw.lstrip())
+                if line_indent <= run_block_indent:
+                    run_block_indent = None  # block ended; fall through to re-handle
+                else:
+                    if not stripped.startswith("#"):
+                        kinds |= _classify_line(stripped)
+                    continue
+
+        if not stripped or stripped.startswith("#"):
             continue
+
+        # Open a run: block scalar? Record its key indent so the body scan
+        # above can scope the block. The `run:` key line itself carries no
+        # tool text (the `|`/`>` is the only payload), so nothing to classify.
+        block_match = _RUN_BLOCK_OPEN_RE.match(raw)
+        if block_match is not None:
+            run_block_indent = len(block_match.group("indent"))
+            continue
+
         # CI expresses checks as `run:` shell or `uses:` actions.
-        if "run:" in line or line.startswith("- run:") or "uses:" in line or line.startswith("-"):
-            kinds |= _classify_line(line)
+        if (
+            "run:" in stripped
+            or stripped.startswith("- run:")
+            or "uses:" in stripped
+            or stripped.startswith("-")
+        ):
+            kinds |= _classify_line(stripped)
     return kinds
 
 

--- a/.claude/lib/tests/test_pre_commit_ci_sync.py
+++ b/.claude/lib/tests/test_pre_commit_ci_sync.py
@@ -108,6 +108,148 @@ jobs:
         self.assertNotIn("ruff-lint", kinds)
 
 
+class BuildKindTightening(unittest.TestCase):
+    """#576: runtime `docker build` / `docker buildx` steps are image-MOVING,
+    not a build-QUALITY gate a local pre-commit hook can mirror — they must
+    NOT classify as the `build` kind, or any docker-image repo gets a
+    permanent un-mirrorable drift. Real build-quality gates still register."""
+
+    def test_docker_buildx_not_build_kind(self) -> None:
+        wf = """
+jobs:
+  publish:
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build and push
+        run: docker buildx build --push -t img:latest .
+"""
+        self.assertNotIn("build", kinds_from_ci(wf))
+
+    def test_bare_docker_build_not_build_kind(self) -> None:
+        self.assertNotIn("build", kinds_from_ci("      - run: docker build -t img .\n"))
+
+    def test_real_build_quality_gates_still_detected(self) -> None:
+        # The classifier inspects step lines (run:/uses:/`- ` list items), so
+        # the build-quality markers are exercised in those positions.
+        for line in (
+            "      - name: build-and-validate\n",
+            "      - run: ./scripts/build-and-test.sh\n",
+            "      - run: npm run build\n",
+        ):
+            with self.subTest(line=line):
+                self.assertIn("build", kinds_from_ci(line))
+
+    def test_docker_publish_workflow_has_no_build_drift(self) -> None:
+        # End-to-end: a publish-only workflow (docker buildx) against a config
+        # that does NOT mirror a build kind produces NO harmful drift.
+        wf = """
+jobs:
+  publish:
+    steps:
+      - run: docker buildx build --push -t img .
+"""
+        cfg = """
+repos:
+  - repo: local
+    hooks:
+      - id: ruff
+"""
+        harmful, _ = compute_drift(kinds_from_precommit(cfg), kinds_from_ci(wf))
+        self.assertNotIn("build", harmful)
+
+
+class MultiLineRunBlockScanning(unittest.TestCase):
+    """#577: tools invoked on a CONTINUATION line of a multi-line `run: |` /
+    `run: >` block must be classified — else the gate has a silent blind spot
+    where a future `ruff`/`mypy` expressed multi-line drops out of the mirror
+    check."""
+
+    def test_pipe_block_continuation_lines_classified(self) -> None:
+        wf = """
+jobs:
+  security-audit:
+    steps:
+      - name: audit
+        run: |
+          uv sync
+          uv run pip-audit
+"""
+        self.assertIn("pip-audit", kinds_from_ci(wf))
+
+    def test_multiple_tools_in_one_block(self) -> None:
+        wf = """
+jobs:
+  checks:
+    steps:
+      - name: lint+type+test
+        run: |
+          ruff check .
+          mypy src/
+          pytest -q
+"""
+        kinds = kinds_from_ci(wf)
+        self.assertEqual(
+            kinds & {"ruff-lint", "mypy", "pytest"},
+            {"ruff-lint", "mypy", "pytest"},
+        )
+
+    def test_folded_block_scalar_also_scanned(self) -> None:
+        # `run: >` (folded) and chomping indicators (`|-`) open a block too.
+        wf = """
+jobs:
+  x:
+    steps:
+      - run: >-
+          mypy src/
+"""
+        self.assertIn("mypy", kinds_from_ci(wf))
+
+    def test_block_ends_at_dedented_sibling_key(self) -> None:
+        # A less-indented sibling key (here `uses:` + its `with:`) closes the
+        # block — its `fetch-depth` body must not leak a spurious classification
+        # and the block's own `ruff check` is still caught.
+        wf = """
+jobs:
+  x:
+    steps:
+      - name: a
+        run: |
+          ruff check .
+      - name: b
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+"""
+        kinds = kinds_from_ci(wf)
+        self.assertIn("ruff-lint", kinds)
+
+    def test_single_line_run_unaffected(self) -> None:
+        # Regression: the common single-line `run:` form still classifies.
+        wf = """
+jobs:
+  x:
+    steps:
+      - run: ruff check .
+      - run: mypy .
+"""
+        kinds = kinds_from_ci(wf)
+        self.assertEqual(kinds & {"ruff-lint", "mypy"}, {"ruff-lint", "mypy"})
+
+    def test_comment_in_block_not_classified(self) -> None:
+        # A commented continuation line inside the block is not a real
+        # invocation and must not register.
+        wf = """
+jobs:
+  x:
+    steps:
+      - run: |
+          # pytest is mentioned here but commented out
+          echo hi
+"""
+        self.assertNotIn("pytest", kinds_from_ci(wf))
+
+
 class DriftDirection(unittest.TestCase):
     def test_ci_enforced_not_local_is_harmful(self) -> None:
         harmful, stricter = compute_drift(


### PR DESCRIPTION
## Summary
Two correctness fixes to the canonical sync-drift gate `.claude/lib/pre_commit_ci_sync.py`, bundled per #577's "consider bundling with #576" note (both touch the same file).

### #576 — `build` kind no longer false-matches runtime docker steps
The `build` CI-kind pattern included `"docker build"`. Because a bare `docker build` substring also matches `docker buildx`, any workflow with `docker build` / `docker buildx` classified as a build-**quality** gate. That's runtime image-**moving** (retag / promote / publish / cold-rebuild / digest resolution), not a quality gate a local pre-commit hook can mirror — so every docker-image repo got a **permanent un-mirrorable `build` drift** and the gate could never exit 0 (surfaced by deploy's 4 runtime workflows; isnad-graph GHCR publish + ingest-platform worker images at the same risk).

Fix: drop `"docker build"` from the `build` tuple, keeping the real build-quality markers (`build-and-validate`, `build-and-test`, `npm run build`). **Lifted verbatim from the deploy-rollout form (deploy#391, A.Idrissi)** and canonicalized in the parent so vendored child copies converge. A genuine docker-build-as-quality-gate should name its job `build-and-validate`/`-test` (or add an explicit pattern).

### #577 — `kinds_from_ci` scans multi-line `run:` block bodies
The classifier only inspected lines containing `run:`/`uses:` or starting with `-`. A tool invoked on a **continuation line** of a `run: |` / `run: >` block (e.g. `security-audit`'s `uv run pip-audit`) was invisible — a silent blind spot where a future `ruff`/`mypy` expressed multi-line would silently drop out of the mirror check.

Fix: on a `run: |` / `run: >` opener (incl. `|-` / `>-` / digit indicators), record the key indent and classify each **more-indented** body line until a dedent to ≤ that indent closes the block (YAML block-scalar scoping). Commented body lines are skipped.

## Tests (+10)
- **`BuildKindTightening`** — `docker buildx` / bare `docker build` NOT classified as `build`; real build-quality gates still detected; a publish-only (docker buildx) workflow produces no `build` harmful drift.
- **`MultiLineRunBlockScanning`** — pipe-block `pip-audit`; multi-tool block (ruff/mypy/pytest); folded `>-`; dedent-closes-block scoping; single-line `run:` regression; commented body line not classified.

Full suite **21 passed** (was 11). Parent self-gate `python3 .claude/lib/pre_commit_ci_sync.py .` still exits 0. `ruff format --check`, `ruff check`, `mypy` all clean.

## Related Issues
Refs #576
Refs #577

(Using `Refs`, not `Closes`: this PR targets the wave-14 branch, and `Closes` only fires on default-branch merges — the issues are closed explicitly at wave wrapup.)

> **Scope note:** #576's child re-vendoring (its acceptance criterion 3) is per-child PR work on each child's wave branch — deploy already carries the form (deploy#391); other image-publishing repos (isnad-graph, ingest-platform) re-vendor separately. Out of scope for this parent-canonical PR.

## Review Checklist
- [ ] `docker build`/`buildx` runtime steps no longer register `build`; real quality gates still do
- [ ] multi-line `run:` block body lines are classified; block scoping ends at the right dedent
- [ ] single-line `run:` classification unchanged (no regression)
- [ ] parent self-gate still exits 0

Co-Authored-By: Aino Virtanen <parametrization+Aino.Virtanen@gmail.com>
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>