### PR TITLE
Phase 5 Wave 3 → main (noorinalabs-main)

### DIFF
--- a/.claude/hooks/_wave_label_parse.py
+++ b/.claude/hooks/_wave_label_parse.py
@@ -137,9 +137,18 @@ class WaveLabelCreate:
 
     Issue NUMBER is not present at parse-time (the create has not yet
     landed); the caller extracts it from PostToolUse stdout.
+
+    `repo` is the short repo name from `--repo owner/name` (e.g.
+    `noorinalabs-main`), or None when the command OMITS `--repo` and relies
+    on gh's ambient-git-context resolution (#659 — the create-surface sibling
+    of the EDIT-path #650 fix). Requiring `--repo` here silently dropped every
+    in-repo `gh issue create` (the create never reached the Wave-field sync →
+    the board Wave field went unset). When `--repo` is absent the consumer
+    resolves the concrete repo from the created-issue URL in PostToolUse
+    stdout, which is the authoritative repo the issue actually landed in.
     """
 
-    repo: str
+    repo: str | None
     add_label: str
 
 
@@ -309,6 +318,14 @@ def parse_wave_label_create(command: str) -> list[WaveLabelCreate]:
     only the FIRST wave-label value is captured (Hook 13's existing
     invariant — one wave label per issue).
 
+    `--repo` is OPTIONAL (#659): an in-repo `gh issue create --label
+    "p{N}-wave-{M}"` run without `--repo` relies on gh's ambient-git-context
+    resolution and carries no `--repo` token. Such a create still yields a
+    `WaveLabelCreate` (with `repo=None`); the consumer resolves the concrete
+    repo from the created-issue URL. Before this fix the `if wave_label and
+    repo:` gate dropped every in-repo create, leaving the board Wave field
+    unset — the create-surface sibling of the EDIT-path #650 silent-drop.
+
     Issue #450 use case: Hook 13 (`auto_add_issue_to_board`) needs to
     know the wave label at create-time so it can set the project board's
     Wave single-select field after adding the issue. The issue NUMBER
@@ -360,6 +377,11 @@ def parse_wave_label_create(command: str) -> list[WaveLabelCreate]:
                 continue
             i += 1
 
-        if wave_label and repo:
+        if wave_label:
+            # `repo` may be None (in-repo `gh issue create` without `--repo`,
+            # #659). Emit the create anyway; the consumer recovers the concrete
+            # repo from the created-issue URL. Gating on `repo` here silently
+            # dropped every in-repo wave-labeled create — the create-surface
+            # twin of the EDIT-path #650 drop.
             out.append(WaveLabelCreate(repo=repo, add_label=wave_label))
     return out

--- a/.claude/hooks/auto_add_issue_to_board.py
+++ b/.claude/hooks/auto_add_issue_to_board.py
@@ -247,19 +247,42 @@ def check(
         # parser may return multiple create-segments for compound commands;
         # pick the one whose repo matches the URL's repo to avoid mis-syncing
         # in `gh issue create --repo A ... && gh issue create --repo B ...`
-        # shapes.
+        # shapes. A create issued WITHOUT `--repo` (in-repo, ambient
+        # resolution — #659) parses with `repo=None`; it cannot match the URL
+        # repo by equality, so fall back to the first `repo is None` segment
+        # (the ambient create targets exactly the repo the URL reports) and
+        # finally `creates[0]`.
         url_repo_match = re.search(r"noorinalabs/([^/]+)/issues/", issue_url)
         url_repo = url_repo_match.group(1) if url_repo_match else None
-        chosen = next((c for c in creates if c.repo == url_repo), creates[0])
-        sync_result = _sync_wave_field_for_create(
-            repo=chosen.repo,
-            issue_number=issue_number,
-            wave_label=chosen.add_label,
-            command=command,
-            auth_status_runner=auth_status_runner,
-            graphql_runner=graphql_runner,
+        chosen = next(
+            (c for c in creates if c.repo == url_repo),
+            next((c for c in creates if c.repo is None), creates[0]),
         )
-        result["wave_field_sync"] = sync_result
+        # `chosen.repo` is None for an ambient (#659) create; the created-issue
+        # URL is the authoritative repo the issue actually landed in, so prefer
+        # it. (No cwd-based `resolve_repo_short_name` is needed on this surface
+        # — unlike the EDIT path #650 — because PostToolUse already has the URL.)
+        effective_repo = chosen.repo or url_repo
+        if not effective_repo:
+            # Defensive: PostToolUse only reaches here with a parsed issue URL,
+            # so url_repo is normally present. Log rather than silently drop.
+            log_posttooluse_event(
+                "auto_add_issue_to_board",
+                command,
+                "skip_no_repo_context: wave-labeled create has no --repo and the "
+                f"issue URL {issue_url!r} yielded no repo; cannot sync Wave field.",
+            )
+            result["wave_field_sync"] = {"action": "skip_no_repo_context"}
+        else:
+            sync_result = _sync_wave_field_for_create(
+                repo=effective_repo,
+                issue_number=issue_number,
+                wave_label=chosen.add_label,
+                command=command,
+                auth_status_runner=auth_status_runner,
+                graphql_runner=graphql_runner,
+            )
+            result["wave_field_sync"] = sync_result
 
     return result
 

--- a/.claude/hooks/tests/test_auto_add_issue_to_board.py
+++ b/.claude/hooks/tests/test_auto_add_issue_to_board.py
@@ -305,6 +305,90 @@ class CreateWithWaveLabelTests(unittest.TestCase):
         self.assertEqual(sync["option_name"], "P3W12")
 
 
+class CreateWithoutRepoFlagWaveLabelTests(unittest.TestCase):
+    """#659 — in-repo `gh issue create` WITHOUT `--repo` (ambient resolution)
+    must still sync the Wave field; the concrete repo is recovered from the
+    created-issue URL. Before the fix the parser dropped the create (gated on
+    `--repo`) and the board Wave field was left unset — the create-surface
+    sibling of the EDIT-path #650 silent-drop.
+    """
+
+    def setUp(self):
+        _wipe_field_sync_cache()
+        field_sync_hook.CACHE_DIR.mkdir(parents=True, exist_ok=True)
+        field_sync_hook._write_cache(_ids_blob())
+
+    def tearDown(self):
+        _wipe_field_sync_cache()
+
+    def test_in_repo_create_without_repo_flag_resolves_repo_from_url(self):
+        cmd = 'gh issue create --title "bug" --body "x" --label "p3-wave-11"'
+        stdout = "https://github.com/noorinalabs/noorinalabs-main/issues/659\n"
+        router = FakeGraphQLRouter(
+            item_lookup=_item_lookup_response,
+            mutation=_mutation_success_response,
+        )
+        with patch.object(hook.subprocess, "run") as mock_run:
+            mock_run.return_value = type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+            result = hook.check(
+                _bash_create(cmd, stdout=stdout),
+                auth_status_runner=_scopes_with_project,
+                graphql_runner=router,
+            )
+        self.assertEqual(result["action"], "added")
+        sync = result["wave_field_sync"]
+        self.assertEqual(sync["action"], "set")
+        self.assertEqual(sync["repo"], "noorinalabs-main")  # recovered from the URL
+        self.assertEqual(sync["issue"], "659")
+        self.assertEqual(sync["option_name"], "P3W11")
+        self.assertEqual(router.calls["mutation"], 1)
+
+    def test_equals_form_without_repo_also_resolves(self):
+        """`--label=p3-wave-11` with no `--repo` (equals form) also syncs."""
+        cmd = "gh issue create --title bug --body x --label=p3-wave-11"
+        stdout = "https://github.com/noorinalabs/noorinalabs-isnad-graph/issues/77\n"
+        router = FakeGraphQLRouter(
+            item_lookup=_item_lookup_response,
+            mutation=_mutation_success_response,
+        )
+        with patch.object(hook.subprocess, "run") as mock_run:
+            mock_run.return_value = type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+            result = hook.check(
+                _bash_create(cmd, stdout=stdout),
+                auth_status_runner=_scopes_with_project,
+                graphql_runner=router,
+            )
+        sync = result["wave_field_sync"]
+        self.assertEqual(sync["action"], "set")
+        self.assertEqual(sync["repo"], "noorinalabs-isnad-graph")
+
+
+class ParseWaveLabelCreateTests(unittest.TestCase):
+    """#659 parser-level coverage for the `--repo`-Optional create path."""
+
+    def test_create_without_repo_returns_change_with_repo_none(self):
+        from _wave_label_parse import parse_wave_label_create
+
+        creates = parse_wave_label_create('gh issue create --title "bug" --label "p5-wave-3"')
+        self.assertEqual(len(creates), 1)
+        self.assertIsNone(creates[0].repo)
+        self.assertEqual(creates[0].add_label, "p5-wave-3")
+
+    def test_create_with_repo_still_captures_short_name(self):
+        from _wave_label_parse import parse_wave_label_create
+
+        creates = parse_wave_label_create(
+            "gh issue create --repo noorinalabs/noorinalabs-main --label p5-wave-3"
+        )
+        self.assertEqual(len(creates), 1)
+        self.assertEqual(creates[0].repo, "noorinalabs-main")
+
+    def test_create_without_wave_label_returns_empty(self):
+        from _wave_label_parse import parse_wave_label_create
+
+        self.assertEqual(parse_wave_label_create("gh issue create --label bug"), [])
+
+
 class ExtractIssueUrlTests(unittest.TestCase):
     """Pure-function coverage for the URL+number extractor."""
 

