### PR TITLE
charter(P4W4 retro): apply 2 owner-approved process changes (state-correction discipline + all-assigned-reviewers gate)

### DIFF
--- a/.claude/team/charter/agents.md
+++ b/.claude/team/charter/agents.md
@@ -498,6 +498,35 @@ For every named caveat in the parent audit / charter / kickoff (e.g., `upload-ar
 - Companion to `pull-requests.md § Trust the Artifact, Not the Framing` — same primitive at the PR review layer ("read the diff at HEAD, not the PR-body framing"); this section is the spawn-brief layer ("enumerate the surface at HEAD, not the issue-body framing").
 - Source memories: `feedback_no_head_in_surface_enumeration.md` (how to count), `feedback_pre_spawn_verify_at_origin.md` (where to verify), `feedback_pre_spawn_brief_verified_at_head.md` (per-caveat applicability).
 
+## Orchestrator State-Correction Discipline — One Aligned Instruction, Never a Serial Toggle <!-- promotion-target: none -->
+
+When correcting a spawned agent's course mid-task (close vs keep-open a PR, reopen, change a branch/label disposition), the orchestrator MUST first re-read the agent's **current** state at the artifact, then issue **one** instruction that is internally consistent with that state and requires no further reversal — explicitly voiding any prior contradictory instruction. NEVER issue serial, contradictory course-corrections (close → keep-open → reopen) that cross the agent's in-flight actions.
+
+### Why
+
+This is **architecturally distinct** from § Pre-Spawn State Check + Crossed-Message Race Protocol (which governs the *message-bus* delivery-order race — an implementer receives "do X" after already shipping X). Here the thrash is **orchestrator-self-generated**: the orchestrator emits a stream of contradictory instructions faster than the agent can act on any one, and each new instruction crosses the agent's in-flight response to the previous one. The remedy is not the canonical-ack shape (that resolves the bus race); it is **don't generate the contradictory stream in the first place**.
+
+### How to apply
+
+1. Before sending a course-correction, re-read the agent's current artifact state (`gh pr view`, `gh issue view`, branch state) — per `state-claims.md § Refresh State Before Acting`.
+2. Decide the **single** end-state you want, then send **one** instruction that reaches it from where the agent actually is now — not from where you last remembered it.
+3. Explicitly void priors in that one message: "Disregard my earlier close/reopen messages — current desired end state is X; do only X."
+4. If the agent has actions in flight, wait for them to land and re-read before instructing — do not pipeline corrections.
+
+### Severity if violated
+
+- One contradictory pair, quickly reconciled: **minor** — round-trip noise.
+- A serial toggle stream that crosses multiple in-flight actions (3+ round-trips of churn): **moderate** — wastes the agent's context, risks leaving the artifact in an unintended state, and is hard for the agent to disentangle.
+
+### Origin
+
+P4W4 #1001↔#1003 vehicle thrash (2026-06-12): the orchestrator issued contradictory serial close/keep-open/reopen instructions on #1001 that crossed Ingrid's in-flight actions (~6 round-trips), resolved only by reading the actual current state and issuing one aligned instruction voiding priors. Owner-approved at the P4W4 retro.
+
+### Cross-references
+
+- `state-claims.md § Refresh State Before Acting` — the read-current-state-before-acting primitive this rule builds on (action-class).
+- § Pre-Spawn State Check + Crossed-Message Race Protocol — the *bus-race* sibling (distinct cause; distinct remedy).
+
 <!-- Promoted from memory: feedback_child_repo_implementer_rule.md (P3W5 retro 2026-05-06) -->
 
 ## Child-Repo Implementer Rule + Spawn-Brief Verification (Mandatory) <!-- promotion-target: hook -->

--- a/.claude/team/charter/pull-requests.md
+++ b/.claude/team/charter/pull-requests.md
@@ -69,6 +69,30 @@ Every PR must have **two reviewers** assigned at wave kickoff — a primary and 
 
 The Program Director's execution plan MUST include a review matrix with two named reviewers per expected PR. The orchestrator verifies this before spawning agents.
 
+## All Deliberately-Assigned Reviewers Must Approve Before Merge (Blast-Radius PRs) <!-- promotion-target: none -->
+
+The two-reviewer rule above is a **floor**, not a cap. When a PR has **three or more reviewers deliberately assigned** — typically because it has app-wide blast radius and each reviewer carries a distinct lens (e.g. correctness, build/dependency, security) — the orchestrator MUST NOT merge once the 2-reviewer minimum is met. It waits for **every** deliberately-assigned reviewer to approve (or to be explicitly released by the orchestrator with a recorded reason).
+
+### Why
+
+`validate_pr_review` (the 2-distinct-Approved hook) is satisfied at two approvals — but when a third reviewer was assigned *on purpose* to cover a lens the first two don't, merging at 2/3 ships the PR without the lens that reviewer was assigned to provide. The minimum-gate being green is not evidence that the deliberate review slate is complete.
+
+### How to apply
+
+1. Track the **assigned** reviewer slate per PR (from the spawn plan / execution matrix), not just the count of approvals received.
+2. For a blast-radius PR (3+ assigned), gate merge on **all** assigned reviewers Approved — even though the hook would let you merge at 2.
+3. To merge before an assigned reviewer finishes, the orchestrator must **explicitly release** that reviewer with a recorded reason (e.g. "released build/dep lens — change is docs-only after rebase"); silent merge-at-2/3 is not permitted.
+4. This is orchestrator discipline today; a future enhancement could key the merge gate on assigned-reviewer count.
+
+### Severity if violated
+
+- Merge at 2/3 where the 3rd reviewer's lens turns out non-applicable: **minor** (lucky).
+- Merge at 2/3 where the 3rd reviewer later surfaces a real finding the merged change embodies: **moderate** — the deliberate slate existed precisely to catch it.
+
+### Origin
+
+P4W4 ig#1002 (the DS `@theme` color bridge — app-wide blast radius): merged at 2/3 approvals before the deliberately-assigned 3rd (build/dependency) reviewer, Junseo, finished. His verdict (a false-alarm primary conclusion but a real adjacent DS-publish-drift finding → DS#111) landed post-merge; the outcome was non-blocking but only by luck. Owner-approved at the P4W4 retro.
+
 ## Single-Reviewer Exception (Wave-Bootstrap Only) <!-- promotion-target: none -->
 The two-reviewer requirement may be waived **exclusively** for wave-bootstrap PRs — i.e., PRs that establish the tooling/CI/hooks that subsequent wave PRs will be gated by (e.g., the pre-commit hook rollout that the CI sweep depends on).
 


### PR DESCRIPTION
## What

Applies the **two owner-approved process changes** recorded (not applied) in the P4W4 retro (PR #644). Owner approved both 2026-06-13 ("(1) both").

### 1. `agents.md` § Orchestrator State-Correction Discipline — One Aligned Instruction, Never a Serial Toggle
Read the agent's **current** state, issue **one** aligned instruction that voids priors; never a serial close → keep-open → reopen toggle that crosses the agent's in-flight actions. Explicitly distinguished from the existing § Pre-Spawn State Check + Crossed-Message Race Protocol (that's the message-bus delivery race; this is orchestrator-self-generated thrash). Cross-links `state-claims.md § Refresh State Before Acting`.
**Origin:** #1001↔#1003 vehicle thrash (P4W4).

### 2. `pull-requests.md` § All Deliberately-Assigned Reviewers Must Approve Before Merge (Blast-Radius PRs)
The 2-reviewer hook is a **floor**, not a cap. A PR with 3+ deliberately-assigned reviewers (distinct lenses) gates merge on **all** assigned — not the minimum — unless a reviewer is explicitly released with a recorded reason.
**Origin:** ig#1002 merged at 2/3 before the deliberately-assigned 3rd (build/dep) reviewer finished (P4W4).

## Files changed
- `.claude/team/charter/agents.md` — new § (state-correction discipline)
- `.claude/team/charter/pull-requests.md` — new § (all-assigned-reviewers gate)

Both are new sections inserted at the natural anchors; no existing rule modified. Documentation-only (charter prose).

## Test Plan
- Markdown lint / cspell / lychee CI green.
- Reviewer confirms each section is non-redundant with adjacent rules (both retro reviewers — Wanjiku + Aino — already assessed non-redundancy at #644).

---
