### PR TITLE
ops(#322): add .github/branch-protection/ to noorinalabs-main

### DIFF
--- a/.github/branch-protection/SPEC.md
+++ b/.github/branch-protection/SPEC.md
@@ -28,7 +28,7 @@ A **repository ruleset** targeting `~DEFAULT_BRANCH`, `enforcement: active`:
   discipline runs on **issue-comment verdicts** validated by Hook 4
   (`validate_pr_review`), not formal reviews. A naive "require 1 approval" rule
   would **deadlock every merge**. Reviewer-count enforcement stays with Hook 4.
-- **`required_status_checks` (strict) — EMPTY required set on this repo.**
+- **`required_status_checks` rule — OMITTED on this repo.**
   `noorinalabs-main`'s `ci.yml` is **path-filtered** (it triggers only on
   changes under `.claude/hooks/**`, `.claude/lib/**`, `.claude/skills/**`,
   `.github/workflows/ci.yml`, `.pre-commit-config.yaml`, `pyproject.toml`). Its
@@ -37,9 +37,13 @@ A **repository ruleset** targeting `~DEFAULT_BRANCH`, `enforcement: active`:
   PR/push that touches only other paths — e.g. the orchestrator's routine
   `cross-repo-status.json` and `ontology/` updates. Hard-requiring those job
   contexts would **deadlock** any non-matching PR forever waiting on a check
