### PR TITLE
process(wave-planning): per-wave tech-debt intake (+20% of feature/bug scope)

### DIFF
--- a/.claude/skills/plan-phase/SKILL.md
+++ b/.claude/skills/plan-phase/SKILL.md
@@ -123,6 +123,8 @@ Group issues into waves based on:
 - **Parallelism:** maximize concurrent work by grouping independent issues
 - **Repo grouping:** minimize context-switching per agent
 
+**Tech-debt intake per wave (+20%).** For each wave, after the feature/bug/security content is set, allocate **tech-debt-only** issues equal to **20% of that content (rounded up)** — add all available if fewer qualify (a shortfall is healthy, never backfilled with invented work). This is the standing intake policy that `/wave-scope` Step 8.5 enforces per-wave at scope-reconciliation time; surface it here at phase-plan time so the wave tables already reflect the TD allocation. Rationale: a cumulative TD-*ratio* gate whipsaws as the backlog shrinks, so steady *intake* replaces ratio-chasing. See [[feedback_td_intake_20pct_per_wave]] and `/wave-scope` Step 8.5.
+
 Present the proposed structure:
 
 ```

--- a/.claude/skills/wave-scope/SKILL.md
+++ b/.claude/skills/wave-scope/SKILL.md
@@ -258,6 +258,64 @@ For each missing-label item, queue a label-apply for step 10.
 
 If a `MUST_INCLUDES` entry is closed or non-existent, the source memory file is stale — surface to the user with a recommendation to remove or update the memory entry. Do NOT silently drop a must-include.
 
+### 8.5. Tech-debt intake top-up (+20% of feature/bug scope) — MANDATORY every wave
+
+**Standing owner policy (2026-06-09).** A hard cumulative TD-*ratio* gate (phase criterion #6) whipsaws as the backlog shrinks: the denominator collapses faster than real debt does, so a genuinely healthy small backlog can still read "over." Replace ratio-chasing with steady **intake** — every wave deliberately pulls in tech-debt work proportional to its feature/bug load.
+
+After Step 7 has fixed the wave's feature + bug + security content, top it up with **tech-debt-only** issues equal to **20% of that content, rounded up**. If fewer qualifying TD issues exist than the target, add **all** of them — a shortfall here is a *good* signal (debt is genuinely low), never something to backfill with invented work. See [[feedback_td_intake_20pct_per_wave]].
+
+**1. Compute base + target.** Base = in-scope (`$WAVE_LABEL`, post-disposition) issues that are NOT `tech-debt` and NOT `meta-issue` — the feature/bug/security set the owner just decided in Step 7.
+
+```bash
+REPOS=(
+    noorinalabs-main noorinalabs-isnad-graph noorinalabs-user-service
+    noorinalabs-deploy noorinalabs-design-system noorinalabs-landing-page
+    noorinalabs-data-acquisition noorinalabs-isnad-ingest-platform
+)
+BASE=0
+for repo in "${REPOS[@]}"; do
+    n=$(gh issue list --repo "noorinalabs/$repo" --state open --label "$WAVE_LABEL" \
+          --json number,labels \
+          --jq '[.[] | select((.labels|map(.name)|index("tech-debt"))|not)
+                     | select((.labels|map(.name)|index("meta-issue"))|not)] | length' 2>/dev/null || echo 0)
+    BASE=$((BASE + n))
+done
+TARGET=$(( (BASE * 20 + 99) / 100 ))   # ceil(0.20 * BASE)
+echo "feature/bug/security in-scope: $BASE  →  TD intake target: $TARGET"
+```
+
+**2. Build candidate pool** — open, `tech-debt`-labeled, NOT `meta-issue`, and NOT already carrying any `p{P}-wave-*` label (un-scheduled debt), pooled across all repos. Oldest-first so long-lived debt drains first; the owner may reorder.
+
+```bash
+> /tmp/wavescope-{M}-td-pool.txt
+for repo in "${REPOS[@]}"; do
+    gh issue list --repo "noorinalabs/$repo" --state open --label tech-debt \
+        --json number,title,labels,createdAt \
+        --jq '.[] | select((.labels|map(.name)|index("meta-issue"))|not)
+                  | select((.labels|map(.name)|any(startswith("p") and contains("-wave-")))|not)
+                  | "\(.createdAt)\t'"$repo"'#\(.number)\t\(.title)"' \
+        2>/dev/null >> /tmp/wavescope-{M}-td-pool.txt || true
+done
+sort /tmp/wavescope-{M}-td-pool.txt
+POOL=$(wc -l < /tmp/wavescope-{M}-td-pool.txt)
+echo "un-scheduled TD pool: $POOL  |  target: $TARGET"
+```
+
+**3. Select + confirm (owner-judgment gate, same as Step 7).**
+- `POOL <= TARGET` → select **all** pool items. Report: `TD intake: <POOL> of <POOL> available — debt backlog below the 20% target (healthy)`.
+- `POOL > TARGET` → surface the top `TARGET` oldest candidates to the owner for confirmation; the owner may swap in higher-priority debt. Final selection = `TARGET` items.
+
+This is a blocking owner-judgment gate exactly like Step 7 — present, don't auto-apply.
+
+**4. Queue + fold in.** For each selected TD issue:
+- queue a `$WAVE_LABEL` label-apply into the **Step 10** batch (do NOT apply here);
+- add it to the `tier_3_tech_debt` array of `WAVE_SCOPE_STRUCTURED` as an assignment-row dict (§ 13.1), assigning implementer/reviewers from the **owning repo's** roster;
+- add it to project board 2 (`gh project item-add 2 --owner noorinalabs --url <url>`).
+
+Record `td_intake: <selected>/<target>` (and `td_pool: <POOL>`) for the Step 12 summary and Step 13 `wave_{M}_scope`.
+
+**Interaction with phase criterion #6.** This step is the operational mechanism behind the TD goal. The cumulative-ratio reading stays *informational*, but the gate the team actually works to is "did the wave take its 20% intake," not a brittle ratio threshold — which avoids the small-backlog whipsaw the owner flagged. Cross-ref `phase-4.md` § criterion #6.
+
 ### 9. Create next-wave label (`p{P}-wave-{M+1}`) if any defer dispositions
 
 If any disposition in step 7 was `defer-to-w{M+1}`, ensure the label exists in every relevant repo:

--- a/.claude/skills/wave-scope/SKILL.md
+++ b/.claude/skills/wave-scope/SKILL.md
@@ -264,7 +264,7 @@ If a `MUST_INCLUDES` entry is closed or non-existent, the source memory file is 
 
 After Step 7 has fixed the wave's feature + bug + security content, top it up with **tech-debt-only** issues equal to **20% of that content, rounded up**. If fewer qualifying TD issues exist than the target, add **all** of them — a shortfall here is a *good* signal (debt is genuinely low), never something to backfill with invented work. See [[feedback_td_intake_20pct_per_wave]].
 
-**1. Compute base + target.** Base = in-scope (`$WAVE_LABEL`, post-disposition) issues that are NOT `tech-debt` and NOT `meta-issue` — the feature/bug/security set the owner just decided in Step 7.
+**1. Compute base + target.** Base = the post-Step-7 **intended** in-scope set that is NOT `tech-debt` and NOT `meta-issue` — the feature/bug/security items the owner just decided to keep. The query below counts items already carrying `$WAVE_LABEL`; some Step-7 keeps / must-includes / carry-forwards are not labeled until Step 10, so **add those not-yet-labeled non-TD keeps to `BASE`** before computing the target (otherwise the intake target undercounts the real scope).
 
 ```bash
 REPOS=(

--- a/.claude/team/phases/phase-4.md
+++ b/.claude/team/phases/phase-4.md
@@ -28,7 +28,7 @@ Phase 4 is that re-opening. Three tracks:
 | 3 | **Admin surface complete** — user mgmt via user-service, data management panel, pipeline controls | noorinalabs-main#603 |
 | 4 | **Zero carry-forward bugs** — us#65/#73/#74, lp#69 closed | noorinalabs-main#604 |
 | 5 | **Security follow-ups closed** — deploy#386/#384/#244, ig#955 | noorinalabs-main#605 |
-| 6 | **Tech-debt <10% cumulative** — resolves the P3 criterion-9 caveat (first-review gate measured over → owner waiver + re-baseline 2026-06-02; ≤20% hard re-measure at W1 wrapup; <10% by exit, re-baselined methodology; holds 2 consecutive reviews) | noorinalabs-main#606 |
+| 6 | **Tech-debt intake — each wave takes its +20%** — every wave pulls in tech-debt-only issues = `ceil(20% of its feature/bug/security scope)` per `/wave-scope` Step 8.5 (all available if fewer). **Replaces** the brittle cumulative-ratio gate (superseded 2026-06-09, PR #619 / main#618); the pooled TD ratio stays **informational**, no longer a hard threshold | noorinalabs-main#606 |
 | 7 | **P3 retro process changes applied + verified** — all 4 owner-approved changes dispositioned | noorinalabs-main#607 |
 
 ## The Phase-3 criterion-9 caveat (inherited obligation) — RESOLVED 2026-06-02
@@ -40,14 +40,14 @@ re-baselined 23.6%) due to denominator shrinkage from P3 closures, not new debt.
 methodology (`meta-issue`-labeled scaffolding excluded from all TD-ratio measurements) and **waived the kickoff
 block**, on the grounds that W1 "Clean slate" is itself the burn-down remedy. Conditions of the waiver:
 
-- The ≤20% gate (re-baselined) is **re-measured at P4W1 `/wave-wrapup` as a hard block** — no second waiver.
-- Criterion #6 (main#606) inherits the re-baselined methodology for its <10% exit gate.
+- ~~The ≤20% gate (re-baselined) is **re-measured at P4W1 `/wave-wrapup` as a hard block** — no second waiver.~~ **Superseded 2026-06-09 (PR #619 / main#618):** the hard ratio re-measure is replaced by the per-wave **tech-debt intake** model (`/wave-scope` Step 8.5 — +20% of each wave's feature/bug/security scope). `/wave-wrapup` no longer enforces any ratio threshold; the pooled ratio is reported as informational only.
+- Criterion #6 (main#606) now measures **per-wave intake compliance**, not a `<10%` cumulative exit ratio. Rationale: a cumulative ratio whipsaws as the backlog shrinks (denominator collapses faster than real debt) — owner call 2026-06-09.
 
 Full record: `phase-3.md` § Criterion #9 caveat resolution.
 
-### TD-ratio measurement methodology (re-baselined 2026-06-02)
+### TD-ratio measurement methodology (re-baselined 2026-06-02; **informational only as of 2026-06-09**)
 
-All Phase-4 TD-ratio measurements (criterion #6, wave-wrapup gates, phase reviews) use:
+As of 2026-06-09 (PR #619) the pooled TD ratio is **reported, not gated** — the gate is per-wave intake (`/wave-scope` Step 8.5). When reporting it (phase reviews, wrapup summaries), use:
 
 ```
 TD ratio = (open issues labeled tech-debt AND NOT meta-issue)
@@ -76,7 +76,7 @@ Wave themes are confirmed (not re-chosen) at each `/wave-scope`; scope reconcili
 
 ## Phase exit gate
 
-Owner runs `/phase-review 4` and verifies all 7 end-state rows are `Done`, including the criterion-6 tech-debt gate (<10% cumulative, held for 2 consecutive reviews). On confirmation, the next phase is defined via `/plan-phase` before any P5 wave can kick off (per `lifecycle.md` § Phase Lifecycle).
+Owner runs `/phase-review 4` and verifies all 7 end-state rows are `Done`, including criterion-6 — **every wave took its +20% tech-debt intake** (`/wave-scope` Step 8.5); the pooled ratio is reported informationally and should be trending down, but is not a hard threshold. On confirmation, the next phase is defined via `/plan-phase` before any P5 wave can kick off (per `lifecycle.md` § Phase Lifecycle).
 
 ## Process changes in force from P3 retro (applied at phase setup, 2026-06-02)
 

--- a/ontology/checksums.json
+++ b/ontology/checksums.json
@@ -117,9 +117,9 @@
     },
     ".claude/skills/wave-retro/SKILL.md": {
       "last_tracked": "00b40976619ae7eade8ac1ca5ef1aae992a771e6c7695ae39121c3fc2ec07e46",
-      "last_resolved": "7f0eb66cbefbae94a4b9276ae901dbbb217435ab9765500b5d10b79801730e4b",
+      "last_resolved": "00b40976619ae7eade8ac1ca5ef1aae992a771e6c7695ae39121c3fc2ec07e46",
       "tracked_at": "2026-06-02T13:30:31.838248+00:00",
-      "resolved_at": "2026-05-06T01:07:41.670330+00:00"
+      "resolved_at": "2026-06-04T20:50:14.260341+00:00"
     },
     ".claude/skills/wave-wrapup/SKILL.md": {
       "last_resolved": "06ec27bab75ff4a97eb5fdfab7fea91db3178b42119c354de8c31aea3debbad9",
@@ -147,9 +147,9 @@
     },
     ".claude/team/charter/issues.md": {
       "last_tracked": "6b7e6f24cb140b969df2451db832dad5ac4cbaabe517672fd8590549546f6fc8",
-      "last_resolved": "60744ea8009688aa75481b9d908968fe3fc8162c597c04889635dc603140da95",
+      "last_resolved": "6b7e6f24cb140b969df2451db832dad5ac4cbaabe517672fd8590549546f6fc8",
       "tracked_at": "2026-06-02T13:30:25.811795+00:00",
-      "resolved_at": "2026-04-23T23:34:47.340707+00:00"
+      "resolved_at": "2026-06-04T20:50:14.260341+00:00"
     },
     ".claude/team/charter/pull-requests.md": {
       "last_tracked": "df75d7e64166855e0f12591358e64d06a34c2d782db742caf15e857fff86b872",
@@ -669,9 +669,9 @@
     },
     ".claude/team/phases/phase-3.md": {
       "last_tracked": "6ededd8608f01314fbeb5ebaa87a316e1f126ed6696218ba3ac44a2dcf86840c",
-      "last_resolved": "e85f396dfb7f7c418fad4d5f6a53b03ed0fdc9aa5ebe1b6e46c196ad7009b46f",
+      "last_resolved": "6ededd8608f01314fbeb5ebaa87a316e1f126ed6696218ba3ac44a2dcf86840c",
       "tracked_at": "2026-06-02T15:41:32.671236+00:00",
-      "resolved_at": "2026-05-10T18:36:01.378480+00:00"
+      "resolved_at": "2026-06-04T20:50:14.260341+00:00"
     },
     ".claude/skills/phase-review/SKILL.md": {
       "last_tracked": "861091d903f2ece1c784c53846881bc9ea802542b39acbb8033c1f670aa1f6a1",
@@ -1329,15 +1329,39 @@
     },
     ".claude/team/promotion_audit_log/p3-wave-15.md": {
       "last_tracked": "15b3d7cfe3bf0ccef6f1a23f966fa881dcba05b243dd377d2761c9e96523eeda",
-      "last_resolved": "",
+      "last_resolved": "15b3d7cfe3bf0ccef6f1a23f966fa881dcba05b243dd377d2761c9e96523eeda",
       "tracked_at": "2026-06-02T01:54:08.205888+00:00",
-      "resolved_at": ""
+      "resolved_at": "2026-06-04T20:50:14.260341+00:00"
     },
     ".claude/team/phases/phase-4.md": {
       "last_tracked": "0795b5f6761cfbd52e30b8b5d5ddc7dff9fe3da97b81b4433167ce36fb4797f3",
-      "last_resolved": "",
+      "last_resolved": "0795b5f6761cfbd52e30b8b5d5ddc7dff9fe3da97b81b4433167ce36fb4797f3",
       "tracked_at": "2026-06-02T15:42:18.322489+00:00",
-      "resolved_at": ""
+      "resolved_at": "2026-06-04T20:50:14.260341+00:00"
+    },
+    ".claude/scratch/nurul_pr_0403.txt": {
+      "last_tracked": "b65795b7e34e5e691ba73fa43024cbc29a29227acb952872f192bbeeac59594b",
+      "last_resolved": "b65795b7e34e5e691ba73fa43024cbc29a29227acb952872f192bbeeac59594b",
+      "tracked_at": "2026-06-03T00:19:37.217207+00:00",
+      "resolved_at": "2026-06-04T20:50:14.260341+00:00"
+    },
+    ".claude/scratch/nurul_review_409.md": {
+      "last_tracked": "efb3d4d05ad373554f976e96935ecb6d15c34d3bfdf1fc5ff7d98f6a0e52ab95",
+      "last_resolved": "efb3d4d05ad373554f976e96935ecb6d15c34d3bfdf1fc5ff7d98f6a0e52ab95",
+      "tracked_at": "2026-06-03T00:28:51.421832+00:00",
+      "resolved_at": "2026-06-04T20:50:14.260341+00:00"
+    },
+    ".claude/scratch/nurul_msg_0403_fixup.txt": {
+      "last_tracked": "95992e2da1cbcd110dc3361084a2c96361c1b2926cfabbbea0d12f63c785fadd",
+      "last_resolved": "95992e2da1cbcd110dc3361084a2c96361c1b2926cfabbbea0d12f63c785fadd",
+      "tracked_at": "2026-06-03T00:31:12.640468+00:00",
+      "resolved_at": "2026-06-04T20:50:14.260341+00:00"
+    },
+    ".claude/scratch/pr415_current_body.md": {
+      "last_tracked": "5b7a8c9aea09b1bf745af3cead503a89788605da4ec1351097617aab6549ba2f",
+      "last_resolved": "5b7a8c9aea09b1bf745af3cead503a89788605da4ec1351097617aab6549ba2f",
+      "tracked_at": "2026-06-03T00:31:58.859099+00:00",
+      "resolved_at": "2026-06-04T20:50:14.260341+00:00"
     }
   },
   "last_cleanup": {


### PR DESCRIPTION
Implements the owner directive (2026-06-09): replace the brittle cumulative TD-**ratio** gate with steady per-wave tech-debt **intake**.

## What changes
- **`/wave-scope` Step 8.5** (new, MANDATORY every wave) — after Step-7 dispositions set the feature/bug/security scope, top up with tech-debt-only issues = `ceil(0.20 * scope)`. Pool = open `tech-debt`, NOT `meta-issue`, NOT already wave-labeled, oldest-first. Owner select+confirm (same gate shape as Step 7); label-applies fold into the existing Step 10 batch + `tier_3_tech_debt` (assignment-row dicts §13.1) + board; records `td_intake`. If fewer qualify than target, add **all** (a shortfall is healthy — never backfilled).
- **`/plan-phase` Step 6** — surfaces the +20% allocation at phase-plan time so wave tables reflect it.

## Why
A cumulative TD-ratio threshold whipsaws as the backlog shrinks (denominator collapses faster than real debt). Steady *intake* is the robust mechanism behind the TD goal; the ratio reading stays informational. Follow-up: owner to decide whether to formally relax/replace Phase-4 criterion #6's hard `<10%` threshold with the intake model.

Closes #618

## Test plan
Docs/process-only (no code). Verified: `/wave-scope` Step 8.5 inserts cleanly between Steps 8 and 9 (label-applies route through the existing Step 10 batch + Step 11 meta refresh + Step 13 `wave_{M}_scope`); `/plan-phase` Step 6 note cross-refs Step 8.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)