--- a/.claude/hooks/tests/test_validate_labels.py
+++ b/.claude/hooks/tests/test_validate_labels.py
@@ -149,6 +149,47 @@ class NegativeMatchLabelsTests(unittest.TestCase):
         )
 
 
+class TokenizeFailureFallbackTests(unittest.TestCase):
+    """#661 — when shlex tokenization FAILS, label extraction must NOT scoop
+    label-shaped tokens out of `--body`/`--title` prose.
+
+    The prior fallback ran a `(?:--label|-l)`-anchored regex over the WHOLE
+    command on shlex failure, which over-matched documented label patterns in
+    the issue body and false-blocked a legitimate `gh issue create`. The fix
+    fails OPEN (returns []) instead of over-matching.
+    """
+
+    def test_exact_issue_661_reproducer_does_not_leak_body_label(self):
+        """The live P4W7 repro: body documents ``--label `p{N}-wave-{M}` `` and
+        contains an apostrophe ("gh's") that breaks shlex. The real flag is
+        `--label bug`; the documented pattern MUST NOT be extracted."""
+        body = "This hook validates --label `p{N}-wave-{M}` tokens. Note gh's resolution."
+        cmd = f"gh issue create --repo noorinalabs/noorinalabs-main --label bug --body '{body}'"
+        from _shell_parse import tokenize
+
+        self.assertIsNone(tokenize(cmd), "precondition: this command must break shlex")
+        labels = hook.extract_labels(cmd)
+        self.assertNotIn("`p{N}-wave-{M}`", labels)
+        self.assertNotIn("p{N}-wave-{M}", labels)
+
+    def test_tokenize_failure_returns_empty_not_body_tokens(self):
+        """A `-l`/`--label` substring inside a quote-broken body must not leak."""
+        body = "see -l phantom and --label ghost; can't parse this"
+        cmd = f"gh issue create --label real --body '{body}'"
+        from _shell_parse import tokenize
+
+        self.assertIsNone(tokenize(cmd))
+        self.assertEqual(hook.extract_labels(cmd), [])
+
+    def test_check_does_not_block_on_malformed_quote_body(self):
+        """End-to-end: the #661 reproducer must ALLOW (no spurious block)."""
+        body = "Documents --label `p{N}-wave-{M}`. Mentions gh's ambient repo."
+        cmd = f"gh issue create --repo noorinalabs/noorinalabs-main --label bug --body '{body}'"
+        with mock.patch.object(hook, "get_existing_labels", return_value={"bug"}):
+            result = hook.check({"tool_name": "Bash", "tool_input": {"command": cmd}})
+        self.assertIsNone(result, f"unexpected block on malformed-quote body: {result}")
+
+
 class ExtractRepoTests(unittest.TestCase):
     """Coverage for Bug 1 (#113) — --repo flag pass-through."""
 

