### PR TITLE
ci: gate .claude/skills/**/*.py with ruff/mypy/compile/pytest (Refs #326)

### DIFF
--- a/.claude/skills/wave-kickoff/_orchestration/w4-kickoff.py
+++ b/.claude/skills/wave-kickoff/_orchestration/w4-kickoff.py
@@ -339,7 +339,12 @@ def run(cmd, **kw):
     return subprocess.run(cmd, capture_output=True, text=True, **kw)
 
 
-results = {"labeled": [], "label_failed": [], "commented": [], "comment_failed": []}
+results: dict[str, list] = {
+    "labeled": [],
+    "label_failed": [],
+    "commented": [],
+    "comment_failed": [],
+}
 
 for repo, num, assignee, branch, revs, tier, bundled, wave_bs in ISSUES:
     # Step 1: label
@@ -368,7 +373,7 @@ for repo, num, assignee, branch, revs, tier, bundled, wave_bs in ISSUES:
         " (single-reviewer per wave-bootstrap exception)" if wave_bs else ""
     )
     body = f"""Requestor: Nadia.Khoury
-Requestee: {assignee.replace('_', '.').title().replace('Mwangi', 'Mwangi').replace('Khoury', 'Khoury')}
+Requestee: {assignee.replace("_", ".").title().replace("Mwangi", "Mwangi").replace("Khoury", "Khoury")}
 RequestOrReplied: Request
 
 **Wave 4 Kickoff — Phase 3**

--- a/.claude/skills/wave-scope/validate_matrix_names.py
+++ b/.claude/skills/wave-scope/validate_matrix_names.py
@@ -179,7 +179,8 @@ def _print_report_to_stderr(report: dict[str, list[dict[str, object]]]) -> int:
             continue
         print(f"\n  {repo}:", file=sys.stderr)
         for f in bad:
-            suggestions = f.get("suggestions") or []
+            raw_suggestions = f.get("suggestions")
+            suggestions = raw_suggestions if isinstance(raw_suggestions, list) else []
             sug_str = ", ".join(suggestions) if suggestions else "(no close matches)"
             print(
                 f"    - {f['role']}: {f['declared']!r}  →  suggestions: {sug_str}",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,12 @@ jobs:
         with:
           python-version: "3.12"
       - run: pip install ruff
-      - run: ruff check .claude/hooks/ .claude/lib/
+      # .claude/skills/ added per #326: skill helper/test .py (validate_matrix_names.py,
+      # promotion-audit/helpers.py, the per-skill tests/, …) was previously
+      # un-linted, violating criterion #5 ("anything in the tree gets the same
+      # lint/format treatment"). ruff has no module-collision concern, so the
+      # flat tree works directly.
+      - run: ruff check .claude/hooks/ .claude/lib/ .claude/skills/
 
   format:
     name: Ruff format check
@@ -41,7 +46,7 @@ jobs:
         with:
           python-version: "3.12"
       - run: pip install ruff
-      - run: ruff format --check .claude/hooks/ .claude/lib/
+      - run: ruff format --check .claude/hooks/ .claude/lib/ .claude/skills/
 
   typecheck:
     name: Mypy type check
@@ -53,6 +58,23 @@ jobs:
           python-version: "3.12"
       - run: pip install mypy
       - run: mypy .claude/hooks/ .claude/lib/ --ignore-missing-imports --no-error-summary
+      # .claude/skills/ added per #326. mypy is run PER-SKILL-DIRECTORY (not as
+      # one flat tree) because two skills each ship a `tests/__init__.py`, which
+      # a flat `mypy .claude/skills/` rejects with "Duplicate module named
+      # 'tests'". A per-skill loop gives each its own package root. Only skills
+      # that contain .py are type-checked.
+      - name: Mypy — per-skill (avoids duplicate-tests-module collision)
+        run: |
+          status=0
+          for d in .claude/skills/*/; do
+            # Only type-check skills that actually contain .py files.
+            if find "$d" -name '*.py' -print -quit | grep -q .; then
+              echo "::group::mypy $d"
+              mypy "$d" --ignore-missing-imports --no-error-summary || status=1
+              echo "::endgroup::"
+            fi
+          done
+          exit $status
 
   smoke-test:
     name: Smoke test — hooks compile and exit cleanly
@@ -62,9 +84,11 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - name: Verify all hooks and lib files compile
+      - name: Verify all hooks, lib, and skill files compile
+        # .claude/skills/**/*.py added per #326 (recursively — skill .py lives in
+        # nested dirs like wave-kickoff/_orchestration/ and */tests/).
         run: |
-          for f in .claude/hooks/*.py .claude/lib/*.py; do
+          for f in .claude/hooks/*.py .claude/lib/*.py $(find .claude/skills -name '*.py'); do
             python3 -c "import py_compile; py_compile.compile('$f', doraise=True)"
           done
       - name: Verify hooks exit 0 on empty stdin
@@ -86,6 +110,21 @@ jobs:
       - run: pip install pytest
       - name: Run hook and lib tests
         run: pytest .claude/hooks/tests/ .claude/lib/tests/ -q
+      # .claude/skills/*/tests/ added per #326. Run PER-SKILL (each from its own
+      # skill dir as rootdir) because multiple skills ship a top-level `tests`
+      # package, which a single flat `pytest .claude/skills/` rejects with a
+      # collection error ("import file mismatch" / duplicate `tests` basename).
+      - name: Run skill test suites (per-skill rootdir)
+        run: |
+          status=0
+          for t in .claude/skills/*/tests; do
+            [ -d "$t" ] || continue
+            skill_dir=$(dirname "$t")
+            echo "::group::pytest $skill_dir"
+            ( cd "$skill_dir" && pytest tests/ -q ) || status=1
+            echo "::endgroup::"
+          done
+          exit $status
 
   precommit-ci-sync:
     name: Pre-commit ⇄ CI sync-drift gate

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,10 +15,12 @@
 #     the commit loop snappy while still catching everything before it leaves
 #     the machine.
 #
-# Scope: `.claude/hooks/` + `.claude/lib/` — the Python that CI checks (CI runs
-# ruff/mypy on BOTH; the pre_commit_ci_sync gate enforces this mirror). The
-# `.claude/worktrees/` tree is excluded because it holds scratch checkouts of
-# other branches; reformatting them would silently overwrite in-progress work.
+# Scope: `.claude/hooks/` + `.claude/lib/` + `.claude/skills/` — the Python that
+# CI checks (CI runs ruff/mypy/pytest on all three; the pre_commit_ci_sync gate
+# enforces this mirror). `.claude/skills/` was added per #326 (criterion #5 —
+# skill helper/test .py was previously un-gated). The `.claude/worktrees/` tree
+# is excluded because it holds scratch checkouts of other branches; reformatting
+# them would silently overwrite in-progress work.
 #
 # The kind-level mirror (ruff-lint, ruff-format, mypy, pytest present on both
 # sides) is enforced in CI by `.claude/lib/pre_commit_ci_sync.py` — if a future
@@ -30,12 +32,12 @@ repos:
     hooks:
       - id: ruff-format
         name: ruff-format
-        files: ^\.claude/(hooks|lib)/.*\.py$
+        files: ^\.claude/(hooks|lib|skills)/.*\.py$
         exclude: ^\.claude/worktrees/
       - id: ruff
         name: ruff-lint
         args: [--fix]
-        files: ^\.claude/(hooks|lib)/.*\.py$
+        files: ^\.claude/(hooks|lib|skills)/.*\.py$
         exclude: ^\.claude/worktrees/
 
   # actionlint mirrors the `Config — Workflow actionlint` CI job in
@@ -64,13 +66,23 @@ repos:
         entry: python3 -m mypy --ignore-missing-imports --no-error-summary
         language: system
         types: [python]
-        files: ^\.claude/(hooks|lib)/.*\.py$
+        files: ^\.claude/(hooks|lib|skills)/.*\.py$
         exclude: ^\.claude/worktrees/
         pass_filenames: true
         stages: [pre-push]
       - id: pytest
         name: pytest (pre-push)
         entry: env ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/ .claude/lib/tests/ -q
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-push]
+      # Skill test suites are run per-skill (each from its own dir) because
+      # several skills ship a top-level `tests` package that collides under one
+      # flat pytest invocation. Mirrors ci.yml § "Run skill test suites". #326.
+      - id: pytest-skills
+        name: pytest-skills (pre-push)
+        entry: bash -c 'status=0; for t in .claude/skills/*/tests; do [ -d "$t" ] || continue; d=$(dirname "$t"); ( cd "$d" && env ENVIRONMENT=test python3 -m pytest tests/ -q ) || status=1; done; exit $status'
         language: system
         pass_filenames: false
         always_run: true


### PR DESCRIPTION
## Summary

Parent-side fix for the one structural gap the #326 org-wide CI-green audit found: **`.claude/skills/**/*.py` was lint/format/type/test UN-gated.** ci.yml ran ruff/mypy/pytest only over `.claude/hooks/` and `.claude/lib/`, even though the path trigger already listed `.claude/skills/**`. (No child repo has `.claude/skills/*.py` — this gap is parent-only.)

This directly violates criterion #5: "anything in the tree gets the same lint/format/syntax/spell treatment."

## What it does

- **ci.yml**
  - `ruff check` + `ruff format --check`: add `.claude/skills/` (flat — ruff has no module-collision concern).
  - `mypy` + `pytest`: run **per-skill-directory**, because two skills each ship a top-level `tests/__init__.py` that a single flat invocation rejects (`Duplicate module named 'tests'` / pytest collection error). Each skill dir becomes its own package/rootdir.
  - smoke-compile: recurse `find .claude/skills -name '*.py'`.
- **.pre-commit-config.yaml**: ruff/mypy `files` globs extended to `^\.claude/(hooks|lib|skills)/`; new `pytest-skills` pre-push hook (per-skill loop). Header scope comment updated.

## Defects the new gate surfaced (fixed so it lands green)

- ruff-format: `wave-kickoff/_orchestration/w4-kickoff.py` reformatted.
- mypy: `w4-kickoff.py:342` `results` needs annotation (`dict[str, list]`); `validate_matrix_names.py:183` `", ".join(object)` narrowed via `isinstance`.

## Verification

- `python3 .claude/lib/pre_commit_ci_sync.py .` → **OK** (kind-level mirror intact — the gate normalizes to ruff/mypy/pytest kinds, not path scopes).
- `actionlint .github/workflows/ci.yml` → clean (shellcheck on PATH).
- Local simulation of every new loop: per-skill mypy clean, recursive compile clean, per-skill pytest all pass (promotion-audit 67, wave-scope 11, wave-kickoff 8, wave-wrapup 7), flat ruff lint+format clean across hooks+lib+skills.
- Existing hooks+lib suite: **1235 passed**.

## Audit context

The full 8-repo audit table (path-class → coverage matrix, per-repo HEAD-sha CI conclusions) is posted on #326. This PR closes the single parent structural gap; the only other open item is a deploy-side `scripts/*.py` ruff/mypy verify (child-repo, routed to the team lead). `Refs #326` — the end-state criterion stays open until both resolve.

Refs #326

🤖 Generated with [Claude Code](https://claude.com/claude-code)
