### PR TITLE
process(wave-lifecycle): merge wave→main every wrapup + retain wave branches

### DIFF
--- a/.claude/skills/wave-start/SKILL.md
+++ b/.claude/skills/wave-start/SKILL.md
@@ -27,7 +27,7 @@ Report any worktrees that were pruned. If active worktrees remain, list them and
 ### 2. Determine base branch
 
 - **Wave 1 of a phase:** Base is `main`
-- **Wave N (N > 1):** Base is the previous wave's deployment branch (`deployments/phase-{P}/wave-{M-1}`), or `main` if the previous wave was already merged
+- **Wave N (N > 1):** Base is `main`. Each wave merges to main at its own `/wave-wrapup` (see `/wave-wrapup` Step 11, every-wave merge — changed 2026-06-09), so the previous wave is already integrated. The previous-wave-branch (`deployments/phase-{P}/wave-{M-1}`) is **retained, not deleted**, but it is not the base — it serves only as a safety-net reference if a prior wrapup's merge was somehow skipped (the warning below fires and Step 3 bases off main regardless).
 
 ```bash
 # Check if previous wave branch exists

--- a/.claude/skills/wave-wrapup/SKILL.md
+++ b/.claude/skills/wave-wrapup/SKILL.md
@@ -147,7 +147,7 @@ For each worktree:
 1. Check if it has uncommitted changes (`git -C <path> status --porcelain`)
 2. If clean, remove with `git worktree remove <path>`
 3. If dirty, report to the user — do NOT force-remove without approval
-4. Delete the remote tracking branch if the PR was merged: `git push origin --delete <branch>`
+4. Delete the remote tracking branch if the PR was merged: `git push origin --delete <branch>` — **feature/worktree branches only; NEVER delete a `deployments/phase-*/wave-*` branch** (wave branches are retained permanently per owner directive 2026-06-09 — see Step 11).
 
 Report what was cleaned:
 ```
@@ -366,9 +366,9 @@ Optionally also write a richer `wave_{M}_summary` block with wave-shape detail (
 
 If a key cannot be computed (e.g., no PRs merged this wave), write the literal `0` — `/wave-retro` Step 2.5 distinguishes "0 cycles" from "key missing" and only the latter is treated as drift.
 
-### 11. Merge to main per repo (final wave only)
+### 11. Merge to main per repo (every wave)
 
-If this is the final wave of the phase, every repo in `wave_{M}_repos_in_scope` has its OWN `deployments/phase-{P}/wave-{M}` branch (created by `/wave-kickoff` step 1) that needs its own PR to main. This is the symmetric counterpart of the multi-repo branch creation gap (main#238).
+**Every wave's wrapup merges its wave branch to main** (changed 2026-06-09 — owner directive; previously gated to the final wave only). Each repo in `wave_{M}_repos_in_scope` has its OWN `deployments/phase-{P}/wave-{M}` branch (created by `/wave-kickoff` step 1) that needs its own PR to main. This is the symmetric counterpart of the multi-repo branch creation gap (main#238). Merging each wave keeps `main` continuously current: the next wave bases off main (`/wave-start` Step 2/3), so an unmerged wave would strand its work the moment the following wave starts.
 
 ```bash
 REPO_ROOT="$(git rev-parse --show-toplevel)"
@@ -397,7 +397,9 @@ Print a per-repo PR summary table (PR# or "no merge needed") and **wait for user
 
 **Do NOT merge to main without user approval.** This is a significant action that affects all downstream repos.
 
-### 11.5. Reachability gate — wave-branch propagation to main (final wave only)
+**Retain the wave branch — do NOT delete it on merge** (owner directive 2026-06-09). Merge each wave→main PR with `gh pr merge <N> --merge` (**never** `--delete-branch`); the `deployments/phase-{P}/wave-{M}` branches are kept permanently as a historical / rollback anchor for every wave. Caveat: if a repo has "Automatically delete head branches" enabled at the repo level, a merge deletes the head branch regardless of the flag — for these repos, either disable that setting or restore the branch immediately after merge (`git push origin <wave-sha>:refs/heads/deployments/phase-{P}/wave-{M}`).
+
+### 11.5. Reachability gate — wave-branch propagation to main (every wave)
 
 After the per-repo wave→main PRs in Step 11 are merged (or declared not-needed), verify each wave-branch is actually reachable from `origin/main`. This is the load-bearing enforcement counterpart to charter `state-claims.md § Sub-rule: merge_commit_sha reachability` — the rule's claim-time discipline becomes a wrapup-time gate.
 


### PR DESCRIPTION
Implements two owner directives (2026-06-09) on the wave-branch model.

## 1. Each wave merges to main at its own `/wave-wrapup` (not final-only)
`/wave-start` Step 3 already bases every wave off `main`, so an unmerged wave strands its work the moment the next wave starts. The skill's "final wave only" guard on Steps 11/11.5 was inconsistent with that flow. (At change time `deployments/phase-4/wave-1` was 21 ahead / 0 behind main, unmerged.)

## 2. Phase/wave branches are retained (never deleted)
Merge wave→main with `gh pr merge --merge` (**never** `--delete-branch`); `deployments/phase-*/wave-*` branches are a permanent historical/rollback anchor. Feature/worktree branches are still deleted normally.

## Changes
- `/wave-wrapup` Step 11 — header → "(every wave)"; rewritten opening; retain-branch paragraph.
- `/wave-wrapup` Step 11.5 — header → "(every wave)".
- `/wave-wrapup` Step 8 — worktree-cleanup branch-delete guarded to never touch `deployments/phase-*/wave-*`.
- `/wave-start` Step 2 — wave N>1 bases off `main`; prior-wave branch retained as a safety-net reference only.

## Notes
`delete_branch_on_merge` verified **false** on all 8 repos — wave branches won't auto-delete on merge (no settings change needed).

Closes #620

## Test plan
Docs/process-only. Verified header/guard edits are internally consistent and cross-reference correctly (Step 11 ⇄ Step 8 ⇄ wave-start Step 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)