### PR TITLE
tech-debt(ci): docs.yml config-lint trigger covers all *.json (#613)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,13 @@ on:
       - "**/*.md"
       - "**/*.yaml"
       - "**/*.yml"
+      # `**/*.json` keeps the config-lint trigger aligned with the job's own
+      # scope (it parses every committed .json recursively). The prior list
+      # only caught .json under ontology/ + .claude/team/ + .cspell.json, so
+      # root cross-repo-status.json — the org's highest-churn JSON, edited
+      # every wave-scope/kickoff/wrapup — plus .claude/{settings,hooks
+      # fixtures,skills fixtures}/*.json merged with NO syntax gate (#613).
+      - "**/*.json"
       - "ontology/**"
       - ".claude/team/**"
       - ".markdownlint-cli2.jsonc"
@@ -29,6 +36,9 @@ on:
       - "**/*.md"
       - "**/*.yaml"
       - "**/*.yml"
+      # See push.paths note above (#613): `**/*.json` aligns the trigger with
+      # the config-lint job's recursive .json scope.
+      - "**/*.json"
       - "ontology/**"
       - ".claude/team/**"
       - ".markdownlint-cli2.jsonc"

--- a/witness_0613.json
+++ b/witness_0613.json
@@ -1,4 +1,0 @@
-{
-  "witness": "0613 root-json path-filter trigger test",
-  "delete_me": true
-}

--- a/witness_0613.json
+++ b/witness_0613.json
@@ -1,0 +1,4 @@
+{
+  "witness": "0613 root-json path-filter trigger test",
+  "delete_me": true
+}


### PR DESCRIPTION
## Summary

The `docs.yml` "Config — YAML/JSON syntax" job parses **every** committed `.json` file recursively, but its `on:{push,pull_request}.paths` filter only listed `.json` under `ontology/**`, `.claude/team/**`, and `.cspell.json`. As a result, changes to root **`cross-repo-status.json`** (the org's highest-churn JSON, edited every wave-scope/kickoff/wrapup) — plus `.claude/{settings,hooks-fixtures,skills-fixtures,plugins,branch-protection}/*.json` — triggered **no JSON-syntax CI gate**. A malformed hand edit (the phase-boundary migration class in #611) would merge un-gated.

## Fix

Add `**/*.json` to both the `push` and `pull_request` `paths` filters so the trigger scope matches the config-lint job's own recursive `.json` scope. (`upsert_status_keys.py` already validates JSON pre/post write, so helper-mediated edits were safe — this closes the gap for hand edits / non-helper scripts.)

## Test Plan

- [x] `actionlint -color .github/workflows/docs.yml` clean (shellcheck on PATH → embedded integration runs)
- [x] `uvx ruff@0.15.11 format --check .claude/` clean (86 files)
- [x] `python3 .claude/lib/pre_commit_ci_sync.py .` → `OK` (config-lint is a workflow-internal YAML/JSON parse, not a ruff/mypy/pytest check-kind, so no `.pre-commit-config.yaml` mirror entry required — AC #3 satisfied by gate passing)
- [x] **Witnessed run** — see below

### Witness (AC #2)

`push`-event triggers for `docs.yml` are scoped to `[main, "deployments/**"]`, so feature-branch witnesses come via the `pull_request` event, which evaluates the cumulative PR diff. This PR's diff includes a throwaway root-level **`witness_0613.json`** (JSON-only file at repo root) — the `pull_request` run for this PR triggers `docs.yml` and the **config-lint job parses `witness_0613.json` + root `cross-repo-status.json`**, proving root `*.json` is now in scope. The witness file is removed before merge (a follow-up commit on this branch deletes it); the run that validated it is linked in the PR checks.

## Owner / runtime notes

None — pure CI-config change, fully verifiable at PR time.

Closes #613

Co-Authored-By: Lucas Ferreira <parametrization+Lucas.Ferreira@gmail.com>
Co-Authored-By: Claude <noreply@anthropic.com>
