### PR TITLE
tech-debt(session-start): point Step 5a repo-list at canonical wave key (#585)

### DIFF
--- a/.claude/skills/session-start/SKILL.md
+++ b/.claude/skills/session-start/SKILL.md
@@ -188,7 +188,15 @@ For each org repo, list the latest default-branch run of each workflow and flag 
 ```bash
 REPO_ROOT="$(cd "$(git rev-parse --git-common-dir 2>/dev/null)/.." 2>/dev/null && pwd)"
 [ -f "$REPO_ROOT/cross-repo-status.json" ] || REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
-REPOS=$(jq -r '.repos[]? // empty' "$REPO_ROOT/cross-repo-status.json" 2>/dev/null)
+# Primary: the most-recent `wave_<N>_repos_in_scope` array (the canonical org repo set;
+# there is no top-level `.repos` key). Falls through to the hardcoded list if the file is
+# missing/unparseable or has no such key.
+REPOS=$(jq -r '
+  [to_entries[]
+   | select(.key | test("^wave_[0-9]+_repos_in_scope$"))
+   | {n: (.key | capture("^wave_(?<n>[0-9]+)_repos_in_scope$").n | tonumber), v: .value}]
+  | max_by(.n) | .v[]? // empty
+' "$REPO_ROOT/cross-repo-status.json" 2>/dev/null)
 [ -n "$REPOS" ] || REPOS="noorinalabs-main noorinalabs-isnad-graph noorinalabs-user-service noorinalabs-deploy noorinalabs-design-system noorinalabs-data-acquisition noorinalabs-isnad-ingest-platform noorinalabs-landing-page"
 RED=()
 for repo in $REPOS; do


### PR DESCRIPTION
## Summary

Step 5a (red default-branch workflow detection, added in PR #583) read a top-level `.repos` key from `cross-repo-status.json` for its primary repo list. **That key does not exist** — the canonical key is `wave_<N>_repos_in_scope`. So the primary read always yielded empty and the hardcoded 8-repo fallback was the operative path: dead code masking a latent footgun (if the fallback were ever trimmed, the step would silently scan zero repos).

## Fix

Repoint the primary read at the **most-recent** `wave_<N>_repos_in_scope` array (selects the highest-numbered key), keeping the hardcoded fallback for the file-missing / unparseable case.

## Verification

Ran the edited block against the real `cross-repo-status.json`:

- **Primary path** now resolves all 8 org repos (`noorinalabs-main` + 7 children) from `wave_15_repos_in_scope`.
- **Simulated empty input** (`{}`) yields empty with clean exit, so `[ -n "$REPOS" ] || REPOS=...` still falls through to the hardcoded fallback.

No functional behavior change (the sweep already covered all 8 repos via the fallback) — this removes the dead primary line and makes the canonical source operative.

Closes #585. Refs #583 #330 (folds into the W15 tech-debt burn-down).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