-  that never reports. So the required set is **EMPTY**, the same canonical choice
-  as `noorinalabs-deploy` (whose CI is also path-filtered). The ruleset still
-  enforces **PR-only + no force-push / branch-delete** on `main`; the per-PR
+  that never reports. So no status check is required at the ruleset layer. Note
+  the GitHub REST API **rejects** a `required_status_checks` rule carrying an
+  empty `required_status_checks` array (HTTP 422: "Expected at least 1 elements,
+  got 0"), so the rule is **omitted entirely** rather than included-with-`[]`.
+  This is the same canonical choice as `noorinalabs-deploy` (whose CI is also
+  path-filtered). The ruleset still enforces **PR-only + no force-push /
+  branch-delete** on `main`; the per-PR
   green-CI gate is carried by **Hook 14** (`validate_pr_ci_status`), which blocks
   merge-on-red for the checks that **did** run.
 

--- a/.github/branch-protection/SPEC.md
+++ b/.github/branch-protection/SPEC.md
@@ -1,0 +1,75 @@
+# Branch Protection — noorinalabs-main (P3 end-state #4, #322)
+
+Phase-3 end-state criterion #4 (`noorinalabs-main#322`): **CI failures block all
+merges** on every repo's default branch, org-wide — enforced server-side by
+GitHub, not only by the Hook 4 comment-gate. This directory carries the
+canonical ruleset for **this parent repo's** `main`.
+
+| File | Purpose |
+|------|---------|
+| `ruleset-main.json` | The repository ruleset payload (GitHub REST `/rulesets`). |
+| `apply-ruleset.sh`  | Owner/admin-gated apply + read-back-verify. Idempotent (create-or-update). |
+| `SPEC.md`           | This document — the shape and the why. |
+
+This is `noorinalabs-main`'s own adoption of the parent-canonical spec
+(charter `pull-requests.md` § *Org-Wide Branch Protection + Admin-Merge
+Exceptions*), modeled on the W13 live pilot
+(`noorinalabs-data-acquisition`, ruleset id `17091263`) and the W14 canonical
+pilot (`noorinalabs-user-service`).
+
+## The ruleset shape (and why)
+
+A **repository ruleset** targeting `~DEFAULT_BRANCH`, `enforcement: active`:
+
+- **`pull_request` with `required_approving_review_count: 0`** — the load-bearing
+  decision. GitHub's "require approvals" counts **formal** GitHub PR reviews,
+  which our team structurally cannot produce: the `gh` auth principal IS the PR
+  author (`parametrization`), so a formal self-approval **422s**, and our review
+  discipline runs on **issue-comment verdicts** validated by Hook 4
+  (`validate_pr_review`), not formal reviews. A naive "require 1 approval" rule
+  would **deadlock every merge**. Reviewer-count enforcement stays with Hook 4.
+- **`required_status_checks` (strict) — EMPTY required set on this repo.**
+  `noorinalabs-main`'s `ci.yml` is **path-filtered** (it triggers only on
+  changes under `.claude/hooks/**`, `.claude/lib/**`, `.claude/skills/**`,
+  `.github/workflows/ci.yml`, `.pre-commit-config.yaml`, `pyproject.toml`). Its
+  gate jobs (`Ruff lint`, `Ruff format check`, `Mypy type check`, `Smoke test …`,
+  `Pytest …`, `Pre-commit ⇄ CI sync-drift gate`) therefore **do not run** on a
+  PR/push that touches only other paths — e.g. the orchestrator's routine
+  `cross-repo-status.json` and `ontology/` updates. Hard-requiring those job
+  contexts would **deadlock** any non-matching PR forever waiting on a check
+  that never reports. So the required set is **EMPTY**, the same canonical choice
+  as `noorinalabs-deploy` (whose CI is also path-filtered). The ruleset still
+  enforces **PR-only + no force-push / branch-delete** on `main`; the per-PR
+  green-CI gate is carried by **Hook 14** (`validate_pr_ci_status`), which blocks
+  merge-on-red for the checks that **did** run.
+
+  If `noorinalabs-main`'s CI ever becomes unconditional (no `paths:` filter), add
+  the job-**name** contexts to `ruleset-main.json` and **re-confirm at apply
+  time** against live check-runs:
+  `gh api repos/<repo>/commits/<default-sha>/check-runs --jq '.check_runs[].name'`.
+- **`deletion` + `non_fast_forward`** — no force-push / branch-delete on `main`.
+- **`bypass_actors`: Repository-admin (`actor_id: 5`, `bypass_mode: always`)** —
+  this repo is special: the orchestrator pushes `cross-repo-status.json` and
+  `ontology/` updates **directly to `main` via the contents API**, and runs
+  `--admin` wave→main wrapup merges. The admin always-bypass keeps both working
+  (the `parametrization` principal holds repo-admin). The GitHub-side bypass is
+  mirrored on the operator side by the hook-validated `ADMIN_MERGE_EXCEPTION`
+  gate (`validate_pr_ci_status`), which **audits** every `--admin` merge to the
+  Annunaki trail — defense in depth: the ruleset covers UI/external/batch-loop
+  merges, the hook covers `gh pr merge` and names the exceptions.
+
+## How to apply (owner)
+
+```bash
+# From a window with NO in-flight default-branch merge (post-wave-wrapup):
+.github/branch-protection/apply-ruleset.sh            # create or update
+DRY_RUN=1 .github/branch-protection/apply-ruleset.sh  # preview only
+
+# Then read-back-verify the detail (contexts + bypass actor):
+gh api repos/noorinalabs/noorinalabs-main/rulesets \
+  --jq '.[] | select(.name|startswith("Protect main")) | .id'
+gh api repos/noorinalabs/noorinalabs-main/rulesets/<id>
+```
+
+`#322` stays **OPEN** as the org-wide rollout tracker until all 8 default
+branches carry the protection and the phase review closes the criterion.

