### PR TITLE
process(P3W14 retro): adopt 3 owner-approved process changes (Refs #569)

### DIFF
--- a/.claude/skills/session-start/SKILL.md
+++ b/.claude/skills/session-start/SKILL.md
@@ -179,6 +179,43 @@ Report:
 
 If the report surfaces unexpected gaps between board view and open-issue counts (e.g., wave-labeled issues missing from project 2, or Wave-field values out of sync with `p{N}-wave-{M}` labels), invoke `/board-audit` to detect and (with confirmation) repair the drift. Per main#199, labels are canonical and the project's Wave field is a derived projection synced by `/board-audit`.
 
+### Step 5a — Red default-branch workflow detection (P3W14 retro Proposed Change #2)
+
+Surface any **publish/deploy/release workflow whose latest run on the repo's default branch FAILED**, across all org repos. *Rationale:* the GHCR frontend publish (isnad-graph commit 5804476) sat RED on `main` for ~12 days undetected — silently breaking every staging deploy at the frontend-pull step — because nothing surfaced a red default-branch publish at session start.
+
+For each org repo, list the latest default-branch run of each workflow and flag any whose conclusion is `failure`/`timed_out`/`cancelled`, filtered to publish/deploy/release-class workflows (these are the ones whose redness silently rots — a red lint run is loud at PR time; a red publish on `main` is not):
+
+```bash
+REPO_ROOT="$(cd "$(git rev-parse --git-common-dir 2>/dev/null)/.." 2>/dev/null && pwd)"
+[ -f "$REPO_ROOT/cross-repo-status.json" ] || REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+REPOS=$(jq -r '.repos[]? // empty' "$REPO_ROOT/cross-repo-status.json" 2>/dev/null)
+[ -n "$REPOS" ] || REPOS="noorinalabs-main noorinalabs-isnad-graph noorinalabs-user-service noorinalabs-deploy noorinalabs-design-system noorinalabs-data-acquisition noorinalabs-isnad-ingest-platform noorinalabs-landing-page"
+RED=()
+for repo in $REPOS; do
+  branch=$(gh api "repos/noorinalabs/$repo" --jq '.default_branch' 2>/dev/null || echo main)
+  # Latest run per workflow on the default branch; keep only publish/deploy/release-class names with a non-success conclusion.
+  while IFS=$'\t' read -r name conclusion url; do
+    case "$conclusion" in
+      failure|timed_out|cancelled|startup_failure)
+        RED+=("$repo :: $name :: $conclusion :: $url") ;;
+    esac
+  done < <(
+    gh api "repos/noorinalabs/$repo/actions/runs?branch=$branch&per_page=50" \
+      --jq '[.workflow_runs[] | select((.name // .display_title) | test("publish|deploy|release|promote|ghcr|image";"i"))]
+            | group_by(.workflow_id) | map(max_by(.run_started_at))
+            | .[] | [(.name // .display_title), .conclusion, .html_url] | @tsv' 2>/dev/null
+  )
+done
+if [ ${#RED[@]} -gt 0 ]; then
+  printf 'RED default-branch publish/deploy run(s) — investigate before relying on staging:\n'
+  printf '  %s\n' "${RED[@]}"
+else
+  echo "All publish/deploy/release workflows green on default branches."
+fi
+```
+
+Report any red runs prominently — a red publish/deploy on a default branch is a stop-and-investigate signal, not background noise: it usually means the artifact consumers (staging, downstream pulls) are silently running stale or broken bits. If `gh api` calls fail (auth/rate-limit), say so rather than reporting a false all-green.
+
 ### Step 6 — Charter freshness check
 
 Read the tail of the feedback log:
@@ -212,6 +249,7 @@ After all steps complete, present a single status block:
 | 3. Ontology | {N dirty resolved / current} |
 | 4. Annunaki | {N errors, action needed? / clear} |
 | 5. Wave | {active wave, stale?, issues} |
+| 5a. Red default-branch runs | {N red publish/deploy runs / all green} |
 | 6. Charter | {current / proposals pending} |
 
 {Then address the user's actual message/request}

--- a/.claude/skills/wave-kickoff/SKILL.md
+++ b/.claude/skills/wave-kickoff/SKILL.md
@@ -205,6 +205,20 @@ Recipe:
 4. Build PUT payload JSON with `message`, `content` (base64), `sha` (current), `branch: "main"`, `author: {name, email}`, `committer: {name, email}`
 5. `gh api -X PUT repos/.../contents/cross-repo-status.json --input <payload>.json`
 
+**MANDATORY — advance the `current_wave` pointer (P3W14 retro Proposed Change #1).** The kickoff status write MUST set `current_wave` to this wave, alongside the active-state keys:
+
+```jq
+. + {
+  "current_wave": "wave-{M}",
+  "last_completed_wave": "wave-{M-1}",
+  "next_wave": "wave-{M+1}",
+  "wave_{M}_active": true,
+  "wave_{M}_kicked_off_at": $now
+}
+```
+
+`validate_wave_audit` derives the current wave **label** (`p{N}-wave-{M}`) from `current_wave` to count open wave issues; if the pointer still names the prior wave, the wave-conclusion audit blocks the **next** wave's `/wave-retro`. This was the one W14 annunaki capture — W14 kicked off without advancing `current_wave`, leaving it at `wave-13`, and the retro was blocked until the pointer was manually corrected. Read-back-verify after the PUT: `gh api .../contents/cross-repo-status.json?ref=main --jq '.content' | base64 -d | jq -r '.current_wave'` MUST print `wave-{M}`.
+
 Attribution: kickoff status commits use Wanjiku Mwangi (TPM); reconciliation/wrapup commits use the role-running implementer.
 
 The local-then-push `jq | mv | git commit | git push` pattern at the end of Step 1 above pre-dates this guidance — it remains acceptable for the `wave_{M}_branches` write (which is wave-branch-scoped, not main) but MUST NOT be used for any commit landing on `main`. Status writes that target `main` (kickoff active, reconciliation, wrapup completion) use the PUT-contents recipe.

--- a/.claude/team/charter/issues.md
+++ b/.claude/team/charter/issues.md
@@ -110,6 +110,21 @@ Every issue must be kept up to date:
 - **Comments** — used for questions, clarifications, progress updates, and decisions.
 - **Close condition** — issues are closed **only** when the corresponding work is complete and verified. Do not close prematurely. For `[MANUAL]` issues, the human confirms completion via comment.
 
+## End-State Criterion: Delivered vs. Applied-and-Verified-at-Origin <!-- promotion-target: none -->
+
+An **end-state criterion** (or any rollout/enforcement issue) is **MET only when the mechanism is APPLIED and verified at origin via API — not when the spec, script, or hook that would apply it is merely *delivered***. "Delivered" (the spec/PR/script exists) and "applied" (the live system actually enforces it) are distinct states; a criterion-tracking issue MUST distinguish them and stay OPEN as the rollout tracker until *applied-and-verified* is true for every target.
+
+**Rule.** Before framing or closing a criterion as met, verify the enforcing state at origin with the authoritative API for that mechanism, and cite the verification. Examples of the right probe per mechanism:
+- **Branch-protection / rulesets** (criterion #4 / #322): `gh api repos/<owner>/<repo>/rulesets` (and `.../rulesets/<id>`) returns the ruleset with the expected required-check contexts — for **every** target default branch, not just the pilot. The spec + hook + one pilot is *delivered*; the criterion is *met* only once the ruleset is read-back-confirmed on all 8 default branches.
+- **CI gate live** (e.g. sync-drift, docs): the gate job appears and is green in the latest default-branch run (`gh api .../actions/runs?branch=main` / `statusCheckRollup`), not just present in the workflow file on a feature branch.
+- **Staging-green** (criterion #3 / #325): a successful `deploy-stg` run exists in run history, not just a `deploy-stg.yml` that *would* run.
+
+**Why:** a spec or script that is merged but never applied leaves the criterion's protection entirely absent while the issue's framing implies it is in place — the exact gap behind #322 (specs+scripts delivered, ruleset unapplied) and the 12-day-red GHCR publish (workflow present, latest default-branch run failing). Aligns with [`pull-requests.md` § Branch Protection — criterion #4](pull-requests.md) ("criterion #4 is met only when the W14 rollout has applied the ruleset to all 8 default branches") and `feedback_honest_audit_over_conclusion_claim` (an honest open-item count before any "done" claim). The discipline generalizes that per-criterion note into a standing rule: deliverable-exists ≠ criterion-met; the origin-verified applied state is the close condition.
+
+**Disposition shorthand:** while the mechanism is delivered-but-not-fully-applied, the tracking issue uses `Refs #N` on the delivering PR (NOT `Closes #N`) and stays open as the rollout tracker; it is closed only after the applied-and-verified-at-origin check passes for all targets. (`Closes` on a wave-branch PR would not fire anyway — see `feedback_wave_branch_issue_close` — but the substantive reason is the delivered-vs-applied distinction, not the merge mechanics.)
+
+<!-- Promoted from: P3W14 retro (2026-06-01) Proposed Process Change #3, owner-approved. Rationale: #322 specs+scripts delivered but unapplied; GHCR publish red on main 12 days undetected. Generalizes pull-requests.md § criterion #4's per-criterion note into a standing close-condition rule. -->
+
 ## Comment Format <!-- promotion-target: none -->
 All issue comments MUST follow this format:
 

--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -117,6 +117,8 @@ uvicorn
 keypairs
 runbook
 runbooks
+ruleset
+rulesets
 
 # --- second-pass terms surfaced once cspell was scoped to authored prose
 #     (charter + skills). Project jargon, identifiers, brand, and a few names. ---


### PR DESCRIPTION
## Summary
Adopts the **three owner-approved P3W14-retro Proposed Process Changes** in one PR (base `main`).

### 1. `wave-kickoff` MUST advance `current_wave` (retro change #1)
`.claude/skills/wave-kickoff/SKILL.md` Step 1a (the atomic `gh api PUT` status write): now **mandates** setting `current_wave="wave-{M}"` (plus `last_completed_wave` / `next_wave` / `wave_{M}_active`) with a read-back-verify. `validate_wave_audit` derives the current wave **label** from `current_wave`; W14 kicked off without advancing it (left at `wave-13`), which blocked the next `/wave-retro` — the one W14 annunaki capture. This codifies the missing kickoff step.

### 2. Red default-branch workflow detection (retro change #2)
`.claude/skills/session-start/SKILL.md` new **Step 5a**: per org repo, lists the latest default-branch run of each publish/deploy/release-class workflow and surfaces any `failure`/`timed_out`/`cancelled`. The GHCR frontend publish sat **RED on `main` for ~12 days undetected**, silently breaking every staging deploy at the frontend-pull step, because nothing surfaced a red default-branch publish at session start. Added a `5a` row to the output table.

### 3. End-state criterion = APPLIED-and-verified-at-origin, not just delivered (retro change #3)
`.claude/team/charter/issues.md` new section **"End-State Criterion: Delivered vs. Applied-and-Verified-at-Origin"**: a criterion/rollout issue is **MET only when the mechanism is applied AND verified at origin** via the authoritative API (rulesets endpoint returns the ruleset on **every** default branch; CI gate green in the latest default-branch run; a `deploy-stg` run exists) — not when the spec/script/hook is merely delivered. Delivered-but-not-applied uses `Refs` (not `Closes`) and the issue stays open as the rollout tracker until applied-verified for all targets. Generalizes `pull-requests.md § criterion #4`'s per-criterion note into a standing close-condition rule. Motivating gaps: #322 (specs delivered, ruleset unapplied) and the 12-day-red publish.

### Supporting
- `.cspell/project-words.txt`: add `ruleset` / `rulesets` — the new section trips the spell gate on these domain terms (also retroactively covers `pull-requests.md`'s pre-existing usages, which CI's cspell-action only re-scans when that file is in a PR diff).

## Validation
- **cspell 8.4.0** (CI-pinned): 0 issues on all changed files.
- **markdownlint-cli2** (CI config): 0 errors (80 files linted).
- New internal links are bare relative `](pull-requests.md)` to an existing same-directory file — identical to the lychee-passing convention already in `issues.md`; no URL fragments to resolve.
- No Python/workflow files touched, so ruff/mypy/actionlint surfaces are unaffected.

## Related Issues
Refs #569 (the P3W14 retro that proposed and owner-approved these three changes)

## Review Checklist
- [ ] change #1: kickoff Step 1a mandates `current_wave` advance + read-back, with the validate_wave_audit rationale
- [ ] change #2: session-start Step 5a surfaces red publish/deploy/release runs on default branches; output table updated
- [ ] change #3: charter section distinguishes delivered vs applied-and-verified-at-origin with per-mechanism probes + Refs-not-Closes disposition
- [ ] cspell/markdownlint clean; internal links resolve

Co-Authored-By: Aino Virtanen <parametrization+Aino.Virtanen@gmail.com>
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
