### PR TITLE
charter: last wave of a phase relaxes the +20% TD-intake cap (owner-approved)

### DIFF
--- a/.claude/skills/plan-phase/SKILL.md
+++ b/.claude/skills/plan-phase/SKILL.md
@@ -125,6 +125,8 @@ Group issues into waves based on:
 
 **Tech-debt intake per wave (+20%).** For each wave, after the feature/bug/security content is set, allocate **tech-debt-only** issues equal to **20% of that content (rounded up)** — add all available if fewer qualify (a shortfall is healthy, never backfilled with invented work). This is the standing intake policy that `/wave-scope` Step 8.5 enforces per-wave at scope-reconciliation time; surface it here at phase-plan time so the wave tables already reflect the TD allocation. Rationale: a cumulative TD-*ratio* gate whipsaws as the backlog shrinks, so steady *intake* replaces ratio-chasing. See [[feedback_td_intake_20pct_per_wave]] and `/wave-scope` Step 8.5.
 
+**Last-wave-of-phase relaxation (owner 2026-06-16).** The +20% is a per-wave *cap* on every wave **except the last wave of the phase**, where it becomes a **floor**: deliberately pull in a large chunk of tech-debt (well beyond 20%) to clean up before phase exit. When laying out the wave table, size the final wave's TD allocation generously — clearing debt *is* the goal there — rather than holding it to the 20% line. The orchestrator/owner sizes the chunk at `/wave-scope` Step 8.5.
+
 Present the proposed structure:
 
 ```

--- a/.claude/skills/wave-scope/SKILL.md
+++ b/.claude/skills/wave-scope/SKILL.md
@@ -264,6 +264,8 @@ If a `MUST_INCLUDES` entry is closed or non-existent, the source memory file is 
 
 After Step 7 has fixed the wave's feature + bug + security content, top it up with **tech-debt-only** issues equal to **20% of that content, rounded up**. If fewer qualifying TD issues exist than the target, add **all** of them — a shortfall here is a *good* signal (debt is genuinely low), never something to backfill with invented work. See [[feedback_td_intake_20pct_per_wave]].
 
+**Last-wave-of-phase relaxation (owner 2026-06-16).** On the **final wave of a phase**, the +20% intake is a **floor, not a cap** — deliberately pull in a large chunk of tech-debt (well beyond 20%) to clean up before phase exit. The per-wave cap that prevents TD from crowding out feature work does **not** apply to a phase's last wave; clearing debt *is* the goal there. The `TARGET` below is the minimum; the orchestrator/owner sizes the actual chunk at scope time (`POOL > TARGET` is no longer a select-`TARGET`-only ceiling on the last wave — surface the whole pool and let the owner take as much as phase-exit warrants).
+
 **1. Compute base + target.** Base = the post-Step-7 **intended** in-scope set that is NOT `tech-debt` and NOT `meta-issue` — the feature/bug/security items the owner just decided to keep. The query below counts items already carrying `$WAVE_LABEL`; some Step-7 keeps / must-includes / carry-forwards are not labeled until Step 10, so **add those not-yet-labeled non-TD keeps to `BASE`** before computing the target (otherwise the intake target undercounts the real scope).
 
 ```bash
@@ -303,7 +305,7 @@ echo "un-scheduled TD pool: $POOL  |  target: $TARGET"
 
 **3. Select + confirm (owner-judgment gate, same as Step 7).**
 - `POOL <= TARGET` → select **all** pool items. Report: `TD intake: <POOL> of <POOL> available — debt backlog below the 20% target (healthy)`.
-- `POOL > TARGET` → surface the top `TARGET` oldest candidates to the owner for confirmation; the owner may swap in higher-priority debt. Final selection = `TARGET` items.
+- `POOL > TARGET` → surface the top `TARGET` oldest candidates to the owner for confirmation; the owner may swap in higher-priority debt. Final selection = `TARGET` items. **On the final wave of a phase, `TARGET` is a floor, not the cap** (see the relaxation note above) — surface the whole pool and let the owner pull in as much debt as phase-exit cleanup warrants.
 
 This is a blocking owner-judgment gate exactly like Step 7 — present, don't auto-apply.
 

