### PR TITLE
tech-debt(ci-parity): mirror cspell in pre-commit + classify in sync-drift gate (#684)

### DIFF
--- a/.claude/lib/pre_commit_ci_sync.py
+++ b/.claude/lib/pre_commit_ci_sync.py
@@ -23,11 +23,15 @@ step vs a `ruff` pre-commit `id:`). We normalize both sides to a small set of
 kind tokens so they compare:
 
     ruff-lint, ruff-format, mypy, pytest, eslint, typescript, prettier,
-    terraform-fmt, gitleaks, actionlint, astro-check, pip-audit, build
+    terraform-fmt, gitleaks, actionlint, astro-check, pip-audit, build,
+    cspell
 
 Unknown tools are ignored (neither side gates on a kind we can't classify),
 which keeps the gate conservative — it never fails on something it doesn't
-understand.
+understand. Closing a blind spot here means ADDING the kind to
+`_KIND_PATTERNS` (cf. `cspell`, #684) so a CI job that runs it starts
+demanding a pre-commit mirror — an un-classified CI check is silently
+un-mirrored, which is the exact divergence this gate exists to prevent.
 
 Input Language
 ==============
@@ -80,6 +84,13 @@ _KIND_PATTERNS: dict[str, tuple[str, ...]] = {
     "actionlint": ("actionlint",),
     "pip-audit": ("pip-audit", "pip audit"),
     "build": ("build-and-validate", "build-and-test", "npm run build"),
+    # `cspell` closes the spell-check blind spot (#684): the CI Spellcheck job
+    # runs the `streetsidesoftware/cspell-action` (or a `cspell` CLI), but until
+    # this kind existed an un-classified spell gate produced ZERO drift signal,
+    # so a repo could enforce cspell in CI with no pre-commit mirror — new
+    # domain vocabulary then failed only after push. Patterns cover the action
+    # ref, the bundled-CLI step name, and the generic job/step word.
+    "cspell": ("cspell", "spellcheck", "streetsidesoftware/cspell"),
 }
 
 # `ruff-lint` is a substring of nothing problematic, but `ruff format` also

--- a/.claude/lib/tests/test_pre_commit_ci_sync.py
+++ b/.claude/lib/tests/test_pre_commit_ci_sync.py
@@ -108,6 +108,84 @@ jobs:
         self.assertNotIn("ruff-lint", kinds)
 
 
+class CspellKindClassification(unittest.TestCase):
+    """#684: the spell-check blind spot. A CI Spellcheck job must classify as
+    the `cspell` kind on EITHER expression — the `streetsidesoftware/cspell-action`
+    `uses:` ref, the bundled-CLI `cspell` step/run, or the generic `spellcheck`
+    word — and a pre-commit cspell hook must classify too, so a CI spell gate
+    with no local mirror produces harmful drift instead of silence."""
+
+    def test_cspell_action_uses_ref_classified(self) -> None:
+        wf = """
+jobs:
+  spellcheck:
+    name: Spellcheck (cspell)
+    steps:
+      - name: cspell
+        uses: streetsidesoftware/cspell-action@de2a73e # v8.4.0
+"""
+        self.assertIn("cspell", kinds_from_ci(wf))
+
+    def test_cspell_cli_run_step_classified(self) -> None:
+        wf = """
+jobs:
+  spell:
+    steps:
+      - run: npx cspell --config .cspell.json "**/*.md"
+"""
+        self.assertIn("cspell", kinds_from_ci(wf))
+
+    def test_generic_spellcheck_word_classified(self) -> None:
+        # A repo that names the step/run with the generic word still registers.
+        self.assertIn("cspell", kinds_from_ci("      - run: make spellcheck\n"))
+
+    def test_precommit_cspell_hook_classified(self) -> None:
+        cfg = """
+repos:
+  - repo: https://github.com/streetsidesoftware/cspell-cli
+    rev: v8.4.0
+    hooks:
+      - id: cspell
+        name: cspell
+"""
+        self.assertIn("cspell", kinds_from_precommit(cfg))
+
+    def test_ci_cspell_without_precommit_is_harmful_drift(self) -> None:
+        # The exact divergence #684 exists to catch: CI enforces cspell, the
+        # pre-commit config does not mirror it.
+        wf = """
+jobs:
+  spellcheck:
+    steps:
+      - uses: streetsidesoftware/cspell-action@de2a73e
+"""
+        cfg = """
+repos:
+  - repo: local
+    hooks:
+      - id: ruff
+"""
+        harmful, _ = compute_drift(kinds_from_precommit(cfg), kinds_from_ci(wf))
+        self.assertIn("cspell", harmful)
+
+    def test_ci_cspell_with_precommit_mirror_no_drift(self) -> None:
+        wf = """
+jobs:
+  spellcheck:
+    steps:
+      - uses: streetsidesoftware/cspell-action@de2a73e
+"""
+        cfg = """
+repos:
+  - repo: https://github.com/streetsidesoftware/cspell-cli
+    rev: v8.4.0
+    hooks:
+      - id: cspell
+"""
+        harmful, _ = compute_drift(kinds_from_precommit(cfg), kinds_from_ci(wf))
+        self.assertNotIn("cspell", harmful)
+
+
 class BuildKindTightening(unittest.TestCase):
     """#576: runtime `docker build` / `docker buildx` steps are image-MOVING,
     not a build-QUALITY gate a local pre-commit hook can mirror — they must
@@ -291,6 +369,31 @@ class RealParentRepoHasNoDrift(unittest.TestCase):
             set(),
             f"parent pre-commit must mirror CI; missing locally: {sorted(harmful)}",
         )
+
+    def test_parent_precommit_mirrors_all_workflows(self) -> None:
+        # The CLI gate globs ALL workflow files, so the parent must have no
+        # harmful drift across the full set — in particular docs.yml carries the
+        # cspell + actionlint jobs (#684/#571). This is the gate exactly as the
+        # `Pre-commit ⇄ CI sync-drift gate` CI job runs it.
+        precommit = _REPO_ROOT / ".pre-commit-config.yaml"
+        wf_dir = _REPO_ROOT / ".github" / "workflows"
+        ci_paths = sorted(wf_dir.glob("*.y*ml"))
+        self.assertTrue(ci_paths, "parent must have workflow files")
+        harmful, _ = check_repo(precommit, ci_paths)
+        self.assertEqual(
+            harmful,
+            set(),
+            f"parent pre-commit must mirror ALL CI workflows; missing locally: {sorted(harmful)}",
+        )
+
+    def test_parent_ci_enforces_cspell(self) -> None:
+        # Guard against the docs.yml cspell job being removed/renamed without the
+        # mirror+kind being revisited: the kind must actually appear in CI.
+        wf_dir = _REPO_ROOT / ".github" / "workflows"
+        ci_text = "\n".join(
+            p.read_text(encoding="utf-8") for p in wf_dir.glob("*.y*ml") if p.is_file()
+        )
+        self.assertIn("cspell", kinds_from_ci(ci_text))
 
 
 if __name__ == "__main__":

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@
 # local pre-commit and in CI.
 #
 # Stage split:
-#   pre-commit (fast, every commit) — ruff-format, ruff-lint.
+#   pre-commit (fast, every commit) — ruff-format, ruff-lint, actionlint, cspell.
 #   pre-push   (heavier, every push) — mypy typecheck, pytest suite. These run
 #     the whole hooks+lib surface, so they're push-time not commit-time to keep
 #     the commit loop snappy while still catching everything before it leaves
@@ -56,6 +56,28 @@ repos:
     hooks:
       - id: actionlint
         name: actionlint
+
+  # cspell mirrors the `Spellcheck (cspell)` CI job in .github/workflows/docs.yml
+  # (the sync-drift gate now classifies the `cspell` kind — #684 — so a
+  # CI-enforced spell gate not mirrored here turns the gate red, same contract as
+  # actionlint above). New domain vocabulary then fails `pre-commit run` locally
+  # instead of only surfacing as a CI red after push (the P5W4 reds: ig#1080
+  # "Aqidah", deploy#460 "Webauth"). Pinned to v8.4.0 of cspell-cli to match the
+  # exact cspell the `streetsidesoftware/cspell-action@…v8.4.0` CI step bundles —
+  # same engine + dictionaries on both sides. `language: node`, so pre-commit
+  # provisions its own node/cspell env (no system cspell required).
+  #
+  # `files` is the regex equivalent of the CI action's authored-prose glob set
+  # (charter, skills, ontology, root docs); `--config .cspell.json` reuses the
+  # same dictionaries + ignore rules CI loads, so a word that passes locally
+  # passes in CI and vice-versa.
+  - repo: https://github.com/streetsidesoftware/cspell-cli
+    rev: v8.4.0
+    hooks:
+      - id: cspell
+        name: cspell
+        args: ["--no-must-find-files", "--no-progress", "--no-summary", "--config", ".cspell.json"]
+        files: ^(\.claude/team/charter/.*\.md|\.claude/skills/.*\.md|ontology/.*\.md|CLAUDE\.md|ONBOARDING\.md|docs/.*\.md)$
 
   # Heavier checks run at pre-push (mirror CI's mypy + pytest jobs). Running as
   # `local`/`system` hooks so we use the system tools and don't drift from


### PR DESCRIPTION
## What & why

Closes the spell-check blind spot raised by the owner 2026-06-14 and surfaced in P5W4 (ig#1080 "Aqidah", deploy#460 "Webauth"): **cspell** ran only in CI, so new domain vocabulary failed only *after* push — and the sync-drift gate (`pre_commit_ci_sync.py`) stayed silent because it never classified a `cspell` kind. An unclassified CI check is silently un-mirrored, which is the exact divergence the gate exists to prevent (cf. `feedback_actionlint_needs_shellcheck`: local "clean" must not diverge from CI).

## Changes

1. **`.claude/lib/pre_commit_ci_sync.py`** — add a `cspell` kind to `_KIND_PATTERNS` (patterns: `cspell`, `spellcheck`, `streetsidesoftware/cspell`). A CI Spellcheck job with no pre-commit mirror now produces **harmful drift** instead of zero signal. Docstring updated to state that closing a blind spot means adding the kind here.
2. **`.pre-commit-config.yaml`** — add a commit-stage `cspell` hook from `streetsidesoftware/cspell-cli` pinned to **v8.4.0**, the exact engine the CI `streetsidesoftware/cspell-action@…v8.4.0` step bundles. Scoped to the same authored-prose globs (`files:` regex of the action's glob set) and reusing `.cspell.json` via `--config`. `language: node`, so pre-commit provisions its own env — no system cspell required.
3. **Tests** — `CspellKindClassification` (action `uses:` ref, CLI `run:`, generic `spellcheck` word, pre-commit hook, drift-both-ways); extend `RealParentRepoHasNoDrift` to the **full** workflow set (the cspell job lives in `docs.yml`, not `ci.yml`) and add a guard that parent CI actually enforces cspell.

## Proof

- `python3 .claude/lib/pre_commit_ci_sync.py .` → `OK` (mirror present, exit 0).
- Strip the hook → gate flags drift `['cspell']`. CI kinds now include `cspell`.
- `pre-commit run cspell --all-files` → **Passed** against the live corpus (engine + config wiring verified end-to-end).
- `pytest .claude/lib/tests/test_pre_commit_ci_sync.py` → 29 passed.
- ruff format/lint + mypy clean on changed files.

## Scope note (org-template + child rollout)
This lands the parent (org-template) half. Per #684, the same `cspell` kind + hook must be vendored into each child repo that runs a CI Spellcheck job; that rollout is tracked by the umbrella #684 and not in this PR.

## Reviewers
Requested: **Wanjiku Mwangi** and **Santiago Ferreira** (charter 2-reviewer).

Refs #684
