### PR TITLE
fix(hook/skill): /wave-scope tier-row shape drift — kickoff comments no longer silent-skip (#586)

### DIFF
--- a/.claude/hooks/post_wave_kickoff_comment.py
+++ b/.claude/hooks/post_wave_kickoff_comment.py
@@ -25,9 +25,13 @@ Behavior summary
    filter) — those are not initial kickoffs.
 2. Read `ontology/cross-repo-status.json` (or fallback paths) and find
    the matching assignment row in `wave_{M}_scope.tier_{1,2,3,4}_*`
-   arrays. Match by:
-     - `id == "<repo>#<num>"` for explicit-issue rows (W7+W8 shape), OR
-     - `repo == "<repo>"` for Tier-1 backlog rows (W6+W7 Tier-1 shape).
+   arrays. Match by (in priority order):
+     - `id == "<repo>#<num>"` (full repo name) OR `ref == "<short>#<num>"`
+       for explicit-issue dict rows (W7+W8 / W15-converted shape), OR
+     - `repo == "<repo>"` for Tier-1 backlog rows (W6+W7 Tier-1 shape), OR
+     - a bare short-ref string entry `"<short>#<num>"` (#586 legacy
+       /wave-scope shape) — synthesizes a placeholder row so the kickoff
+       posts with `(unassigned)` slots instead of silently skipping.
 3. If found, render a charter-format kickoff comment using the row's
    `implementer` / `reviewer` / `reviewer_2` fields.
 4. Skip if the issue == `wave_{M}_meta_issue` (meta-issue gets its own
@@ -165,31 +169,60 @@ def parse_label_apply_command(command: str) -> tuple[str, str, str] | None:
     return change.repo, change.issue_number, change.add_label
 
 
+def _short_ref(repo: str, issue_number: str) -> str:
+    """Return the short-ref form `<short-repo>#<num>` for (repo, num).
+
+    `/wave-scope` and the meta-issue body use the `noorinalabs-`-stripped
+    short repo name (e.g. `main#322`, `deploy#363`) — the dict-row `ref`
+    field and the legacy plain-string tier entries both use this shape.
+    The full repo name (`noorinalabs-main`) only appears in the dict-row
+    `id` field. We strip a leading `noorinalabs-` if present; a repo name
+    that does not carry the org prefix is returned unchanged.
+    """
+    short = repo[len("noorinalabs-") :] if repo.startswith("noorinalabs-") else repo
+    return f"{short}#{issue_number}"
+
+
 def find_assignment_row(status: dict, repo: str, issue_number: str, wave_num: int) -> dict | None:
     """Locate the assignment row for (repo, issue_number) in wave_{M}_scope.
 
     Match priority:
-      1. Exact `id == "<repo>#<issue_number>"` in any tier_N array
-         (W7+W8 shape — explicit issue rows).
+      1. Exact `id == "<repo>#<issue_number>"` (full repo name) in any
+         tier_N array (W7+W8 / W15-hand-converted shape — explicit dict
+         rows). Also matches a dict row whose `ref` equals the short-ref
+         `<short-repo>#<num>`.
       2. Exact `repo == "<repo>"` AND row has no `id` field, in any
          tier_N array (W6+W7 Tier-1 backlog shape — applies to all
          backlog issues in that repo).
+      3. **Legacy plain-string fallback (#586):** a tier entry that is a
+         bare short-ref string (e.g. `"main#322"`) matching this issue's
+         short-ref. `/wave-scope` historically wrote these (W14 + W15
+         pre-conversion), and the hook silently skipped every per-issue
+         kickoff comment because Pass 1/2 only matched dict rows. We
+         synthesize a minimal row (`{"id": ..., "ref": ...}`) so
+         `render_kickoff_comment` falls through to its `(unassigned)`
+         placeholders instead of the hook silent-skipping — a visible
+         kickoff comment the orchestrator can backfill beats no comment.
 
     Returns the row dict (with `implementer` / `reviewer` / `reviewer_2`
-    fields) or None if no match.
+    fields, or the synthesized placeholder row for the string shape) or
+    None if no match.
     """
     scope = status.get(f"wave_{wave_num}_scope") or {}
     if not isinstance(scope, dict):
         return None
 
     expected_id = f"{repo}#{issue_number}"
+    expected_ref = _short_ref(repo, issue_number)
 
-    # Pass 1: match by explicit id.
+    # Pass 1: match by explicit id (full repo name) or short-ref on a dict row.
     for key, value in scope.items():
         if not key.startswith("tier_") or not isinstance(value, list):
             continue
         for row in value:
-            if isinstance(row, dict) and row.get("id") == expected_id:
+            if isinstance(row, dict) and (
+                row.get("id") == expected_id or row.get("ref") == expected_ref
+            ):
                 return row
 
     # Pass 2: match by repo (backlog-tier fallback).
@@ -199,6 +232,15 @@ def find_assignment_row(status: dict, repo: str, issue_number: str, wave_num: in
         for row in value:
             if isinstance(row, dict) and "id" not in row and row.get("repo") == repo:
                 return row
+
+    # Pass 3: legacy plain-string short-ref fallback (#586). Render with
+    # `(unassigned)` placeholders rather than silent-skipping.
+    for key, value in scope.items():
+        if not key.startswith("tier_") or not isinstance(value, list):
+            continue
+        for row in value:
+            if isinstance(row, str) and row == expected_ref:
+                return {"id": expected_id, "ref": expected_ref}
 
     return None
 

--- a/.claude/hooks/tests/test_post_wave_kickoff_comment.py
+++ b/.claude/hooks/tests/test_post_wave_kickoff_comment.py
@@ -321,6 +321,74 @@ class FindAssignmentRowTests(unittest.TestCase):
         row = hook.find_assignment_row(status, "noorinalabs-main", "1", 9)
         self.assertEqual(row["implementer"], "Y")
 
+    def test_dict_row_short_ref_match(self):
+        """#586: dict row keyed by `ref` (short form) matches even without `id`."""
+        status = {
+            "wave_9_scope": {
+                "tier_1_x": [
+                    {"ref": "main#322", "implementer": "Wanjiku Mwangi"},
+                ]
+            }
+        }
+        row = hook.find_assignment_row(status, "noorinalabs-main", "322", 9)
+        self.assertEqual(row["implementer"], "Wanjiku Mwangi")
+
+    def test_dict_row_full_id_preferred_when_both_present(self):
+        """A dict row with both `id` (full) and `ref` (short) is matched on either."""
+        status = {
+            "wave_9_scope": {
+                "tier_1_x": [
+                    {"id": "noorinalabs-deploy#393", "ref": "deploy#393", "implementer": "Lucas"},
+                ]
+            }
+        }
+        # Full-name caller resolves via id; the synthesized short-ref also resolves.
+        row = hook.find_assignment_row(status, "noorinalabs-deploy", "393", 9)
+        self.assertEqual(row["implementer"], "Lucas")
+
+    def test_legacy_plain_string_short_ref_fallback(self):
+        """#586: bare short-ref string entries (the pre-conversion /wave-scope
+        shape) synthesize a placeholder row instead of silently skipping."""
+        status = {
+            "wave_14_scope": {
+                "tier_1_end_state_rollout": ["main#322", "main#329"],
+                "tier_4_remainder": ["main#560"],
+            }
+        }
+        row = hook.find_assignment_row(status, "noorinalabs-main", "560", 14)
+        self.assertIsNotNone(row)
+        self.assertEqual(row["id"], "noorinalabs-main#560")
+        self.assertEqual(row["ref"], "main#560")
+        # No implementer/reviewer in the synthesized row → render shows placeholders.
+        self.assertNotIn("implementer", row)
+
+    def test_legacy_plain_string_no_match_returns_none(self):
+        """A plain-string tier with no matching short-ref still returns None."""
+        status = {"wave_14_scope": {"tier_1": ["main#322", "deploy#393"]}}
+        self.assertIsNone(hook.find_assignment_row(status, "noorinalabs-main", "999", 14))
+
+    def test_dict_row_wins_over_plain_string(self):
+        """When both a dict row and a plain string could match, the dict (with
+        real implementer data) is returned, not the placeholder synthesis."""
+        status = {
+            "wave_14_scope": {
+                "tier_1_strings": ["main#322"],
+                "tier_2_dicts": [{"id": "noorinalabs-main#322", "implementer": "REAL"}],
+            }
+        }
+        row = hook.find_assignment_row(status, "noorinalabs-main", "322", 14)
+        self.assertEqual(row["implementer"], "REAL")
+
+    def test_synthesized_row_renders_with_unassigned_placeholders(self):
+        """End-to-end #586: a plain-string match flows through render with
+        `(unassigned)` slots rather than producing a silent skip."""
+        status = {"wave_14_scope": {"tier_1": ["main#322"]}}
+        row = hook.find_assignment_row(status, "noorinalabs-main", "322", 14)
+        body = hook.render_kickoff_comment(row, wave_num=14, phase_num=3, repo="noorinalabs-main")
+        self.assertIn("Requestee: (unassigned)", body)
+        self.assertIn("- Peer reviewer: (unassigned)", body)
+        self.assertIn("- Secondary reviewer: (unassigned)", body)
+
 
 class RenderKickoffCommentTests(unittest.TestCase):
     """Direct coverage of comment body rendering."""

--- a/.claude/skills/wave-scope/SKILL.md
+++ b/.claude/skills/wave-scope/SKILL.md
@@ -434,7 +434,7 @@ The helper writes **four** keys (added P3W5 #273; structured-keys triplet added 
 | `wave_{M}_scope_reconciled_at` | `$TS` — UTC ISO timestamp captured at write time | string |
 | `wave_{M}_repos_in_scope` | the canonical 8-repo `REPOS` array from Step 4, optionally overridden by `WAVE_SCOPE_REPOS` (space-separated repo names) when a wave deliberately excludes a repo | array of strings |
 | `wave_{M}_meta_issue` | `$META_ISSUE` from Step 3 | integer |
-| `wave_{M}_scope` | from `WAVE_SCOPE_STRUCTURED` env var (a JSON object the orchestrator built from the meta-issue body — tier_*_*, deliberately_not_in_w*, concentration metrics, etc.) — falls back to a minimal `{"declared_refs": [...], "carry_forwards": [...], "must_includes": [...]}` shape derived from steps 1-3 if the env var is unset | object |
+| `wave_{M}_scope` | from `WAVE_SCOPE_STRUCTURED` env var (a JSON object the orchestrator built from the meta-issue body — tier_*_*, deliberately_not_in_w*, concentration metrics, etc.) — falls back to a minimal `{"declared_refs": [...], "carry_forwards": [...], "must_includes": [...]}` shape derived from steps 1-3 if the env var is unset. **`tier_*_*` arrays MUST hold assignment-row dicts, not bare short-ref strings — see § 13.1.** | object |
 
 **Why not raw jq:** `jq ... > tmp && mv` round-trips reformat the entire file from compact-inline (the deliberate shape used by `/wave-kickoff` and `/wave-start` for `wave_{N}_*` keys) to jq's default pretty form, doubling line count and producing a 500+ line cosmetic diff per run. P3W5 PR #276 review flagged this as load-bearing. The targeted upsert helper below preserves the existing shape — replace-in-place when the key exists (zero churn), insert-near-sibling when it doesn't (delta = 1 line per new key).
 
@@ -548,6 +548,32 @@ The helper validates JSON pre- and post-write, replaces top-level keys in place 
 The optional `wave_{M}_scope_reconciliation_note` is for capturing edge cases (e.g., "no drift; no memory must-includes; manual run because skill not yet built"). Set `SCOPE_RECONCILIATION_NOTE` in the environment before invoking the helper if there is a non-trivial summary worth preserving for the next retro.
 
 The companion read-side check is `/wave-kickoff` SKILL.md § 0a — it stops kickoff if this timestamp is missing or predates the prior wave's retro.
+
+### 13.1. Tier-row shape — assignment-row dicts, not bare strings (#586)
+
+The `tier_*_*` arrays inside `wave_{M}_scope` are consumed by the `post_wave_kickoff_comment.py` PostToolUse hook (Hook: kickoff-comment), which renders a per-issue charter-format kickoff comment when the wave label is applied. The hook's `find_assignment_row` matches an issue to its row by `id` / `ref`, then reads `implementer` / `reviewer` / `reviewer_2` / `priority` off that row to fill the comment.
+
+Each tier entry MUST therefore be an **assignment-row dict**, not a bare short-ref string:
+
+```json
+{
+  "id": "noorinalabs-main#322",
+  "ref": "main#322",
+  "implementer": "Wanjiku Mwangi",
+  "reviewer": "Santiago Ferreira",
+  "reviewer_2": "Aino Virtanen",
+  "priority": "tech-debt"
+}
+```
+
+- **`id`** — full repo name + `#<num>` (`noorinalabs-<repo>#<num>`). This is the hook's primary match key.
+- **`ref`** — short form (`<repo>#<num>`, org prefix stripped). Convenience for human-readable scope review; the hook also matches on this.
+- **`implementer` / `reviewer` / `reviewer_2`** — may be `null` at scope time if the slate is not yet decided; `/wave-kickoff` Step 0.4 fills them. The hook renders `(unassigned)` for any missing slot rather than blanking the bullet.
+- **`priority`** — optional; defaults to `feature` in the rendered comment.
+
+**Why dicts and not strings (the #586 regression).** `/wave-scope` historically wrote tier entries as plain short-ref strings (`["main#322", "deploy#363", …]`). The hook only matched dict rows, so every per-issue kickoff comment was silently skipped — this bit both W14 and W15 (zero auto-posted kickoff comments until the W15 orchestrator hand-converted the tiers, commit `3d2387c`). Emitting dict rows here is the source-of-truth fix; the hook additionally degrades gracefully on any residual plain-string entry (synthesizes a placeholder row, posts with `(unassigned)` slots) so the failure mode is a visible-and-backfillable comment, never a silent skip.
+
+When building `WAVE_SCOPE_STRUCTURED`, construct each tier as an array of these dicts. If the implementer/reviewer matrix (§ 12.5) is already validated, fold its names directly into the rows so kickoff has nothing to backfill.
 
 ## Relationship to other wave skills
 


### PR DESCRIPTION
## Summary

Fixes the `/wave-scope` ⇄ `post_wave_kickoff_comment` tier-row shape drift that silently skipped every per-issue kickoff comment in W14 and W15.

`/wave-scope` wrote `wave_{M}_scope.tier_*` entries as plain short-ref strings (`"main#322"`), but the kickoff hook's `find_assignment_row` only matched dict rows keyed by full-repo `id`. Every per-issue comment fell through to `skip_no_row` (annunaki-log-only). The W15 orchestrator hand-converted the tiers (commit 3d2387c) to recover; this is the source-of-truth fix.

## Changes (option 1 + 2 together, per the issue)

**(a) Skill** — `/wave-scope` SKILL.md:
- New § 13.1 documents the canonical assignment-row dict shape `{id, ref, implementer, reviewer, reviewer_2, priority}` the kickoff hook consumes, with the W14/W15 regression context.
- `wave_{M}_scope` table cell now requires `tier_*` arrays to hold dicts, not bare strings.

**(b) Hook** — `find_assignment_row`:
- Pass 1 now also matches a dict row on its `ref` short-form (not just full-name `id`).
- New Pass 3: legacy plain-string short-ref fallback synthesizes a placeholder row `{id, ref}` so `render_kickoff_comment` posts with `(unassigned)` slots instead of silent-skipping. A visible, backfillable comment beats no comment.
- Top-of-file behavior summary updated to match.

## Tests

6 new regression tests covering both shapes:
- dict-row `ref` short-form match
- legacy plain-string fallback (synthesized row)
- plain-string no-match returns None
- dict-row wins over plain-string (real implementer data preferred)
- end-to-end render with `(unassigned)` placeholders

Full kickoff hook suite: **47 passed**. ruff format + lint clean; mypy clean.

## Acceptance (from #586)

- [x] `/wave-scope` emits hook-compatible dict rows (documented as required shape)
- [x] Hook falls back to short-ref string matching instead of silent skip (posts with `(unassigned)` placeholders)
- [x] Hook regression test covering both shapes
- [x] W16 kickoff will post per-issue comments without manual intervention (both source-shape fix + graceful degradation)

Closes #586

🤖 Generated with [Claude Code](https://claude.com/claude-code)
