### PR TITLE
docs(pre-commit): refresh stale actionlint-pin comment after #579 (Refs #578)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,8 +46,9 @@ repos:
   # embedded shellcheck integration runs rather than silently skipping
   # (feedback_actionlint_needs_shellcheck) — CI gets this from ubuntu-latest's
   # preinstalled shellcheck; locally, install shellcheck before committing.
-  # Pinned to v1.7.12 to match what CI's `download-actionlint.bash` (tracking
-  # the latest release off `main`) resolves to.
+  # Pinned to v1.7.12 to match CI's docs.yml actionlint job, which downloads the
+  # v1.7.12 release tarball and verifies its SHA256 before running (#579/#578) —
+  # the same pinned version on both sides, no `main`-tracking installer.
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.12
     hooks:


### PR DESCRIPTION
## Summary

Parent-side slice of #578. The parent docs.yml actionlint installer was already pinned to v1.7.12 + sha256-verify by **PR #579** (merged). This PR cleans up the now-stale comment left behind in `.pre-commit-config.yaml`, which still claimed CI installs actionlint via `download-actionlint.bash` tracking the latest release off `main`.

After #579 that is no longer true — both sides pin v1.7.12 (CI downloads + SHA256-verifies the v1.7.12 tarball; the pre-commit mirror pins `rev: v1.7.12`). The comment now says so. The `rev` pin itself is unchanged.

## Remaining #578 scope (child repos — routed, not in this PR)

The 7 rolled-out child repos' `docs.yml` still use the unpinned `bash <(curl ... download-actionlint.bash)` installer. Per the child-repo implementer rule, the exact pinned-installer patch + per-repo notes have been handed to the team lead for routing to each child repo's own roster. `#578` stays **open** until all 7 land. Collision note: isnad-graph's docs.yml actionlint job is being edited concurrently by PR #944 (ig#939) — the isnad-graph pin should fold into #944 rather than race it.

## Verification
- SHA256 `8aca8db9…a3d8` independently re-verified against upstream `actionlint_1.7.12_checksums.txt` (linux_amd64) — exact match.

Refs #578 #579 #571 #326.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
