### PR TITLE
tech-debt(ci): commit-identity gate covers child-repo personas (#634)

### DIFF
--- a/.claude/lib/roster_union_sync.py
+++ b/.claude/lib/roster_union_sync.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Sync-drift gate: the committed parent roster must cover every child persona.
+
+Why this exists (noorinalabs-main#634)
+======================================
+The commit-identity gate (`verify_commit_identity.py`) resolves "known roster
+names" from the COMMITTED parent roster `.claude/team/roster.json`, which is
+maintained as the org-wide UNION manifest (parent team + every child-repo
+persona). That manifest is the only thing CI can see — the commit-identity
+workflow does a single-repo checkout of `noorinalabs-main`, so sibling child
+repos are NOT present (the original bug: a live filesystem scan of sibling
+rosters was inert in CI, #634).
+
+A hand-maintained union manifest rots: when a child repo onboards a persona,
+nobody is forced to fold that name into the parent roster, and a future
+child-persona-authored PR to `main` would be FALSE-BLOCKED by the
+commit-identity gate. This module is the drift GATE that keeps the manifest
+honest: it fetches each child repo's `roster.json` via the GitHub API and
+asserts the committed parent roster is a SUPERSET of the child union, naming
+any persona the parent is missing.
+
+It is the roster analogue of `pre_commit_ci_sync.py` — a committed
+cross-repo-derived artifact paired with a sync-drift gate that detects when the
+artifact has fallen behind its sources.
+
+Non-blocking by design (continue-on-error)
+==========================================
+Per the org pattern for CI checks over cross-repo-derived artifacts (a single
+`noorinalabs-main` PR cannot deterministically reconcile a name that a SIBLING
+repo just added, and the GitHub-API fetch is non-hermetic), the CI job that
+runs this script is `continue-on-error: true`. A drift finding surfaces as a
+red ADVISORY check naming the missing personas to fold into the parent roster;
+it does not hard-block the PR. See charter `org_wide_artifact_gate_non_blocking`
+(deploy#363/PR396) and `cross_repo_ghcr_registry_auth_proof`.
+
+Fetch is fail-open per child repo: a child with no `roster.json` (e.g. a repo
+that keeps only a `roster/` directory of per-member files), a private repo the
+CI token cannot read, or a transient API error contributes no names and is
+reported as SKIPPED — never a drift failure on its own. Drift is only ever
+asserted on names we positively observed in a child roster.
+
+Input Language
+==============
+CLI:  roster_union_sync.py [--repo-root <dir>] [--repos a,b,c] [--owner <org>]
+
+`--repos` overrides the default child-repo list (used by tests to avoid the
+network). `--owner` defaults to `noorinalabs`.
+
+Exit codes (CLI):
+    0 — no drift (parent roster covers every observed child persona), or every
+        child fetch was skipped (nothing positively observed to compare against)
+    1 — drift: at least one observed child persona is missing from the parent
+    2 — usage / parent-roster load error
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+# The org's child repos that publish an aggregated `.claude/team/roster.json`.
+# Mirrors the repo map in CLAUDE.md. `noorinalabs-deploy` is intentionally
+# absent: it keeps only a per-member `roster/` directory (no aggregated
+# roster.json), so there is nothing to fetch — its personas are folded into the
+# parent roster directly. A child not listed here is simply not cross-checked;
+# add it when it grows an aggregated roster.json.
+DEFAULT_CHILD_REPOS: tuple[str, ...] = (
+    "noorinalabs-isnad-graph",
+    "noorinalabs-user-service",
+    "noorinalabs-design-system",
+    "noorinalabs-data-acquisition",
+    "noorinalabs-isnad-ingest-platform",
+    "noorinalabs-landing-page",
+)
+
+ROSTER_PATH_IN_REPO = ".claude/team/roster.json"
+
+
+def parent_roster_names(repo_root: Path) -> set[str]:
+    """Names in the committed parent roster — the union manifest under test."""
+    roster = repo_root / ".claude" / "team" / "roster.json"
+    try:
+        data = json.loads(roster.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return set()
+    return set(data.keys()) if isinstance(data, dict) else set()
+
+
+def fetch_child_roster(owner: str, repo: str) -> dict[str, str] | None:
+    """Fetch a child repo's roster.json via `gh api`, or None if unavailable.
+
+    Returns the parsed name→email mapping, or None when the file does not exist,
+    the repo is unreadable by the CI token, or the response cannot be parsed
+    (fail-open — the caller treats None as SKIPPED, never as drift).
+    """
+    try:
+        proc = subprocess.run(
+            [
+                "gh",
+                "api",
+                f"repos/{owner}/{repo}/contents/{ROSTER_PATH_IN_REPO}",
+                "--jq",
+                ".content",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+    raw = proc.stdout.strip()
+    if not raw:
+        return None
+    try:
+        decoded = base64.b64decode(raw).decode("utf-8")
+        data = json.loads(decoded)
+    except (ValueError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def compute_drift(
+    parent_names: set[str], child_rosters: dict[str, dict[str, str]]
+) -> dict[str, list[str]]:
+    """Return {missing_name: [child repos that have it]} for names absent from parent.
+
+    Pure: the network/IO lives in fetch_child_roster, so this is fully testable
+    with injected rosters. A name present in several child repos lists them all.
+    """
+    missing: dict[str, list[str]] = {}
+    for repo, roster in child_rosters.items():
+        for name in roster:
+            if name not in parent_names:
+                missing.setdefault(name, []).append(repo)
+    return {name: sorted(repos) for name, repos in sorted(missing.items())}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", default=".", help="repo root hosting the parent roster.json")
+    parser.add_argument(
+        "--owner", default="noorinalabs", help="GitHub org/owner of the child repos"
+    )
+    parser.add_argument(
+        "--repos",
+        help="comma-separated child repo list (default: the org's child repos)",
+    )
+    args = parser.parse_args(argv)
+
+    repo_root = Path(args.repo_root).expanduser().resolve()
+    parent_names = parent_roster_names(repo_root)
+    if not parent_names:
+        print(
+            f"ERROR: no parent roster names loaded from {repo_root}/{ROSTER_PATH_IN_REPO}.",
+            file=sys.stderr,
+        )
+        return 2
+
+    repos = (
+        [r.strip() for r in args.repos.split(",") if r.strip()]
+        if args.repos
+        else list(DEFAULT_CHILD_REPOS)
+    )
+
+    child_rosters: dict[str, dict[str, str]] = {}
+    skipped: list[str] = []
+    for repo in repos:
+        roster = fetch_child_roster(args.owner, repo)
+        if roster is None:
+            skipped.append(repo)
+            print(f"SKIPPED {repo}: no readable {ROSTER_PATH_IN_REPO} (fail-open).")
+        else:
+            child_rosters[repo] = roster
+            print(f"OK      {repo}: {len(roster)} persona(s).")
+
+    drift = compute_drift(parent_names, child_rosters)
+    if drift:
+        print(
+            "\nDRIFT: the committed parent roster .claude/team/roster.json is MISSING "
+            "child-repo persona(s) below. Fold each into the parent roster so the "
+            "commit-identity gate (verify_commit_identity.py) recognizes them on a "
+            "cross-repo main PR (#634):",
+            file=sys.stderr,
+        )
+        for name, owners in drift.items():
+            print(f'  - "{name}"  (canonical in: {", ".join(owners)})', file=sys.stderr)
+        return 1
+
+    observed = sum(len(r) for r in child_rosters.values())
+    if not child_rosters:
+        print(
+            f"\nNo child roster could be read ({len(skipped)} skipped); "
+            "nothing to cross-check. Passing (advisory)."
+        )
+        return 0
+    print(
+        f"\nParent roster covers all {observed} observed child persona(s) "
+        f"across {len(child_rosters)} repo(s). No drift."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/lib/tests/test_roster_union_sync.py
+++ b/.claude/lib/tests/test_roster_union_sync.py
@@ -1,0 +1,121 @@
+"""Tests for roster_union_sync — the parent-roster ⊇ child-union drift gate (#634).
+
+Verifies:
+  1. The pure drift computation: a child persona absent from the parent roster
+     is reported (with the child repos that carry it); a covered union is clean.
+  2. parent_roster_names reads the committed parent roster keys.
+  3. CLI wiring with an injected (monkeypatched) fetcher so tests never touch
+     the network: clean union → exit 0, drift → exit 1, all-skipped → exit 0,
+     missing parent roster → exit 2.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import roster_union_sync  # noqa: E402
+from roster_union_sync import (  # noqa: E402
+    compute_drift,
+    main,
+    parent_roster_names,
+)
+
+
+def _write_parent_roster(repo_root: Path, roster: dict[str, str]) -> None:
+    path = repo_root / ".claude" / "team" / "roster.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(roster), encoding="utf-8")
+
+
+class ComputeDrift(unittest.TestCase):
+    def test_covered_union_has_no_drift(self) -> None:
+        parent = {"Aino Virtanen", "Imelda Santos"}
+        children = {"noorinalabs-isnad-ingest-platform": {"Imelda Santos": "i@x"}}
+        self.assertEqual(compute_drift(parent, children), {})
+
+    def test_missing_persona_is_reported_with_owning_repos(self) -> None:
+        parent = {"Aino Virtanen"}
+        children = {
+            "noorinalabs-isnad-ingest-platform": {"Imelda Santos": "i@x"},
+            "noorinalabs-user-service": {"Imelda Santos": "i@x", "Aino Virtanen": "a@x"},
+        }
+        drift = compute_drift(parent, children)
+        # Imelda is missing and appears in BOTH child repos (sorted); Aino is
+        # covered by the parent so it is not reported.
+        self.assertEqual(
+            drift,
+            {"Imelda Santos": ["noorinalabs-isnad-ingest-platform", "noorinalabs-user-service"]},
+        )
+
+    def test_empty_children_no_drift(self) -> None:
+        self.assertEqual(compute_drift({"Aino Virtanen"}, {}), {})
+
+
+class ParentRosterNames(unittest.TestCase):
+    def test_reads_committed_parent_keys(self) -> None:
+        with TemporaryDirectory() as td:
+            repo = Path(td)
+            _write_parent_roster(repo, {"Aino Virtanen": "a@x", "Imelda Santos": "i@x"})
+            self.assertEqual(parent_roster_names(repo), {"Aino Virtanen", "Imelda Santos"})
+
+    def test_missing_roster_returns_empty(self) -> None:
+        with TemporaryDirectory() as td:
+            self.assertEqual(parent_roster_names(Path(td)), set())
+
+
+class CliWithInjectedFetcher(unittest.TestCase):
+    """Drive main() with fetch_child_roster monkeypatched — no network."""
+
+    def _run(self, parent: dict[str, str], fetched: dict[str, dict | None], repos: str) -> int:
+        with TemporaryDirectory() as td:
+            repo = Path(td)
+            _write_parent_roster(repo, parent)
+            orig = roster_union_sync.fetch_child_roster
+            roster_union_sync.fetch_child_roster = lambda owner, r: fetched.get(r)  # type: ignore[assignment]
+            try:
+                return main(["--repo-root", str(repo), "--repos", repos])
+            finally:
+                roster_union_sync.fetch_child_roster = orig
+
+    def test_clean_union_exit_0(self) -> None:
+        rc = self._run(
+            {"Aino Virtanen": "a@x", "Imelda Santos": "i@x"},
+            {"noorinalabs-isnad-ingest-platform": {"Imelda Santos": "i@x"}},
+            "noorinalabs-isnad-ingest-platform",
+        )
+        self.assertEqual(rc, 0)
+
+    def test_drift_exit_1(self) -> None:
+        rc = self._run(
+            {"Aino Virtanen": "a@x"},
+            {"noorinalabs-isnad-ingest-platform": {"Imelda Santos": "i@x"}},
+            "noorinalabs-isnad-ingest-platform",
+        )
+        self.assertEqual(rc, 1)
+
+    def test_all_children_skipped_exit_0(self) -> None:
+        # Fail-open: every child unreadable (fetch returns None) → nothing to
+        # cross-check → pass (advisory), never a drift failure on its own.
+        rc = self._run(
+            {"Aino Virtanen": "a@x"},
+            {"noorinalabs-deploy": None},
+            "noorinalabs-deploy",
+        )
+        self.assertEqual(rc, 0)
+
+    def test_missing_parent_roster_exit_2(self) -> None:
+        with TemporaryDirectory() as td:
+            empty = Path(td) / "no-roster"
+            empty.mkdir()
+            rc = main(["--repo-root", str(empty), "--repos", "noorinalabs-isnad-graph"])
+            self.assertEqual(rc, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/lib/tests/test_verify_commit_identity.py
+++ b/.claude/lib/tests/test_verify_commit_identity.py
@@ -1,8 +1,10 @@
 """Tests for verify_commit_identity — the landed-state commit-author gate (#627).
 
 Verifies:
-  1. Roster-name loading from a parent roster, with child-repo sibling rosters
-     merged in (the cross-repo persona case).
+  1. Roster-name loading from the COMMITTED parent roster only — the org union
+     manifest. Sibling child-repo rosters are NOT scanned (#634: that scan was
+     inert in CI's single-repo checkout); cross-repo personas are recognized by
+     being folded into the parent roster.
   2. The two real evasions the gate exists to catch:
        - bare gh principal `parametrization` as author (deploy#409);
        - a persona in NEITHER `Kofi Mensah` / `Kofi Mensah-Williams` form
@@ -55,9 +57,12 @@ class LoadKnownNames(unittest.TestCase):
             names = load_known_names(main_repo)
             self.assertEqual(names, {"Aino Virtanen", "Steven French"})
 
-    def test_child_sibling_rosters_merged(self) -> None:
-        # A persona canonical only in a sibling child repo must be accepted
-        # (charter child_repo_implementer_rule).
+    def test_sibling_child_rosters_NOT_scanned(self) -> None:
+        # #634: the gate reads ONLY the committed parent roster (the org union
+        # manifest). A sibling child-repo roster on disk must NOT be merged —
+        # that filesystem scan was inert in CI's single-repo checkout while
+        # passing locally, the divergence that gave false confidence. A child
+        # persona is recognized only by being folded INTO the parent roster.
         with TemporaryDirectory() as td:
             org = Path(td)
             main_repo = org / "noorinalabs-main"
@@ -68,23 +73,32 @@ class LoadKnownNames(unittest.TestCase):
             _write_roster(child, {"Aisling Brennan": "b@x"})
 
             names = load_known_names(main_repo)
-            self.assertIn("Aino Virtanen", names)
-            self.assertIn("Aisling Brennan", names)
+            self.assertEqual(names, {"Aino Virtanen"})
+            self.assertNotIn("Aisling Brennan", names)
 
-    def test_malformed_child_roster_is_skipped_not_fatal(self) -> None:
+    def test_child_persona_folded_into_parent_is_recognized(self) -> None:
+        # The supported path for cross-repo personas: present in the parent
+        # roster (kept honest by roster_union_sync.py).
         with TemporaryDirectory() as td:
             org = Path(td)
             main_repo = org / "noorinalabs-main"
-            child = org / "noorinalabs-broken"
             main_repo.mkdir()
-            child.mkdir()
-            _write_roster(main_repo, {"Aino Virtanen": "a@x"})
-            bad = child / ".claude" / "team" / "roster.json"
-            bad.parent.mkdir(parents=True)
-            bad.write_text("{not json", encoding="utf-8")
+            _write_roster(main_repo, {"Aino Virtanen": "a@x", "Imelda Santos": "i@x"})
 
             names = load_known_names(main_repo)
-            self.assertEqual(names, {"Aino Virtanen"})
+            self.assertIn("Imelda Santos", names)
+
+    def test_malformed_parent_roster_yields_empty_not_fatal(self) -> None:
+        with TemporaryDirectory() as td:
+            org = Path(td)
+            main_repo = org / "noorinalabs-main"
+            roster = main_repo / ".claude" / "team" / "roster.json"
+            roster.parent.mkdir(parents=True)
+            roster.write_text("{not json", encoding="utf-8")
+
+            # An empty set is the caller's load-error signal (CLI exit 2), not a
+            # crash.
+            self.assertEqual(load_known_names(main_repo), set())
 
 
 class CheckAuthors(unittest.TestCase):
@@ -352,6 +366,9 @@ class RealRosterSmoke(unittest.TestCase):
         names = load_known_names(_REPO_ROOT)
         self.assertIn("Aino Virtanen", names)
         self.assertIn("Steven French", names)
+        # A child-repo persona must be folded into the parent union manifest
+        # (#634: ingest-platform's Imelda Santos was previously omitted).
+        self.assertIn("Imelda Santos", names)
         # The bare gh login is NOT a roster name.
         self.assertNotIn(GH_PRINCIPAL_LOGIN, names)
 

--- a/.claude/lib/verify_commit_identity.py
+++ b/.claude/lib/verify_commit_identity.py
@@ -33,14 +33,31 @@ is the ground truth.
 
 What "known roster name" means
 ==============================
-The authoritative name set is the union of every `.claude/team/roster.json`
-in the org: the parent (`noorinalabs-main`) roster PLUS each child repo's
-roster, since a cross-repo wave PR may legitimately carry an author who is
-canonical in a sibling repo (charter `child_repo_implementer_rule`). The
-merge is name-keyed; we only assert membership of the *name*, not the
-name→email pairing (the commit-time hook already gates the email pairing for
-hook-path commits, and this gate must accept child-repo personas whose email
-lives only in the child roster).
+The authoritative name set is the **committed parent roster**
+`<repo_root>/.claude/team/roster.json`, maintained as the org-wide UNION
+manifest: it carries the parent (`noorinalabs-main`) team PLUS every
+child-repo persona, since a cross-repo wave PR may legitimately carry an
+author who is canonical in a sibling repo (charter
+`child_repo_implementer_rule`). We assert membership of the *name* only, not
+the name→email pairing (the commit-time hook already gates the email pairing
+for hook-path commits, and this gate must accept child-repo personas whose
+email canonically lives in the child roster).
+
+Why the committed parent roster — not a live sibling scan (#634)
+----------------------------------------------------------------
+An earlier version merged the parent roster with a filesystem scan of sibling
+child-repo `roster.json` files. That scan is **inert in CI**: the workflow does
+a single-repo checkout of `noorinalabs-main` only, so no sibling directories
+exist and the CI-effective set silently collapsed to the parent roster — while
+passing LOCALLY (where siblings are checked out), a local-vs-CI divergence that
+gave false confidence (#634). The fix makes the committed parent roster the
+single hermetic source of truth, so the gate behaves identically locally and in
+CI. A separate **continue-on-error** sync-drift gate
+(`.claude/lib/roster_union_sync.py`) fetches each child `roster.json` via the
+GitHub API and fails (advisorily) when the committed union has fallen behind a
+child roster — that is the mechanism that keeps this manifest complete over
+time, mirroring the `pre_commit_ci_sync.py` committed-mirror + sync-gate
+pattern.
 
 `parametrization` / `Steven French` handling
 =============================================
@@ -83,12 +100,12 @@ GH_PRINCIPAL_LOGIN = "parametrization"
 
 
 def _read_roster(roster_path: Path) -> dict[str, str]:
-    """Read one roster.json, returning {} on any failure (fail-open per file).
+    """Read one roster.json, returning {} on any failure (fail-open).
 
-    A single malformed or unreadable child roster must never crash the gate;
-    it just contributes no names. The parent roster being unreadable is the
-    only fatal case, handled by the caller (an empty name set is treated as a
-    load error, not a pass).
+    A malformed or unreadable roster must never crash the gate; it just
+    contributes no names. The parent roster yielding an empty set is the only
+    consequential case, handled by the caller (an empty name set is treated as
+    a load error, not a pass).
     """
     try:
         data = json.loads(roster_path.read_text(encoding="utf-8"))
@@ -98,37 +115,21 @@ def _read_roster(roster_path: Path) -> dict[str, str]:
 
 
 def load_known_names(repo_root: Path) -> set[str]:
-    """Collect the union of roster names from the parent + every child repo.
+    """Return the known author NAMES from the committed parent roster.
 
-    The parent roster is `<repo_root>/.claude/team/roster.json`. Child repos
-    are sibling directories of `repo_root` (the org layout: all repos cloned
-    side-by-side under one parent `code/` dir) that each carry their own
-    `.claude/team/roster.json`. We scan one level of siblings only — matching
-    the ONE-level walk discipline the commit-time hook uses (#112) — so a
-    nested `code/` tree can't pull in unrelated rosters.
+    The single hermetic source of truth is `<repo_root>/.claude/team/roster.json`,
+    maintained as the org-wide UNION manifest (parent team + every child-repo
+    persona — see the module docstring). We deliberately do NOT scan sibling
+    child-repo rosters from the filesystem: that scan is inert in CI's
+    single-repo checkout while passing locally, a divergence that gave false
+    confidence (#634). The committed parent roster reads identically in both
+    environments; `roster_union_sync.py` is the continue-on-error gate that
+    keeps it complete as child rosters evolve.
 
     Returns the set of all known author NAMES (roster keys).
     """
-    names: set[str] = set()
-
     parent_roster = repo_root / ".claude" / "team" / "roster.json"
-    names.update(_read_roster(parent_roster).keys())
-
-    # Sibling child repos live next to repo_root. The parent repo .gitignores
-    # the children, so they are plain directories here.
-    siblings_dir = repo_root.parent
-    try:
-        for child in siblings_dir.iterdir():
-            if child == repo_root or not child.is_dir():
-                continue
-            child_roster = child / ".claude" / "team" / "roster.json"
-            if child_roster.is_file():
-                names.update(_read_roster(child_roster).keys())
-    except OSError:
-        # Sibling scan is best-effort; the parent roster is the floor.
-        pass
-
-    return names
+    return set(_read_roster(parent_roster).keys())
 
 
 def authors_in_range(base: str, head: str, repo_root: Path) -> list[str]:

--- a/.claude/team/roster.json
+++ b/.claude/team/roster.json
@@ -70,5 +70,18 @@
   "Priya Nair": "parametrization+Priya.Nair@gmail.com",
   "Sable Nakamura-Whitfield": "parametrization+Sable.Nakamura-Whitfield@gmail.com",
 
+  "Adaeze Okonkwo": "parametrization+Adaeze.Okonkwo@gmail.com",
+  "Bjørn Henriksen": "parametrization+Bjorn.Henriksen@gmail.com",
+  "Camila Restrepo": "parametrization+Camila.Restrepo@gmail.com",
+  "Fatima Bensalah": "parametrization+Fatima.Bensalah@gmail.com",
+  "Imelda Santos": "parametrization+Imelda.Santos@gmail.com",
+  "Kalinda Ranasinghe": "parametrization+Kalinda.Ranasinghe@gmail.com",
+  "Léopold Mbongo": "parametrization+Leopold.Mbongo@gmail.com",
+  "Petra Vidović": "parametrization+Petra.Vidovic@gmail.com",
+  "Sayed Reza": "parametrization+Sayed.Reza@gmail.com",
+  "Tomás Carvalho": "parametrization+Tomas.Carvalho@gmail.com",
+  "Yusuke Inoue": "parametrization+Yusuke.Inoue@gmail.com",
+  "Cédric Novák": "parametrization+Cedric.Novak@gmail.com",
+
   "Annunaki": "parametrization+Annunaki@gmail.com"
 }

--- a/.github/workflows/commit-identity.yml
+++ b/.github/workflows/commit-identity.yml
@@ -38,3 +38,30 @@ jobs:
             --repo-root . \
             --base "${{ github.event.pull_request.base.sha }}" \
             --head "${{ github.event.pull_request.head.sha }}"
+
+  # noorinalabs-main#634 — keep the committed parent roster (the union manifest
+  # the gate above reads) honest as child rosters evolve. The hard gate is
+  # hermetic (parent roster only); THIS job fetches each child repo's roster.json
+  # via the GitHub API and fails if a child persona is missing from the parent.
+  #
+  # continue-on-error: a single noorinalabs-main PR cannot deterministically
+  # reconcile a name a SIBLING repo just added, and the gh-API fetch is
+  # non-hermetic — so this is an ADVISORY drift signal (red check naming the
+  # personas to fold), never a hard PR block. Org pattern for CI checks over
+  # cross-repo-derived artifacts (charter org_wide_artifact_gate_non_blocking,
+  # deploy#363/PR396).
+  roster-union-sync:
+    name: Roster union sync-drift gate (parent ⊇ child personas)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Verify the parent roster covers every child-repo persona (#634)
+        env:
+          # The org's child repos are public, so the default token reads their
+          # contents. Set explicitly so the intent (cross-repo read) is visible.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 .claude/lib/roster_union_sync.py --repo-root .


### PR DESCRIPTION
Closes #634.

## Problem
The commit-identity CI gate (`verify_commit_identity.py` via `commit-identity.yml`, #627/#630) resolved "known roster names" from a **parent roster ∪ live sibling-roster filesystem scan**. But CI does a **single-repo checkout** of `noorinalabs-main`, so the sibling scan is **inert in CI** — the effective name set silently collapses to the parent roster, while passing **locally** (where siblings are checked out). That local-vs-CI divergence gave false confidence: all 11 ingest-platform personas (Imelda Santos, Tomás Carvalho, Bjørn Henriksen, …) — plus landing-page's accented `Cédric Novák` — were omitted from the CI-effective set, so a future child-persona-authored PR to `main` would be **false-blocked**.

## Approach — committed union manifest + continue-on-error sync-drift gate
Chosen because it mirrors the org's existing `pre_commit_ci_sync.py` precedent (committed cross-repo-derived artifact + sync gate) and keeps the **hard** identity gate hermetic (no network, local == CI). Issue option 1 ("fold into the parent roster — one source of truth for CI"), hardened with a drift gate so the manifest can't silently rot.

- **Fold** the 12 missing child personas into the committed `.claude/team/roster.json`, now the single hermetic source of truth (the org **union manifest**).
- **Simplify** `load_known_names` to read **only** the committed parent roster — the gate now behaves identically locally and in CI; the inert sibling scan is removed.
- **Add `roster_union_sync.py`** — fetches each child `roster.json` via `gh api` and fails if the parent union is missing a child persona. Fail-open per repo (`noorinalabs-deploy` has only a `roster/` dir, no `roster.json`; private/unreadable repos are skipped, never a drift on their own).
- **Add the `roster-union-sync` CI job** as **`continue-on-error: true`** — an advisory drift signal (red check naming the personas to fold), never a hard block. A single `noorinalabs-main` PR can't deterministically reconcile a name a sibling repo just added, and the gh-API fetch is non-hermetic — the org pattern for CI checks over cross-repo-derived artifacts (`org_wide_artifact_gate_non_blocking`, deploy#363/PR396).
- Updated tests + docstrings to the parent-only model.

## Diff summary
- `.claude/team/roster.json` — +12 child personas (11 ingest-platform + `Cédric Novák`); 66 → 78 names.
- `.claude/lib/verify_commit_identity.py` — `load_known_names` now parent-roster-only; docstring corrected (the #634 false premise).
- `.claude/lib/roster_union_sync.py` — **new** sync-drift gate.
- `.claude/lib/tests/test_verify_commit_identity.py` — sibling-merge tests replaced with parent-only + boundary tests.
- `.claude/lib/tests/test_roster_union_sync.py` — **new** (pure drift logic + CLI with injected fetcher, no network).
- `.github/workflows/commit-identity.yml` — **new** `roster-union-sync` job (continue-on-error).

## Test Plan
- Live `roster_union_sync.py` (gh-authed): **no drift** — parent covers all 53 child personas across 6 repos.
- `verify_commit_identity.py --authors "Imelda Santos,Bjørn Henriksen"` → exit 0 (was previously omitted in CI); bare `parametrization` still blocked.
- `ruff format --check` / `ruff check` / `mypy` / `actionlint` / `pre_commit_ci_sync.py` — all green.
- `pytest .claude/lib/tests/ .claude/hooks/tests/` — 1339 passed.
- **Runtime (post-merge):** confirm the `roster-union-sync` CI job runs green on this PR (public child repos → default `GITHUB_TOKEN` reads them).

Reviewers: @Nino Kavtaradze (primary), @Wanjiku Mwangi (secondary).
