### PR TITLE
feat(P4W2): commit-identity verification gate — landed-author roster check (#627)

### DIFF
--- a/.claude/lib/tests/test_verify_commit_identity.py
+++ b/.claude/lib/tests/test_verify_commit_identity.py
@@ -185,6 +185,133 @@ class AuthorsInRange(unittest.TestCase):
             # Newest first, base excluded (base..head is exclusive of base).
             self.assertEqual(authors, [GH_PRINCIPAL_LOGIN, "Santiago Ferreira"])
 
+    def _make_principal_merge(self, repo: Path) -> str:
+        """Build a repo with a principal-authored MERGE commit in `base..HEAD`.
+
+        Returns the base sha. Layout after this runs:
+          base (Aino) ← advance (Aino) ← MERGE (parametrization, 2 parents)
+                     \\── feat (Santiago) ─────────┘
+        The merge is the GitHub-merge shape: authored by the bare principal,
+        two parents, forced via --no-ff.
+        """
+        self._git(repo, "init", "-q")
+        (repo / "f").write_text("0", encoding="utf-8")
+        self._git(repo, "add", "f")
+        self._git(
+            repo,
+            "-c",
+            "user.name=Aino Virtanen",
+            "-c",
+            "user.email=a@x",
+            "commit",
+            "-q",
+            "-m",
+            "base",
+        )
+        base = subprocess.run(
+            ["git", "-C", str(repo), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+
+        self._git(repo, "checkout", "-q", "-b", "feature")
+        (repo / "g").write_text("1", encoding="utf-8")
+        self._git(repo, "add", "g")
+        self._git(
+            repo,
+            "-c",
+            "user.name=Santiago Ferreira",
+            "-c",
+            "user.email=s@x",
+            "commit",
+            "-q",
+            "-m",
+            "feat content",
+        )
+
+        # Advance the base branch so the merge is a true 2-parent merge.
+        self._git(repo, "checkout", "-q", "-")
+        (repo / "f").write_text("0b", encoding="utf-8")
+        self._git(repo, "add", "f")
+        self._git(
+            repo,
+            "-c",
+            "user.name=Aino Virtanen",
+            "-c",
+            "user.email=a@x",
+            "commit",
+            "-q",
+            "-m",
+            "advance",
+        )
+        self._git(
+            repo,
+            "-c",
+            f"user.name={GH_PRINCIPAL_LOGIN}",
+            "-c",
+            "user.email=p@x",
+            "merge",
+            "--no-ff",
+            "-q",
+            "-m",
+            "Merge pull request",
+            "feature",
+        )
+        return base
+
+    def test_merge_commit_by_principal_excluded_but_nonmerge_caught(self) -> None:
+        """PR #630 regression: a `parametrization`-authored MERGE commit in the
+        range must NOT be flagged (GitHub authors merges as the bare principal
+        by design), while a `parametrization`-authored NON-merge content commit
+        in the same range IS still caught (the deploy#409 evasion)."""
+        with TemporaryDirectory() as td:
+            repo = Path(td)
+            base = self._make_principal_merge(repo)
+
+            # Add a NON-merge content commit authored as the bare principal —
+            # the evasion that MUST still be caught after --no-merges.
+            (repo / "h").write_text("2", encoding="utf-8")
+            self._git(repo, "add", "h")
+            self._git(
+                repo,
+                "-c",
+                f"user.name={GH_PRINCIPAL_LOGIN}",
+                "-c",
+                "user.email=p@x",
+                "commit",
+                "-q",
+                "-m",
+                "sneaky content",
+            )
+
+            authors = authors_in_range(base, "HEAD", repo)
+            # Santiago's content commit is present; the principal appears ONLY
+            # because of the non-merge sneaky commit (the merge is excluded).
+            self.assertIn("Santiago Ferreira", authors)
+            self.assertIn(GH_PRINCIPAL_LOGIN, authors)
+            # check_authors must flag the principal (the sneaky non-merge), proving
+            # --no-merges did not silence the real evasion.
+            unknown = check_authors(authors, {"Aino Virtanen", "Santiago Ferreira"})
+            self.assertEqual(unknown, [GH_PRINCIPAL_LOGIN])
+
+    def test_merge_only_range_by_principal_is_clean(self) -> None:
+        """A range whose ONLY principal-authored commit is a merge yields no
+        principal violation — the core #630 false-positive case in isolation
+        (the exact wave-branch→main shape Santiago reproduced against #622)."""
+        with TemporaryDirectory() as td:
+            repo = Path(td)
+            base = self._make_principal_merge(repo)
+            authors = authors_in_range(base, "HEAD", repo)
+            self.assertNotIn(
+                GH_PRINCIPAL_LOGIN,
+                authors,
+                "a principal-authored MERGE commit must not appear in the author set",
+            )
+            # Only the two real content authors remain (Santiago's feat, the
+            # Aino advance); the merge contributed nothing.
+            self.assertEqual(set(authors), {"Aino Virtanen", "Santiago Ferreira"})
+
 
 class CliExitCodes(unittest.TestCase):
     def _setup_roster(self, td: str) -> Path:

--- a/.claude/lib/tests/test_verify_commit_identity.py
+++ b/.claude/lib/tests/test_verify_commit_identity.py
@@ -1,0 +1,243 @@
+"""Tests for verify_commit_identity — the landed-state commit-author gate (#627).
+
+Verifies:
+  1. Roster-name loading from a parent roster, with child-repo sibling rosters
+     merged in (the cross-repo persona case).
+  2. The two real evasions the gate exists to catch:
+       - bare gh principal `parametrization` as author (deploy#409);
+       - a persona in NEITHER `Kofi Mensah` / `Kofi Mensah-Williams` form
+         (an unknown / typo'd / stale name).
+  3. A valid roster name (incl. the owner `Steven French`) passes.
+  4. `git log base..head` range author extraction over a real temp repo.
+  5. CLI exit codes: 0 clean, 1 violation, 2 load error.
+  6. The real parent roster loads a non-empty name set (smoke).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+# Helper lives at .claude/lib/verify_commit_identity.py; test is at
+# .claude/lib/tests/test_*.py. parent.parent reaches the lib root.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from verify_commit_identity import (  # noqa: E402
+    GH_PRINCIPAL_LOGIN,
+    authors_in_range,
+    check_authors,
+    load_known_names,
+    main,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _write_roster(repo_dir: Path, roster: dict[str, str]) -> None:
+    """Write a .claude/team/roster.json under repo_dir."""
+    roster_path = repo_dir / ".claude" / "team" / "roster.json"
+    roster_path.parent.mkdir(parents=True, exist_ok=True)
+    roster_path.write_text(json.dumps(roster), encoding="utf-8")
+
+
+class LoadKnownNames(unittest.TestCase):
+    def test_parent_roster_names_loaded(self) -> None:
+        with TemporaryDirectory() as td:
+            org = Path(td)
+            main_repo = org / "noorinalabs-main"
+            main_repo.mkdir()
+            _write_roster(main_repo, {"Aino Virtanen": "a@x", "Steven French": "s@x"})
+
+            names = load_known_names(main_repo)
+            self.assertEqual(names, {"Aino Virtanen", "Steven French"})
+
+    def test_child_sibling_rosters_merged(self) -> None:
+        # A persona canonical only in a sibling child repo must be accepted
+        # (charter child_repo_implementer_rule).
+        with TemporaryDirectory() as td:
+            org = Path(td)
+            main_repo = org / "noorinalabs-main"
+            child = org / "noorinalabs-isnad-graph"
+            main_repo.mkdir()
+            child.mkdir()
+            _write_roster(main_repo, {"Aino Virtanen": "a@x"})
+            _write_roster(child, {"Aisling Brennan": "b@x"})
+
+            names = load_known_names(main_repo)
+            self.assertIn("Aino Virtanen", names)
+            self.assertIn("Aisling Brennan", names)
+
+    def test_malformed_child_roster_is_skipped_not_fatal(self) -> None:
+        with TemporaryDirectory() as td:
+            org = Path(td)
+            main_repo = org / "noorinalabs-main"
+            child = org / "noorinalabs-broken"
+            main_repo.mkdir()
+            child.mkdir()
+            _write_roster(main_repo, {"Aino Virtanen": "a@x"})
+            bad = child / ".claude" / "team" / "roster.json"
+            bad.parent.mkdir(parents=True)
+            bad.write_text("{not json", encoding="utf-8")
+
+            names = load_known_names(main_repo)
+            self.assertEqual(names, {"Aino Virtanen"})
+
+
+class CheckAuthors(unittest.TestCase):
+    def setUp(self) -> None:
+        self.known = {"Aino Virtanen", "Steven French", "Kofi Mensah-Williams"}
+
+    def test_valid_roster_name_passes(self) -> None:
+        self.assertEqual(check_authors(["Aino Virtanen"], self.known), [])
+
+    def test_owner_steven_french_passes(self) -> None:
+        # The owner IS a roster name and must pass.
+        self.assertEqual(check_authors(["Steven French"], self.known), [])
+
+    def test_bare_gh_principal_fails_even_if_in_roster(self) -> None:
+        # The bare login is the unattributed-commit signature (deploy#409). It
+        # must fail even if it somehow appears as a roster key.
+        known_with_login = self.known | {GH_PRINCIPAL_LOGIN}
+        self.assertEqual(
+            check_authors([GH_PRINCIPAL_LOGIN], known_with_login),
+            [GH_PRINCIPAL_LOGIN],
+        )
+
+    def test_unknown_persona_fails(self) -> None:
+        # `Kofi Mensah` is NOT in this known set (only the -Williams form is) —
+        # stands in for the cross-repo divergence / typo case.
+        self.assertEqual(check_authors(["Kofi Mensah"], self.known), ["Kofi Mensah"])
+
+    def test_mixed_range_reports_only_offenders(self) -> None:
+        authors = ["Aino Virtanen", GH_PRINCIPAL_LOGIN, "Ghost Persona"]
+        self.assertEqual(
+            check_authors(authors, self.known),
+            [GH_PRINCIPAL_LOGIN, "Ghost Persona"],
+        )
+
+
+class AuthorsInRange(unittest.TestCase):
+    def _git(self, repo: Path, *args: str, **env: str) -> None:
+        subprocess.run(
+            ["git", "-C", str(repo), *args],
+            check=True,
+            capture_output=True,
+            text=True,
+            env={**_BASE_GIT_ENV, **env},
+        )
+
+    def test_range_collects_distinct_authors_newest_first(self) -> None:
+        with TemporaryDirectory() as td:
+            repo = Path(td)
+            self._git(repo, "init", "-q")
+            (repo / "f").write_text("0", encoding="utf-8")
+            self._git(repo, "add", "f")
+            self._git(
+                repo,
+                "-c",
+                "user.name=Aino Virtanen",
+                "-c",
+                "user.email=a@x",
+                "commit",
+                "-q",
+                "-m",
+                "base",
+            )
+            base = subprocess.run(
+                ["git", "-C", str(repo), "rev-parse", "HEAD"],
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout.strip()
+
+            (repo / "f").write_text("1", encoding="utf-8")
+            self._git(repo, "add", "f")
+            self._git(
+                repo,
+                "-c",
+                "user.name=Santiago Ferreira",
+                "-c",
+                "user.email=s@x",
+                "commit",
+                "-q",
+                "-m",
+                "c1",
+            )
+            (repo / "f").write_text("2", encoding="utf-8")
+            self._git(repo, "add", "f")
+            self._git(
+                repo,
+                "-c",
+                f"user.name={GH_PRINCIPAL_LOGIN}",
+                "-c",
+                "user.email=p@x",
+                "commit",
+                "-q",
+                "-m",
+                "c2",
+            )
+
+            authors = authors_in_range(base, "HEAD", repo)
+            # Newest first, base excluded (base..head is exclusive of base).
+            self.assertEqual(authors, [GH_PRINCIPAL_LOGIN, "Santiago Ferreira"])
+
+
+class CliExitCodes(unittest.TestCase):
+    def _setup_roster(self, td: str) -> Path:
+        org = Path(td)
+        main_repo = org / "noorinalabs-main"
+        main_repo.mkdir()
+        _write_roster(main_repo, {"Aino Virtanen": "a@x", "Steven French": "s@x"})
+        return main_repo
+
+    def test_clean_authors_exit_0(self) -> None:
+        with TemporaryDirectory() as td:
+            repo = self._setup_roster(td)
+            rc = main(["--repo-root", str(repo), "--authors", "Aino Virtanen,Steven French"])
+            self.assertEqual(rc, 0)
+
+    def test_violation_exit_1(self) -> None:
+        with TemporaryDirectory() as td:
+            repo = self._setup_roster(td)
+            rc = main(["--repo-root", str(repo), "--authors", f"{GH_PRINCIPAL_LOGIN}"])
+            self.assertEqual(rc, 1)
+
+    def test_empty_authors_exit_0(self) -> None:
+        with TemporaryDirectory() as td:
+            repo = self._setup_roster(td)
+            rc = main(["--repo-root", str(repo), "--authors", ""])
+            self.assertEqual(rc, 0)
+
+    def test_no_roster_exit_2(self) -> None:
+        with TemporaryDirectory() as td:
+            empty = Path(td) / "no-roster"
+            empty.mkdir()
+            rc = main(["--repo-root", str(empty), "--authors", "Aino Virtanen"])
+            self.assertEqual(rc, 2)
+
+
+class RealRosterSmoke(unittest.TestCase):
+    def test_parent_roster_loads_known_personas(self) -> None:
+        names = load_known_names(_REPO_ROOT)
+        self.assertIn("Aino Virtanen", names)
+        self.assertIn("Steven French", names)
+        # The bare gh login is NOT a roster name.
+        self.assertNotIn(GH_PRINCIPAL_LOGIN, names)
+
+
+# git refuses to commit without an identity in some CI images; pin a base env
+# so the per-commit -c flags in tests are the only identity source.
+_BASE_GIT_ENV: dict[str, str] = {
+    "GIT_CONFIG_GLOBAL": "/dev/null",
+    "GIT_CONFIG_SYSTEM": "/dev/null",
+    "PATH": __import__("os").environ.get("PATH", ""),
+    "HOME": __import__("os").environ.get("HOME", ""),
+}
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/lib/verify_commit_identity.py
+++ b/.claude/lib/verify_commit_identity.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""CI gate: verify a wave-PR's commit author names are known roster members.
+
+Why this exists (noorinalabs-main#627, P4W1 retro change #2)
+===========================================================
+The per-commit `-c user.name=`/`-c user.email=` convention is enforced at
+*commit time* by the `validate_commit_identity.py` PreToolUse hook. But that
+hook only sees the literal Bash `git commit` command the agent runs in THIS
+harness. Two real evasions still landed commits whose author is NOT a valid
+roster persona:
+
+  1. deploy#409 — the PR head commit was authored as the bare gh principal
+     `parametrization` (no roster identity). This happens when a commit is
+     created outside the hooked Bash path: a GitHub-side merge/squash, a
+     `gh` API commit, a web-UI edit, or any tooling that doesn't go through
+     `git -c user.name=… commit`. The PreToolUse hook never fired, so an
+     unattributed commit reached the branch.
+  2. `Kofi Mensah` vs `Kofi Mensah-Williams` — a cross-repo persona
+     divergence. The PreToolUse hook accepts BOTH (both are in the parent
+     roster), so it cannot catch "the wrong one of two near-identical names
+     was used in this repo." That is a roster-canonicalization concern, but
+     the *first* line of defence is still "every author name resolves to
+     SOME known roster member" — a typo'd or stale persona that is in
+     NEITHER form fails here.
+
+This module is the *landed-state* gate that closes the gap the commit-time
+hook structurally cannot: it inspects the author name of every commit a PR
+introduces and asserts each is a recognized roster name. It runs in CI on the
+PR, where the actual committed author metadata — not the intended `-c` flag —
+is the ground truth.
+
+What "known roster name" means
+==============================
+The authoritative name set is the union of every `.claude/team/roster.json`
+in the org: the parent (`noorinalabs-main`) roster PLUS each child repo's
+roster, since a cross-repo wave PR may legitimately carry an author who is
+canonical in a sibling repo (charter `child_repo_implementer_rule`). The
+merge is name-keyed; we only assert membership of the *name*, not the
+name→email pairing (the commit-time hook already gates the email pairing for
+hook-path commits, and this gate must accept child-repo personas whose email
+lives only in the child roster).
+
+`parametrization` / `Steven French` handling
+=============================================
+The bare gh principal author shows up as the git author name `parametrization`
+(the GitHub account login) — NOT a roster *name*. `Steven French` (the owner)
+IS a roster name and is allowed. So a commit authored literally as
+`parametrization` fails (that is exactly the deploy#409 evasion), while the
+owner committing as `Steven French` passes.
+
+Input Language
+==============
+CLI:  verify_commit_identity.py --base <ref> --head <ref> [--repo-root <dir>]
+      verify_commit_identity.py --authors "Name A,Name B" [--repo-root <dir>]
+
+`--base`/`--head` resolve the commit range `base..head` via `git log` and
+collect the distinct author names. `--authors` accepts a pre-resolved
+comma-separated list (used by CI when the range is computed by the workflow,
+and by tests). Exactly one of (`--base`+`--head`) or `--authors` is required.
+
+Exit codes (CLI):
+    0 — every author name is a known roster member
+    1 — at least one author name is NOT a known roster member
+    2 — usage / git / roster-load error
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+# The git author name the bare gh principal commits as. It is the GitHub
+# account LOGIN, not a roster persona, so it must never be treated as valid
+# even though `Steven French` (the human owner) is a roster name. Listed
+# explicitly so the failure message can name it as the canonical evasion.
+GH_PRINCIPAL_LOGIN = "parametrization"
+
+
+def _read_roster(roster_path: Path) -> dict[str, str]:
+    """Read one roster.json, returning {} on any failure (fail-open per file).
+
+    A single malformed or unreadable child roster must never crash the gate;
+    it just contributes no names. The parent roster being unreadable is the
+    only fatal case, handled by the caller (an empty name set is treated as a
+    load error, not a pass).
+    """
+    try:
+        data = json.loads(roster_path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def load_known_names(repo_root: Path) -> set[str]:
+    """Collect the union of roster names from the parent + every child repo.
+
+    The parent roster is `<repo_root>/.claude/team/roster.json`. Child repos
+    are sibling directories of `repo_root` (the org layout: all repos cloned
+    side-by-side under one parent `code/` dir) that each carry their own
+    `.claude/team/roster.json`. We scan one level of siblings only — matching
+    the ONE-level walk discipline the commit-time hook uses (#112) — so a
+    nested `code/` tree can't pull in unrelated rosters.
+
+    Returns the set of all known author NAMES (roster keys).
+    """
+    names: set[str] = set()
+
+    parent_roster = repo_root / ".claude" / "team" / "roster.json"
+    names.update(_read_roster(parent_roster).keys())
+
+    # Sibling child repos live next to repo_root. The parent repo .gitignores
+    # the children, so they are plain directories here.
+    siblings_dir = repo_root.parent
+    try:
+        for child in siblings_dir.iterdir():
+            if child == repo_root or not child.is_dir():
+                continue
+            child_roster = child / ".claude" / "team" / "roster.json"
+            if child_roster.is_file():
+                names.update(_read_roster(child_roster).keys())
+    except OSError:
+        # Sibling scan is best-effort; the parent roster is the floor.
+        pass
+
+    return names
+
+
+def authors_in_range(base: str, head: str, repo_root: Path) -> list[str]:
+    """Return the distinct author names of commits in `base..head`.
+
+    Uses `git log base..head --format=%an` so merge commits and every
+    introduced commit are covered — not just the single head commit. This is
+    strictly stronger than the issue's "head-commit" framing: a non-roster
+    author ANYWHERE in the PR's introduced commits is a violation, which
+    catches a mid-stack bad author that a head-only check would miss.
+
+    Order is preserved (newest first) and de-duplicated.
+    """
+    proc = subprocess.run(
+        ["git", "-C", str(repo_root), "log", f"{base}..{head}", "--format=%an"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for line in proc.stdout.splitlines():
+        name = line.strip()
+        if name and name not in seen:
+            seen.add(name)
+            ordered.append(name)
+    return ordered
+
+
+def check_authors(authors: list[str], known_names: set[str]) -> list[str]:
+    """Return the list of author names that are NOT known roster members.
+
+    The bare gh principal login is rejected even if it somehow appeared in a
+    roster, because it is the unattributed-commit signature (#627 case 1); we
+    treat it as never-valid by removing it from the accepted set.
+    """
+    accepted = known_names - {GH_PRINCIPAL_LOGIN}
+    return [a for a in authors if a not in accepted]
+
+
+def _resolve_authors(args: argparse.Namespace, repo_root: Path) -> list[str]:
+    """Resolve the author list from either --authors or the --base/--head range."""
+    if args.authors is not None:
+        return [a.strip() for a in args.authors.split(",") if a.strip()]
+    return authors_in_range(args.base, args.head, repo_root)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", help="base ref of the PR commit range")
+    parser.add_argument("--head", help="head ref of the PR commit range")
+    parser.add_argument(
+        "--authors",
+        help="comma-separated pre-resolved author names (alternative to --base/--head)",
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=".",
+        help="repo root hosting the parent roster.json (default: cwd)",
+    )
+    args = parser.parse_args(argv)
+
+    if args.authors is None and not (args.base and args.head):
+        parser.error("provide either --authors or both --base and --head")
+
+    repo_root = Path(args.repo_root).expanduser().resolve()
+
+    known_names = load_known_names(repo_root)
+    if not known_names:
+        print(
+            f"ERROR: no roster names loaded from {repo_root}/.claude/team/roster.json "
+            "(or it is empty/malformed). Cannot verify commit identity.",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        authors = _resolve_authors(args, repo_root)
+    except subprocess.CalledProcessError as exc:
+        print(
+            f"ERROR: git log failed resolving the commit range: {exc.stderr.strip()}",
+            file=sys.stderr,
+        )
+        return 2
+
+    if not authors:
+        # No introduced commits (e.g. an empty range). Nothing to verify;
+        # a no-op PR is not an identity violation.
+        print("No commits in range to verify; passing.")
+        return 0
+
+    unknown = check_authors(authors, known_names)
+    if unknown:
+        print(
+            "BLOCKED: the following commit author name(s) are NOT recognized roster members:",
+            file=sys.stderr,
+        )
+        for name in unknown:
+            if name == GH_PRINCIPAL_LOGIN:
+                print(
+                    f"  - {name!r}  (bare gh principal — an unattributed commit "
+                    "that bypassed the per-commit `-c user.name=` identity convention; "
+                    "this is the deploy#409 evasion)",
+                    file=sys.stderr,
+                )
+            else:
+                print(
+                    f"  - {name!r}  (not in any parent or child roster.json — a "
+                    "typo'd, stale, or cross-repo-divergent persona)",
+                    file=sys.stderr,
+                )
+        print(
+            "\nEvery commit author in a wave PR must be a known roster name. "
+            "Re-author the offending commit(s) with a roster identity, e.g.:\n"
+            '  git -c user.name="Aino Virtanen" '
+            '-c user.email="parametrization+Aino.Virtanen@gmail.com" commit --amend\n'
+            "See noorinalabs-main#627 for the rationale and the two evasions "
+            "this gate closes.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"All {len(authors)} commit author name(s) are known roster members.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/lib/verify_commit_identity.py
+++ b/.claude/lib/verify_commit_identity.py
@@ -24,8 +24,10 @@ roster persona:
      NEITHER form fails here.
 
 This module is the *landed-state* gate that closes the gap the commit-time
-hook structurally cannot: it inspects the author name of every commit a PR
-introduces and asserts each is a recognized roster name. It runs in CI on the
+hook structurally cannot: it inspects the author name of every non-merge
+content commit a PR introduces and asserts each is a recognized roster name
+(merge commits are excluded — GitHub authors them as the bare principal by
+design; see `authors_in_range`). It runs in CI on the
 PR, where the actual committed author metadata — not the intended `-c` flag —
 is the ground truth.
 
@@ -53,8 +55,9 @@ Input Language
 CLI:  verify_commit_identity.py --base <ref> --head <ref> [--repo-root <dir>]
       verify_commit_identity.py --authors "Name A,Name B" [--repo-root <dir>]
 
-`--base`/`--head` resolve the commit range `base..head` via `git log` and
-collect the distinct author names. `--authors` accepts a pre-resolved
+`--base`/`--head` resolve the commit range `base..head` via `git log
+--no-merges` and collect the distinct non-merge author names. `--authors`
+accepts a pre-resolved
 comma-separated list (used by CI when the range is computed by the workflow,
 and by tests). Exactly one of (`--base`+`--head`) or `--authors` is required.
 
@@ -129,18 +132,33 @@ def load_known_names(repo_root: Path) -> set[str]:
 
 
 def authors_in_range(base: str, head: str, repo_root: Path) -> list[str]:
-    """Return the distinct author names of commits in `base..head`.
+    """Return the distinct author names of the NON-MERGE commits in `base..head`.
 
-    Uses `git log base..head --format=%an` so merge commits and every
-    introduced commit are covered — not just the single head commit. This is
+    Uses `git log --no-merges base..head --format=%an` so every introduced
+    content commit is covered — not just the single head commit. This is
     strictly stronger than the issue's "head-commit" framing: a non-roster
-    author ANYWHERE in the PR's introduced commits is a violation, which
-    catches a mid-stack bad author that a head-only check would miss.
+    author ANYWHERE in the PR's introduced content commits is a violation,
+    which catches a mid-stack bad author that a head-only check would miss.
+
+    Why `--no-merges` (PR #630 review, Santiago Ferreira)
+    ----------------------------------------------------
+    Under this org's merge strategy (`allow_merge_commit: true`), every
+    GitHub-side merge commit is authored by the bare gh principal
+    `parametrization` BY GITHUB'S DESIGN — the merger has no roster identity to
+    stamp. Counting merge commits would false-block every legitimate
+    wave-branch→main PR (the every-wave-merges-to-main flow), every per-issue
+    merge into a wave branch, and any feature PR brought up to date via
+    "Update with merge commit". A merge commit's tree is the only thing GitHub
+    controls; the actual INTRODUCED CONTENT always lives in the non-merge
+    commits, which is exactly where a bad author must be caught. `--no-merges`
+    therefore drops the false positives without reopening the gap — the
+    deploy#409 evasion was a CONTENT (non-merge) head commit authored as
+    `parametrization`, which `--no-merges` still catches.
 
     Order is preserved (newest first) and de-duplicated.
     """
     proc = subprocess.run(
-        ["git", "-C", str(repo_root), "log", f"{base}..{head}", "--format=%an"],
+        ["git", "-C", str(repo_root), "log", "--no-merges", f"{base}..{head}", "--format=%an"],
         capture_output=True,
         text=True,
         check=True,

--- a/.github/workflows/commit-identity.yml
+++ b/.github/workflows/commit-identity.yml
@@ -1,0 +1,40 @@
+name: Commit identity gate
+
+# noorinalabs-main#627 — assert every commit author name a PR introduces is a
+# known roster member. This is the LANDED-STATE counterpart to the
+# `validate_commit_identity.py` PreToolUse hook: the hook gates commit-TIME
+# `-c user.name=` flags it can see in the Bash command, this gate inspects the
+# author metadata of the commits that actually reached the branch. It closes
+# the gap the hook structurally cannot (gh-API / merge / web-UI commits, and
+# the bare `parametrization` principal — the deploy#409 evasion).
+#
+# Deliberately NO `paths:` filter (unlike ci.yml): a PR touching only docs or
+# child-repo-pointer files can still carry a bad-author commit, so identity
+# must be verified on EVERY PR to a protected branch.
+
+on:
+  pull_request:
+    branches: [main, "deployments/**"]
+
+permissions:
+  contents: read
+
+jobs:
+  verify-commit-identity:
+    name: Verify commit authors are roster members
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Need both base and head reachable to enumerate the PR's commit
+          # range with `git log base..head`. fetch-depth: 0 = full history.
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Verify commit author names against the roster
+        run: |
+          python3 .claude/lib/verify_commit_identity.py \
+            --repo-root . \
+            --base "${{ github.event.pull_request.base.sha }}" \
+            --head "${{ github.event.pull_request.head.sha }}"


### PR DESCRIPTION
## What
Adds a **landed-state commit-identity gate** (P4W1 retro change #2, closes #627): a CI job that inspects the author name of every commit a PR introduces and asserts each is a known roster member.

## Why
`validate_commit_identity.py` (PreToolUse hook) enforces `-c user.name=`/`-c user.email=` at *commit time*, but only sees the literal `git commit` Bash command in this harness. Two evasions still landed non-roster authors:

1. **deploy#409** — the PR head commit was authored as the bare gh principal `parametrization` (a gh-API / merge / web-UI commit the hook never saw).
2. **`Kofi Mensah` vs `Kofi Mensah-Williams`** — a cross-repo persona divergence the commit-time hook can't catch because *both* forms are in the roster.

This gate closes the gap the commit-time hook structurally cannot: it checks the actual landed author metadata.

## How
- **`.claude/lib/verify_commit_identity.py`** — gate logic + CLI. Loads the union of the parent roster plus any sibling child rosters (`child_repo_implementer_rule`), enumerates `git log base..head` authors, asserts each is a known name. Bare `parametrization` login is rejected outright; `Steven French` (owner) is valid. Exit 0 (clean) / 1 (violation) / 2 (load/git error).
- **`.github/workflows/commit-identity.yml`** — runs on every PR to `main` / `deployments/**`, with **no `paths:` filter** (a docs-only PR can still carry a bad-author commit). Checks out `fetch-depth: 0` so the base..head range is resolvable.
- **`.claude/lib/tests/test_verify_commit_identity.py`** — 14 tests: parent+child roster merge, malformed-child skip, both evasions, real `git log` range extraction, CLI exit codes, real-parent-roster smoke.

## Verification
- `pytest .claude/lib/tests/test_verify_commit_identity.py` → 14 passed.
- Full `pytest .claude/hooks/tests/ .claude/lib/tests/` → 1312 passed (1 unrelated failure is a worktree-path artifact of `test_ontology_tracker` only when run nested under `.claude/worktrees/`; passes in a clean checkout and in CI).
- `ruff format --check` / `ruff check` / `mypy` clean; pre-commit + pre-push hooks passed; actionlint validated the new workflow.
- E2E against the real roster: `--authors parametrization` → exit 1; `--authors "Kofi Mensa"` → exit 1; `--authors "Aino Virtanen,Steven French"` → exit 0.

## Reviewers
@ Santiago Ferreira + @ Wanjiku Mwangi (2 Approved verdicts required).

Closes #627

🤖 Generated with [Claude Code](https://claude.com/claude-code)
