### PR TITLE
retro(P5W2): API light-up — trust matrix + feedback log

### DIFF
--- a/.claude/team/feedback_log.md
+++ b/.claude/team/feedback_log.md
@@ -3039,3 +3039,46 @@ Dominant signals: `validate_labels` multi-cmd + stale-cache (orchestrator, → #
 
 ### Memory-to-automation audit
 No new conversions. The wave's promotion-worthy pattern (production-realistic fixtures) is captured as Proposed Change #1 (charter/standards). The `validate_labels` gotcha memory written this session is the only new memory; it stays as memory (operational workaround) until #661/#663 land the durable fix.
+
+## Retrospective: Phase 5 Wave 2 — 2026-06-14 (API light-up)
+
+### Team Performance
+5 PRs merged to the wave branch, then wave→main (#1047); CI green throughout; staging promotion GREEN (deploy-stg run 27506467050). 6 issues closed (5 delivered + #1023 relocated→deploy#449). **0 ChangesRequested cycles** — every PR approved first-pass. Counters (5 / 0 / 20%) recomputed at retro == wrapup-claimed (no drift; the `git show origin/main` "null" read was a stale-local-ref artifact, gh api confirmed correct).
+
+### Per-Engineer Assessments
+- **Ingrid Lindqvist** — #1045 (narrators 500, keystone). Shipped under her identity but orchestrator-authored after a dispatch stall; held at 5, not credited (integrity). Severity: none (gap is process, not hers).
+- **Jun-Seo Park** — #1033 (search 422). Correct dual-cap fix + boundary tests; both first-pass approvals. Hold 4. Severity: none.
+- **Ravi Wickramasinghe** — #1030 (i18n page-body, TD). Clean; 7-locale parity verified. 3→4 (▲). Severity: none.
+- **Idris Yusuf** — #1029 (auth refresh-on-401). Clean, both approvals. Hold 4. Severity: none.
+- **Mateo Salazar** — #1028 (subscriptions/facet) + 2 reviews (#1045, #1030, latter flagged ig#1046). Hold 5. Severity: none.
+- **Marisol Vega-Cruz** — 4 verified reviews + the predicted #1033↔#1028 merge-conflict flag. Reviews-MVP. 3→4 (▲).
+
+### Wave-shape table
+| Metric | Value |
+|--------|-------|
+| PRs merged | 5 |
+| ChangesRequested cycles | 0 |
+| Top-implementer concentration | 1/5 = 20% (5 distinct implementers — healthy, no fragility) |
+| Issues closed | 6 (1 relocated) |
+| Staging promotion | success (run 27506467050) |
+| Tech-debt filed | ig#1046 + P5W3 backlog |
+
+### Top 3 Going Well
+1. **Cleanest wave in recent memory** — 0 ChangesRequested, all first-pass approvals, CI + staging green.
+2. **Strong independent review culture** — reviewers ran tests + verified against head; Marisol's 4 reviews + the load-bearing merge-sequencing prediction; Mateo's TS-nullable follow-up (ig#1046).
+3. **Honest scope discipline** — #1023 relocated to deploy#449 (explicit), not silently dropped; healthy 20% concentration across 5 implementers.
+
+### Top 3 Pain Points
+1. **Implementer dispatch had no task-tracking** — the keystone #1024 implementer produced zero output (no branch/PR/commit) and `TaskList` was empty, so the stall was invisible until a manual user nudge. The keystone bug nearly didn't ship. → Proposed Change #1.
+2. **Local full-suite test runs hang on absent sandbox DB services** — pytest blocked 14 min on a DB connection (Marisol hit the same ~9-min stall). Wasted wall-clock + masked as "still running." → Proposed Change #2.
+3. **PUT-contents commits leave the local `origin/main` ref stale** — counter re-verification read `null` via `git show origin/main` until re-fetched; state claims must use `gh api`, not the local ref (already a memory; recurred).
+
+### Proposed Process Changes
+1. **TaskCreate-per-implementer at kickoff** — every spawned implementer gets a tracked task so a zero-output stall is visible (and nudge-able) before wrapup, instead of surfacing only via manual user prompt. Rationale: P5W2's keystone stalled invisibly. Owner: Wanjiku (TPM) / kickoff skill.
+2. **Sandbox test-verification pattern (charter/standards):** when the full suite hangs on absent local services, verify logic via targeted unit construction (no app/DB startup) + cite the green CI job, rather than burning wall-clock on a hung run. Document the `uv run` lock-contention gotcha (use `.venv/bin/<tool>` directly). Owner: Aino.
+
+### Annunaki (16 captures this wave — all noise/benign)
+8× benign `post_label_change` hook events (kickoff labeling), 2× `enforce_librarian` hook correctly blocking (known #169 worktree-cwd race, already addressed), 6× orchestrator transient session-command errors (cd path fatals, python one-liner tracebacks, the hung-pytest FAILED). No NEW automation warranted. Log cleared, marker written.
+
+### Memory-to-automation audit
+No new conversions. 140 memory files; this wave's promotion-worthy patterns are captured as Proposed Changes #1/#2 (process/charter) rather than as standalone memories.

--- a/.claude/team/trust_matrix.md
+++ b/.claude/team/trust_matrix.md
@@ -1458,3 +1458,33 @@ First Phase-5 wave (data-acquisition only). 4 PRs, **0 ChangesRequested cycles**
 ### Done Well / Needs Improvement (Phase 5 Wave 1)
 - **Done well:** every reviewer verified rather than rubber-stamped — the keystone review even caught that the fix's own test masks a NEW precision bug (fixture-masks-bug recurring one layer down); three independent forward-looking throughlines; premise-false caught by the implementer (Kavitha) AND independently confirmed; honest scope-splitting (da#153/154/155 filed, nothing dropped).
 - **Needs improvement (process):** the `validate_labels` hook bit the orchestrator twice (multi-cmd `--repo` cross-association + stale label cache) — tracked in #661/#663, worked around; and the fixture-masks-bug class keeps recurring — proposed as a charter rule this retro.
+
+## Phase 5 Wave 2 Trust Updates (2026-06-14) — API light-up
+
+Clean wave: 5 PRs, **0 ChangesRequested cycles** (every PR approved first-pass), CI green, staging green. Team = isnad-graph roster. One integrity note: the keystone #1024/#1045 shipped under Ingrid's identity but was an **orchestrator-takeover** (the assigned implementer produced no branch/PR/commit and no task was tracked — see feedback_log pain point #1); Ingrid is therefore **held, not credited**, for that PR.
+
+### Implementers
+| Rated | Old | New | Reason |
+|-------|-----|-----|--------|
+| Ingrid Lindqvist | 5 | 5 | Hold at ceiling on prior standing. #1045 (narrators 500 keystone) shipped under her identity but was orchestrator-authored after a dispatch stall — **not credited** to her this wave (integrity: don't credit unearned work). No negative signal either — the stall was a dispatch/tracking gap, not her slip. |
+| Jun-Seo Park | 4 | 4 | #1033 (search 422) — correct dual-cap fix (keyword 100 / semantic 50), non-vacuous boundary tests both sides, both approvals first-pass. Trivial post-#1028 merge conflict resolved by orchestrator. Hold (clean, at 4 since W4). |
+| Ravi Wickramasinghe | 3 | **4** (▲) | #1030 (i18n page-body, TD intake) — clean; reviewers verified 7-locale key parity programmatically (72-key base, 0 missing/extra) + correct grade-filter scope policy. Also reviewed #1028. Recovery from the stale W-early DS-integration neutral. |
+| Idris Yusuf | 4 | 4 | #1029 (auth refresh-on-401 across admin+profile clients) — clean, both approvals (Anya + Arjun). Hold (clean trajectory). |
+| Mateo Salazar | 5 | 5 | Dual contributor: implemented #1028 (subscriptions/me origin + derive collection facet) AND reviewed #1045 + #1030 (the #1045 review flagged the frontend-TS-nullable follow-up → ig#1046). Maintain at ceiling. |
+
+### Reviewers
+| Rated | Old | New | Reason |
+|-------|-----|-----|--------|
+| Marisol Vega-Cruz | 3 | **4** (▲) | **Wave MVP (reviews)** — 4 rigorous code-verified reviews (#1045, #1033, #1030, #1028), each run-the-tests + verify-against-head, and the load-bearing #1033↔#1028 merge-sequencing flag that predicted the exact conflict. Strong recovery from the old tarball-lockfile neutral. |
+| Farhan Malik | 5 | 5 | #1033 review — independently reproduced the dual-cap root cause + confirmed tests non-vacuous. Maintain at ceiling. |
+| Anya Kowalczyk | 5 | 5 | #1029 review. Maintain at ceiling. |
+| Arjun Raghavan | 4 | 4 | #1029 review. Hold. |
+
+### Orchestrator (Self-Assessment)
+| Rated | Old | New | Reason |
+|-------|-----|-----|--------|
+| Orchestrator (Steven via Claude) | 4 | 4 | (hold) Drove the wave to a clean close (5 PRs, wave→main, stg green, counters exact 5/0/20) AND handled a wide product/ops surface in parallel (landing-page hotfix, monitoring check-in, 3 issue-set filings for P5W3). Caught the #1024 dispatch stall and took it over correctly (sound fix + regression test), but **the stall itself is a process gap I own** — implementers were spawned without TaskCreate tracking, so a zero-output implementer was invisible until a manual nudge. Holding 4: clean execution offset by the dispatch-tracking gap (proposed fix this retro). |
+
+### Done Well / Needs Improvement (Phase 5 Wave 2)
+- **Done well:** cleanest wave in recent memory (0 CR cycles, all first-pass approvals); strong independent review culture (Marisol's 4 verified reviews + the predicted merge-conflict flag; Mateo's TS-nullable follow-up); honest scope handling (#1023 relocated to deploy#449, not silently dropped); the keystone narrators-500 fix unblocks /graph + narrator search.
+- **Needs improvement (process):** (1) implementer dispatch had no task-tracking → a zero-output implementer (#1024) was invisible until manual nudge; (2) local full-suite test runs hang on absent sandbox DB services (14-min stall) — needs a documented verify-via-unit-construction-then-cite-CI pattern.


### PR DESCRIPTION
## P5W2 retro outputs

Files changed (both in diff):
- `.claude/team/trust_matrix.md` — Phase 5 Wave 2 Trust Updates section
- `.claude/team/feedback_log.md` — Phase 5 Wave 2 retrospective entry

### Summary
Clean wave: 5 PRs merged + wave→main (#1047), **0 ChangesRequested cycles**, CI + staging green (deploy-stg 27506467050).

**Trust changes:** Ravi 3→4 (clean i18n + review), Marisol 3→4 (reviews-MVP, 4 verified reviews + predicted the merge conflict). Ingrid held at 5 — **not credited** for #1045 (orchestrator-takeover after a dispatch stall; integrity). Mateo/Farhan/Anya hold ceiling; Idris/Jun-Seo/Arjun hold 4. Orchestrator self-assessment: hold 4.

**Top pain points:** (1) implementer dispatch had no task-tracking → keystone #1024 stalled invisibly until a manual nudge; (2) local full-suite tests hang on absent sandbox DB services.

**Proposed changes (await owner approval):** (1) TaskCreate-per-implementer at kickoff; (2) sandbox test-verification pattern (unit-construct + cite-CI; `.venv/bin` over `uv run`).

Annunaki: 16 captures, all noise/benign, cleared. Memory audit: no new conversions.