--- a/.claude/hooks/validate_labels.py
+++ b/.claude/hooks/validate_labels.py
@@ -84,23 +84,23 @@ def extract_labels(command: str) -> list[str]:
     treated as opaque single tokens and cannot leak into the label set
     (Bug 2 fix). Comma-separated values within a single flag are split.
 
-    Falls back to a conservative regex on shlex parse failure (e.g. command
-    contains a malformed quote). The fallback still anchors on `--label`
-    appearing at a shell-token boundary.
+    Returns an empty list (→ the gate ALLOWS) when shlex tokenization fails
+    (e.g. a malformed/unbalanced quote — typically an apostrophe such as
+    "gh's" inside a single-quoted `--body`). This is the #661 fix: the prior
+    fallback ran a `(?:--label|-l)`-anchored regex over the WHOLE command,
+    which scooped label-shaped tokens out of `--body`/`--title` prose (e.g. a
+    documented ``--label `p{N}-wave-{M}` `` pattern) and FALSE-BLOCKED a
+    legitimate `gh issue create`. Without reliable token boundaries we cannot
+    tell a real `--label` flag from one quoted inside body text, so we
+    deliberately fail OPEN here: the label-existence check is a best-effort
+    pre-flight and `gh` itself rejects a genuinely-missing label server-side,
+    whereas a false block stops valid work. We therefore prefer skipping
+    validation over over-matching. Comma-separated values within a single
+    flag are split.
     """
     tokens = tokenize(command)
     if tokens is None:
-        labels: list[str] = []
-        for match in re.finditer(
-            r'(?:^|\s)(?:--label|-l)(?:=|\s+)["\']?([^"\'\s]+)["\']?',
-            command,
-        ):
-            raw = match.group(1).strip()
-            for label in raw.split(","):
-                label = label.strip()
-                if label:
-                    labels.append(label)
-        return labels
+        return []
 
     labels = []
     for raw in walk_flag_values(tokens, _LABEL_FLAGS):


### PR DESCRIPTION
Final P5W3 wave merge for `noorinalabs-main` — theme **Trustworthy data & search** (meta noorinalabs-main#675). All 1 wave PR(s) reviewed (2 Approved) + CI green, merged to `deployments/phase-5/wave-3` and source issues closed. Wave branch retained (no --delete-branch) per owner directive.