### PR TITLE
tech-debt(upsert_status_keys): indent-tolerant update + --remove-key (#595, #611)

### DIFF
--- a/.claude/lib/tests/test_upsert_status_keys.py
+++ b/.claude/lib/tests/test_upsert_status_keys.py
@@ -24,7 +24,10 @@ from pathlib import Path
 # .claude/lib/tests/test_*.py. parent.parent reaches the lib root.
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from upsert_status_keys import upsert_top_level_key  # noqa: E402
+from upsert_status_keys import (  # noqa: E402
+    remove_top_level_key,
+    upsert_top_level_key,
+)
 
 
 class UpsertSinglelineSiblingTests(unittest.TestCase):
@@ -342,6 +345,107 @@ class IsTopLevelPositionTests(unittest.TestCase):
         text = '{\n  "a": "before {b} brace",\n  "real_top": 1\n}\n'
         pos = text.index('"real_top"')
         self.assertTrue(_is_top_level_position(text, pos))
+
+
+class UpsertUpdateExistingScalarTests(unittest.TestCase):
+    """main#595 — UPDATING an existing scalar key must replace in place,
+    not produce a duplicate. The reproducer that aborted the W15 wrapup.
+    """
+
+    def test_update_existing_2_space_scalar(self):
+        text = '{\n  "wave_15_active": true,\n  "other": 1\n}\n'
+        out = upsert_top_level_key(text, "wave_15_active", "false")
+        parsed = json.loads(out)
+        self.assertIs(parsed["wave_15_active"], False)
+        self.assertEqual(parsed["other"], 1)
+        self.assertEqual(out.count('"wave_15_active"'), 1)
+
+    def test_update_existing_1_space_legacy_scalar_no_duplicate(self):
+        """The exact #595 failure: a 1-space-indent legacy key (P3W1 era).
+        Pre-fix, `^(  )` could not match it, so the update fell through to
+        the insert path and emitted a DUPLICATE `current_wave` key — text
+        last-wins kept the OLD value while main()'s parsed dict held the NEW
+        one, triggering the divergence abort."""
+        text = '{\n "current_wave": "wave-15",\n "next_wave": "wave-16"\n}\n'
+        out = upsert_top_level_key(text, "current_wave", '"wave-1"')
+        parsed = json.loads(out)
+        self.assertEqual(parsed["current_wave"], "wave-1")
+        self.assertEqual(out.count('"current_wave"'), 1)
+        # The key's original 1-space indentation is preserved.
+        self.assertIn('\n "current_wave": "wave-1",', out)
+
+    def test_update_existing_compact_object_value(self):
+        """Updating a key whose existing value is a single-line (compact)
+        object — the wave_N_branches shape."""
+        text = '{\n  "wave_1_branches": {"a": 1},\n  "other": 2\n}\n'
+        out = upsert_top_level_key(text, "wave_1_branches", '{"b": 2}')
+        parsed = json.loads(out)
+        self.assertEqual(parsed["wave_1_branches"], {"b": 2})
+        self.assertEqual(parsed["other"], 2)
+        self.assertEqual(out.count('"wave_1_branches"'), 1)
+
+
+class RemoveTopLevelKeyTests(unittest.TestCase):
+    """main#611 — `remove_top_level_key` / `--remove-key` mode for phase-
+    boundary cleanup of bare `wave_{M}_*` keys.
+    """
+
+    def test_remove_single_line_key(self):
+        text = '{\n  "wave_1_active": true,\n  "wave_1_scope": "x",\n  "keep": 1\n}\n'
+        out = remove_top_level_key(text, "wave_1_scope")
+        self.assertEqual(json.loads(out), {"wave_1_active": True, "keep": 1})
+
+    def test_remove_multiline_object_key(self):
+        text = (
+            "{\n"
+            '  "wave_1_scope": {\n'
+            '    "tier_1": [1, 2],\n'
+            '    "tier_2": {"a": 3}\n'
+            "  },\n"
+            '  "keep": 1\n'
+            "}\n"
+        )
+        out = remove_top_level_key(text, "wave_1_scope")
+        self.assertEqual(json.loads(out), {"keep": 1})
+
+    def test_remove_multiline_array_key(self):
+        text = '{\n  "wave_1_scope": [\n    "#1",\n    "#2"\n  ],\n  "keep": 1\n}\n'
+        out = remove_top_level_key(text, "wave_1_scope")
+        self.assertEqual(json.loads(out), {"keep": 1})
+
+    def test_remove_final_single_line_key_strips_preceding_comma(self):
+        """Removing the JSON-final key must strip the now-final preceding
+        entry's trailing comma so the result is valid JSON."""
+        text = '{\n  "keep": 1,\n  "wave_1_scope": "x"\n}\n'
+        out = remove_top_level_key(text, "wave_1_scope")
+        self.assertEqual(json.loads(out), {"keep": 1})
+
+    def test_remove_final_multiline_key_strips_preceding_comma(self):
+        text = '{\n  "keep": 1,\n  "wave_1_scope": {\n    "a": 1\n  }\n}\n'
+        out = remove_top_level_key(text, "wave_1_scope")
+        self.assertEqual(json.loads(out), {"keep": 1})
+
+    def test_remove_1_space_legacy_key(self):
+        """Indent-tolerance: a 1-space legacy key is removable (#595/#611)."""
+        text = '{\n "current_wave": "wave-1",\n "keep": 1\n}\n'
+        out = remove_top_level_key(text, "current_wave")
+        self.assertEqual(json.loads(out), {"keep": 1})
+
+    def test_remove_nonexistent_key_raises(self):
+        with self.assertRaises(KeyError):
+            remove_top_level_key('{\n  "a": 1\n}\n', "nope")
+
+    def test_remove_ignores_nested_key_of_same_name(self):
+        """A nested key sharing the name must NOT be the removal target —
+        the same _is_top_level_position guard as the upsert path."""
+        text = '{\n  "wave_1_scope": {\n  "wave_1_scope": 99\n  },\n  "keep": 1\n}\n'
+        out = remove_top_level_key(text, "wave_1_scope")
+        self.assertEqual(json.loads(out), {"keep": 1})
+
+    def test_remove_sole_key_yields_empty_object(self):
+        text = '{\n  "wave_1_scope": "x"\n}\n'
+        out = remove_top_level_key(text, "wave_1_scope")
+        self.assertEqual(json.loads(out), {})
 
 
 if __name__ == "__main__":

--- a/.claude/lib/upsert_status_keys.py
+++ b/.claude/lib/upsert_status_keys.py
@@ -8,19 +8,45 @@ reformats every compact line to jq's default pretty form, doubling the file
 length and producing a 500+ line cosmetic diff per wave.
 
 This helper does targeted text-level upsert:
-  - If the key exists at top level → replace its line in place.
+  - If the key exists at top level → replace its line in place, preserving the
+    key's existing leading indentation (1-space legacy keys and 2-space keys
+    are both handled — main#595/#611 indent-tolerance fix).
   - If the key does not exist → insert a new compact-inline line right after
     the most-recent wave_{N}_* sibling (or before the closing `}`).
 
+It also supports REMOVING a top-level key (`--remove-key` mode / the
+`remove_top_level_key` function) — needed at phase boundaries where bare
+`wave_{M}_*` keys from a prior phase must be cleared before the new phase
+writes its own (main#611).
+
 Validates JSON before AND after the rewrite so a malformed write is caught.
+
+Phase-boundary key convention (main#611)
+----------------------------------------
+Wave bookkeeping uses BARE `wave_{M}_*` top-level keys (e.g. `wave_1_scope`),
+NOT phase-prefixed ones. A bare `wave_{M}_*` key always belongs to the
+**current** phase. At the first `/wave-scope` of each new phase, the prior
+phase's `wave_{M}_*` keys are REMOVED (their record is preserved in git
+history and the relevant `.claude/team/phases/phase-{N}.md`) before the new
+phase writes its own `wave_{M}_*` keys. This is the "overwrite convention":
+phase-prefixed keys (`p4_wave_1_*`) were considered and rejected because they
+would require a coordinated read-contract change across /wave-kickoff,
+/wave-wrapup, /wave-retro, /wave-scope and the post_wave_kickoff_comment hook.
+Use `--remove-key` for the phase-boundary cleanup so it no longer needs an
+ad-hoc script.
 
 Invocation:
   upsert_status_keys.py <path> <key>=<json-encoded-value> [<key>=<json-encoded-value> ...]
+  upsert_status_keys.py <path> --remove-key <key> [<key> ...]
 
-Example:
+Example (upsert):
   upsert_status_keys.py cross-repo-status.json \
     wave_5_scope_reconciled_at='"2026-05-05T22:31:00Z"' \
     wave_5_scope_reconciliation_note='"manual run"'
+
+Example (phase-boundary cleanup):
+  upsert_status_keys.py cross-repo-status.json --remove-key \
+    wave_1_scope wave_1_wrap_status wave_1_completed_at
 
 Each VALUE must be a self-contained JSON literal (string/number/bool/array/object).
 Strings include their quotes — pass `'"foo"'` from the shell.
@@ -142,11 +168,25 @@ def upsert_top_level_key(text: str, key: str, json_value: str) -> str:
     either invalid JSON or a logical/text divergence aborted by the
     post-write validation.
 
+    Indent-tolerance (main#595/#611): the replace-in-place and sibling-finder
+    regexes accept ANY leading whitespace, not just exactly 2 spaces. The
+    file mixes 1-space legacy keys (P3W1-era, e.g. `current_wave` /
+    `last_completed_wave` near line ~1211) with 2-space newer keys. Pre-fix,
+    the `^(  )` anchor could not match a 1-space key at all, so an UPDATE of
+    an existing 1-space scalar fell through to the insert path and produced a
+    DUPLICATE top-level key — the logical/text divergence that aborted the
+    W15-wrapup write (main#595). The replacement now reuses the matched key's
+    own leading indent so the line's style is preserved.
+
     Falls back to inserting right after the opening `{` line if no sibling
     exists.
     """
-    line_re = re.compile(r'^(  )"' + re.escape(key) + r'":\s.*?,?\s*$', re.MULTILINE)
-    new_line = f'  "{key}": {json_value},'
+    # `[ \t]*` captures the key's own indentation so it is preserved on
+    # replace; the value pattern is greedy to end-of-line so a trailing
+    # comma (or its absence) is captured as part of the line rather than
+    # left dangling — the pre-fix non-greedy `.*?,?\s*$` could under-match
+    # certain value shapes (main#595).
+    line_re = re.compile(r'^([ \t]*)"' + re.escape(key) + r'":[ \t].*$', re.MULTILINE)
     # Replace-in-place: walk every match and pick the first one that's at
     # top-level depth. The pre-#456 code took the first regex match
     # unconditionally; that mis-matched nested keys whose NAME happened to
@@ -155,18 +195,18 @@ def upsert_top_level_key(text: str, key: str, json_value: str) -> str:
     for m in line_re.finditer(text):
         if not _is_top_level_position(text, m.start()):
             continue
-        existing = m.group(0)
-        last_existing = existing.rstrip()
-        if last_existing.endswith(","):
-            replacement = new_line
-        else:
-            replacement = new_line.rstrip(",")
+        indent = m.group(1)
+        existing = m.group(0).rstrip()
+        replacement = f'{indent}"{key}": {json_value}'
+        if existing.endswith(","):
+            replacement += ","
         return text[: m.start()] + replacement + text[m.end() :]
 
+    new_line = f'  "{key}": {json_value},'
     wave_num_match = re.match(r"wave_(\d+)_", key)
     if wave_num_match:
         sibling_re = re.compile(
-            r'^(  )"wave_' + re.escape(wave_num_match.group(1)) + r'_[^"]+":.*$',
+            r'^([ \t]*)"wave_' + re.escape(wave_num_match.group(1)) + r'_[^"]+":.*$',
             re.MULTILINE,
         )
         # Filter to top-level matches only; the pre-#456 code took ALL
@@ -193,12 +233,130 @@ def upsert_top_level_key(text: str, key: str, json_value: str) -> str:
     return text[:insertion_point] + new_line + "\n" + text[insertion_point:]
 
 
+def remove_top_level_key(text: str, key: str) -> str:
+    """Remove the top-level `"<key>": ...` entry from `text` entirely.
+
+    Used at phase boundaries to clear a prior phase's bare `wave_{M}_*` keys
+    before the new phase writes its own (main#611). Reuses the same structural
+    primitives as the upsert path:
+      - `_is_top_level_position` rejects a name match that is nested inside a
+        multi-line value, so removing `wave_1_scope` never deletes a nested
+        key that happens to share the name.
+      - `_find_value_end` handles both single-line and multi-line (array /
+        object) values, so a multi-line block is removed in full.
+
+    Indent-tolerant (`[ \t]*`) so 1-space legacy keys and 2-space keys are
+    both removable.
+
+    The whole physical line(s) — from the start of the key's line through its
+    value's terminator and trailing comma plus the newline — is excised, so no
+    blank line or dangling comma is left behind. If the removed entry was the
+    JSON-final key (its value had no trailing comma), the now-final preceding
+    entry's trailing comma is stripped to keep the JSON valid.
+
+    Raises KeyError if no top-level key by that name exists (the caller can
+    decide whether a missing key is fatal — `main` treats it as an error so a
+    typo'd phase-cleanup key surfaces rather than silently no-op'ing).
+    """
+    opener_re = re.compile(r'^([ \t]*)"' + re.escape(key) + r'":[ \t]', re.MULTILINE)
+    for m in opener_re.finditer(text):
+        if not _is_top_level_position(text, m.start()):
+            continue
+        line_start = text.rfind("\n", 0, m.start()) + 1
+        # `_find_value_end` expects the END of the opener LINE (it inspects
+        # the line's last char to decide single- vs multi-line); m.end() is
+        # only just past the `": "`. Advance to the line's newline first.
+        line_end = text.find("\n", m.end())
+        if line_end == -1:
+            line_end = len(text)
+        value_end = _find_value_end(text, line_end)
+        # `_find_value_end` already consumed a trailing comma if present.
+        # Consume the rest of the line (whitespace) and the newline so we
+        # excise whole physical lines, leaving no blank line behind.
+        cut_end = value_end
+        while cut_end < len(text) and text[cut_end] in " \t":
+            cut_end += 1
+        if cut_end < len(text) and text[cut_end] == "\n":
+            cut_end += 1
+        had_trailing_comma = value_end > 0 and text[value_end - 1] == ","
+        new_text = text[:line_start] + text[cut_end:]
+        if not had_trailing_comma:
+            # The removed entry was the JSON-final key; the entry now
+            # immediately before the closing brace must lose its trailing
+            # comma. Find the last `,` before the closing `}` and drop it.
+            close = new_text.rfind("}")
+            comma = new_text.rfind(",", 0, close)
+            if comma != -1 and new_text[comma + 1 : close].strip() == "":
+                new_text = new_text[:comma] + new_text[comma + 1 :]
+        return new_text
+    raise KeyError(f"top-level key {key!r} not found")
+
+
+def _run_remove(path: Path, keys: list[str]) -> int:
+    """Remove each top-level `key` from the file, validating JSON pre/post.
+
+    Mirrors the upsert path's safety contract: parse before, apply all
+    removals text-level, parse after, and confirm the text-level result
+    matches the logical result (the original parsed dict minus the removed
+    keys) before writing. A missing key is a hard error so a typo in a
+    phase-cleanup invocation surfaces instead of silently no-op'ing.
+    """
+    if not keys:
+        print("ERROR: --remove-key requires at least one key", file=sys.stderr)
+        return 2
+
+    text = path.read_text()
+    parsed = json.loads(text)
+
+    for key in keys:
+        if key not in parsed:
+            print(f"ERROR: top-level key {key!r} not found in {path}", file=sys.stderr)
+            return 1
+        try:
+            text = remove_top_level_key(text, key)
+        except (KeyError, ValueError) as exc:
+            print(f"ERROR: could not remove {key!r}: {exc}", file=sys.stderr)
+            return 1
+        del parsed[key]
+
+    try:
+        reparsed = json.loads(text)
+    except json.JSONDecodeError as exc:
+        print(
+            f"ERROR: text-level removal produced invalid JSON: {exc}\n  Offending keys: {keys}",
+            file=sys.stderr,
+        )
+        return 1
+
+    if reparsed != parsed:
+        diverged_keys = sorted(set(reparsed.keys()) ^ set(parsed.keys()))
+        for k in set(reparsed.keys()) & set(parsed.keys()):
+            if reparsed[k] != parsed[k]:
+                diverged_keys.append(k)
+        print(
+            f"ERROR: text-level removal diverged from logical removal; aborting write.\n"
+            f"  Diverged keys: {sorted(set(diverged_keys))}\n"
+            f"  Removed keys (this call): {keys}",
+            file=sys.stderr,
+        )
+        return 1
+
+    path.write_text(text)
+    for key in keys:
+        print(f"  removed: {key}")
+    return 0
+
+
 def main(argv: list[str]) -> int:
     if len(argv) < 3:
         print(__doc__, file=sys.stderr)
         return 2
 
     path = Path(argv[1])
+
+    if argv[2] == "--remove-key":
+        return _run_remove(path, argv[3:])
+
     pairs = []
     for arg in argv[2:]:
         if "=" not in arg:


### PR DESCRIPTION
## Summary

Fixes two related defects in `.claude/lib/upsert_status_keys.py`, both rooted in the helper's 2-space-only indentation assumption. Done as one PR because #611's indent-tolerance acceptance criterion is the same root cause as #595.

### #595 — update-existing-scalar diverges and aborts
The replace-in-place regex anchored on exactly two leading spaces (`^(  )`), so a **1-space legacy key** (P3W1-era, e.g. `current_wave` / `last_completed_wave` near line ~1211) could not be matched. An UPDATE of such a key fell through to the *insert* path and emitted a **duplicate** top-level key; the text-level last-wins value then diverged from `main()`'s logical dict, triggering the divergence abort that blocked the W15 wrapup.

**Fix:** regex now accepts any leading whitespace (`^([ \t]*)`), captures the key's own indent, and reuses it on replacement so the line's style is preserved. The value pattern is also made greedy to end-of-line (the prior non-greedy `.*?,?\s*$` could under-match certain value shapes).

### #611 — phase-boundary `wave_{M}_*` key collision
- **`--remove-key` mode / `remove_top_level_key()`** so prior-phase bare `wave_{M}_*` keys can be cleared at the first `/wave-scope` of a new phase without an ad-hoc script. Reuses `_is_top_level_position` (won't delete a nested key of the same name) and `_find_value_end` (removes multi-line blocks in full), with the same JSON pre/post validation + logical-vs-text divergence guard as the upsert path. Removing the JSON-final key strips the now-final preceding entry's trailing comma; a missing key is a hard error.
- **Documented convention** (module docstring): bare `wave_{M}_*` keys belong to the CURRENT phase; prior-phase keys are removed at each new phase's first `/wave-scope` (record preserved in git history + `phase-{N}.md`). The phase-prefixed-keys alternative (`p4_wave_1_*`) is explicitly considered and rejected — it would require a coordinated read-contract change across `/wave-kickoff`, `/wave-wrapup`, `/wave-retro`, `/wave-scope`, and the `post_wave_kickoff_comment` hook.
- **Indent-tolerance** also applied to the sibling-finder regex.

## Acceptance criteria coverage (#611)
- [x] Phase-boundary convention documented (module docstring)
- [x] `--remove-key` mode added
- [x] Indent-tolerance (helper regexes accept any leading whitespace; fixes 1-space legacy keys)
- [x] Alternative (phase-prefixed keys) considered and explicitly rejected with rationale

## Test Plan
- **12 new test cases** in `test_upsert_status_keys.py`:
  - update existing 2-space scalar, 1-space legacy scalar (no-duplicate, indent-preserved), compact-object value
  - remove single-line / multi-line-object / multi-line-array / JSON-final / 1-space-legacy / sole keys
  - remove nonexistent key raises `KeyError`
  - remove ignores nested key of the same name
- Existing 18 tests retained and passing → 51 lib tests total.
- End-to-end on a copy of the real `cross-repo-status.json`: `current_wave` 1-space update produced **no duplicate** (the #595 repro), and `--remove-key` cleanly removed a multi-line `wave_1_scope` block + a 1-space legacy key.
- Local CI gates green: `ruff@0.15.11 format --check`, `ruff@0.15.11 check`, `mypy`, `pytest .claude/lib/tests/`, and the pre-commit ⇄ CI sync-drift gate.

> Note for reviewers: running `pytest .claude/hooks/tests/` *from inside the worktree path* trips one unrelated `test_ontology_tracker` case because that test's `REPO_ROOT` resolves to a path containing `.worktrees`. It passes from a clean checkout (verified) and on CI. No `.claude/hooks/` files are touched by this PR.

Closes #595
Closes #611

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Aino Virtanen <parametrization+Aino.Virtanen@gmail.com>
Co-Authored-By: Claude <noreply@anthropic.com>
