### PR TITLE
tooling(main#688): deterministic wave repo-iteration + counter helper (kill zsh word-split)

### DIFF
--- a/.claude/lib/tests/test_wave_status.py
+++ b/.claude/lib/tests/test_wave_status.py
@@ -1,0 +1,274 @@
+"""Tests for wave_status — the deterministic wave repo-iteration + counter
+helper that replaces the zsh-word-split-fragile bash loops (main#688).
+
+Verifies:
+  1. `repos` emits wave_{M}_repos_in_scope one-per-line.
+  2. EVERY gh call goes through subprocess.run with a LIST arg vector and
+     never `shell=True` — the regression guard that makes word-splitting
+     structurally impossible.
+  3. merged-prs applies the wave_{M}_kicked_off_at cross-window filter (#423).
+  4. Counter math reproduces the P5W4 actuals 19 / 4 / 16.
+  5. `--expect N` exits 1 on a count mismatch.
+  6. An empty wave yields zeros (no division-by-zero — the original crash).
+  7. `--write` upserts the three canonical top-level keys through the shared
+     upsert_status_keys helper, preserving the file.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+from unittest import mock
+
+# Helper lives at .claude/lib/wave_status.py; this test is at
+# .claude/lib/tests/test_*.py. parent.parent reaches the lib root.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import wave_status  # noqa: E402
+
+_REPOS = [
+    "noorinalabs-isnad-graph",
+    "noorinalabs-user-service",
+    "noorinalabs-deploy",
+    "noorinalabs-isnad-ingest-platform",
+]
+
+
+def _p5w4_prs() -> list[dict]:
+    """19 PRs whose top commit-author owns 3 (3/19 = 15.78 → 16%) and whose
+    ChangesRequested comments sum to 4 — the canonical P5W4 shape."""
+    authors = (
+        ["Aino Virtanen"] * 3
+        + ["Wanjiku Mwangi"] * 3
+        + ["Santiago Ferreira"] * 3
+        + ["Nadia Khoury"] * 3
+        + ["Imelda Okoro"] * 3
+        + ["Aisling Brennan"] * 3
+        + ["Tariq Mansour"] * 1
+    )
+    assert len(authors) == 19
+    cr_by_index = {0: 2, 5: 1, 10: 1}  # sums to 4
+    prs = []
+    for i, author in enumerate(authors):
+        prs.append(
+            {
+                "repo": _REPOS[i % len(_REPOS)],
+                "number": 100 + i,
+                "sha": f"sha{i:02d}",
+                "mergedAt": "2026-06-15T02:00:00Z",
+                "login": "octocat",
+                "commit_author": author,
+                "cr": cr_by_index.get(i, 0),
+            }
+        )
+    return prs
+
+
+class _FakeGh:
+    """A subprocess.run side_effect that emulates the gh calls wave_status
+    makes, driven by a flat PR fixture. Records every command vector so the
+    test can assert the list-args / no-shell contract."""
+
+    def __init__(self, prs: list[dict]) -> None:
+        self.prs = prs
+        self.calls: list[list[str]] = []
+
+    def __call__(self, cmd, *args, **kwargs):  # noqa: ANN001
+        # Contract guard: gh is always invoked with an explicit list vector and
+        # NEVER through a shell. This is the structural fix for main#688.
+        assert isinstance(cmd, list), f"gh called with non-list cmd: {cmd!r}"
+        assert cmd[0] == "gh"
+        assert kwargs.get("shell") is not True
+        self.calls.append(cmd)
+
+        if cmd[1:3] == ["pr", "list"]:
+            repo = cmd[cmd.index("--repo") + 1].removeprefix("noorinalabs/")
+            listed = [
+                {
+                    "number": p["number"],
+                    "headRefOid": p["sha"],
+                    "mergedAt": p["mergedAt"],
+                    "author": {"login": p["login"]},
+                }
+                for p in self.prs
+                if p["repo"] == repo
+            ]
+            return SimpleNamespace(stdout=json.dumps(listed), returncode=0, stderr="")
+
+        if cmd[1] == "api":
+            path = cmd[2]
+            parts = path.split("/")
+            if "/commits/" in path:
+                sha = parts[4]
+                name = next(p["commit_author"] for p in self.prs if p["sha"] == sha)
+                return SimpleNamespace(stdout=name + "\n", returncode=0, stderr="")
+            if path.endswith("/comments"):
+                number = int(parts[4])
+                cr = next(p["cr"] for p in self.prs if p["number"] == number)
+                return SimpleNamespace(stdout=f"{cr}\n", returncode=0, stderr="")
+
+        raise AssertionError(f"unexpected gh call: {cmd!r}")
+
+
+def _write_status(path: Path, *, repos: list[str], wave: str, kickoff: str | None) -> None:
+    data: dict = {"current_wave": int(wave), f"wave_{wave}_repos_in_scope": repos}
+    if kickoff is not None:
+        data[f"wave_{wave}_kicked_off_at"] = kickoff
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+class Repos(unittest.TestCase):
+    def test_emits_one_per_line(self) -> None:
+        with TemporaryDirectory() as td:
+            status = Path(td) / "cross-repo-status.json"
+            _write_status(status, repos=_REPOS, wave="4", kickoff=None)
+            self.assertEqual(wave_status.read_repos("4", status), _REPOS)
+
+    def test_missing_key_raises(self) -> None:
+        with TemporaryDirectory() as td:
+            status = Path(td) / "cross-repo-status.json"
+            status.write_text('{"current_wave": 4}\n', encoding="utf-8")
+            with self.assertRaises(KeyError):
+                wave_status.read_repos("4", status)
+
+
+class MergedPrs(unittest.TestCase):
+    def test_kickoff_window_filter(self) -> None:
+        prs = [
+            {
+                "repo": _REPOS[0],
+                "number": 1,
+                "sha": "old",
+                "mergedAt": "2026-06-14T00:00:00Z",  # before kickoff → dropped
+                "login": "octocat",
+                "commit_author": "Aino Virtanen",
+                "cr": 0,
+            },
+            {
+                "repo": _REPOS[0],
+                "number": 2,
+                "sha": "new",
+                "mergedAt": "2026-06-15T03:00:00Z",  # after kickoff → kept
+                "login": "octocat",
+                "commit_author": "Aino Virtanen",
+                "cr": 0,
+            },
+        ]
+        with TemporaryDirectory() as td:
+            status = Path(td) / "cross-repo-status.json"
+            _write_status(status, repos=[_REPOS[0]], wave="4", kickoff="2026-06-15T01:52:55Z")
+            with mock.patch.object(wave_status.subprocess, "run", _FakeGh(prs)):
+                got = wave_status.merged_prs("5", "4", status)
+        self.assertEqual([p["number"] for p in got], [2])
+        self.assertEqual(got[0]["commit_author_name"], "Aino Virtanen")
+
+    def test_no_kickoff_key_means_no_filter(self) -> None:
+        prs = [
+            {
+                "repo": _REPOS[0],
+                "number": 1,
+                "sha": "a",
+                "mergedAt": "2026-01-01T00:00:00Z",
+                "login": "octocat",
+                "commit_author": "Aino Virtanen",
+                "cr": 0,
+            }
+        ]
+        with TemporaryDirectory() as td:
+            status = Path(td) / "cross-repo-status.json"
+            _write_status(status, repos=[_REPOS[0]], wave="4", kickoff=None)
+            with mock.patch.object(wave_status.subprocess, "run", _FakeGh(prs)):
+                got = wave_status.merged_prs("5", "4", status)
+        self.assertEqual(len(got), 1)
+
+
+class Counters(unittest.TestCase):
+    def test_reproduces_p5w4_19_4_16(self) -> None:
+        prs = _p5w4_prs()
+        fake = _FakeGh(prs)
+        with TemporaryDirectory() as td:
+            status = Path(td) / "cross-repo-status.json"
+            _write_status(status, repos=_REPOS, wave="4", kickoff="2026-06-15T01:52:55Z")
+            with mock.patch.object(wave_status.subprocess, "run", fake):
+                counters = wave_status.compute_counters("5", "4", status)
+        self.assertEqual(
+            counters,
+            {
+                "final_pr_count": 19,
+                "changes_requested_cycles": 4,
+                "top_concentration_pct": 16,
+            },
+        )
+        # Contract: every recorded gh call was a list vector starting with "gh".
+        self.assertTrue(all(c[0] == "gh" and isinstance(c, list) for c in fake.calls))
+
+    def test_changes_requested_jq_filter_double_escapes_backslash(self) -> None:
+        # The comments call's --jq arg must carry a DOUBLED backslash (\\s) so
+        # jq's string parser yields the regex \s. A single backslash is an
+        # "invalid escape sequence" jq error — the mocked fake can't see jq, so
+        # assert the literal sequence the helper builds.
+        prs = _p5w4_prs()[:1]
+        fake = _FakeGh(prs)
+        with TemporaryDirectory() as td:
+            status = Path(td) / "cross-repo-status.json"
+            _write_status(status, repos=_REPOS, wave="4", kickoff=None)
+            with mock.patch.object(wave_status.subprocess, "run", fake):
+                wave_status.compute_counters("5", "4", status)
+        comments_calls = [c for c in fake.calls if c[1] == "api" and c[2].endswith("/comments")]
+        self.assertTrue(comments_calls)
+        self.assertIn("\\\\s", comments_calls[0][-1])
+
+    def test_empty_wave_is_zeros_no_div_by_zero(self) -> None:
+        with TemporaryDirectory() as td:
+            status = Path(td) / "cross-repo-status.json"
+            _write_status(status, repos=_REPOS, wave="4", kickoff=None)
+            with mock.patch.object(wave_status.subprocess, "run", _FakeGh([])):
+                counters = wave_status.compute_counters("5", "4", status)
+        self.assertEqual(
+            counters,
+            {"final_pr_count": 0, "changes_requested_cycles": 0, "top_concentration_pct": 0},
+        )
+
+    def test_expect_mismatch_exits_1(self) -> None:
+        with TemporaryDirectory() as td:
+            status = Path(td) / "cross-repo-status.json"
+            _write_status(status, repos=_REPOS, wave="4", kickoff="2026-06-15T01:52:55Z")
+            with mock.patch.object(wave_status.subprocess, "run", _FakeGh(_p5w4_prs())):
+                rc = wave_status.main(
+                    ["counters", "5", "4", "--status", str(status), "--expect", "20"]
+                )
+        self.assertEqual(rc, 1)
+
+    def test_expect_match_exits_0(self) -> None:
+        with TemporaryDirectory() as td:
+            status = Path(td) / "cross-repo-status.json"
+            _write_status(status, repos=_REPOS, wave="4", kickoff="2026-06-15T01:52:55Z")
+            with mock.patch.object(wave_status.subprocess, "run", _FakeGh(_p5w4_prs())):
+                rc = wave_status.main(
+                    ["counters", "5", "4", "--status", str(status), "--expect", "19"]
+                )
+        self.assertEqual(rc, 0)
+
+
+class Write(unittest.TestCase):
+    def test_write_upserts_three_canonical_keys(self) -> None:
+        with TemporaryDirectory() as td:
+            status = Path(td) / "cross-repo-status.json"
+            _write_status(status, repos=_REPOS, wave="4", kickoff="2026-06-15T01:52:55Z")
+            with mock.patch.object(wave_status.subprocess, "run", _FakeGh(_p5w4_prs())):
+                rc = wave_status.main(["counters", "5", "4", "--status", str(status), "--write"])
+            self.assertEqual(rc, 0)
+            data = json.loads(status.read_text())
+            self.assertEqual(data["wave_4_final_pr_count"], 19)
+            self.assertEqual(data["wave_4_changes_requested_cycles"], 4)
+            self.assertEqual(data["wave_4_top_concentration_pct"], 16)
+            # The pre-existing keys must survive the targeted upsert.
+            self.assertEqual(data["wave_4_repos_in_scope"], _REPOS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/lib/wave_status.py
+++ b/.claude/lib/wave_status.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Deterministic wave repo-iteration + counter helper (main#688).
+
+zsh — this org's shell (memory ``feedback_zsh_shell_environment``) — does NOT
+word-split an unquoted parameter expansion ``$var`` the way bash/sh do. The
+hand-rolled ``for R in $WAVE_REPOS_IN_SCOPE`` loops in /wave-wrapup,
+/wave-kickoff and /wave-scope therefore collapsed the whole newline-joined
+repo list into a SINGLE iteration: the string
+``"noorinalabs-isnad-graph noorinalabs-user-service ..."`` was passed to ``gh``
+as one repo, which 404'd ("Could not resolve repository") → merged-PR count 0
+→ division-by-zero in the top-concentration math. It bit a single P5W4
+``/wave-wrapup`` three times — a soft memory had not stopped the recurrence, so
+the iteration + counter math is moved here, into deterministic code.
+
+Design contract:
+  * EVERY ``gh`` invocation goes through :func:`_run_gh`, which calls
+    ``subprocess.run(["gh", *args], ...)`` with an explicit ARG LIST — never a
+    shell string, never ``shell=True``. There is no word-splitting anywhere,
+    under any shell.
+  * ``repos``      — emit ``wave_{M}_repos_in_scope`` one-per-line so a bash
+                     caller can iterate safely (``while IFS= read -r R``).
+  * ``merged-prs`` — the wave's merged-PR set as JSON, cross-window-filtered by
+                     ``wave_{M}_kicked_off_at`` (the #423 partition fix).
+  * ``counters``   — ``final_pr_count`` / ``changes_requested_cycles`` /
+                     ``top_concentration_pct``; ``--write`` upserts the three
+                     canonical top-level keys that /wave-retro Step 2.5 reads
+                     (via :mod:`upsert_status_keys`, preserving the
+                     compact-inline file shape); ``--expect N`` loud-fails on a
+                     count mismatch.
+
+CLI:
+  wave_status.py repos       <P> <M> [--status PATH]
+  wave_status.py merged-prs  <P> <M> [--status PATH]
+  wave_status.py counters    <P> <M> [--write] [--expect N] [--status PATH]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import subprocess
+import sys
+from collections import Counter
+from pathlib import Path
+
+# upsert_status_keys.py lives alongside this file in .claude/lib/. When this
+# module is run as a script its own directory is on sys.path[0]; the tests add
+# the lib dir explicitly. Import lazily inside _write_counters so a missing
+# helper only matters for the --write path.
+
+# Repo root = two parents above .claude/lib/ (lib -> .claude -> root). Resolved
+# from this file so the default is correct from any cwd or worktree, with no
+# `git rev-parse` subprocess (which would re-introduce a shell dependency).
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DEFAULT_STATUS = _REPO_ROOT / "cross-repo-status.json"
+
+# A ChangesRequested verdict comment on a PR's issue-comments timeline. Mirrors
+# the regex the pre-#688 bash Step 10.5 block used. The DOUBLED backslash is
+# load-bearing: this string is embedded into a jq filter, and jq's own string
+# parser collapses ``\\s`` to the regex ``\s`` — a single backslash would be an
+# "invalid escape sequence" jq error (caught live, not by the mocked tests).
+_CHANGES_REQUESTED_RE = "RequestOrReplied:\\\\s*ChangesRequested"
+
+
+def _run_gh(args: list[str]) -> str:
+    """Run ``gh <args>`` with an explicit arg list and return stdout.
+
+    Never a shell string and never ``shell=True`` — this is the whole point of
+    the helper (main#688): no shell means no word-splitting, so a multi-word
+    repo list can never collapse into one bogus ``--repo`` value.
+    """
+    proc = subprocess.run(
+        ["gh", *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return proc.stdout
+
+
+def _load_status(status_path: Path) -> dict:
+    return json.loads(status_path.read_text())
+
+
+def read_repos(wave: str, status_path: Path) -> list[str]:
+    """Return ``wave_{M}_repos_in_scope`` as a list of repo names.
+
+    Raises KeyError if the key is absent — by the time any of these subcommands
+    runs the wave's scope must already be recorded, so a missing key is an
+    operator error to surface rather than silently treat as the empty set.
+    """
+    data = _load_status(status_path)
+    key = f"wave_{wave}_repos_in_scope"
+    if key not in data:
+        raise KeyError(key)
+    repos = data[key]
+    if not isinstance(repos, list):
+        raise TypeError(f"{key} is not a list: {repos!r}")
+    return [str(r) for r in repos]
+
+
+def _kickoff_ts(wave: str, status_path: Path) -> str | None:
+    """The cross-window filter boundary — ``wave_{M}_kicked_off_at`` or None.
+
+    Absent for legacy waves (W1-W3 pre-/wave-start); in that case no filter is
+    applied and the caller relies on the base-branch scoping alone (#423).
+    """
+    data = _load_status(status_path)
+    val = data.get(f"wave_{wave}_kicked_off_at")
+    return str(val) if val else None
+
+
+def merged_prs(phase: str, wave: str, status_path: Path) -> list[dict]:
+    """Build the wave's merged-PR set across every in-scope repo.
+
+    For each repo: list merged PRs based on ``deployments/phase-<P>/wave-<M>``,
+    drop any merged before ``wave_{M}_kicked_off_at`` (the #423 cross-window
+    filter), and attach the head commit's author name (the identity the
+    top-concentration metric is computed over).
+    """
+    repos = read_repos(wave, status_path)
+    kickoff = _kickoff_ts(wave, status_path)
+    base = f"deployments/phase-{phase}/wave-{wave}"
+
+    out: list[dict] = []
+    for repo in repos:
+        listed = json.loads(
+            _run_gh(
+                [
+                    "pr",
+                    "list",
+                    "--repo",
+                    f"noorinalabs/{repo}",
+                    "--state",
+                    "merged",
+                    "--base",
+                    base,
+                    "--json",
+                    "number,headRefOid,mergedAt,author",
+                ]
+            )
+        )
+        for pr in listed:
+            merged_at = pr.get("mergedAt") or ""
+            if kickoff and merged_at < kickoff:
+                continue
+            sha = pr["headRefOid"]
+            commit_author = _run_gh(
+                [
+                    "api",
+                    f"repos/noorinalabs/{repo}/commits/{sha}",
+                    "--jq",
+                    ".commit.author.name",
+                ]
+            ).strip()
+            out.append(
+                {
+                    "repo": repo,
+                    "number": pr["number"],
+                    "mergedAt": merged_at,
+                    "headRefOid": sha,
+                    "author": (pr.get("author") or {}).get("login"),
+                    "commit_author_name": commit_author,
+                }
+            )
+    return out
+
+
+def _changes_requested_cycles(prs: list[dict]) -> int:
+    """Sum ChangesRequested verdict comments across every PR's timeline."""
+    total = 0
+    for pr in prs:
+        count = _run_gh(
+            [
+                "api",
+                f"repos/noorinalabs/{pr['repo']}/issues/{pr['number']}/comments",
+                "--jq",
+                f'[.[] | select(.body | test("{_CHANGES_REQUESTED_RE}"))] | length',
+            ]
+        ).strip()
+        total += int(count or 0)
+    return total
+
+
+def _top_concentration_pct(prs: list[dict]) -> int:
+    """Top commit-author's PR-count as a half-up-rounded percentage of total.
+
+    Returns 0 for an empty wave (no PRs) rather than dividing by zero — the
+    exact crash main#688 set out to kill. Half-up rounding (``floor(x + 0.5)``)
+    matches the pre-#688 bash ``printf "%d" x + 0.5`` so historical counter
+    rows reproduce (e.g. 3/19 = 15.78 → 16).
+    """
+    total = len(prs)
+    if total == 0:
+        return 0
+    counts = Counter(pr["commit_author_name"] for pr in prs)
+    top = counts.most_common(1)[0][1]
+    return math.floor(top * 100 / total + 0.5)
+
+
+def compute_counters(phase: str, wave: str, status_path: Path) -> dict[str, int]:
+    """Compute the three canonical wave counters from the merged-PR set."""
+    prs = merged_prs(phase, wave, status_path)
+    return {
+        "final_pr_count": len(prs),
+        "changes_requested_cycles": _changes_requested_cycles(prs),
+        "top_concentration_pct": _top_concentration_pct(prs),
+    }
+
+
+def _write_counters(wave: str, counters: dict[str, int], status_path: Path) -> int:
+    """Upsert the three canonical top-level keys via upsert_status_keys.main.
+
+    Reuses the shared helper so the compact-inline shape of
+    cross-repo-status.json is preserved and the write is JSON-validated before
+    AND after (main#332/#456). Values are plain integers → bare JSON literals.
+    """
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from upsert_status_keys import main as upsert_main
+
+    # upsert_status_keys.main treats argv[0] as the program name (argv[1] is the
+    # status path), so prepend a placeholder element.
+    return upsert_main(
+        [
+            "wave_status",
+            str(status_path),
+            f"wave_{wave}_final_pr_count={counters['final_pr_count']}",
+            f"wave_{wave}_changes_requested_cycles={counters['changes_requested_cycles']}",
+            f"wave_{wave}_top_concentration_pct={counters['top_concentration_pct']}",
+        ]
+    )
+
+
+def _cmd_repos(args: argparse.Namespace) -> int:
+    for repo in read_repos(args.wave, args.status):
+        print(repo)
+    return 0
+
+
+def _cmd_merged_prs(args: argparse.Namespace) -> int:
+    print(json.dumps(merged_prs(args.phase, args.wave, args.status), indent=2))
+    return 0
+
+
+def _cmd_counters(args: argparse.Namespace) -> int:
+    counters = compute_counters(args.phase, args.wave, args.status)
+    print(json.dumps(counters, indent=2))
+
+    if args.expect is not None and counters["final_pr_count"] != args.expect:
+        print(
+            f"ERROR: final_pr_count {counters['final_pr_count']} != --expect {args.expect}",
+            file=sys.stderr,
+        )
+        return 1
+
+    if args.write:
+        rc = _write_counters(args.wave, counters, args.status)
+        if rc != 0:
+            return rc
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    def _add_pm(p: argparse.ArgumentParser) -> None:
+        p.add_argument("phase", help="phase number (P)")
+        p.add_argument("wave", help="wave number (M)")
+        p.add_argument(
+            "--status",
+            type=Path,
+            default=_DEFAULT_STATUS,
+            help="path to cross-repo-status.json (default: repo-root copy)",
+        )
+
+    p_repos = sub.add_parser("repos", help="emit wave_{M}_repos_in_scope one per line")
+    _add_pm(p_repos)
+    p_repos.set_defaults(func=_cmd_repos)
+
+    p_merged = sub.add_parser("merged-prs", help="emit the wave's merged-PR set as JSON")
+    _add_pm(p_merged)
+    p_merged.set_defaults(func=_cmd_merged_prs)
+
+    p_counters = sub.add_parser("counters", help="compute (and optionally write) wave counters")
+    _add_pm(p_counters)
+    p_counters.add_argument(
+        "--write",
+        action="store_true",
+        help="upsert the three canonical top-level keys into cross-repo-status.json",
+    )
+    p_counters.add_argument(
+        "--expect",
+        type=int,
+        default=None,
+        help="loud-fail (exit 1) if final_pr_count != N",
+    )
+    p_counters.set_defaults(func=_cmd_counters)
+    return parser
+
+
+def main(argv: list[str]) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        return int(args.func(args))
+    except KeyError as exc:
+        print(f"ERROR: missing key in cross-repo-status.json: {exc}", file=sys.stderr)
+        return 1
+    except subprocess.CalledProcessError as exc:
+        print(
+            f"ERROR: gh call failed (exit {exc.returncode}): {' '.join(exc.cmd)}\n{exc.stderr}",
+            file=sys.stderr,
+        )
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.claude/skills/wave-kickoff/SKILL.md
+++ b/.claude/skills/wave-kickoff/SKILL.md
@@ -125,7 +125,12 @@ BRANCH="deployments/phase-{N}/wave-{M}"
 declare -A BRANCH_SHA  # repo -> resulting SHA (for status-file update + table)
 declare -A BRANCH_STATUS  # repo -> "created" | "exists-clean" | "exists-ancestor" | "exists-drift" | "dry-run-create" | "error:<msg>"
 
-for R in $WAVE_REPOS_IN_SCOPE; do
+# zsh-safe iteration: here-string into `while read` (NOT `for R in
+# $WAVE_REPOS_IN_SCOPE` — zsh does not word-split a parameter, so the whole list
+# would collapse into one bogus repo; main#688). The here-string keeps the loop
+# in the current shell so the BRANCH_SHA / BRANCH_STATUS assoc arrays persist
+# past `done` (a `| while` pipe would lose them to the subshell).
+while IFS= read -r R; do
   MAIN_SHA=$(gh api "repos/noorinalabs/$R/git/refs/heads/main" --jq '.object.sha' 2>/dev/null) || {
     BRANCH_STATUS[$R]="error:cannot-read-main"; continue;
   }
@@ -170,7 +175,7 @@ for R in $WAVE_REPOS_IN_SCOPE; do
       BRANCH_STATUS[$R]="error:$(echo "$CREATE_OUT" | head -1 | tr -d '"' | cut -c1-80)"
     fi
   }
-done
+done <<< "$WAVE_REPOS_IN_SCOPE"
 ```
 
 Print a status table (always, in both dry-run and live mode):
@@ -194,9 +199,9 @@ Print a status table (always, in both dry-run and live mode):
 ```bash
 # Build a JSON object {repo: {sha, status}} and merge under wave_{M}_branches
 TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-JSON=$(for R in $WAVE_REPOS_IN_SCOPE; do
+JSON=$(while IFS= read -r R; do
   printf '%s\n' "$R ${BRANCH_SHA[$R]:-null} ${BRANCH_STATUS[$R]}"
-done | jq -Rn --arg ts "$TS" --arg branch "$BRANCH" '
+done <<< "$WAVE_REPOS_IN_SCOPE" | jq -Rn --arg ts "$TS" --arg branch "$BRANCH" '
   [inputs | split(" ")] |
   map({(.[0]): {sha: (.[1] | if . == "null" then null else . end), status: .[2]}}) |
   add | {branch: $branch, created_at: $ts, repos: .}')

--- a/.claude/skills/wave-scope/SKILL.md
+++ b/.claude/skills/wave-scope/SKILL.md
@@ -325,7 +325,12 @@ NEXT_LABEL="p{P}-wave-$(({M} + 1))"
 # Match the color/description of the current wave label for consistency
 CURRENT_COLOR=$(gh label list --repo noorinalabs/noorinalabs-main --search "$WAVE_LABEL" --json color --jq '.[0].color')
 
-for repo in $REPOS_WITH_DEFER; do
+# Build REPOS_WITH_DEFER as a bash/zsh ARRAY (e.g. REPOS_WITH_DEFER=(repo-a
+# repo-b)) and iterate it quoted — `for repo in $REPOS_WITH_DEFER` would
+# collapse a multi-repo string into one iteration under zsh (main#688), the
+# same word-split trap as the other wave skills. The `"${arr[@]}"` form matches
+# the `REPOS` iteration earlier in this skill.
+for repo in "${REPOS_WITH_DEFER[@]}"; do
     gh label list --repo "noorinalabs/$repo" --search "$NEXT_LABEL" --json name --jq '.[].name' | grep -q "$NEXT_LABEL" || \
         gh label create "$NEXT_LABEL" --repo "noorinalabs/$repo" \
             --description "Phase {P} Wave $(({M} + 1))" --color "$CURRENT_COLOR"

--- a/.claude/skills/wave-wrapup/SKILL.md
+++ b/.claude/skills/wave-wrapup/SKILL.md
@@ -281,73 +281,27 @@ Use the shared `upsert_status_keys.py` helper at `.claude/lib/` — it does targ
 ```bash
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 STATUS="$REPO_ROOT/cross-repo-status.json"
-UPSERT="$REPO_ROOT/.claude/lib/upsert_status_keys.py"
 
-# FINAL_PR_COUNT is the Step 10 "PRs: Merged" number — already in hand.
-FINAL_PR_COUNT={count_of_merged_PRs}
-
-# Cross-window filter (Option A — #423). The wave's canonical window starts
-# at `wave_{M}_kicked_off_at`; anything merged before is from a prior window
-# (W9 partition lesson). If the key is missing (legacy waves W1-W3 pre-/wave-start),
-# fall back to no-filter and rely solely on Option B's cross-check below.
-KICKOFF=$(jq -r '.["wave_{M}_kicked_off_at"] // empty' "$STATUS")
-
-# Build the wave's merged-PR set across all repos in scope. Includes mergedAt
-# so the kickoff filter applies; falls through unfiltered when KICKOFF is empty.
-PRS_JSON=$(jq -r '.["wave_{M}_repos_in_scope"][]' "$STATUS" | while read -r REPO; do
-  if [ -n "$KICKOFF" ]; then
-    gh pr list --repo "noorinalabs/$REPO" --state merged \
-      --base "deployments/phase-{P}/wave-{M}" \
-      --json number,headRefOid,mergedAt \
-      --jq ".[] | select(.mergedAt >= \"$KICKOFF\") | . + {repo: \"$REPO\"}"
-  else
-    gh pr list --repo "noorinalabs/$REPO" --state merged \
-      --base "deployments/phase-{P}/wave-{M}" \
-      --json number,headRefOid,mergedAt \
-      --jq ".[] | . + {repo: \"$REPO\"}"
-  fi
-done | jq -s .)
-
-# Cross-check (Option B — #423). After the kickoff filter, the PR set should
-# match Step 10's `FINAL_PR_COUNT`. A mismatch indicates either a re-roll
-# within the canonical window (rare but possible) or a missing `kicked_off_at`
-# key. Loud-fail rather than emit silently-wrong counters; the operator must
-# manually scope the PR set (e.g., by hand-listing the canonical PR numbers).
-GH_COUNT=$(echo "$PRS_JSON" | jq 'length')
-if [ "$GH_COUNT" != "$FINAL_PR_COUNT" ]; then
-  echo "ERROR: post-kickoff-filter PR count ($GH_COUNT) != FINAL_PR_COUNT ($FINAL_PR_COUNT)" >&2
-  echo "Possible cross-window contamination or re-roll within canonical window." >&2
-  echo "Inspect: gh pr list --base deployments/phase-{P}/wave-{M} --state merged --json number,mergedAt" >&2
-  echo "Then either: (a) verify wave_{M}_kicked_off_at in cross-repo-status.json is correct," >&2
-  echo "or (b) manually scope the PR list by editing this step's PRS_JSON construction." >&2
-  exit 1
-fi
-
-# CHANGES_REQUESTED_CYCLES — count `RequestOrReplied: ChangesRequested` verdict
-# comments across every wave PR's issue-comments timeline.
-CHANGES_REQUESTED_CYCLES=$(echo "$PRS_JSON" | jq -r '.[] | "\(.repo) \(.number)"' | while read -r R N; do
-  gh api "repos/noorinalabs/$R/issues/$N/comments" \
-    --jq '[.[] | select(.body | test("RequestOrReplied:\\s*ChangesRequested"))] | length'
-done | awk '{s+=$1} END {print s+0}')
-
-# TOP_CONCENTRATION_PCT — derived from commit-identity concentration on each
-# PR's head: count PRs per commit-author name, take the top author's PR count
-# as a percentage of total. Half-up rounding via awk `printf "%d\n", x + 0.5`
-# (4/6 = 66.67 → 67) so the counter matches the human-recorded W9 history row
-# (Wanjiku TPM-vote 2026-05-13).
-TOP_CONCENTRATION_PCT=$(echo "$PRS_JSON" | jq -r '.[] | "\(.repo) \(.headRefOid)"' | while read -r R SHA; do
-  gh api "repos/noorinalabs/$R/commits/$SHA" --jq '.commit.author.name'
-done | sort | uniq -c | sort -rn | awk -v total="$(echo "$PRS_JSON" | jq 'length')" \
-  'NR==1 {printf "%d\n", $1 * 100 / total + 0.5}')
-
-# Each value MUST be a self-contained JSON literal (integer here — no quotes).
-python3 "$UPSERT" "$STATUS" \
-    "wave_{M}_final_pr_count=${FINAL_PR_COUNT}" \
-    "wave_{M}_changes_requested_cycles=${CHANGES_REQUESTED_CYCLES}" \
-    "wave_{M}_top_concentration_pct=${TOP_CONCENTRATION_PCT}"
+# Counters are computed by the deterministic helper (main#688). It replaces the
+# hand-rolled bash that used to live here, which collapsed under zsh: a
+# `for R in $WAVE_REPOS_IN_SCOPE` loop does NOT word-split a parameter in zsh
+# (this org's shell — `feedback_zsh_shell_environment`), so the whole repo list
+# was passed to `gh` as one bogus `--repo` value → "Could not resolve
+# repository" → merged PR count 0 → division-by-zero. The helper issues every
+# `gh` call as `subprocess.run([...])` with an explicit arg list (no shell, no
+# word-split), applies the `wave_{M}_kicked_off_at` cross-window filter
+# (Option A — #423), and computes final_pr_count / changes_requested_cycles /
+# top_concentration_pct.
+#
+#   --expect {count_of_merged_PRs}  is the Option-B cross-check: loud-fail
+#     (exit 1, NO write) if the tallied PR count != Step 10's "PRs: Merged".
+#   --write                         upserts the three canonical top-level keys
+#     via upsert_status_keys.py, preserving the compact-inline file shape.
+python3 "$REPO_ROOT/.claude/lib/wave_status.py" counters {P} {M} \
+    --expect {count_of_merged_PRs} --write
 
 # Read-back verify (memory `feedback_gh_pr_edit_silent_noop` family — any
-# jq/upsert pipeline that silently fails produces zero diff but exit 0).
+# upsert pipeline that silently fails produces zero diff but exit 0).
 jq -r --arg m "{M}" '
   "wave_" + $m + "_final_pr_count = " + (.["wave_" + $m + "_final_pr_count"] | tostring),
   "wave_" + $m + "_changes_requested_cycles = " + (.["wave_" + $m + "_changes_requested_cycles"] | tostring),
@@ -375,7 +329,12 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 WAVE_REPOS_IN_SCOPE=$(jq -r ".wave_{M}_repos_in_scope[]" "$REPO_ROOT/cross-repo-status.json")
 BRANCH="deployments/phase-{P}/wave-{M}"
 
-for R in $WAVE_REPOS_IN_SCOPE; do
+# zsh-safe iteration: a here-string into `while IFS= read -r` (NOT
+# `for R in $WAVE_REPOS_IN_SCOPE` — zsh does not word-split a parameter, so the
+# whole list would collapse into one bogus repo; main#688). The here-string
+# keeps the loop in the current shell — relevant for the array-accumulating
+# loops below.
+while IFS= read -r R; do
   # Skip repos where the wave branch is already merged or doesn't exist
   EXISTING=$(gh api "repos/noorinalabs/$R/git/refs/heads/$BRANCH" --jq '.object.sha' 2>/dev/null || true)
   [ -z "$EXISTING" ] && { echo "$R: no wave branch — skip"; continue; }
@@ -390,7 +349,7 @@ for R in $WAVE_REPOS_IN_SCOPE; do
   gh pr create --repo "noorinalabs/$R" --base main --head "$BRANCH" \
     --title "Phase {P} Wave {M} → main ($R)" \
     --body "Final wave merge for $R. All PRs reviewed and merged to wave branch."
-done
+done <<< "$WAVE_REPOS_IN_SCOPE"
 ```
 
 Print a per-repo PR summary table (PR# or "no merge needed") and **wait for user approval before merging any PR**. Each PR must be merged independently.
@@ -413,7 +372,10 @@ WAVE_REPOS_IN_SCOPE=$(jq -r ".wave_{M}_repos_in_scope[]" "$REPO_ROOT/cross-repo-
 BRANCH="deployments/phase-{P}/wave-{M}"
 
 STRANDED=()
-for R in $WAVE_REPOS_IN_SCOPE; do
+# zsh-safe iteration via here-string into `while read` (main#688). The
+# here-string (NOT a `| while` pipe) keeps the loop in the current shell so the
+# STRANDED array survives past `done`.
+while IFS= read -r R; do
   # Skip repos where the wave branch doesn't exist (scope-drop case)
   WAVE_SHA=$(gh api "repos/noorinalabs/$R/git/refs/heads/$BRANCH" --jq '.object.sha' 2>/dev/null || true)
   [ -z "$WAVE_SHA" ] && { echo "$R: no wave branch — skip (scope-drop)"; continue; }
@@ -434,7 +396,7 @@ for R in $WAVE_REPOS_IN_SCOPE; do
   else
     echo "$R: wave-branch reachable from main (ahead_by=$AHEAD, status=$STATUS) — OK"
   fi
-done
+done <<< "$WAVE_REPOS_IN_SCOPE"
 
 if [ ${#STRANDED[@]} -gt 0 ]; then
   echo "════════════════════════════════════════════════════════════"
@@ -565,9 +527,12 @@ For each repo in `wave_{M}_repos_in_scope` that participates in the staging fan-
 
 ```bash
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-FANIN="noorinalabs-isnad-graph noorinalabs-user-service"
+# Newline-joined so `while read` iterates safely; `for repo in $FANIN` would
+# collapse the whole string into one iteration under zsh (main#688). The
+# here-string below keeps the loop in the current shell so PUB_RED persists.
+FANIN=$'noorinalabs-isnad-graph\nnoorinalabs-user-service'
 PUB_RED=()
-for repo in $FANIN; do
+while IFS= read -r repo; do
   # Only the fan-in repos actually in this wave's scope.
   jq -e --arg r "$repo" '.["wave_{M}_repos_in_scope"] | index($r)' "$REPO_ROOT/cross-repo-status.json" >/dev/null 2>&1 || continue
   branch=$(gh api "repos/noorinalabs/$repo" --jq '.default_branch' 2>/dev/null || echo main)
@@ -584,7 +549,7 @@ for repo in $FANIN; do
       printf '%s' "$log" | grep -Eiq 'trivy|grype|\bCVE-[0-9]{4}-[0-9]+|apk[ -].*(upgrade|CVE)|openssl.*(vuln|CVE|advisor)|base[ -]image' && cls=base-image-drift
       PUB_RED+=("$repo :: ghcr-publish.yml :: $conclusion :: $cls :: $url") ;;
   esac
-done
+done <<< "$FANIN"
 if [ ${#PUB_RED[@]} -gt 0 ]; then
   printf 'RED fan-in publish run(s) — a wave is NOT closeable while a fan-in publish is red:\n'
   printf '  %s\n' "${PUB_RED[@]}"
@@ -727,15 +692,19 @@ If the count is **0**, the repo had declared work that did not ship. Resolve the
 Symmetric to § Scope-Drop Reconciliation, but for the inverted case: the declared implementer was replaced silently. Before closing a wave, reconcile **declared implementer vs actual PR author** for every PR merged to a wave branch.
 
 ```bash
-# For each repo in scope, for each merged PR:
-for repo in $(jq -r ".wave_{M}_repos_in_scope[]" "$REPO_ROOT/cross-repo-status.json"); do
-  for pr in $(gh pr list --repo "noorinalabs/$repo" --state merged --base "deployments/phase-{N}/wave-{M}" --json number --jq '.[].number'); do
-    actual=$(gh pr view $pr --repo "noorinalabs/$repo" --json author --jq '.author.login')
-    branch=$(gh pr view $pr --repo "noorinalabs/$repo" --json headRefName --jq '.headRefName')
+# For each repo in scope, for each merged PR (zsh-safe `while read` fed from the
+# repos helper + process substitution — main#688). Command substitution like
+# `for repo in $(jq …)` happens to split in zsh, but a parameter
+# (`for repo in $REPOS`) would not; standardize on `while read` so the safe form
+# is the one operators copy.
+while IFS= read -r repo; do
+  while IFS= read -r pr; do
+    actual=$(gh pr view "$pr" --repo "noorinalabs/$repo" --json author --jq '.author.login')
+    branch=$(gh pr view "$pr" --repo "noorinalabs/$repo" --json headRefName --jq '.headRefName')
     # Compare actual against wave_{M}_scope.tier_*[].implementer or .tier_*[].assignee for that issue.
     # Branch prefix (e.g., "T.Mansour/...") is the cheap proxy when author is the github org bot.
-  done
-done
+  done < <(gh pr list --repo "noorinalabs/$repo" --state merged --base "deployments/phase-{N}/wave-{M}" --json number --jq '.[].number')
+done < <(python3 "$REPO_ROOT/.claude/lib/wave_status.py" repos {N} {M})
 ```
 
 If the actual author (or branch-prefix initials) does not match the kickoff-declared implementer, the substitution must be recorded EXPLICITLY — silent swaps are not allowed.

--- a/.claude/team/charter/skills.md
+++ b/.claude/team/charter/skills.md
@@ -73,7 +73,7 @@ Each `key=value` argument's VALUE must be a self-contained JSON literal (string 
 ### Current consumers
 
 - `/wave-scope` Step 13 — writes `wave_{M}_scope_reconciled_at`, `wave_{M}_repos_in_scope`, `wave_{M}_meta_issue`, `wave_{M}_scope`, optional `wave_{M}_scope_reconciliation_note`.
-- `/wave-wrapup` Step 10.5 — writes `wave_{M}_final_pr_count`, `wave_{M}_changes_requested_cycles`, `wave_{M}_top_concentration_pct`.
+- `/wave-wrapup` Step 10.5 — writes `wave_{M}_final_pr_count`, `wave_{M}_changes_requested_cycles`, `wave_{M}_top_concentration_pct` via `.claude/lib/wave_status.py counters … --write`, which delegates to this helper (main#688).
 - Future skills writing top-level `wave_{N}_*` keys → MUST use the helper; do NOT reinvent.
 
 ### Promotion provenance
@@ -83,6 +83,39 @@ Memory `feedback_enforcement_hierarchy.md` (hook > skill > charter). Acute fix l
 ### Hook-class enforcement decision
 
 Per #292 item 4 — should a `validate_cross_repo_status_format` PostToolUse hook fire on Edit/Write of `cross-repo-status.json` and block writes that expand line count >N% relative to additions OR reformat compact-inline to pretty? **Decision: DEFER.** Rationale: zero charter-rule violations observed across W6–W9 since the helper landed. The two current consumers (`/wave-scope`, `/wave-wrapup`) both invoke the helper correctly. Per `feedback_enforcement_hierarchy.md`, charter-only-without-violations does NOT require hook promotion; promote-on-first-violation is the established trigger. Re-evaluate if any future skill OR manual edit produces a non-helper-mediated write that expands the file >2x its prior line count.
+
+## Zsh-safe repo iteration in wave skills <!-- promotion-target: hook -->
+
+Skill bash blocks run under **zsh** (this org's shell — memory `feedback_zsh_shell_environment`). Unlike bash/sh, zsh does **NOT** word-split an unquoted **parameter** expansion: `for R in $WAVE_REPOS_IN_SCOPE` (where the variable holds a newline- or space-joined list) collapses the **entire list into ONE iteration**. The collapsed blob is then passed to `gh --repo`, which 404s ("Could not resolve repository") → merged-PR count 0 → division-by-zero in the counter math. This bit a single P5W4 `/wave-wrapup` three times (main#688).
+
+### The rule
+
+To iterate a repo list (or any multi-item parameter) in a skill bash block, use **one** of these — never `for X in $VAR`:
+
+```bash
+# (a) here-string into `while read` — keeps the loop in the CURRENT shell, so
+#     arrays/assoc-arrays mutated inside the loop survive past `done`.
+while IFS= read -r R; do …; done <<< "$WAVE_REPOS_IN_SCOPE"
+
+# (b) process substitution from the deterministic helper — same current-shell
+#     property; preferred when the source is the repos-in-scope list.
+while IFS= read -r R; do …; done < <(python3 "$REPO_ROOT/.claude/lib/wave_status.py" repos {P} {M})
+
+# (c) a quoted array expansion when the list is already a bash/zsh array.
+for repo in "${REPOS[@]}"; do …; done
+```
+
+**Do NOT use `… | while IFS= read -r R` (a pipe) when the loop body mutates a variable used after the loop** — a piped `while` runs in a subshell and the mutation is lost. Use the here-string (a) or process-substitution (b) form, both of which keep the loop in the current shell.
+
+`$(…)` command substitution (`for R in $(jq …)`) *does* split under zsh, so it is not broken — but standardize on `while read` anyway so the form operators copy is the one that is also parameter-safe.
+
+### Deterministic counter helper
+
+`/wave-wrapup` Step 10.5 counter math (final-PR-count / changes-requested-cycles / top-concentration) is computed by `.claude/lib/wave_status.py`, which issues every `gh` call as `subprocess.run([...])` with an explicit arg list (no shell → no word-split anywhere) and reproduces the canonical P5W4 actuals 19 / 4 / 16. New skills computing wave counters MUST use this helper rather than re-rolling bash.
+
+### Promotion provenance
+
+main#688; memory `feedback_zsh_shell_environment` (codified here) and `feedback_enforcement_hierarchy.md` (hook > skill > charter). **Hook-class decision: DEFER** — the three wave skills are swept clean and the counter math is now code, so there are zero current violations; promote a `validate_skill_bash_no_param_for_loop` lint-style gate (grep skill `*.md` bash fences for `for \w+ in \$[A-Z_]`) on first recurrence, per the promote-on-first-violation trigger.
 
 ## Promotion Pipeline Marker Convention <!-- promotion-target: none -->
 


### PR DESCRIPTION
## Summary
Closes #688. Replaces the zsh-word-split-fragile bash loops in `/wave-wrapup`, `/wave-kickoff` and `/wave-scope` with a deterministic helper, `.claude/lib/wave_status.py`.

Under **zsh** (this org's shell — `feedback_zsh_shell_environment`) an unquoted parameter is **not** word-split, so `for R in $WAVE_REPOS_IN_SCOPE` collapsed the whole repo list into one bogus `gh --repo` value → "Could not resolve repository" → merged-PR count 0 → division-by-zero. It bit a single P5W4 `/wave-wrapup` three times.

## What changed
- **`.claude/lib/wave_status.py`** — `repos` / `merged-prs` / `counters` subcommands. EVERY `gh` call goes through `subprocess.run([...])` with an explicit **arg list** — never a shell string, never `shell=True` — so word-splitting is structurally impossible under any shell.
  - `counters` applies the `wave_{M}_kicked_off_at` cross-window filter (#423), supports `--write` (upsert via `upsert_status_keys.py`, compact-inline shape preserved) and `--expect N` (loud-fail / exit 1, no write, replacing the old Option-B cross-check).
- **`.claude/lib/tests/test_wave_status.py`** — 10 tests, mocked `subprocess`: `repos` emit, kickoff window filter, P5W4 fixture reproducing **19 / 4 / 16**, `--expect` mismatch exit 1, empty-wave → zeros (no div-by-zero), the jq double-backslash escape guard, `--write` round-trip, and a list-args/no-`shell=True` contract assertion.
- **`/wave-wrapup` Step 10.5** now calls `python3 .claude/lib/wave_status.py counters {P} {M} --expect {count} --write` (read-back-verify retained).
- **Sweep** — every parameter `for X in $VAR` repo loop across the three skills converted to here-string / process-substitution `while IFS= read -r` (kept in the current shell so `STRANDED` / `PUB_RED` / `BRANCH_SHA` assoc arrays persist) or quoted-array `"${arr[@]}"` form. `$(…)` command-substitution loops (which *do* split under zsh) were standardized to `while read` too.
- **`.claude/team/charter/skills.md`** — codifies the zsh-safe iteration rule + the deterministic-counter-helper mandate.

## Verification
- `python3 .claude/lib/wave_status.py counters 5 4 --expect 19` against **live** gh → `{final_pr_count: 19, changes_requested_cycles: 4, top_concentration_pct: 16}`, exit 0.
- `pre-commit run --all-files` (ruff-format, ruff-lint, actionlint) → pass; mypy → clean; sync-drift gate → OK.
- Full pytest suite: **1383 passed, 49 subtests passed**. The one failure under the suite — `test_ontology_tracker.py::ShouldSkipTopLevelWorktreesTests::test_worktrees_segment_not_substring_false_match` — is the documented cwd-only artifact (`project_ontology_tracker_test_worktree_location_fragile`): it false-fails only when pytest runs from inside `.claude/worktrees/` (REPO_ROOT inherits the `.worktrees` segment), passes from a normal checkout (verified) and in CI. `ontology_tracker` is untouched by this PR.

## Reviewers
Per charter: 2 reviewers (Wanjiku Mwangi + Santiago Ferreira).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