--- a/.github/branch-protection/apply-ruleset.sh
+++ b/.github/branch-protection/apply-ruleset.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Apply the noorinalabs-main default-branch protection ruleset.
+#
+# Phase-3 end-state criterion #4 (noorinalabs-main#322): CI failures block all
+# merges on every repo's default branch, enforced server-side by GitHub (not
+# only by the Hook 4 comment-gate). This script is the OWNER/ADMIN-gated apply
+# step: it POSTs (or, if a same-named ruleset already exists, PUT-updates) the
+# canonical ruleset committed alongside it (ruleset-main.json).
+#
+# Why this is a post-merge, owner-run step — not done in the PR:
+#   Creating/updating a repository ruleset requires repo-admin permission, and
+#   applying default-branch protection while a wave-branch PR is in flight can
+#   block our own merges. So the durable PR artifact is the SPEC + this script;
+#   the owner runs it from a window with no in-flight default-branch merge
+#   (post-wave-wrapup is the safe window), then read-back-verifies.
+#
+# Design notes (see SPEC.md in this directory + charter pull-requests.md
+# § Org-Wide Branch Protection):
+#   * required_approving_review_count: 0 — GitHub's "require approvals" counts
+#     FORMAL PR reviews, which our team structurally cannot produce (the gh auth
+#     principal IS the PR author, so a formal self-approval 422s). Reviewer-count
+#     enforcement stays with Hook 4 (validate_pr_review). A "require 1 approval"
+#     rule would deadlock every merge.
+#   * Required status checks: noorinalabs-main's ci.yml is PATH-FILTERED
+#     (.claude/hooks|lib|skills, ci.yml, .pre-commit-config.yaml, pyproject.toml),
+#     so its gate jobs DO NOT run on a PR/push that touches only other paths
+#     (e.g. cross-repo-status.json, ontology/). Hard-requiring those job
+#     contexts would deadlock any non-matching PR waiting on a check that never
+#     reports. So the required set is EMPTY here (same canonical choice as
+#     noorinalabs-deploy, whose CI is also path-filtered): the ruleset enforces
+#     PR-only + no force-push / branch-delete on main, and the per-PR green-CI
+#     gate is carried by Hook 14 (validate_pr_ci_status) which blocks merge-on-red
+#     for the checks that DID run. If main's CI later becomes unconditional, add
+#     the job-NAME contexts here (confirm against live check-runs:
+#     `gh api repos/<repo>/commits/<default-sha>/check-runs --jq '.check_runs[].name'`).
+#   * Repository-admin always-bypass (actor_id 5) keeps the orchestrator's
+#     --admin wave→main wrapup merges AND its direct contents-API status/ontology
+#     pushes to main working. The hook-side ADMIN_MERGE_EXCEPTION gate
+#     (validate_pr_ci_status) audits every such bypass to the Annunaki trail.
+#
+# Usage:
+#   ./apply-ruleset.sh                 # apply to noorinalabs/noorinalabs-main
+#   REPO=owner/name ./apply-ruleset.sh # override target repo (for re-use)
+#   DRY_RUN=1 ./apply-ruleset.sh       # print the payload + planned action, no write
+
+set -euo pipefail
+
+REPO="${REPO:-noorinalabs/noorinalabs-main}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PAYLOAD="$SCRIPT_DIR/ruleset-main.json"
+RULESET_NAME="$(python3 -c "import json,sys; print(json.load(open(sys.argv[1]))['name'])" "$PAYLOAD")"
+
+if [[ ! -f "$PAYLOAD" ]]; then
+  echo "ERROR: ruleset payload not found at $PAYLOAD" >&2
+  exit 1
+fi
+
+echo "Repo:    $REPO"
+echo "Ruleset: $RULESET_NAME"
+echo "Payload: $PAYLOAD"
+echo
+
+# Is there already a ruleset with this name? (idempotent re-apply / update.)
+EXISTING_ID="$(gh api "repos/$REPO/rulesets" \
+  --jq ".[] | select(.name == \"$RULESET_NAME\") | .id" 2>/dev/null || true)"
+
+if [[ "${DRY_RUN:-0}" == "1" ]]; then
+  echo "DRY_RUN — would $( [[ -n "$EXISTING_ID" ]] && echo "UPDATE ruleset $EXISTING_ID" || echo "CREATE a new ruleset" ):"
+  cat "$PAYLOAD"
+  exit 0
+fi
+
+if [[ -n "$EXISTING_ID" ]]; then
+  echo "Updating existing ruleset id $EXISTING_ID ..."
+  gh api -X PUT "repos/$REPO/rulesets/$EXISTING_ID" --input "$PAYLOAD"
+else
+  echo "Creating new ruleset ..."
+  gh api -X POST "repos/$REPO/rulesets" --input "$PAYLOAD"
+fi
+
+echo
+echo "=== Read-back verification ==="
+gh api "repos/$REPO/rulesets" \
+  --jq ".[] | select(.name == \"$RULESET_NAME\") | {id, name, enforcement, target}"
+echo
+echo "Confirm the required-status-check contexts and bypass actor in the ruleset"
+echo "detail (gh api repos/$REPO/rulesets/<id>) before declaring #322 met for this repo."

