### PR TITLE
process(P5W3-retro): agent-liveness + ledger-reconcile + roster guard + wave-key reset

### DIFF
--- a/.claude/lib/roster_consistency_check.py
+++ b/.claude/lib/roster_consistency_check.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Roster consistency check: .claude/team/roster.json <-> .claude/team/roster/*.md
+
+Detects drift between the union-manifest roster.json and the per-member
+roster/*.md identity cards, for every team member who has a roster/*.md file.
+
+Checks per roster/*.md (cross-checked against roster.json):
+  1. Intra-file consistency — ## Identity "Name:" must equal
+     ## Git Identity "user.name:" within the same card.
+  2. md->json presence — user.name must exist as a key in roster.json.
+  3. Email match — roster.json[user.name] must equal user.email from the card.
+
+Why this is NOT a blocking hook
+================================
+Blocking PreToolUse hooks that load and parse files on every Edit/Write call
+add latency to every agent operation. A buggy blocking hook halts all work
+until fixed, which is a higher cost than the drift it prevents. This check is
+therefore wired non-blocking:
+
+  * /session-start advisory step: run automatically; reported as a health
+    warning in the session-start status table. Operator sees drift
+    immediately at session open without being blocked.
+  * CI job (continue-on-error: true): fires on PRs that touch roster.*
+    files, surfacing drift to reviewers as an advisory check. A single PR
+    that adds a roster.json entry but not the .md (or vice-versa) should not
+    hard-block the PR, per org pattern for cross-repo-derived artifact gates
+    (memory feedback_org_wide_artifact_gate_non_blocking).
+
+Use roster_union_sync.py for the complementary check (parent roster.json
+covers every child-repo persona) — this module covers the intra-parent
+.md <-> roster.json consistency only.
+
+Invocation:
+  roster_consistency_check.py [--repo-root <dir>]
+
+Exit codes:
+  0 -- roster consistent (all .md entries agree with roster.json), or no
+       roster/*.md files found (nothing to check)
+  1 -- drift found (drift list printed to stdout)
+  2 -- usage error or roster.json load failure
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+ROSTER_JSON_PATH = ".claude/team/roster.json"
+ROSTER_DIR_PATH = ".claude/team/roster"
+
+
+def load_roster_json(repo_root: Path) -> dict[str, str] | None:
+    """Load name->email mapping from roster.json.
+
+    Returns the parsed dict, or None when the file is missing or malformed
+    (caller treats None as a load error -- exit 2).
+    """
+    path = repo_root / ROSTER_JSON_PATH
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def parse_roster_md(path: Path) -> dict[str, str | None]:
+    """Extract identity fields from a roster/*.md card.
+
+    Parses the roster card template (## Identity / ## Git Identity sections)
+    and returns a dict with three keys:
+
+      identity_name  -- "Name:" line under "## Identity"
+      git_user_name  -- "user.name:" line under "## Git Identity"
+      git_user_email -- "user.email:" line under "## Git Identity"
+
+    Values are None when the corresponding field is absent from the card.
+    """
+    text = path.read_text(encoding="utf-8")
+    result: dict[str, str | None] = {
+        "identity_name": None,
+        "git_user_name": None,
+        "git_user_email": None,
+    }
+
+    # Roster cards follow the template: "- **Name:** <value>" or
+    # "- **user.name:** <value>" -- both bullet and bold-key forms.
+    name_m = re.search(r"^[-*]\s+\*\*Name:\*\*\s+(.+)$", text, re.MULTILINE)
+    if name_m:
+        result["identity_name"] = name_m.group(1).strip()
+
+    git_name_m = re.search(r"^[-*]\s+\*\*user\.name:\*\*\s+(.+)$", text, re.MULTILINE)
+    if git_name_m:
+        result["git_user_name"] = git_name_m.group(1).strip()
+
+    git_email_m = re.search(r"^[-*]\s+\*\*user\.email:\*\*\s+(.+)$", text, re.MULTILINE)
+    if git_email_m:
+        result["git_user_email"] = git_email_m.group(1).strip()
+
+    return result
+
+
+def check_consistency(repo_root: Path) -> list[str]:
+    """Cross-check every roster/*.md entry against roster.json.
+
+    Pure function given loaded data -- IO lives in load_roster_json and
+    parse_roster_md, keeping the drift logic unit-testable without tmp files.
+
+    Returns a (possibly empty) list of human-readable drift strings.
+    An empty list means the roster is consistent.
+    """
+    roster_json = load_roster_json(repo_root)
+    if roster_json is None:
+        return [
+            f"ERROR: could not load {ROSTER_JSON_PATH} -- verify the file exists and is valid JSON"
+        ]
+
+    roster_dir = repo_root / ROSTER_DIR_PATH
+    md_files: list[Path] = sorted(roster_dir.glob("*.md")) if roster_dir.is_dir() else []
+
+    drift: list[str] = []
+
+    for md_path in md_files:
+        fields = parse_roster_md(md_path)
+        id_name = fields["identity_name"]
+        git_name = fields["git_user_name"]
+        git_email = fields["git_user_email"]
+        short = md_path.name
+
+        # Missing required fields -- report each independently so the operator
+        # can fix them one by one.
+        if id_name is None:
+            drift.append(f"{short}: missing '## Identity / **Name:**' field")
+        if git_name is None:
+            drift.append(f"{short}: missing '## Git Identity / **user.name:**' field")
+        if git_email is None:
+            drift.append(f"{short}: missing '## Git Identity / **user.email:**' field")
+
+        # Check 1 (intra-file): Identity Name must equal Git Identity user.name.
+        if id_name is not None and git_name is not None and id_name != git_name:
+            drift.append(
+                f"{short}: Identity Name ({id_name!r}) != Git Identity user.name ({git_name!r})"
+            )
+
+        # Check 2 (md->json): user.name must be a key in roster.json.
+        if git_name is not None and git_name not in roster_json:
+            drift.append(f"{short}: user.name={git_name!r} not found in roster.json")
+
+        # Check 3 (email match): roster.json[user.name] must equal user.email.
+        if git_name is not None and git_email is not None and git_name in roster_json:
+            expected = roster_json[git_name]
+            if expected != git_email:
+                drift.append(
+                    f"{short}: user.email={git_email!r} != roster.json[{git_name!r}]={expected!r}"
+                )
+
+    return drift
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Check roster.json <-> roster/*.md consistency (non-blocking advisory)."
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=".",
+        help="path to the repository root containing .claude/team/ (default: .)",
+    )
+    args = parser.parse_args(argv)
+
+    repo_root = Path(args.repo_root).expanduser().resolve()
+    drift = check_consistency(repo_root)
+
+    if drift:
+        print("ROSTER DRIFT DETECTED -- the following inconsistencies need resolution:")
+        for item in drift:
+            print(f"  - {item}")
+        return 1
+
+    roster_dir = repo_root / ROSTER_DIR_PATH
+    md_count = len(list(roster_dir.glob("*.md"))) if roster_dir.is_dir() else 0
+    print(
+        f"roster consistent -- {md_count} roster/*.md file(s) verified against roster.json,"
+        " no drift."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/lib/tests/test_roster_consistency_check.py
+++ b/.claude/lib/tests/test_roster_consistency_check.py
@@ -1,0 +1,242 @@
+"""Tests for roster_consistency_check -- roster.json <-> roster/*.md drift gate.
+
+Verifies:
+  1. Consistent card: identity fields match roster.json exactly -> exit 0.
+  2. Intra-file mismatch: Identity Name != Git Identity user.name -> exit 1.
+  3. Missing from json: user.name not in roster.json -> exit 1.
+  4. Email mismatch: user.email in .md differs from roster.json email -> exit 1.
+  5. Missing field: .md lacks ## Git Identity user.name -> exit 1.
+  6. No .md files: nothing to check -> exit 0 (clean by definition).
+  7. Mixed: one clean card + one drifted card -> only drifted card reported.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from roster_consistency_check import check_consistency, main  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Fixture card templates
+# ---------------------------------------------------------------------------
+
+CONSISTENT_MD = """\
+# Team Member Roster Card
+
+## Identity
+- **Name:** Aino Virtanen
+- **Role:** Standards & Quality Lead
+
+## Git Identity
+- **user.name:** Aino Virtanen
+- **user.email:** parametrization+Aino.Virtanen@gmail.com
+"""
+
+# Identity Name uses unhyphenated form; Git Identity user.name is hyphenated.
+# Mirrors the Mei-Lin Chang incident that motivated this check.
+INTRA_NAME_MISMATCH_MD = """\
+# Team Member Roster Card
+
+## Identity
+- **Name:** Mei Lin Chang
+- **Role:** Data Engineer
+
+## Git Identity
+- **user.name:** Mei-Lin Chang
+- **user.email:** parametrization+Mei-Lin.Chang@gmail.com
+"""
+
+# user.name exists in the card but is absent from roster.json.
+MISSING_FROM_JSON_MD = """\
+# Team Member Roster Card
+
+## Identity
+- **Name:** Ghost Member
+- **Role:** Phantom
+
+## Git Identity
+- **user.name:** Ghost Member
+- **user.email:** parametrization+Ghost.Member@gmail.com
+"""
+
+# user.name is in roster.json but the .md email differs.
+EMAIL_MISMATCH_MD = """\
+# Team Member Roster Card
+
+## Identity
+- **Name:** Aino Virtanen
+- **Role:** Standards & Quality Lead
+
+## Git Identity
+- **user.name:** Aino Virtanen
+- **user.email:** wrong+typo@example.com
+"""
+
+# .md is missing the user.name field entirely.
+MISSING_GIT_NAME_MD = """\
+# Team Member Roster Card
+
+## Identity
+- **Name:** Aino Virtanen
+
+## Git Identity
+- **user.email:** parametrization+Aino.Virtanen@gmail.com
+"""
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _setup_repo(
+    tmp: Path,
+    roster_json: dict[str, str],
+    md_files: dict[str, str],
+) -> Path:
+    """Write roster.json and roster/*.md files under a tmp repo root."""
+    team_dir = tmp / ".claude" / "team"
+    team_dir.mkdir(parents=True)
+    (team_dir / "roster.json").write_text(json.dumps(roster_json), encoding="utf-8")
+    roster_dir = team_dir / "roster"
+    roster_dir.mkdir()
+    for filename, content in md_files.items():
+        (roster_dir / filename).write_text(content, encoding="utf-8")
+    return tmp
+
+
+# ---------------------------------------------------------------------------
+# check_consistency unit tests
+# ---------------------------------------------------------------------------
+
+
+class CheckConsistencyTests(unittest.TestCase):
+    def test_consistent_card_returns_no_drift(self) -> None:
+        with TemporaryDirectory() as tmp:
+            repo = _setup_repo(
+                Path(tmp),
+                {"Aino Virtanen": "parametrization+Aino.Virtanen@gmail.com"},
+                {"standards_lead_aino.md": CONSISTENT_MD},
+            )
+            self.assertEqual(check_consistency(repo), [])
+
+    def test_intra_name_mismatch_reported(self) -> None:
+        with TemporaryDirectory() as tmp:
+            # roster.json matches the git-identity name (with hyphen)
+            repo = _setup_repo(
+                Path(tmp),
+                {"Mei-Lin Chang": "parametrization+Mei-Lin.Chang@gmail.com"},
+                {"mei_lin_chang.md": INTRA_NAME_MISMATCH_MD},
+            )
+            drift = check_consistency(repo)
+            self.assertTrue(
+                any("Identity Name" in d and "user.name" in d for d in drift),
+                msg=f"Expected intra-name mismatch in drift; got: {drift}",
+            )
+
+    def test_missing_from_json_reported(self) -> None:
+        with TemporaryDirectory() as tmp:
+            repo = _setup_repo(
+                Path(tmp),
+                {"Aino Virtanen": "parametrization+Aino.Virtanen@gmail.com"},
+                {"ghost.md": MISSING_FROM_JSON_MD},
+            )
+            drift = check_consistency(repo)
+            self.assertTrue(
+                any("not found in roster.json" in d for d in drift),
+                msg=f"Expected missing-from-json in drift; got: {drift}",
+            )
+
+    def test_email_mismatch_reported(self) -> None:
+        with TemporaryDirectory() as tmp:
+            repo = _setup_repo(
+                Path(tmp),
+                {"Aino Virtanen": "parametrization+Aino.Virtanen@gmail.com"},
+                {"standards_lead_aino.md": EMAIL_MISMATCH_MD},
+            )
+            drift = check_consistency(repo)
+            self.assertTrue(
+                any("user.email" in d and "roster.json" in d for d in drift),
+                msg=f"Expected email mismatch in drift; got: {drift}",
+            )
+
+    def test_missing_git_name_field_reported(self) -> None:
+        with TemporaryDirectory() as tmp:
+            repo = _setup_repo(
+                Path(tmp),
+                {"Aino Virtanen": "parametrization+Aino.Virtanen@gmail.com"},
+                {"standards_lead_aino.md": MISSING_GIT_NAME_MD},
+            )
+            drift = check_consistency(repo)
+            self.assertTrue(
+                any("user.name" in d for d in drift),
+                msg=f"Expected missing-field report in drift; got: {drift}",
+            )
+
+    def test_no_md_files_returns_no_drift(self) -> None:
+        with TemporaryDirectory() as tmp:
+            repo = _setup_repo(
+                Path(tmp),
+                {"Aino Virtanen": "parametrization+Aino.Virtanen@gmail.com"},
+                {},  # no .md files -- nothing to check
+            )
+            self.assertEqual(check_consistency(repo), [])
+
+    def test_mixed_cards_only_drifted_reported(self) -> None:
+        with TemporaryDirectory() as tmp:
+            repo = _setup_repo(
+                Path(tmp),
+                {
+                    "Aino Virtanen": "parametrization+Aino.Virtanen@gmail.com",
+                    "Mei-Lin Chang": "parametrization+Mei-Lin.Chang@gmail.com",
+                },
+                {
+                    "standards_lead_aino.md": CONSISTENT_MD,
+                    "mei_lin_chang.md": INTRA_NAME_MISMATCH_MD,
+                },
+            )
+            drift = check_consistency(repo)
+            # Aino is clean; Mei-Lin has the intra-name mismatch.
+            self.assertTrue(
+                any("mei_lin_chang.md" in d for d in drift),
+                msg=f"Expected mei_lin_chang drift; got: {drift}",
+            )
+            self.assertFalse(
+                any("standards_lead_aino.md" in d for d in drift),
+                msg=f"Aino should be clean; got unexpected entry: {drift}",
+            )
+
+
+# ---------------------------------------------------------------------------
+# CLI (main) tests
+# ---------------------------------------------------------------------------
+
+
+class MainTests(unittest.TestCase):
+    def test_consistent_exits_0(self) -> None:
+        with TemporaryDirectory() as tmp:
+            _setup_repo(
+                Path(tmp),
+                {"Aino Virtanen": "parametrization+Aino.Virtanen@gmail.com"},
+                {"standards_lead_aino.md": CONSISTENT_MD},
+            )
+            self.assertEqual(main(["--repo-root", tmp]), 0)
+
+    def test_drift_exits_1(self) -> None:
+        with TemporaryDirectory() as tmp:
+            _setup_repo(
+                Path(tmp),
+                {"Aino Virtanen": "parametrization+Aino.Virtanen@gmail.com"},
+                {"ghost.md": MISSING_FROM_JSON_MD},
+            )
+            self.assertEqual(main(["--repo-root", tmp]), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/skills/wave-kickoff/SKILL.md
+++ b/.claude/skills/wave-kickoff/SKILL.md
@@ -408,7 +408,7 @@ When composing spawn prompts for implementers, pull the manager's specified revi
 
 **Mechanics:**
 - At spawn (step 9 / 9a), call `TaskCreate` for each implementer: subject `"{repo}#{issue} — {slug}"`, owner = implementer name, plus the reviewer pairing in the description.
-- Mid-wave, `TaskList` is the at-a-glance stall detector: any task still `pending`/`in_progress` with **no branch/PR after a reasonable interval** is a stall — re-prod the implementer (`SendMessage`) or take it over (per `feedback_throttle_takeover`), don't wait for it to surface manually.
+- Mid-wave, `TaskList` is the at-a-glance stall detector: any task still `pending`/`in_progress` with **no branch/PR** is a potential stall. Apply the liveness threshold from charter `agents.md § Agent Liveness Checkpoint, Part (b)`: after **two idle notifications with zero artifact** (no branch, no PR, no commit), auto-flag for takeover — do not wait for a third notification. "Reasonable interval" means two zero-artifact idle notifications, not elapsed time alone.
 - `/wave-wrapup` and `/wave-retro` cross-check the task list against merged PRs; a task with no delivered PR is a scope-drop or substitution to reconcile explicitly (already required by those skills' reconciliation steps — this makes the input ledger reliable).
 
 This is the input-side counterpart to the wrapup scope-drop / implementer-substitution reconciliation: those catch silent drops/swaps at *close*; the task ledger catches a zero-output stall *during* the wave.

--- a/.claude/skills/wave-start/SKILL.md
+++ b/.claude/skills/wave-start/SKILL.md
@@ -116,6 +116,62 @@ for label in "tech-debt" "feature" "bug" "security" "infra" "process"; do
 done
 ```
 
+### 5a. Wave-key per-phase reset (when a phase reuses a wave number)
+
+At phase boundaries, bare `wave_{M}_*` keys from the prior phase's wave M remain in `cross-repo-status.json` under the same names (e.g. `wave_3_final_pr_count`, `wave_3_completed_at`, `wave_3_annunaki_attack_ran_at`). These stale values bleed into the new phase's wave M if not explicitly cleared.
+
+**Detection:** before writing any new active-state keys, check whether `wave_{M}_completed_at` or `wave_{M}_wrapped_up_at` exists in the current file AND `current_phase` in the file differs from the phase `{P}` you are starting:
+
+```bash
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+STATUS_FILE="$REPO_ROOT/cross-repo-status.json"
+
+FILE_PHASE=$(python3 -c "import json; d=json.load(open('$STATUS_FILE')); print(d.get('current_phase',''))")
+HAS_PRIOR=$(python3 -c "
+import json; d=json.load(open('$STATUS_FILE'))
+print('yes' if d.get('wave_{M}_completed_at') or d.get('wave_{M}_wrapped_up_at') else 'no')
+")
+
+if [ "$HAS_PRIOR" = "yes" ] && [ "$FILE_PHASE" != "{P}" ]; then
+  echo "Phase reuse detected: wave-{M} previously used in phase $FILE_PHASE; resetting stale keys before starting phase-{P}/wave-{M}."
+fi
+```
+
+**When the condition is true, reset ALL of the following `wave_{M}_*` keys to `null` via `upsert_status_keys.py` — only for keys that exist in the file (skip non-existent keys to avoid inserting `null` noise):**
+
+```bash
+# Keys to reset (enumerate exactly — no glob, to keep the surface auditable):
+RESET_KEYS=(
+  wave_{M}_final_pr_count
+  wave_{M}_changes_requested_cycles
+  wave_{M}_top_concentration_pct
+  wave_{M}_completed_at
+  wave_{M}_wrapped_up_at
+  wave_{M}_kicked_off_at
+  wave_{M}_started_at
+  wave_{M}_scope_reconciled_at
+  wave_{M}_stg_promotion
+  wave_{M}_stg_promotion_url
+  wave_{M}_annunaki_attack_ran_at
+  wave_{M}_memory_audit_ran_at
+)
+
+for KEY in "${RESET_KEYS[@]}"; do
+  EXISTS=$(python3 -c "import json; d=json.load(open('$STATUS_FILE')); print('yes' if '$KEY' in d else 'no')")
+  if [ "$EXISTS" = "yes" ]; then
+    python3 "$REPO_ROOT/.claude/lib/upsert_status_keys.py" "$STATUS_FILE" "$KEY"=null
+    echo "  reset: $KEY"
+  fi
+done
+echo "Wave-key reset complete. Prior-phase values are cleared from the live file; git history preserves them."
+```
+
+This reset runs BEFORE the § 6 PUT-contents write so the active-state keys written in § 6 are the only non-null `wave_{M}_*` values once the step completes. Fold the null assignments into the same PUT-contents payload as § 6 to avoid a separate round-trip: `jq` can del() or set-to-null the stale keys in the same content transformation.
+
+**When the condition is false** (first wave of a phase, or `current_phase` already matches `{P}` because /wave-start is being re-run within the same phase): skip this step silently.
+
+**Why `upsert_status_keys.py` and not raw `jq`:** the file uses mixed compact-inline + pretty-indented style; a naive jq round-trip reformats every compact line, producing a 500+ line cosmetic diff per wave. `upsert_status_keys.py` performs targeted text-level upsert that preserves the existing style (see skills.md § Cross-repo-status.json upsert pattern).
+
 ### 6. Update cross-repo status — PUT-contents on `main`
 
 Set the active-wave fields for this repo in `cross-repo-status.json`. This is a **main-targeting** status write, so use the **`gh api` PUT-contents recipe** — the atomic, no-local-orphan pattern documented in `/wave-kickoff` Step 1a (added P3W6 retro, supersedes local-commit-then-push). Do **not** `git add/commit/push` the file from the local tree: a local commit here re-introduces the orphan / stale-tree hazard this issue (#653) closes, and the local `main` parked in § 2 races the remote after the PUT lands.

--- a/.claude/team/charter/agents.md
+++ b/.claude/team/charter/agents.md
@@ -611,6 +611,40 @@ The two rules are complementary:
 
 P3W10 retro PR #441 § Proposed Process Changes #4. 22-substitution evidence (34% of 65 W10 PRs). Owner-adopted 2026-05-16 (PR #444). Sibling memory: `feedback_child_repo_implementer_rule.md` (which the parent § Child-Repo Implementer Rule + Spawn-Brief Verification already supersedes for roster-source rules; this sub-section adds the authority-source clarification).
 
+## Agent Liveness Checkpoint <!-- promotion-target: hook -->
+
+P5W2 and P5W3 each produced a zero-output stall invisible until manual intervention: the P5W2 #1024 narrators-500 dispatch produced no branch, no PR, no commit across the full wave; the P5W3 Nneka (#1038) silent-idle on ig#1038 went undetected until the orchestrator took over. Both required a manual nudge to surface. This section encodes the two-part rule that prevents both failure shapes from recurring silently.
+
+### Part (a): TaskCreate per implementer at spawn (mandatory)
+
+Every spawned implementer MUST have a corresponding `TaskCreate` entry at spawn time (subject = repo + issue ref + slug; owner = implementer name). The task list is the live ledger of in-flight wave work. See `/wave-kickoff` § 9b for the specific mechanics and the point in the kickoff flow at which the `TaskCreate` fires.
+
+**Rationale:** Without a task entry, a zero-output stall is invisible at the next `TaskList` sweep — the orchestrator only discovers it via a manual nudge. A tracked task makes the stall surface automatically at the next sweep.
+
+### Part (b): Zero-artifact after 2 idle notifications = auto-flag (mandatory)
+
+An implementer sending an **idle notification** ("working on it", "running tests", "will report back") but producing **no artifact** (no branch pushed, no PR opened, no commit landed) is not evidence of forward progress. The orchestrator MUST apply the following rule:
+
+- **Idle notification 1 (zero artifact):** Re-probe via `SendMessage`. Verify the task exists in `TaskList`; if absent, re-create it and note the gap.
+- **Idle notification 2 (still zero artifact):** Auto-flag for takeover or reassignment. A second successive zero-artifact idle notification is NOT "still working" — it is a stall. The orchestrator initiates the takeover mechanic described in § Throttle-Stall Recovery without waiting for a third notification.
+
+**Silent idle is categorically not evidence of forward progress.** The orchestrator MUST NOT infer progress from the absence of a completion message; the artifact (branch, PR, commit) is the only valid evidence of forward motion.
+
+### Relationship to § Throttle-Stall Recovery
+
+§ Throttle-Stall Recovery covers the **mid-task stall**: an implementer has committed or modified files but is stuck on a subsequent step. The trigger is `worktree dirty + no completion` after 30/45/60 min.
+
+This section covers the **zero-artifact stall**: the implementer has produced nothing at all despite sending idle notifications. The trigger is **notification count, not elapsed time**. The two rules are complementary: this section catches the stall earlier (before any artifact exists to assess worktree-dirty state against).
+
+### Severity
+
+- Orchestrator misses a zero-artifact stall because `TaskList` is empty (Part (a) violated): **moderate** — the stall the task list was designed to surface goes unreported.
+- Orchestrator infers "still working" from a second zero-artifact idle notification and takes no action (Part (b) violated): **moderate** — wave-level deadline risk; the P5W2 and P5W3 instances were both narrow misses on shipping the keystone deliverable.
+
+### Provenance
+
+P5W3 retro (2026-06-14) § Proposed Process Change #1 — recurred two consecutive waves. Part (a) (TaskCreate at spawn) was codified via P5W2 retro in `/wave-kickoff` § 9b. Part (b) (zero-artifact threshold) is the P5W3 addition. Both promoted here to charter level so the liveness rule applies across all spawn contexts, not just those initiated via `/wave-kickoff`.
+
 ## Throttle-Stall Recovery — Trigger Thresholds <!-- promotion-target: hook -->
 
 `feedback_throttle_takeover` covers the takeover *mechanic* — when a spawned implementer throttle-stalls mid-task with sound partial work, the orchestrator finishes directly with the implementer's per-commit identity (~5min vs respawn's ~15min). This section encodes the **trigger**: when the orchestrator should detect the stall and invoke that mechanic, rather than discovering it reactively hours later.

--- a/.claude/team/charter/state-claims.md
+++ b/.claude/team/charter/state-claims.md
@@ -110,6 +110,31 @@ The reachability discipline distinguishes "discipline violation" from "wave-orch
 
 <!-- Promoted from memory: feedback_refresh_before_acting.md (P3W9 #346 memory audit, 2026-05-10) -->
 
+### Sub-rule: Ledger-artifact reconciliation before status-driven decisions
+
+Before any implementer-status claim — "implementing", "blocked", "done" — drives an orchestrator decision (merge sequencing, issue closure, task reassignment, or takeover), the orchestrator MUST reconcile the claimed status against actual artifacts via `gh api`. The ledger (SendMessage inbox, TaskList status, team-member status reports) lags artifact reality in high-churn waves.
+
+**Required verification before acting on a status claim:**
+
+```bash
+# Branch existence: has the implementer pushed code at all?
+gh api repos/noorinalabs/{repo}/git/refs/heads/{branch} --jq '.object.sha' 2>/dev/null \
+  || echo "branch not found — zero-artifact stall"
+
+# PR existence: is there an open or merged PR for this issue?
+gh pr list --repo noorinalabs/{repo} \
+  --search "in:title #{issue}" --state all \
+  --json number,state,headRefOid,mergedAt
+```
+
+If the ledger says "implementing" but `gh api` finds no branch and no PR, the claimed status is **unverified**. Treat the task as a zero-artifact stall (charter `agents.md § Agent Liveness Checkpoint, Part (b)`) — do NOT make a merge/close/reassign decision based on the unverified ledger claim.
+
+This sub-rule is the **ledger-lag class** of the refresh-before-claim discipline: whereas the other sub-rules guard against stale API responses for artifacts that DO exist, this one guards against missing artifacts the ledger incorrectly implies exist.
+
+**Why:** P5W3 retro § Proposed Process Change #2 surfaced two consecutive waves where implementer status reports diverged from artifact reality: P5W2 ig#1023 reported "implementing" while deploy#454 had already resolved it; P5W3 ig#1038 reported "implementing" while no branch existed. Both required manual artifact checks to unblock the correct orchestrator decision.
+
+**Severity:** Acting on an unverified status claim without artifact check — merge/close/reassign based solely on an inbox report: **moderate** regardless of whether the decision is ultimately correct (the artifact check is cheap; skipping it is habitual rather than cost-justified).
+
 ## Refresh State Before Acting (Mandatory) <!-- promotion-target: skill -->
 
 The § Refresh State Before Claim discipline above governs **assertions** about artifact state. This section extends the same primitive to **actions**: re-check artifact state immediately before taking parallel or competing action, not based on N-minute-old snapshots.


### PR DESCRIPTION
## Summary

Four owner-approved process changes from the P5W3 retro (2026-06-14), implemented as a single cohesive charter-hardening PR.

## Changes

### 1. Agent Liveness Checkpoint — `.claude/team/charter/agents.md` + `.claude/skills/wave-kickoff/SKILL.md`

**Retro rationale:** P5W2 #1024 narrators-500 dispatch produced zero output (no branch, no PR, no commit) invisible until manual nudge; P5W3 Nneka (#1038) silent-idle went undetected until orchestrator takeover. Recurred two consecutive waves.

- **`agents.md`**: new `## Agent Liveness Checkpoint` section with two parts: (a) every spawned implementer must have a `TaskCreate` at spawn (referencing wave-kickoff § 9b for mechanics); (b) a zero-artifact implementer after 2 idle notifications is auto-flagged for takeover — silent idle is NOT "still working."
- **`wave-kickoff/SKILL.md` § 9b**: sharpened "reasonable interval" to the 2-idle-notification threshold with cross-reference to agents.md.

### 2. Ledger-Artifact Reconciliation — `.claude/team/charter/state-claims.md`

**Retro rationale:** P5W2 ig#1023 reported "implementing" while deploy#454 already resolved it; P5W3 ig#1038 reported "implementing" while no branch existed. Both required manual artifact checks to unblock.

- New `### Sub-rule: Ledger-artifact reconciliation before status-driven decisions` added after the existing `### Sub-rule: merge_commit_sha reachability` entry. Requires `gh api` branch/PR verification before any "implementing/done/blocked" status claim drives a merge, close, reassign, or takeover decision.

### 3. Roster Consistency Guard — `.claude/lib/roster_consistency_check.py` + `.claude/lib/tests/test_roster_consistency_check.py`

**Retro rationale:** Mei-Lin Chang's `roster.json` entry and `roster/*.md` identity card disagreed on name/identity.

- **`roster_consistency_check.py`**: new lib module that cross-checks every `roster/*.md` card against `roster.json` (3 checks: intra-file Name vs user.name, md→json presence, email match). Non-zero exit + drift list on mismatch; exit 0 + "roster consistent" when clean.
- **`test_roster_consistency_check.py`**: 9 pytest tests covering all drift cases and the clean case; 9/9 pass.
- **Wired non-blocking**: documented in the module docstring as a `/session-start` advisory step and `continue-on-error` CI job. NOT a blocking PreToolUse hook (per change 3 brief: a buggy blocking hook halts all work).

### 4. Wave-Key Per-Phase Reset — `.claude/skills/wave-start/SKILL.md`

**Retro rationale:** Stale P4W3 values (`final_pr_count=34`, `completed_at`, `annunaki_attack_ran_at`, `memory_audit_ran_at`) bled into P5W3 under reused `wave_3_*` keys; cleared by hand at wrapup. A stale `*_ran_at` would have made retro silently skip its audits.

- New `### 5a. Wave-key per-phase reset` step added between § 5 (Create wave label) and § 6 (Update cross-repo status). Detects phase reuse via `wave_{M}_completed_at` / `wave_{M}_wrapped_up_at` presence AND `current_phase != {P}`. When triggered, resets ALL listed stale-prone keys to `null` via `upsert_status_keys.py` before writing new active-state values.
- Exact key list enumerated in the step: counters (`final_pr_count`, `changes_requested_cycles`, `top_concentration_pct`), timestamps (`completed_at`, `wrapped_up_at`, `kicked_off_at`, `started_at`, `scope_reconciled_at`), promotion (`stg_promotion`, `stg_promotion_url`), audit markers (`annunaki_attack_ran_at`, `memory_audit_ran_at`).

## Files Changed

| File | Change |
|------|--------|
| `.claude/team/charter/agents.md` | Add `## Agent Liveness Checkpoint` section (Part a + b + severity + provenance) |
| `.claude/team/charter/state-claims.md` | Add `### Sub-rule: Ledger-artifact reconciliation before status-driven decisions` |
| `.claude/skills/wave-kickoff/SKILL.md` | Sharpen § 9b idle-notification threshold; cross-reference agents.md |
| `.claude/skills/wave-start/SKILL.md` | Add `### 5a. Wave-key per-phase reset` step |
| `.claude/lib/roster_consistency_check.py` | New: roster consistency checker (3-check drift gate) |
| `.claude/lib/tests/test_roster_consistency_check.py` | New: 9 pytest tests for roster consistency checker |

## Reviewers

Requesting 2 reviewers per charter convention. Suggested: Wanjiku Mwangi (TPM, owns wave-status and task-tracking concerns), Nadia Khoury (Program Director, owns orchestration patterns and process change ratification).

🤖 Authored by Aino Virtanen (Standards & Quality Lead)