--- a/.claude/team/phases/phase-5.md
+++ b/.claude/team/phases/phase-5.md
@@ -46,6 +46,8 @@ Wave themes are confirmed (not re-chosen) at each `/wave-scope`; scope reconcili
 
 Every wave takes its **+20%** TD intake (`/wave-scope` Step 8.5) — `ceil(20% of feature/bug/security scope)`, all available if fewer. The pooled TD ratio is **informational only** (the cumulative-ratio gate was superseded 2026-06-09). P4W7 process follow-ups feed the W2/W3 intake: main#659 (CREATE-path parser), main#661 (validate_labels over-match), main#663 (parser-invariant charter/standards — owner-adopted), main#664 (validate_wave_audit exemption — owner-adopted).
 
+On the **final wave (W6)** the +20% becomes a **floor, not a cap** (owner 2026-06-16): deliberately pull in a large chunk of debt to clean up before phase exit, sized by the owner at `/wave-scope`.
+
 ## Out of scope for P5 (deferred)
 
 - **Billing/payments** (ig#717/#718) — needs product traction first.


### PR DESCRIPTION
## Owner directive (2026-06-16)

The owner set a new **standing policy**: the **last wave of a phase has its tech-debt intake ratio relaxed** — it may exceed the standing **+20% per-wave TD-intake cap**. On a phase's final wave, the team deliberately pulls in a **large chunk** of tech-debt to clean up before phase exit.

> On the final wave of a phase, the +20% intake is a **floor, not a cap** — deliberately pull in a large chunk of tech-debt (well beyond 20%) to clean up before phase exit. The per-wave cap that prevents TD from crowding out feature work does NOT apply to a phase's last wave; clearing debt IS the goal there. The orchestrator/owner sizes the chunk at `/wave-scope`.

## Rationale

The +20% per-wave cap exists to stop tech-debt from crowding out feature/bug work mid-phase. At **phase exit**, that constraint inverts: clearing accumulated debt before cutover *is* the goal, so the cap would work against us. This codifies the owner's intent that the final wave deliberately over-takes debt.

## Surfaces touched

The +20% intake policy has **no standalone charter rule** — it is operationalized in the two skills (per memory `feedback_td_intake_20pct_per_wave`: "Enforced /wave-scope Step 8.5 + /plan-phase Step 6") plus the per-phase doc. I added the relaxation clause to each canonical surface, in the existing voice:

- **`.claude/skills/wave-scope/SKILL.md` Step 8.5** — relaxation clause after the intro; plus a last-wave override note on the `POOL > TARGET` select-logic line (so the floor-not-cap behavior is discoverable at the decision point).
- **`.claude/skills/plan-phase/SKILL.md` Step 6** — floor-not-cap note so phase-plan wave tables size the final wave's TD allocation generously.
- **`.claude/team/phases/phase-5.md`** standing-policy section — one-line note that W6 (the final wave) treats +20% as a floor.

Cross-links memory `feedback_td_intake_20pct_per_wave`.

## Green-before-push

- **cspell** (gates `.claude/skills/**/*.md`): 0 issues on both SKILL.md files.
- **markdownlint** (`**/*.md`): 0 errors in the 3 edited files (local run's only errors were in untracked `.claude/scratch/` files that do not exist in CI's checkout; docs.yml is green on main).
- **lychee** (`**/*.md`, internal links): no new `[text](url)` links added (only `[[wiki]]` refs + inline code), so no new link surface; lychee green on main.
- **config-lint**: no YAML/JSON touched.
- Pre-push hooks (mypy + pytest suites) ran green on push.

No `--no-verify`, no force. Reviewers + merge handled by Standards & Quality Lead (Aino Virtanen).