--- a/.github/branch-protection/apply-ruleset.sh
+++ b/.github/branch-protection/apply-ruleset.sh
@@ -26,8 +26,11 @@
 #     so its gate jobs DO NOT run on a PR/push that touches only other paths
 #     (e.g. cross-repo-status.json, ontology/). Hard-requiring those job
 #     contexts would deadlock any non-matching PR waiting on a check that never
-#     reports. So the required set is EMPTY here (same canonical choice as
-#     noorinalabs-deploy, whose CI is also path-filtered): the ruleset enforces
+#     reports. So the required_status_checks rule is OMITTED here (the GitHub API
+#     422s on an empty required_status_checks array — "Expected at least 1
+#     elements, got 0" — so the rule is dropped, not included-with-[]); same
+#     canonical choice as noorinalabs-deploy, whose CI is also path-filtered:
+#     the ruleset enforces
 #     PR-only + no force-push / branch-delete on main, and the per-PR green-CI
 #     gate is carried by Hook 14 (validate_pr_ci_status) which blocks merge-on-red
 #     for the checks that DID run. If main's CI later becomes unconditional, add

--- a/.github/branch-protection/ruleset-main.json
+++ b/.github/branch-protection/ruleset-main.json
@@ -1,0 +1,42 @@
+{
+  "name": "Protect main — require PR + green CI (P3 end-state #4, main#322)",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "always"
+    }
+  ],
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false,
+        "required_reviewers": [],
+        "allowed_merge_methods": ["merge", "squash", "rebase"]
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": []
+      }
+    }
+  ]
+}

--- a/.github/branch-protection/ruleset-main.json
+++ b/.github/branch-protection/ruleset-main.json
@@ -29,14 +29,6 @@
         "required_reviewers": [],
         "allowed_merge_methods": ["merge", "squash", "rebase"]
       }
-    },
-    {
-      "type": "required_status_checks",
-      "parameters": {
-        "strict_required_status_checks_policy": true,
-        "do_not_enforce_on_create": false,
-        "required_status_checks": []
-      }
     }
   ]
 }


### PR DESCRIPTION
## What

Adds `.github/branch-protection/` to **noorinalabs-main** — the parent repo's own canonical branch-protection artifacts for Phase-3 end-state criterion #4 (#322): `SPEC.md` + `apply-ruleset.sh` + `ruleset-main.json`.

Modeled on the W14 canonical pilot (`noorinalabs-user-service`) and the W13 live pilot (`noorinalabs-data-acquisition`, ruleset id `17091263`). noorinalabs-main was one of two repos (with landing-page) missing this dir.

## Repo-specific decision — EMPTY required_status_checks

noorinalabs-main's `ci.yml` is **path-filtered** (`.claude/hooks|lib|skills/**`, `ci.yml`, `.pre-commit-config.yaml`, `pyproject.toml`). Its gate jobs do NOT run on a PR/push touching only other paths (e.g. the orchestrator's routine `cross-repo-status.json` / `ontology/` updates). Hard-requiring those job contexts would deadlock any non-matching PR. So the required-checks set is **EMPTY** — the same canonical choice as `noorinalabs-deploy` (also path-filtered). The ruleset enforces **PR-only + no force-push / branch-delete**; merge-on-red is gated by **Hook 14** (`validate_pr_ci_status`) for the checks that did run.

The **admin always-bypass** (`actor_id: 5`) preserves the orchestrator's direct contents-API status/ontology pushes to `main` and its `--admin` wave→main wrapup merges (the `parametrization` principal holds repo-admin).

## Apply / verify

The live ruleset apply is the **owner/admin-gated** step (owner-authorized for this session, #322). This PR ships the durable artifact; the apply + 8-repo API verification is tracked on #322 and reported there.

## Scope

- `Refs #322` (NOT Closes — end-state criteria stay OPEN until the phase review closes them; W13 retro lesson).

## Verification done
- `ruleset-main.json` parses; `DRY_RUN=1 apply-ruleset.sh` previews correctly.
- `apply-ruleset.sh` is shellcheck-clean.
- pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
