### PR TITLE
feat(skills): add /watch-deploy — monitor & bounded-remediate triggered deploys (#623)

### DIFF
--- a/.claude/skills/watch-deploy/SKILL.md
+++ b/.claude/skills/watch-deploy/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: watch-deploy
+description: Monitor (and, within bounds, remediate) a deploy triggered by a merge — staging automatically post-merge, production only after the owner approves the queued deploy. Polls the deploy run to a terminal state, classifies failures, attempts bounded fix-forward, and escalates with a precise diagnosis.
+args: env (stg|prod), optional triggering sha, optional run-id
+---
+
+Watch a deploy that a merge to `main` triggered, confirm it reaches a healthy terminal state, and fix-forward or escalate when it does not. This is the active counterpart to `/wave-wrapup` Step 11.6's passive "latest run is green" check: it follows the *specific* deploy a merge kicked off, rather than inspecting only the most-recent run.
+
+Motivation: deploy#418 — a user-service merge silently broke the staging deploy at the image-pull step and only self-healed because an isnad-graph push happened to follow. Nothing watched the dispatched run or remediated. See also main#623 (this skill's tracking issue) and the P3W14-retro session-start "red default-branch publish" check, which is passive and does not follow a fresh deploy.
+
+> Note: all repo paths in bash blocks below are rooted at `$REPO_ROOT` to avoid cwd drift when the skill is invoked from a worktree or child-repo subdirectory (#149).
+
+## When to use
+
+- **Automatically after a merge that triggers a staging deploy** — any merge to `main` in a fan-in repo (`noorinalabs-isnad-graph`, `noorinalabs-user-service`) fires a `repository_dispatch` to `noorinalabs-deploy/.github/workflows/deploy-stg.yml`. Call `/watch-deploy stg <sha>` to follow it.
+- **From `/wave-wrapup` Step 11.6** — once per wave→main merge in a deploy-triggering repo, so a wave is not declared green until *its* triggered deploys are confirmed healthy (not just the latest run on the board).
+- **For production — only after the owner has approved the queued prod deploy.** Prod deploys wait on a manual approval gate (owner directive 2026-06-09). This skill MUST NOT approve, trigger, or otherwise advance a prod deploy. Once the owner approves, call `/watch-deploy prod <sha>` to monitor the approved run.
+
+## Environment contract
+
+| env | Workflow (in `noorinalabs-deploy`) | Trigger | This skill may act before owner? |
+|-----|------------------------------------|---------|----------------------------------|
+| `stg` | `deploy-stg.yml` | auto — `repository_dispatch` from a service repo's `ghcr-publish.yml` after both images publish | **Yes** — staging is auto-deploy; bounded remediation is allowed |
+| `prod` | `deploy-prod.yml` | `workflow_dispatch` from `promote.yml`, **gated on owner approval** | **No** — never approve/trigger; monitor only after approval, never auto-remediate prod |
+
+## Instructions
+
+### 1. Resolve the run to watch
+
+```bash
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+DEPLOY_REPO="noorinalabs/noorinalabs-deploy"
+ENV="{stg|prod}"                     # first arg
+SHA="{triggering sha or empty}"      # optional second arg
+RUN_ID="{run-id or empty}"           # optional third arg
+
+case "$ENV" in
+  stg)  WORKFLOW="deploy-stg.yml";  RUN_NAME="Deploy to staging" ;;
+  prod) WORKFLOW="deploy-prod.yml"; RUN_NAME="Deploy to production" ;;
+  *) echo "ERROR: env must be stg or prod"; exit 1 ;;
+esac
+```
+
+Find the run. Note two facts that make naive matching wrong:
+
+- A `$WORKFLOW` run's `headSha` is the **deploy repo's** sha, and its `displayTitle` is the **event-type** (`deploy-noorinalabs-<service>`) — neither is the triggering **service** sha. So you cannot filter `gh run list` by the service sha.
+- The service sha lives in the dispatch `client_payload`, which is not exposed by `gh run list`.
+
+Correlate by **time** instead (deploys are serialized — `deploy-stg.yml` uses `concurrency: deploy-staging, cancel-in-progress: false`): the run a merge triggered is the **earliest `$WORKFLOW` run whose `createdAt` is at/after the merge commit's timestamp**.
+
+```bash
+if [ -n "$RUN_ID" ]; then
+  RUN=$(gh run view "$RUN_ID" --repo "$DEPLOY_REPO" --json databaseId,status,conclusion,url,headSha,createdAt)
+elif [ -n "$SHA" ]; then
+  # Resolve the service commit's timestamp. We don't know which fan-in repo the
+  # sha belongs to, so probe them (the sha is unique across repos in practice).
+  MERGE_TS=""
+  for r in noorinalabs-isnad-graph noorinalabs-user-service; do
+    ts=$(gh api "repos/noorinalabs/$r/commits/$SHA" --jq '.commit.committer.date' 2>/dev/null || true)
+    [ -n "$ts" ] && { MERGE_TS="$ts"; SRC_REPO="$r"; break; }
+  done
+  if [ -z "$MERGE_TS" ]; then
+    echo "Could not resolve $SHA in any fan-in repo — falling back to latest $WORKFLOW run."
+    RUN=$(gh run list --repo "$DEPLOY_REPO" --workflow "$WORKFLOW" --limit 1 \
+      --json databaseId,status,conclusion,url,headSha,createdAt --jq '.[0] // empty')
+  else
+    echo "Merge $SHA in $SRC_REPO at $MERGE_TS — selecting earliest $WORKFLOW run at/after that."
+    RUN=$(gh run list --repo "$DEPLOY_REPO" --workflow "$WORKFLOW" --limit 30 \
+      --json databaseId,status,conclusion,url,headSha,createdAt \
+      --jq "[.[] | select(.createdAt >= \"$MERGE_TS\")] | sort_by(.createdAt) | .[0] // empty")
+  fi
+else
+  # No sha — watch the latest run, and say so (not a specific merge's deploy).
+  echo "No sha given — watching the latest $WORKFLOW run."
+  RUN=$(gh run list --repo "$DEPLOY_REPO" --workflow "$WORKFLOW" --limit 1 \
+    --json databaseId,status,conclusion,url,headSha,createdAt --jq '.[0] // empty')
+fi
+[ -z "$RUN" ] && { echo "No $WORKFLOW run found to watch (env=$ENV, sha=${SHA:-none})."; exit 0; }
+RUN_DB=$(echo "$RUN" | jq -r '.databaseId'); RUN_URL=$(echo "$RUN" | jq -r '.url')
+echo "Watching: $RUN_URL"
+```
+
+For **prod**, the `$WORKFLOW` is dispatched by `promote.yml` (a `workflow_dispatch`, not a service-repo push), so the sha-correlation above does not apply — pass the `RUN_ID` of the approved prod run, or omit the sha to watch the latest prod run.
+
+### 2. Production approval guard (prod only — HARD STOP)
+
+For `prod`, before watching, confirm the run is **past** the owner-approval gate. If the run is `waiting`/`action_required` (pending approval), **STOP and report** — do not poll, do not nudge, do not approve. Surface the approval URL and wait for the owner.
+
+```bash
+if [ "$ENV" = "prod" ]; then
+  ST=$(echo "$RUN" | jq -r '.status')
+  if [ "$ST" = "waiting" ] || [ "$ST" = "action_required" ]; then
+    echo "PROD DEPLOY AWAITING OWNER APPROVAL — $RUN_URL"
+    echo "This skill will NOT approve or advance it. Re-invoke /watch-deploy prod once you have approved."
+    exit 0
+  fi
+fi
+```
+
+### 3. Poll to a terminal state
+
+Poll the run until `status == completed` (bounded wait; deploys are minutes, not hours). Prefer `gh run watch` where available; otherwise poll.
+
+```bash
+gh run watch "$RUN_DB" --repo "$DEPLOY_REPO" --exit-status >/dev/null 2>&1 || true
+RUN=$(gh run view "$RUN_DB" --repo "$DEPLOY_REPO" --json status,conclusion,url,databaseId)
+CONCLUSION=$(echo "$RUN" | jq -r '.conclusion')
+echo "Terminal conclusion: $CONCLUSION — $RUN_URL"
+```
+
+If `CONCLUSION == success`: for stg, confirm the post-deploy verifier is also green (the `Verify Deployment` / health-check run). Report success and stop.
+
+### 4. Classify the failure
+
+If `CONCLUSION != success`, pull the failed step log and classify:
+
+```bash
+LOG=$(gh run view "$RUN_DB" --repo "$DEPLOY_REPO" --log-failed 2>/dev/null || true)
+```
+
+| Class | Signal in failed log | Meaning |
+|-------|----------------------|---------|
+| **image-not-found** | `failed to resolve reference`, `: not found`, `manifest unknown`, or a `MISS ` line from the deploy-stg pre-flight | A resolved image tag is absent in GHCR (deploy#418 class) |
+| **health-check** | `health check failed`, `kafka` healthcheck flap | Container came up but a healthcheck did not pass (often the pipeline-only kafka flap — deploy#393 class, non-blocking) |
+| **migrate-gate** | `alembic`, `upgrade head`, advisory-lock contention | Pre-deploy DB migration failed |
+| **infra/ssh** | `ssh`, `connection refused`, `Permission denied`, runner/network error | Transient or host-level infra problem |
+| **other** | none of the above | Unknown — escalate with the raw failing step |
+
+### 5. Remediate (bounded) or escalate
+
+**Staging** — bounded fix-forward is allowed:
+
+| Class | Action |
+|-------|--------|
+| **image-not-found** | Re-dispatch the last-good stg images: `gh workflow run deploy-stg.yml --repo "$DEPLOY_REPO"` (defaults to `stg-latest` for every service). Then re-watch ONCE. If the original was a per-sha deploy whose image never published, also surface the upstream publish run so the real gap is filed. (Post-deploy#418 this class should be caught by the pre-flight with a readable `MISS`; if it still reaches a deploy, that is itself worth a follow-up.) |
+| **health-check** | If it is the known kafka pipeline-only flap (deploy#393 class), note it as non-blocking and do **not** count it as a wave-blocking failure; confirm the app containers (api, user-service) are healthy. Otherwise re-watch ONCE; if still red, escalate. |
+| **migrate-gate** | Do **not** auto-retry migrations. Escalate with the alembic error and the failing revision. |
+| **infra/ssh** | Re-watch / re-dispatch ONCE (likely transient). If it recurs, escalate. |
+| **other** | Escalate with the raw failing step. |
+
+After **one** remediation attempt, re-resolve and re-poll (Steps 1–3) exactly once. Do **not** loop indefinitely — a second failure escalates.
+
+**Production** — NO auto-remediation. On any prod failure: report the class + failing step, and recommend the owner-gated path (`rollback.yml` to the prior `prod-<short>`, or fix-forward + re-promote via `promote.yml`). Never trigger a prod redeploy or rollback yourself.
+
+### 6. Report
+
+```
+**watch-deploy: {env} — {merge sha or "latest"}**
+
+- Run: {url}
+- Terminal: {success | <class> failure}
+- Verifier (stg): {green | red | n/a}
+- Remediation: {none | re-dispatched stg-latest, re-watched → green | escalated}
+- Escalation: {none | <what the owner/operator must do>}
+```
+
+If a real defect surfaced (a publish gap, a recurring health failure, an infra problem), file it per `/file-bug` and link it. Do not silently swallow a failure that self-healed on retry — record it so the underlying flake is tracked.
+
+## What this skill does NOT do
+
+- It never approves, triggers, or advances a **production** deploy — that gate is the owner's. It only monitors after approval.
+- It does not loop more than one remediation attempt — a second failure is an escalation, not another retry.
+- It does not edit code or workflows — fixes to the deploy mechanics themselves are filed as issues (e.g. deploy#418) and go through the normal PR path.
+- It does not roll back production — it recommends `rollback.yml`; the owner runs it.

--- a/.claude/skills/wave-wrapup/SKILL.md
+++ b/.claude/skills/wave-wrapup/SKILL.md
@@ -549,6 +549,22 @@ export STG_PROMOTION_OVERRIDE_RATIONALE="W13 is charter/skill-meta only; no serv
 
 Include the staging-promotion result (`success`/`failure`/`deferred`/`overridden`) and the run URL in the Step 10 final wave report. `/wave-retro` records it in the wave history row alongside PR count and admin overrides.
 
+### 11.6a. Per-merge deploy watch (active — `/watch-deploy`)
+
+The Step 11.6 gate above inspects only the **latest** `deploy-stg.yml` run. That misses the failure mode deploy#418 surfaced: a wave→main merge in one repo triggers a deploy that fails (e.g. a user-service merge that broke the image pull), which is then masked when a later merge's deploy goes green and becomes "latest". To close this, **actively follow the deploy each wave→main merge triggered**, not just the most-recent run.
+
+For each repo in `wave_{M}_repos_in_scope` that participates in the staging fan-in (`noorinalabs-isnad-graph`, `noorinalabs-user-service` — the repos whose `ghcr-publish.yml` dispatches `deploy-stg.yml`), take that repo's Step 11 wave→main merge commit and run:
+
+```
+/watch-deploy stg <merge_sha>
+```
+
+`/watch-deploy` polls that specific dispatched deploy to a terminal state, classifies any failure, attempts a single bounded fix-forward (e.g. re-dispatch `stg-latest`), and escalates with a diagnosis otherwise. A wave is not closeable while any fan-in merge's deploy is red and unremediated — fold any escalation into the Step 11.6 block/override decision above.
+
+Landing-page and meta-only repos do not participate in the stg fan-in (no dispatch), so they have no per-merge deploy to watch — skip them.
+
+**Production counterpart:** prod deploys are gated on owner approval (owner directive 2026-06-09). `/wave-wrapup` must NOT approve or trigger them. When the owner approves a queued prod deploy for this wave's promotion, run `/watch-deploy prod <sha>` to monitor it the same way; `/watch-deploy` never advances or auto-remediates prod.
+
 ### 12. Ontology rebuild
 
 Run `/ontology-rebuild` to process any files that changed during this wave. This ensures the ontology reflects the current state of all repos before the wave closes.

--- a/.claude/team/lifecycle.md
+++ b/.claude/team/lifecycle.md
@@ -95,6 +95,7 @@ flowchart TD
 |-------|--------------|------------------------------|-------------|
 | `/retro` | Active wave (read from `cross-repo-status.json` `current_wave`). | (none) — inline diagnostic output only. No trust-matrix updates, no feedback_log writes. | Mid-wave checkpoint, after an incident, or when the team lead wants a quick pulse without the overhead of `/wave-retro`. |
 | `/promotion-audit [{wave_name}]` | Resolves `current_wave` from `cross-repo-status.json` if not provided. | Two writes: appends to `feedback_log.md` (under current retro if today's date matches, else new section); writes `.claude/team/promotion_audit_log/{wave_name}.md`. May open AUTO-tier PRs (memory→charter, charter→skill) and file DECIDE-tier issues (skill→hook always DECIDE). | Auto-invoked from `/wave-retro` Step 7.5. Standalone run between retros if drift is suspected. |
+| `/watch-deploy {stg\|prod} [sha]` | A merge has triggered (stg) or the owner has approved (prod) a deploy in `noorinalabs-deploy`. | (none persisted) — polls the dispatched deploy run to terminal, classifies failures, attempts one bounded fix-forward on **stg** (e.g. re-dispatch `stg-latest`), escalates otherwise. Never approves/triggers/auto-remediates **prod**. May `/file-bug` a real defect. | After any merge that triggers a staging deploy; auto-invoked from `/wave-wrapup` Step 11.6a per fan-in wave→main merge; for prod, only after owner approval. |
 
 ### End-of-wave
 


### PR DESCRIPTION
## Summary

Adds the `/watch-deploy` step requested after deploy#418: actively **monitor (and within bounds, remediate) a deploy triggered by a merge** — staging automatically post-merge, production only after the owner approves the queued deploy.

Today `/wave-wrapup` Step 11.6 inspects only the **latest** `deploy-stg.yml` run, so a per-merge failure is masked the moment a greener run lands. deploy#418 (a user-service merge that broke the image pull) self-healed only because an isnad-graph push followed.

## What's added

- **`.claude/skills/watch-deploy/SKILL.md`** — resolves the dispatched deploy run for a triggering sha, polls it to a terminal state, classifies failures (`image-not-found` / `health-check` / `migrate-gate` / `infra` / `other`), attempts **one** bounded fix-forward on **staging** (e.g. re-dispatch `stg-latest`), and escalates with a diagnosis otherwise.
  - **Production is monitor-only.** The skill never approves, triggers, or auto-remediates a prod deploy — a HARD STOP guard returns immediately if the prod run is still awaiting owner approval. After approval it monitors identically and, on failure, recommends the owner-gated `rollback.yml` / re-promote path rather than acting.
- **`/wave-wrapup` Step 11.6a** — invokes `/watch-deploy stg <sha>` per fan-in wave→main merge (`isnad-graph`, `user-service`), so a wave is not closeable while a per-merge deploy is red and unremediated. Documents the prod-after-approval counterpart.
- **`lifecycle.md`** — registers `/watch-deploy` in the mid-wave on-demand skills table.

## Design choices

- **One remediation attempt, not a loop** — a second failure escalates (avoids masking a real defect behind infinite retries).
- **Bounded to staging** — staging is auto-deploy, so fix-forward there is safe. Prod stays entirely owner-gated per the 2026-06-09 directive.
- **No code edits** — fixes to deploy mechanics (like deploy#418) go through the normal issue→PR path; this skill only monitors/dispatches.

Closes #623. Companion to the merged deploy-side fix deploy#418 (PR noorinalabs-deploy#419).
