### PR TITLE
fix(hooks #650): resolve ambient repo for --repo-less wave-label edits

### DIFF
--- a/.claude/hooks/_shell_parse.py
+++ b/.claude/hooks/_shell_parse.py
@@ -107,6 +107,19 @@ Public API
         cd targets are ambiguous (they'd be relative to the already-wrong
         stdin cwd) so they are ignored.
 
+    resolve_repo_short_name(input_data, *, git_runner=None) -> str | None
+        Resolve the GitHub repository NAME (e.g. `noorinalabs-main`) from the
+        invocation cwd's `origin` remote. This mirrors how `gh` itself
+        resolves a `gh issue edit/create ...` invocation that OMITS `--repo`:
+        it falls back to the ambient git context. Hooks that need the repo
+        name to drive a GraphQL/REST call (e.g. the Wave-field sync and the
+        kickoff-comment hooks) call this to recover the repo when the parsed
+        command carried no `--repo` flag. Returns the last path segment of
+        the `origin` URL with any trailing `.git` stripped, or None when the
+        cwd is not a git repo / has no origin / the runner fails. The
+        `git_runner(cwd) -> str | None` injection point lets tests avoid
+        shelling out (#650).
+
     is_shutdown_request_message(message) -> bool
         True only if `message` is a structured shutdown_request JSON
         (dict-form OR str-form parseable to a dict with type==
@@ -139,6 +152,7 @@ import json
 import os
 import re
 import shlex
+import subprocess
 from typing import Iterator
 
 # Shell control tokens that segment a compound command. Any of these,
@@ -509,6 +523,59 @@ def resolve_invocation_cwd(input_data: dict) -> str:
         if cd_target and os.path.isdir(cd_target):
             return cd_target
     return resolve_tool_cwd(input_data)
+
+
+def _default_origin_url_runner(cwd: str) -> str | None:
+    """Return the `origin` remote URL for the git repo at `cwd`, or None.
+
+    Shells out to `git -C <cwd> remote get-url origin`. Any failure (not a
+    git repo, no `origin` remote, git missing) yields None so the caller
+    treats the repo as unresolvable rather than crashing.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "-C", cwd, "remote", "get-url", "origin"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (subprocess.SubprocessError, FileNotFoundError, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout
+
+
+def resolve_repo_short_name(input_data: dict, *, git_runner=None) -> str | None:
+    """Resolve the GitHub repo NAME from the invocation cwd's `origin` remote.
+
+    When a `gh issue edit/create` command omits `--repo`, gh resolves the
+    target repository from the ambient git context (the cwd's `origin`
+    remote). Hooks that need the repo name to drive a GraphQL/REST call must
+    mirror that resolution. Returns the last path segment of the `origin`
+    URL with any trailing `.git` stripped — for both scp-form and https-form
+    URLs:
+
+        git@github.com:noorinalabs/noorinalabs-main.git  -> noorinalabs-main
+        https://github.com/noorinalabs/noorinalabs-main   -> noorinalabs-main
+
+    Returns None when the cwd is not a git repo, has no `origin` remote, or
+    the runner otherwise fails. The cwd is resolved via
+    `resolve_invocation_cwd` so a worktree-subagent's real dir is used (the
+    `cd <dir> && ...` recovery path, #521).
+
+    `git_runner(cwd) -> str | None` is the injection point for tests; the
+    default shells out to `git -C <cwd> remote get-url origin`.
+    """
+    cwd = resolve_invocation_cwd(input_data)
+    runner = git_runner or _default_origin_url_runner
+    url = runner(cwd)
+    if not url:
+        return None
+    name = url.strip().rstrip("/").split("/")[-1]
+    if name.endswith(".git"):
+        name = name[: -len(".git")]
+    return name or None
 
 
 def is_shutdown_request_message(message) -> bool:

--- a/.claude/hooks/_wave_label_parse.py
+++ b/.claude/hooks/_wave_label_parse.py
@@ -40,7 +40,10 @@ Public API
 
         Result fields (shared with the plural form):
           repo          — `noorinalabs-<name>` short form (last path segment
-                          of `--repo owner/name` or `--repo=owner/name`).
+                          of `--repo owner/name` or `--repo=owner/name`), or
+                          None when `--repo` is OMITTED (in-repo invocation,
+                          ambient gh resolution — #650). The consuming hook
+                          resolves the None case from the invocation cwd.
           issue_number  — the bare positional issue number after `edit`.
           add_label     — the FIRST `--add-label "p{N}-wave-{M}"` value, or
                           None if no add operation present.
@@ -114,9 +117,15 @@ class WaveLabelChange:
     """Result of parsing a `gh issue edit ... --add-label|--remove-label` command.
 
     At least one of `add_label` / `remove_label` is non-None.
+
+    `repo` is the short repo name from `--repo owner/name` (e.g.
+    `noorinalabs-main`), or None when the command OMITS `--repo` and relies
+    on gh's ambient-git-context resolution. Consumers that need a concrete
+    repo (for a GraphQL/REST call) resolve the None case from the invocation
+    cwd via `_shell_parse.resolve_repo_short_name` (#650).
     """
 
-    repo: str
+    repo: str | None
     issue_number: str
     add_label: str | None
     remove_label: str | None
@@ -154,9 +163,17 @@ def parse_wave_label(value: str) -> tuple[int, int] | None:
 def _parse_edit_segment(rest: list[str]) -> WaveLabelChange | None:
     """Parse the rest of a tokenized `gh issue edit <num> ...` segment.
 
-    Returns the WaveLabelChange if the segment has issue_number, repo,
-    AND at least one canonical wave-label `--add-label`/`--remove-label`.
-    Otherwise returns None.
+    Returns the WaveLabelChange if the segment has an issue_number AND at
+    least one canonical wave-label `--add-label`/`--remove-label`. Otherwise
+    returns None.
+
+    `--repo` is OPTIONAL (#650): a `gh issue edit <num> --remove-label
+    "p4-wave-5"` run from inside the target repo carries no `--repo` and
+    relies on gh's ambient-git-context resolution. Requiring `--repo` here
+    silently dropped every such in-repo label edit (the change never reached
+    the field-sync hook → board Wave field went unsynced). When `--repo` is
+    absent the returned `repo` is None; the consuming hook resolves the
+    ambient repo from the invocation cwd.
     """
     if len(rest) < 3 or rest[0] != "issue" or rest[1] != "edit":
         return None
@@ -208,7 +225,7 @@ def _parse_edit_segment(rest: list[str]) -> WaveLabelChange | None:
             continue
         i += 1
 
-    if issue_number and repo and (add_label or remove_label):
+    if issue_number and (add_label or remove_label):
         return WaveLabelChange(
             repo=repo,
             issue_number=issue_number,

--- a/.claude/hooks/post_label_change_wave_field_sync.py
+++ b/.claude/hooks/post_label_change_wave_field_sync.py
@@ -125,11 +125,13 @@ import os
 import subprocess
 import sys
 import time
+from dataclasses import replace
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import re  # noqa: E402
 
+from _shell_parse import resolve_repo_short_name  # noqa: E402
 from _wave_label_parse import (  # noqa: E402
     WaveLabelChange,
     parse_wave_label,
@@ -475,9 +477,14 @@ def _apply_one_change(
 ) -> dict:
     """Apply a single WaveLabelChange against project 2. Returns a result dict.
 
-    Pre-condition: caller has verified auth scope + ids are present. This
-    function is invoked once per change in the multi-cmd loop in `check()`.
+    Pre-condition: caller has verified auth scope + ids are present AND has
+    resolved `change.repo` to a concrete repo name (the ambient-repo
+    resolution loop in `check()` replaces a None repo or drops the change).
+    This function is invoked once per change in the multi-cmd loop in
+    `check()`.
     """
+    # `check()` guarantees repo is resolved before dispatch (see pre-condition).
+    assert change.repo is not None
     # POST-edit state semantics: if BOTH add and remove fired in one
     # command, the added value is the post-edit Wave field value.
     target_label: str = change.add_label or change.remove_label or ""
@@ -619,6 +626,7 @@ def check(
     input_data: dict,
     auth_status_runner=None,
     graphql_runner=None,
+    git_runner=None,
 ) -> dict | None:
     """Pure decision function. Returns a dict describing the action taken
     (or skipped), or None when the hook does not apply.
@@ -631,6 +639,8 @@ def check(
     Single-cmd result variants:
       None                                       — hook didn't apply
       {"action": "killed", ...}                  — kill-switch env var set
+      {"action": "skip_no_repo_context", ...}    — --repo omitted AND ambient
+                                                   repo unresolvable from cwd
       {"action": "skip_no_auth_scope", ...}      — gh missing project scope
       {"action": "skip_no_project_ids", ...}     — introspection failed
       {"action": "skip_no_option", ...}          — wave option missing
@@ -644,7 +654,9 @@ def check(
 
     Injection points let tests mock external state without mocking
     subprocess: `auth_status_runner()` returns the gh-auth-status output;
-    `graphql_runner(query, variables)` returns the gh-api-graphql output.
+    `graphql_runner(query, variables)` returns the gh-api-graphql output;
+    `git_runner(cwd)` returns the `origin` remote URL used to resolve the
+    ambient repo when a command omits `--repo` (#650).
     """
     if input_data.get("tool_name", "") != "Bash":
         return None
@@ -675,6 +687,40 @@ def check(
             )
             return {"action": "skip_parser_returned_empty"}
         return None
+
+    # #650: a `gh issue edit <num> --remove-label "p4-wave-5"` run from inside
+    # the target repo carries NO `--repo`; the parser returns the change with
+    # repo=None. Mirror gh's own ambient-git-context resolution by recovering
+    # the repo from the invocation cwd, otherwise the Wave-field sync silently
+    # no-ops (the original #650 symptom). All `--repo`-less changes in one
+    # compound command share a single cwd, so resolve at most once.
+    ambient_repo: str | None = None
+    ambient_resolved = False
+    resolved_changes: list[WaveLabelChange] = []
+    for change in changes:
+        if change.repo is None:
+            if not ambient_resolved:
+                ambient_repo = resolve_repo_short_name(input_data, git_runner=git_runner)
+                ambient_resolved = True
+            if ambient_repo is None:
+                log_posttooluse_event(
+                    "post_label_change_wave_field_sync",
+                    command,
+                    f"skip_no_repo_context: `gh issue edit {change.issue_number}` omitted "
+                    "--repo and the ambient repo could not be resolved from the invocation "
+                    "cwd (no git origin); cannot sync Wave field for this change.",
+                )
+                continue
+            change = replace(change, repo=ambient_repo)
+        resolved_changes.append(change)
+
+    if not resolved_changes:
+        return {
+            "action": "skip_no_repo_context",
+            "issue": changes[0].issue_number,
+            "skipped_count": len(changes),
+        }
+    changes = resolved_changes
 
     if not _has_project_scope(auth_status_runner=auth_status_runner):
         _ensure_auth_warned_once(

--- a/.claude/hooks/post_wave_kickoff_comment.py
+++ b/.claude/hooks/post_wave_kickoff_comment.py
@@ -65,6 +65,7 @@ import time
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _shell_parse import resolve_repo_short_name  # noqa: E402
 from _wave_label_parse import parse_wave_label, parse_wave_label_change  # noqa: E402
 from annunaki_log import log_posttooluse_event  # noqa: E402
 
@@ -140,13 +141,17 @@ def _read_status() -> dict | None:
     return None
 
 
-def parse_label_apply_command(command: str) -> tuple[str, str, str] | None:
-    """Parse `gh issue edit <num> --repo <repo> --add-label "p{N}-wave-{M}"`.
+def parse_label_apply_command(command: str) -> tuple[str | None, str, str] | None:
+    """Parse `gh issue edit <num> [--repo <repo>] --add-label "p{N}-wave-{M}"`.
 
     Returns (repo, issue_number, wave_label) if the command APPLIES a wave
     label, else None. Tolerates additional flags and arbitrary flag
     ordering. The kickoff hook only fires on label-APPLY, so commands
     that only `--remove-label` a wave label return None here.
+
+    `repo` is None when the command OMITS `--repo` (in-repo invocation,
+    #650); the caller (`check`) resolves the ambient repo from the
+    invocation cwd before using it.
 
     Between-wave relabel filter (#467): commands that ALSO remove a
     canonical wave label in the same invocation
@@ -398,6 +403,7 @@ def check(
     comment_fetcher=None,
     comment_poster=None,
     body_writer=None,
+    git_runner=None,
 ) -> dict | None:
     """Pure decision function. Returns a dict describing the action taken
     (or skipped), or None when the hook does not apply.
@@ -409,13 +415,17 @@ def check(
       {"action": "skip_idempotent", ...}       — kickoff already posted
       {"action": "skip_no_scope", ...}         — wave_{M}_scope missing
       {"action": "skip_no_row", ...}           — issue not in any tier
+      {"action": "skip_no_repo_context", ...}  — --repo omitted AND ambient
+                                                 repo unresolvable from cwd
       {"action": "skip_post_failed", ...}      — gh post call failed
 
     Injection points let tests mock external state without mocking
     subprocess: `status_loader()` returns the status dict, `comment_fetcher
     (repo, num)` returns the comment list, `comment_poster(repo, num, path)`
     returns success bool, `body_writer(body, repo, num)` returns the Path
-    of the written body file.
+    of the written body file, `git_runner(cwd)` returns the `origin` remote
+    URL used to resolve the ambient repo when a command omits `--repo`
+    (#650).
     """
     if input_data.get("tool_name", "") != "Bash":
         return None
@@ -428,6 +438,22 @@ def check(
     if parsed is None:
         return None
     repo, issue_number, wave_label = parsed
+
+    # #650: a label-apply run from inside the target repo carries no `--repo`
+    # (repo=None). Mirror gh's ambient-git-context resolution by recovering
+    # the repo from the invocation cwd; without it the downstream
+    # `--repo noorinalabs/<repo>` call would be malformed.
+    if repo is None:
+        repo = resolve_repo_short_name(input_data, git_runner=git_runner)
+        if repo is None:
+            log_posttooluse_event(
+                "post_wave_kickoff_comment",
+                command,
+                f"skip_no_repo_context: label-apply for issue {issue_number} omitted "
+                "--repo and the ambient repo could not be resolved from the invocation "
+                "cwd (no git origin); cannot render/post kickoff comment.",
+            )
+            return {"action": "skip_no_repo_context", "issue": issue_number}
 
     parsed_label = parse_wave_label(wave_label)
     if parsed_label is None:

--- a/.claude/hooks/tests/test_post_label_change_wave_field_sync.py
+++ b/.claude/hooks/tests/test_post_label_change_wave_field_sync.py
@@ -851,12 +851,19 @@ class MultiCmdBashTests(unittest.TestCase):
 
     def test_parser_skip_logs_for_unparseable_wave_label_cmd(self):
         """When the command CONTAINS `gh issue edit` + canonical wave-label
-        but the parser extracts nothing (e.g., missing --repo), the hook
-        emits a parser-skip annunaki event per #455 acceptance criterion."""
+        but the parser extracts nothing, the hook emits a parser-skip
+        annunaki event per #455 acceptance criterion.
+
+        #650 update: a missing `--repo` is NO LONGER the unparseable shape —
+        the parser now returns the change (repo=None) and the hook resolves
+        the ambient repo from cwd. The remaining genuinely-unparseable shape
+        is an UNEXPANDED shell variable as the issue number
+        (`gh issue edit $ISSUE ...`): `$ISSUE` is not a digit so no change is
+        extracted, yet the command clearly intended a wave-label edit."""
         cmd = (
-            # Missing --repo flag → parser returns empty, but the command
-            # clearly intended a wave-label edit
-            'gh issue edit 600 --add-label "p3-wave-11"'
+            # Unexpanded `$ISSUE` → issue_number not a digit → parser returns
+            # empty, but the command clearly intended a wave-label edit.
+            'gh issue edit $ISSUE --repo noorinalabs/noorinalabs-main --add-label "p3-wave-11"'
         )
         result = hook.check(_bash(cmd))
         self.assertEqual(result["action"], "skip_parser_returned_empty")
@@ -1115,14 +1122,19 @@ class CanonicalWaveLabelRegexTests(unittest.TestCase):
         )
 
     def test_parser_skip_logs_for_spaced_bare_eof_cmd(self):
-        """End-to-end via check(): spaced-bare-EOF wave-label with missing
-        --repo (parser returns empty) must produce a skip_parser_returned_empty
+        """End-to-end via check(): a spaced-bare-EOF wave-label on a command
+        the parser still can't resolve must produce a skip_parser_returned_empty
         event so /annunaki-attack catches the silent miss.
+
+        #650 update: missing-`--repo` is now resolved from cwd, so the
+        unparseable shape here uses an unexpanded `$N` issue number while
+        keeping the spaced-bare-EOF `--add-label p3-wave-11` form that
+        exercises the #463 right-anchor.
         """
-        # `gh issue edit 1 --add-label p3-wave-11` — no --repo, no quotes.
-        # Pre-#463 the regex would not match this, so the hook would return
-        # None silently. Post-#463 it must return skip_parser_returned_empty.
-        result = hook.check(_bash("gh issue edit 1 --add-label p3-wave-11"))
+        # `gh issue edit $N --add-label p3-wave-11` — unexpanded var, no quotes.
+        # `$N` is not a digit → parser returns empty; the spaced-bare-EOF
+        # canonical label still matches _CANONICAL_WAVE_LABEL_IN_CMD (#463).
+        result = hook.check(_bash("gh issue edit $N --add-label p3-wave-11"))
         self.assertEqual(
             result.get("action") if result else None,
             "skip_parser_returned_empty",
@@ -1164,6 +1176,174 @@ class MultiCmdNoMatchPreservedTests(unittest.TestCase):
         )
         result = hook.check(_bash(cmd))
         self.assertIsNone(result)
+
+
+class AmbientRepoResolutionTests(unittest.TestCase):
+    """Bucket 9 (ACTIONABLE) — issue #650 ambient `--repo` resolution.
+
+    A `gh issue edit <num> --remove-label "p4-wave-5"` run from INSIDE the
+    target repo carries no `--repo`; gh resolves it from the ambient git
+    context. The parser now returns the change with repo=None and the hook
+    recovers the repo from the invocation cwd via the injected git_runner.
+    Before #650 this produced a `skip_parser_returned_empty` and the board
+    Wave field silently went unsynced.
+    """
+
+    _ORIGIN = "git@github.com:noorinalabs/noorinalabs-main.git\n"
+
+    def setUp(self):
+        _wipe_cache()
+        hook.CACHE_DIR.mkdir(parents=True, exist_ok=True)
+        hook._write_cache(_ids_blob())
+
+    def tearDown(self):
+        _wipe_cache()
+
+    def _git_runner(self, url=None):
+        """Return a (runner, calls) pair; calls[0] counts invocations."""
+        calls = [0]
+        resolved = self._ORIGIN if url is None else url
+
+        def runner(_cwd):
+            calls[0] += 1
+            return resolved
+
+        return runner, calls
+
+    def test_exact_issue_650_reproducer_clears_field(self):
+        """The exact `comment ; echo ; edit --remove-label ; echo ; view`
+        shape from issue #650 (no --repo) must resolve repo from cwd and
+        CLEAR the Wave field — not skip_parser_returned_empty."""
+        router = FakeGraphQLRouter(
+            item_lookup=_item_lookup_response,
+            mutation=_mutation_success_response,
+        )
+        runner, _ = self._git_runner()
+        cmd = (
+            'gh issue comment 601 -b "P4W5 close-out" ; '
+            "echo done ; "
+            'gh issue edit 601 --remove-label "p4-wave-5" ; '
+            "echo ok ; "
+            "gh issue view 601"
+        )
+        # P4W5 option must exist for the (cleared) lookup path; clear doesn't
+        # need the option but item-lookup runs regardless.
+        hook._write_cache(
+            {
+                "project_id": "PROJ_NODE_ID",
+                "field_id": "WAVE_FIELD_ID",
+                "option_ids": {"P4W5": "OPT_P4W5"},
+            }
+        )
+        result = hook.check(
+            _bash(cmd),
+            auth_status_runner=_scopes_with_project,
+            graphql_runner=router,
+            git_runner=runner,
+        )
+        self.assertEqual(result["action"], "cleared")
+        self.assertEqual(result["repo"], "noorinalabs-main")
+        self.assertEqual(result["issue"], "601")
+
+    def test_single_no_repo_add_label_resolves_and_sets(self):
+        router = FakeGraphQLRouter(
+            item_lookup=_item_lookup_response,
+            mutation=_mutation_success_response,
+        )
+        runner, _ = self._git_runner()
+        result = hook.check(
+            _bash('gh issue edit 123 --add-label "p3-wave-11"'),
+            auth_status_runner=_scopes_with_project,
+            graphql_runner=router,
+            git_runner=runner,
+        )
+        self.assertEqual(result["action"], "set")
+        self.assertEqual(result["repo"], "noorinalabs-main")
+        self.assertEqual(result["option_name"], "P3W11")
+
+    def test_https_origin_url_strips_dotgit(self):
+        router = FakeGraphQLRouter(
+            item_lookup=_item_lookup_response,
+            mutation=_mutation_success_response,
+        )
+        runner, _ = self._git_runner(url="https://github.com/noorinalabs/noorinalabs-deploy\n")
+        result = hook.check(
+            _bash('gh issue edit 123 --add-label "p3-wave-11"'),
+            auth_status_runner=_scopes_with_project,
+            graphql_runner=router,
+            git_runner=runner,
+        )
+        self.assertEqual(result["action"], "set")
+        self.assertEqual(result["repo"], "noorinalabs-deploy")
+
+    def test_multi_cmd_no_repo_resolves_once(self):
+        """Two `--repo`-less edits in one compound command share one cwd; the
+        git origin should be resolved at most once."""
+        router = FakeGraphQLRouter(
+            item_lookup=_item_lookup_response,
+            mutation=_mutation_success_response,
+        )
+        runner, calls = self._git_runner()
+        cmd = (
+            'gh issue edit 100 --add-label "p3-wave-11" ; '
+            'gh issue edit 101 --add-label "p3-wave-11"'
+        )
+        result = hook.check(
+            _bash(cmd),
+            auth_status_runner=_scopes_with_project,
+            graphql_runner=router,
+            git_runner=runner,
+        )
+        self.assertEqual(result["action"], "multi")
+        self.assertEqual(result["count"], 2)
+        self.assertTrue(all(r["repo"] == "noorinalabs-main" for r in result["results"]))
+        self.assertEqual(calls[0], 1, "ambient repo should be resolved once for a shared cwd")
+
+    def test_explicit_repo_does_not_invoke_git_runner(self):
+        """When `--repo` IS present, the ambient resolver must not be called."""
+        router = FakeGraphQLRouter(
+            item_lookup=_item_lookup_response,
+            mutation=_mutation_success_response,
+        )
+        runner, calls = self._git_runner()
+        result = hook.check(
+            _bash('gh issue edit 123 --repo noorinalabs/noorinalabs-main --add-label "p3-wave-11"'),
+            auth_status_runner=_scopes_with_project,
+            graphql_runner=router,
+            git_runner=runner,
+        )
+        self.assertEqual(result["action"], "set")
+        self.assertEqual(calls[0], 0, "explicit --repo must not trigger ambient resolution")
+
+    def test_unresolvable_repo_skips_no_repo_context(self):
+        """No --repo AND no git origin → skip_no_repo_context (not a crash,
+        not a silent skip_parser_returned_empty)."""
+        result = hook.check(
+            _bash('gh issue edit 123 --remove-label "p3-wave-10"'),
+            auth_status_runner=_scopes_with_project,
+            graphql_runner=FakeGraphQLRouter(),
+            git_runner=lambda _cwd: None,
+        )
+        self.assertEqual(result["action"], "skip_no_repo_context")
+        self.assertEqual(result["issue"], "123")
+
+    def test_unresolvable_repo_logs(self):
+        """skip_no_repo_context must emit an annunaki log entry."""
+        captured = []
+        orig = hook.log_posttooluse_event
+        hook.log_posttooluse_event = lambda *a, **k: captured.append(a)
+        try:
+            hook.check(
+                _bash('gh issue edit 123 --remove-label "p3-wave-10"'),
+                auth_status_runner=_scopes_with_project,
+                git_runner=lambda _cwd: None,
+            )
+            self.assertTrue(
+                any("skip_no_repo_context" in str(a) for a in captured),
+                f"skip_no_repo_context must log; captured: {captured}",
+            )
+        finally:
+            hook.log_posttooluse_event = orig
 
 
 if __name__ == "__main__":

--- a/.claude/hooks/tests/test_post_wave_kickoff_comment.py
+++ b/.claude/hooks/tests/test_post_wave_kickoff_comment.py
@@ -264,6 +264,14 @@ class ParseLabelApplyCommandTests(unittest.TestCase):
             ("noorinalabs-main", "200", "p3-wave-11"),
         )
 
+    def test_no_repo_returns_none_repo_field(self):
+        """#650: a label-apply run from inside the repo omits --repo; the pure
+        parser returns repo=None (the caller resolves it from cwd)."""
+        self.assertEqual(
+            hook.parse_label_apply_command('gh issue edit 601 --add-label "p4-wave-7"'),
+            (None, "601", "p4-wave-7"),
+        )
+
 
 class FindAssignmentRowTests(unittest.TestCase):
     """Direct coverage of tier-array row lookup with both shapes."""
@@ -515,6 +523,91 @@ class NonBashToolTests(unittest.TestCase):
     def test_empty_command_not_matched(self):
         result = hook.check({"tool_name": "Bash", "tool_input": {"command": ""}})
         self.assertIsNone(result)
+
+
+class AmbientRepoResolutionTests(unittest.TestCase):
+    """#650: a label-apply run from inside the repo omits --repo; the kickoff
+    hook resolves the ambient repo from the invocation cwd before rendering
+    and posting the kickoff comment."""
+
+    _ORIGIN = "git@github.com:noorinalabs/noorinalabs-main.git\n"
+
+    def _status(self):
+        return {
+            "wave_7_scope": {
+                "tier_1_close_out": [
+                    {
+                        "id": "noorinalabs-main#601",
+                        "implementer": "Aino Virtanen",
+                        "reviewer": "Weronika Zielinska",
+                        "reviewer_2": "Nino Kavtaradze",
+                    }
+                ]
+            }
+        }
+
+    def test_no_repo_resolves_and_posts(self):
+        captured = {}
+
+        def fake_post(repo, num, body_path):
+            captured["repo"] = repo
+            captured["num"] = num
+            return True
+
+        with tempfile.TemporaryDirectory() as td:
+
+            def fake_writer(body, repo, num):
+                path = Path(td) / f"body-{repo}-{num}.md"
+                path.write_text(body, encoding="utf-8")
+                return path
+
+            result = hook.check(
+                _bash('gh issue edit 601 --add-label "p4-wave-7"'),
+                status_loader=self._status,
+                comment_fetcher=lambda repo, num: [],
+                comment_poster=fake_post,
+                body_writer=fake_writer,
+                git_runner=lambda _cwd: self._ORIGIN,
+            )
+        self.assertEqual(result["action"], "post")
+        self.assertEqual(result["repo"], "noorinalabs-main")
+        self.assertEqual(captured["repo"], "noorinalabs-main")
+
+    def test_no_repo_unresolvable_skips_no_repo_context(self):
+        result = hook.check(
+            _bash('gh issue edit 601 --add-label "p4-wave-7"'),
+            status_loader=self._status,
+            git_runner=lambda _cwd: None,
+        )
+        self.assertEqual(result["action"], "skip_no_repo_context")
+        self.assertEqual(result["issue"], "601")
+
+    def test_explicit_repo_does_not_invoke_git_runner(self):
+        calls = [0]
+
+        def runner(_cwd):
+            calls[0] += 1
+            return self._ORIGIN
+
+        with tempfile.TemporaryDirectory() as td:
+
+            def fake_writer(body, repo, num):
+                path = Path(td) / f"body-{repo}-{num}.md"
+                path.write_text(body, encoding="utf-8")
+                return path
+
+            result = hook.check(
+                _bash(
+                    'gh issue edit 601 --repo noorinalabs/noorinalabs-main --add-label "p4-wave-7"'
+                ),
+                status_loader=self._status,
+                comment_fetcher=lambda repo, num: [],
+                comment_poster=lambda repo, num, path: True,
+                body_writer=fake_writer,
+                git_runner=runner,
+            )
+        self.assertEqual(result["action"], "post")
+        self.assertEqual(calls[0], 0, "explicit --repo must not trigger ambient resolution")
 
 
 if __name__ == "__main__":

--- a/.claude/hooks/tests/test_shell_parse.py
+++ b/.claude/hooks/tests/test_shell_parse.py
@@ -450,5 +450,71 @@ class ResolveInvocationCwdTests(unittest.TestCase):
         self.assertEqual(sp.resolve_invocation_cwd(input_data), "/orchestrator")
 
 
+class ResolveRepoShortNameTests(unittest.TestCase):
+    """#650: resolve the ambient repo NAME from the invocation cwd's origin."""
+
+    _INPUT = {"tool_input": {"command": "gh issue edit 1 --remove-label p4-wave-5"}, "cwd": "/x"}
+
+    def test_scp_form_url(self):
+        self.assertEqual(
+            sp.resolve_repo_short_name(
+                self._INPUT, git_runner=lambda _c: "git@github.com:noorinalabs/noorinalabs-main.git"
+            ),
+            "noorinalabs-main",
+        )
+
+    def test_https_form_url_no_dotgit(self):
+        self.assertEqual(
+            sp.resolve_repo_short_name(
+                self._INPUT,
+                git_runner=lambda _c: "https://github.com/noorinalabs/noorinalabs-deploy\n",
+            ),
+            "noorinalabs-deploy",
+        )
+
+    def test_https_form_url_with_dotgit(self):
+        self.assertEqual(
+            sp.resolve_repo_short_name(
+                self._INPUT,
+                git_runner=lambda _c: (
+                    "https://github.com/noorinalabs/noorinalabs-design-system.git"
+                ),
+            ),
+            "noorinalabs-design-system",
+        )
+
+    def test_trailing_slash_tolerated(self):
+        self.assertEqual(
+            sp.resolve_repo_short_name(
+                self._INPUT,
+                git_runner=lambda _c: "https://github.com/noorinalabs/noorinalabs-main/\n",
+            ),
+            "noorinalabs-main",
+        )
+
+    def test_runner_returns_none_yields_none(self):
+        self.assertIsNone(sp.resolve_repo_short_name(self._INPUT, git_runner=lambda _c: None))
+
+    def test_runner_returns_empty_yields_none(self):
+        self.assertIsNone(sp.resolve_repo_short_name(self._INPUT, git_runner=lambda _c: ""))
+
+    def test_runner_receives_invocation_cwd(self):
+        """The runner must be called with the resolved invocation cwd (the
+        `cd <dir>` recovery path, #521), not a hardcoded dir."""
+        real_dir = str(Path(__file__).resolve().parent)
+        seen = {}
+
+        def runner(cwd):
+            seen["cwd"] = cwd
+            return "git@github.com:noorinalabs/noorinalabs-main.git"
+
+        input_data = {
+            "tool_input": {"command": f"cd {real_dir} && gh issue edit 1 --remove-label p4-wave-5"},
+            "cwd": "/some/orchestrator/dir",
+        }
+        sp.resolve_repo_short_name(input_data, git_runner=runner)
+        self.assertEqual(seen["cwd"], real_dir)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Closes #650.

`post_label_change_wave_field_sync` emitted `skip_parser_returned_empty` for a
canonical wave-label change issued inside a multi-command Bash block during
P4W5 wrap-up, so the project-2 Wave field silently went unsynced.

**Root cause (NOT the multi-command shape).** The `;`/`&&`/newline segment
splitting in the shared parser already worked. The real defect was in
`_wave_label_parse._parse_edit_segment`: it **required a `--repo` flag**. The
captured command —
`gh issue comment 601 … ; … ; gh issue edit 601 --remove-label "p4-wave-5" ; … ; gh issue view 601`
— was run from inside `noorinalabs-main` with **no `--repo`** (gh resolves the
repo from the ambient git context). The parser dropped the change → empty list
→ `skip_parser_returned_empty`. A clean multi-command block *with* `--repo`
parsed fine; the only differentiator was the missing `--repo`.

## Fix (shared parser + both consumers benefit)

- **`_wave_label_parse.py`** — `WaveLabelChange.repo` is now `str | None`;
  `_parse_edit_segment` parses the edit even when `--repo` is omitted
  (`repo=None`). Anchored `^p\d+-wave-\d+$` semantics and the suffixed-label
  exclusion are unchanged.
- **`_shell_parse.py`** — new `resolve_repo_short_name(input_data, *, git_runner=None)`
  recovers the repo name from the invocation cwd's `origin` remote (scp + https
  forms, `.git` stripped), mirroring gh's own `--repo`-less resolution. Uses
  `resolve_invocation_cwd` so a worktree subagent's real dir is honoured (#521).
- **`post_label_change_wave_field_sync.py`** + **`post_wave_kickoff_comment.py`**
  — when a parsed change/apply carries no `--repo`, resolve the ambient repo
  from cwd before the GraphQL/`gh` call; emit a `skip_no_repo_context` annunaki
  event (not a silent skip) if it can't be resolved. The between-wave relabel
  filter and compound add+remove (post-edit-state-wins) semantics are preserved.

The `skip_parser_returned_empty` log path is retained for the cases it is
actually meant to catch (unexpanded `$VAR` issue numbers, tokenize failures),
not for missing-`--repo`.

## Test Plan

- `test_shell_parse.py` — `ResolveRepoShortNameTests`: scp/https/`.git`/
  trailing-slash forms, `None`/empty runner, invocation-cwd recovery.
- `test_post_label_change_wave_field_sync.py` — `AmbientRepoResolutionTests`:
  the **exact #650 reproducer** (`comment ; echo ; edit --remove-label ; echo ;
  view`, no `--repo`) → Wave field **cleared**; single/multi no-`--repo` resolve;
  resolve-once for a shared cwd; explicit `--repo` does not invoke the resolver;
  unresolvable → `skip_no_repo_context` (+ logs). Updated the two #455/#463
  tests that encoded the old missing-`--repo`→skip behavior to an
  unexpanded-`$VAR` shape.
- `test_post_wave_kickoff_comment.py` — no-`--repo` parse returns `repo=None`;
  `check()` resolves + posts; unresolvable → `skip_no_repo_context`; explicit
  `--repo` does not invoke the resolver.

Local checks (pinned ruff 0.15.11):
- `ruff format --check` + `ruff check` over all 7 changed files — clean.
- `mypy --ignore-missing-imports` over the 4 changed hooks (+ `auto_add_issue_to_board`) — clean.
- `pytest` the three affected suites — **199 passed**. Full hooks+lib suite —
  **1356 passed**; the single failure (`test_ontology_tracker`
  `…worktrees_segment_not_substring_false_match`) is a **worktree-location
  false-fail** (REPO_ROOT resolves under `.claude/worktrees/`, so the test's
  synthetic path genuinely contains a `worktrees` segment); it passes from the
  main checkout / fresh CI checkout and is not in this changeset.
- `pre_commit_ci_sync.py .` — OK (mirror intact).

## Reviewers

Requesting **Weronika Zielinska** (peer) and **Nino Kavtaradze** (secondary).
The 2-reviewer `Approved` + `TechDebt:` trailer gate applies — both verdict
comments must carry a `TechDebt:` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
