### PR TITLE
fix(wave-start §5a): mechanize per-phase wave-key reset — 3 cross-phase-collision defects (#683)

### DIFF
--- a/.claude/lib/tests/test_wave_key_reset.py
+++ b/.claude/lib/tests/test_wave_key_reset.py
@@ -1,0 +1,185 @@
+"""Tests for wave_key_reset — the mechanical /wave-start § 5a per-phase
+wave-key reset that replaces three defective hand-rolled bash probes (main#683).
+
+Each defect from the issue has a dedicated regression test:
+
+  Defect 1 — detection must fire for a SAME-PHASE re-use even when
+             ``current_phase`` already equals the phase being started (the case
+             the old ``current_phase != {P}`` guard could never catch), and must
+             key off the wave's own phase stamps, never ``current_phase``.
+  Defect 2 — detection must not depend on any lifecycle-marker key name
+             (``wave_{M}_completed_at`` etc.); a wave that never wrapped up but
+             carries a prior-phase scope stamp is still detected as stale.
+  Defect 3 — the reset surface is prefix-complete: EVERY ``wave_{M}_*`` key is
+             removed (incl. ``wave_{M}_branches`` — the dangerous omission),
+             and ``wave_{M2}_*`` siblings are never touched (no ``wave_4`` vs
+             ``wave_42`` prefix bleed).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+# Helper lives at .claude/lib/wave_key_reset.py; this test is at
+# .claude/lib/tests/test_*.py. parent.parent reaches the lib root.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import wave_key_reset  # noqa: E402
+
+
+def _p4w4_status() -> dict:
+    """A file that has advanced to phase 5 (``current_phase`` == 5) but whose
+    bare ``wave_4_*`` keys were all written by P4W4 — the exact collision state
+    from the issue. The phase stamps inside the keys say 4."""
+    return {
+        "current_phase": 5,
+        "wave_4_active": True,
+        "wave_4_scope": {"phase": 4, "wave": 4, "theme": "P4W4 theme"},
+        "wave_4_repos_in_scope": ["noorinalabs-isnad-graph"],
+        "wave_4_branches": {"branch": "deployments/phase-4/wave-4", "created_at": "x"},
+        "wave_4_meta_issue": "noorinalabs-main#400",
+        "wave_4_final_pr_count": 19,
+        "wave_4_wrapup_completed_at": "2026-05-01T00:00:00Z",
+        # An unrelated sibling wave that must never be touched by a wave-4 reset.
+        "wave_42_active": True,
+        "last_updated": "2026-06-16T00:00:00Z",
+    }
+
+
+class TestBranchPhase(unittest.TestCase):
+    def test_parses_phase_segment(self) -> None:
+        self.assertEqual(wave_key_reset.branch_phase("deployments/phase-4/wave-4"), 4)
+        self.assertEqual(wave_key_reset.branch_phase("deployments/phase-12/wave-3"), 12)
+
+    def test_none_for_unstamped_or_non_string(self) -> None:
+        self.assertIsNone(wave_key_reset.branch_phase("main"))
+        self.assertIsNone(wave_key_reset.branch_phase(""))
+        self.assertIsNone(wave_key_reset.branch_phase(None))  # type: ignore[arg-type]
+
+
+class TestStampedPhases(unittest.TestCase):
+    def test_collects_scope_and_branch_stamps(self) -> None:
+        status = _p4w4_status()
+        self.assertEqual(wave_key_reset.stamped_phases(status, 4), {4})
+
+    def test_scope_and_branch_can_disagree(self) -> None:
+        status = _p4w4_status()
+        status["wave_4_branches"]["branch"] = "deployments/phase-3/wave-4"
+        self.assertEqual(wave_key_reset.stamped_phases(status, 4), {3, 4})
+
+    def test_empty_when_no_stamped_keys(self) -> None:
+        self.assertEqual(wave_key_reset.stamped_phases({"current_phase": 5}, 4), set())
+
+    def test_ignores_current_phase(self) -> None:
+        # current_phase=5 must NOT leak into the stamp set (Defect 1 root cause).
+        self.assertEqual(wave_key_reset.stamped_phases(_p4w4_status(), 4), {4})
+
+
+class TestIsStaleReuse(unittest.TestCase):
+    def test_defect1_detects_reuse_when_current_phase_already_matches(self) -> None:
+        # current_phase == 5 == phase being started; the OLD guard
+        # (current_phase != P) would be FALSE → miss it. The stamp says 4.
+        status = _p4w4_status()
+        stale, prior = wave_key_reset.is_stale_reuse(status, wave=4, phase=5)
+        self.assertTrue(stale)
+        self.assertEqual(prior, {4})
+
+    def test_defect2_detected_without_lifecycle_marker(self) -> None:
+        # No wave_4_completed_at / wave_4_wrapped_up_at at all — only the scope
+        # stamp. Old probe found nothing; stamp-based detection still fires.
+        status = _p4w4_status()
+        del status["wave_4_wrapup_completed_at"]
+        del status["wave_4_branches"]  # leave ONLY the scope stamp
+        stale, prior = wave_key_reset.is_stale_reuse(status, wave=4, phase=5)
+        self.assertTrue(stale)
+        self.assertEqual(prior, {4})
+
+    def test_not_stale_when_stamp_matches(self) -> None:
+        # /wave-start re-run within the same phase (scope already phase 5).
+        status = _p4w4_status()
+        status["wave_4_scope"]["phase"] = 5
+        status["wave_4_branches"]["branch"] = "deployments/phase-5/wave-4"
+        stale, prior = wave_key_reset.is_stale_reuse(status, wave=4, phase=5)
+        self.assertFalse(stale)
+        self.assertEqual(prior, set())
+
+    def test_not_stale_when_no_stamps(self) -> None:
+        stale, prior = wave_key_reset.is_stale_reuse({"current_phase": 5}, wave=4, phase=5)
+        self.assertFalse(stale)
+        self.assertEqual(prior, set())
+
+
+class TestStaleWaveKeys(unittest.TestCase):
+    def test_defect3_surface_is_prefix_complete(self) -> None:
+        keys = wave_key_reset.stale_wave_keys(_p4w4_status(), 4)
+        # Every wave_4_* key — including the dangerous wave_4_branches.
+        self.assertIn("wave_4_branches", keys)
+        self.assertIn("wave_4_active", keys)
+        self.assertIn("wave_4_scope", keys)
+        self.assertIn("wave_4_meta_issue", keys)
+        self.assertEqual(
+            set(keys),
+            {
+                "wave_4_active",
+                "wave_4_scope",
+                "wave_4_repos_in_scope",
+                "wave_4_branches",
+                "wave_4_meta_issue",
+                "wave_4_final_pr_count",
+                "wave_4_wrapup_completed_at",
+            },
+        )
+
+    def test_no_prefix_bleed_into_sibling_wave(self) -> None:
+        keys = wave_key_reset.stale_wave_keys(_p4w4_status(), 4)
+        self.assertNotIn("wave_42_active", keys)
+        self.assertNotIn("current_phase", keys)
+        self.assertNotIn("last_updated", keys)
+
+
+class TestApplyEndToEnd(unittest.TestCase):
+    def _write(self, status: dict) -> Path:
+        self.tmp = TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        p = Path(self.tmp.name) / "cross-repo-status.json"
+        p.write_text(json.dumps(status, indent=2) + "\n")
+        return p
+
+    def test_apply_removes_only_stale_wave_keys(self) -> None:
+        p = self._write(_p4w4_status())
+        rc = wave_key_reset.main([str(p), "4", "5", "--apply"])
+        self.assertEqual(rc, 0)
+
+        result = json.loads(p.read_text())
+        # All wave_4_* removed …
+        self.assertFalse(any(k.startswith("wave_4_") for k in result))
+        # … siblings + scalars preserved.
+        self.assertEqual(result["wave_42_active"], True)
+        self.assertEqual(result["current_phase"], 5)
+        self.assertEqual(result["last_updated"], "2026-06-16T00:00:00Z")
+
+    def test_apply_is_noop_when_not_stale(self) -> None:
+        status = _p4w4_status()
+        status["wave_4_scope"]["phase"] = 5
+        status["wave_4_branches"]["branch"] = "deployments/phase-5/wave-4"
+        p = self._write(status)
+        before = p.read_text()
+
+        rc = wave_key_reset.main([str(p), "4", "5", "--apply"])
+        self.assertEqual(rc, 0)
+        self.assertEqual(p.read_text(), before)  # untouched
+
+    def test_dry_run_does_not_modify_file(self) -> None:
+        p = self._write(_p4w4_status())
+        before = p.read_text()
+        rc = wave_key_reset.main([str(p), "4", "5"])  # no --apply
+        self.assertEqual(rc, 0)
+        self.assertEqual(p.read_text(), before)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/lib/wave_key_reset.py
+++ b/.claude/lib/wave_key_reset.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Detect + reset stale cross-phase ``wave_{M}_*`` keys in cross-repo-status.json.
+
+Backs ``/wave-start`` § 5a. A wave number reused across phases (e.g. P4W4 ↔
+P5W4) leaves the *prior* phase's ``wave_{M}_*`` operational keys in the file
+under identical names (the bare-key "overwrite convention" — see
+``upsert_status_keys`` docstring / main#611). Those values bleed into the new
+phase's wave M unless explicitly cleared. This module is the mechanical,
+test-backed form of that cleanup; it replaces the three defective hand-rolled
+bash probes that § 5a used to inline (main#683):
+
+Defect 1 — phase guard can never be true for a later same-number wave.
+  The old guard inferred "wave_{M}_* is stale" from ``current_phase != {P}``.
+  But ``current_phase`` tracks the *latest* phase, not the phase that wrote the
+  stale ``wave_{M}_*`` keys — it was advanced to {P} back at this phase's W1
+  kickoff, so for an intra-phase same-number reuse the guard is structurally
+  always false. Fix: detect staleness from a **phase stamp carried INSIDE the
+  wave's own keys** — ``wave_{M}_scope.phase`` (written by /wave-scope) and the
+  ``phase-{X}`` segment of ``wave_{M}_branches.branch`` (written by
+  /wave-kickoff). If any such stamp differs from the phase being started, the
+  keys are stale. ``current_phase`` is never consulted.
+
+Defect 2 — detection key-name mismatch.
+  The old probe looked for ``wave_{M}_completed_at`` / ``wave_{M}_wrapped_up_at``
+  while /wave-wrapup actually writes ``wave_{M}_wrapup_completed_at`` — so the
+  probe found nothing and ``HAS_PRIOR`` was always ``no``. Moot here: detection
+  no longer keys off any lifecycle-marker name; it keys off the phase stamps
+  above, which exist regardless of how far the prior wave progressed.
+
+Defect 3 — incomplete RESET_KEYS list.
+  The old enumerated 12-key list missed ≥10 keys a wave actually writes
+  (``wave_{M}_active``, ``_branches``, ``_carry_forward``, ``_scope``,
+  ``_repos_in_scope``, ``_meta_issue``, …). ``wave_{M}_branches`` was the
+  dangerous omission: a stale ``deployments/phase-4/wave-4`` ref misleads
+  /wave-kickoff Step 1 into thinking the phase-5 branches already exist. Fix:
+  reset is **prefix-complete by construction** — every top-level key matching
+  ``wave_{M}_`` is cleared, so the surface can never drift out of sync with what
+  the wave skills write.
+
+Why REMOVE and not set-to-null: the bare-key overwrite convention (main#611)
+removes the prior phase's ``wave_{M}_*`` keys before the new phase writes its
+own; setting-to-null would leave a pile of ``null`` noise. Removal reuses
+``upsert_status_keys.remove_top_level_key`` so the file's mixed compact-inline /
+pretty-indented shape is preserved and the write is JSON-validated before AND
+after (no 500-line cosmetic diff).
+
+CLI:
+  wave_key_reset.py <status_path> <wave> <phase>            # dry-run (detect)
+  wave_key_reset.py <status_path> <wave> <phase> --apply    # remove stale keys
+
+Dry-run prints the detection verdict and the keys that WOULD be reset, exit 0.
+``--apply`` removes them (only when stale) and exits non-zero on any write
+failure. Both are no-ops (exit 0, "not stale") when the wave's own phase stamps
+match {P} — i.e. first wave of a phase, or /wave-start re-run within the same
+phase (idempotent).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+# Repo root = two parents above .claude/lib/ (lib -> .claude -> root). Resolved
+# from this file so the default status path is correct from any cwd or worktree.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DEFAULT_STATUS = _REPO_ROOT / "cross-repo-status.json"
+
+# `deployments/phase-{X}/wave-{M}` — the branch ref /wave-kickoff stamps into
+# wave_{M}_branches.branch. The phase segment is a second, independent phase
+# stamp (corroborates wave_{M}_scope.phase).
+_BRANCH_PHASE_RE = re.compile(r"phase-(\d+)/wave-\d+")
+
+
+def branch_phase(branch: str) -> int | None:
+    """Parse the phase number out of a ``deployments/phase-{X}/wave-{M}`` ref.
+
+    Returns ``None`` for any string that does not carry the phase-{X} segment.
+    """
+    if not isinstance(branch, str):
+        return None
+    m = _BRANCH_PHASE_RE.search(branch)
+    return int(m.group(1)) if m else None
+
+
+def stamped_phases(status: dict, wave: int) -> set[int]:
+    """Collect every phase number stamped INSIDE this wave's own keys.
+
+    Two independent stamps, both written by the wave skills for the phase that
+    owns the keys (never the global ``current_phase``):
+
+      * ``wave_{M}_scope.phase`` — written by /wave-scope.
+      * the ``phase-{X}`` segment of ``wave_{M}_branches.branch`` — written by
+        /wave-kickoff Step 1.
+
+    Returns the set of distinct phase ints found (empty if the wave has no
+    stamped keys yet — a never-before-used wave number, nothing to reset).
+    """
+    phases: set[int] = set()
+
+    scope = status.get(f"wave_{wave}_scope")
+    if isinstance(scope, dict):
+        p = scope.get("phase")
+        if isinstance(p, int):
+            phases.add(p)
+
+    branches = status.get(f"wave_{wave}_branches")
+    if isinstance(branches, dict):
+        bp = branch_phase(branches.get("branch", ""))
+        if bp is not None:
+            phases.add(bp)
+
+    return phases
+
+
+def is_stale_reuse(status: dict, wave: int, phase: int) -> tuple[bool, set[int]]:
+    """Return ``(stale, prior_phases)`` for wave ``M`` about to start in ``P``.
+
+    Stale iff the wave carries a phase stamp belonging to a DIFFERENT phase than
+    the one starting. ``prior_phases`` is the set of stamped phases that differ
+    from ``phase`` (the evidence). When no stamp exists, or every stamp already
+    equals ``phase``, the result is ``(False, set())`` — nothing to reset.
+    """
+    stamps = stamped_phases(status, wave)
+    prior = {p for p in stamps if p != phase}
+    return (bool(prior), prior)
+
+
+def stale_wave_keys(status: dict, wave: int) -> list[str]:
+    """Every top-level key matching ``wave_{M}_`` — the complete reset surface.
+
+    Prefix-complete by construction (Defect 3): the trailing underscore makes
+    ``wave_4_`` match ``wave_4_active`` but never ``wave_42_active``. Returned in
+    sorted order for a stable, auditable reset log.
+    """
+    prefix = f"wave_{wave}_"
+    return sorted(k for k in status if k.startswith(prefix))
+
+
+def _apply_reset(status_path: Path, keys: list[str]) -> int:
+    """Remove ``keys`` from the file via the shared upsert helper.
+
+    Reuses ``upsert_status_keys._run_remove`` so the compact-inline file shape
+    is preserved and the rewrite is JSON-validated before AND after. Importing
+    lazily keeps the detection-only (dry-run) path free of the dependency.
+    """
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from upsert_status_keys import _run_remove
+
+    return _run_remove(status_path, keys)
+
+
+def _cmd(args: argparse.Namespace) -> int:
+    status = json.loads(args.status.read_text())
+    stale, prior = is_stale_reuse(status, args.wave, args.phase)
+
+    if not stale:
+        stamps = stamped_phases(status, args.wave)
+        reason = (
+            f"phase stamp(s) {sorted(stamps)} already match {args.phase}"
+            if stamps
+            else f"wave-{args.wave} carries no phase stamp (never used before)"
+        )
+        print(f"not stale: {reason}; nothing to reset.")
+        return 0
+
+    keys = stale_wave_keys(status, args.wave)
+    print(
+        f"stale cross-phase reuse: wave-{args.wave} carries phase stamp(s) "
+        f"{sorted(prior)} but phase-{args.phase} is starting."
+    )
+    print(f"{len(keys)} stale wave_{args.wave}_* key(s) to reset:")
+    for k in keys:
+        print(f"  {k}")
+
+    if not args.apply:
+        print("(dry-run — pass --apply to remove these keys)")
+        return 0
+
+    return _apply_reset(args.status, keys)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "status",
+        type=Path,
+        nargs="?",
+        default=_DEFAULT_STATUS,
+        help="path to cross-repo-status.json (default: repo-root copy)",
+    )
+    parser.add_argument("wave", type=int, help="wave number (M) being started")
+    parser.add_argument("phase", type=int, help="phase number (P) being started")
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="remove the stale keys (default is a dry-run detection report)",
+    )
+    parser.set_defaults(func=_cmd)
+    return parser
+
+
+def main(argv: list[str]) -> int:
+    args = _build_parser().parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.claude/skills/wave-scope/SKILL.md
+++ b/.claude/skills/wave-scope/SKILL.md
@@ -587,6 +587,15 @@ else
     '{declared_refs: $d, carry_forwards: $c, must_includes: $m}')
 fi
 
+# Stamp the owning phase into the scope object regardless of which branch built
+# it. This is the per-phase phase-stamp that /wave-start § 5a reads to detect a
+# same-number wave reused across phases (P4W4 ↔ P5W4) — the reliable signal that
+# replaces the broken `current_phase` guard (main#683). `current_phase` tracks
+# the LATEST phase, not the phase that owns these wave_{M}_* keys, so the stamp
+# must live INSIDE the wave's own scope. Force-set (not default) so a stale
+# WAVE_SCOPE_STRUCTURED carried over from a prior phase cannot poison it.
+SCOPE_JSON=$(echo "$SCOPE_JSON" | jq -c --argjson p "{P}" '.phase = $p')
+
 UPSERT_ARGS=(
   "wave_{M}_scope_reconciled_at=$(jq -nc --arg t "$TS" '$t')"
   "wave_{M}_repos_in_scope=$REPOS_IN_SCOPE_JSON"

--- a/.claude/skills/wave-start/SKILL.md
+++ b/.claude/skills/wave-start/SKILL.md
@@ -118,59 +118,26 @@ done
 
 ### 5a. Wave-key per-phase reset (when a phase reuses a wave number)
 
-At phase boundaries, bare `wave_{M}_*` keys from the prior phase's wave M remain in `cross-repo-status.json` under the same names (e.g. `wave_3_final_pr_count`, `wave_3_completed_at`, `wave_3_annunaki_attack_ran_at`). These stale values bleed into the new phase's wave M if not explicitly cleared.
+At phase boundaries, bare `wave_{M}_*` keys from the prior phase's wave M remain in `cross-repo-status.json` under the same names (e.g. `wave_4_final_pr_count`, `wave_4_branches`, `wave_4_scope`). These stale values bleed into the new phase's wave M if not explicitly cleared. (Bare keys — NOT phase-prefixed `p{P}_wave_{M}_*` — are deliberate: the phase-prefix scheme was considered and rejected in main#611 because it would require a coordinated read-contract change across every wave skill. The fix is correct cleanup of the bare keys, not renaming them.)
 
-**Detection:** before writing any new active-state keys, check whether `wave_{M}_completed_at` or `wave_{M}_wrapped_up_at` exists in the current file AND `current_phase` in the file differs from the phase `{P}` you are starting:
+**This step is fully mechanized** by `.claude/lib/wave_key_reset.py` (main#683). Do NOT hand-roll the detection or the key list in bash — three defects in the old inline version (a `current_phase`-based guard that could never fire for an intra-phase same-number reuse; a detection probe that looked for the wrong key names; and a hand-enumerated reset list that missed ≥10 keys including the dangerous `wave_{M}_branches`) are exactly what that helper exists to prevent.
+
+**Detection signal:** the helper decides staleness from the **phase stamp carried inside the wave's own keys** — `wave_{M}_scope.phase` (written by `/wave-scope`) and the `phase-{X}` segment of `wave_{M}_branches.branch` (written by `/wave-kickoff`). It NEVER consults the global `current_phase` (which tracks the latest phase, not the phase that wrote the stale keys — the root cause of the old guard's blind spot). If any stamp differs from the phase `{P}` you are starting, the wave's keys are stale.
 
 ```bash
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 STATUS_FILE="$REPO_ROOT/cross-repo-status.json"
 
-FILE_PHASE=$(python3 -c "import json; d=json.load(open('$STATUS_FILE')); print(d.get('current_phase',''))")
-HAS_PRIOR=$(python3 -c "
-import json; d=json.load(open('$STATUS_FILE'))
-print('yes' if d.get('wave_{M}_completed_at') or d.get('wave_{M}_wrapped_up_at') else 'no')
-")
+# Dry-run first — prints the verdict and the exact keys that would be reset:
+python3 "$REPO_ROOT/.claude/lib/wave_key_reset.py" "$STATUS_FILE" {M} {P}
 
-if [ "$HAS_PRIOR" = "yes" ] && [ "$FILE_PHASE" != "{P}" ]; then
-  echo "Phase reuse detected: wave-{M} previously used in phase $FILE_PHASE; resetting stale keys before starting phase-{P}/wave-{M}."
-fi
+# Apply — removes every stale wave_{M}_* key (prefix-complete; no-op if not stale):
+python3 "$REPO_ROOT/.claude/lib/wave_key_reset.py" "$STATUS_FILE" {M} {P} --apply
 ```
 
-**When the condition is true, reset ALL of the following `wave_{M}_*` keys to `null` via `upsert_status_keys.py` — only for keys that exist in the file (skip non-existent keys to avoid inserting `null` noise):**
+The `--apply` path REMOVES the stale keys (the main#611 bare-key overwrite convention — the new phase's `/wave-start` § 6 and `/wave-scope` then write fresh `wave_{M}_*` keys). It is a safe no-op when the wave's stamps already match `{P}` — i.e. the first wave of a phase, or `/wave-start` re-run within the same phase (idempotent). Removal reuses `upsert_status_keys.remove_top_level_key`, so the file's mixed compact-inline / pretty-indented shape is preserved and the rewrite is JSON-validated before AND after (no 500-line cosmetic diff).
 
-```bash
-# Keys to reset (enumerate exactly — no glob, to keep the surface auditable):
-RESET_KEYS=(
-  wave_{M}_final_pr_count
-  wave_{M}_changes_requested_cycles
-  wave_{M}_top_concentration_pct
-  wave_{M}_completed_at
-  wave_{M}_wrapped_up_at
-  wave_{M}_kicked_off_at
-  wave_{M}_started_at
-  wave_{M}_scope_reconciled_at
-  wave_{M}_stg_promotion
-  wave_{M}_stg_promotion_url
-  wave_{M}_annunaki_attack_ran_at
-  wave_{M}_memory_audit_ran_at
-)
-
-for KEY in "${RESET_KEYS[@]}"; do
-  EXISTS=$(python3 -c "import json; d=json.load(open('$STATUS_FILE')); print('yes' if '$KEY' in d else 'no')")
-  if [ "$EXISTS" = "yes" ]; then
-    python3 "$REPO_ROOT/.claude/lib/upsert_status_keys.py" "$STATUS_FILE" "$KEY"=null
-    echo "  reset: $KEY"
-  fi
-done
-echo "Wave-key reset complete. Prior-phase values are cleared from the live file; git history preserves them."
-```
-
-This reset runs BEFORE the § 6 PUT-contents write so the active-state keys written in § 6 are the only non-null `wave_{M}_*` values once the step completes. Fold the null assignments into the same PUT-contents payload as § 6 to avoid a separate round-trip: `jq` can del() or set-to-null the stale keys in the same content transformation.
-
-**When the condition is false** (first wave of a phase, or `current_phase` already matches `{P}` because /wave-start is being re-run within the same phase): skip this step silently.
-
-**Why `upsert_status_keys.py` and not raw `jq`:** the file uses mixed compact-inline + pretty-indented style; a naive jq round-trip reformats every compact line, producing a 500+ line cosmetic diff per wave. `upsert_status_keys.py` performs targeted text-level upsert that preserves the existing style (see skills.md § Cross-repo-status.json upsert pattern).
+This reset runs BEFORE the § 6 PUT-contents write so the only `wave_{M}_*` values left once the step completes are the active-state keys § 6 writes. When operating on the `main` copy via PUT-contents, run the helper against a local working copy of the fetched content and fold the result into the same § 6 payload to avoid a separate round-trip.
 
 ### 6. Update cross-repo status — PUT-contents on `main`
 


### PR DESCRIPTION
## Summary

Fixes the `/wave-start` § 5a "per-phase wave-key reset" so a wave number reused across phases (P4W4 ↔ P5W4) reliably clears the prior phase's stale `wave_{M}_*` keys from `cross-repo-status.json`. Closes #683.

The hand-rolled bash in § 5a never fired this wave — 16 stale P4W5 `wave_5_*` keys had to be nulled by hand. Replaced with a mechanical, test-backed helper `.claude/lib/wave_key_reset.py`.

## The 3 defects addressed

1. **Guard could never fire (Defect 1).** The old guard inferred staleness from `current_phase != {P}`, but `current_phase` tracks the *latest* phase (advanced at this phase's W1 kickoff), not the phase that wrote the stale keys — so for an intra-phase same-number reuse it was structurally always false. Detection now keys off a phase stamp carried **inside the wave's own keys**: `wave_{M}_scope.phase` and the `phase-{X}` segment of `wave_{M}_branches.branch`. `current_phase` is never consulted. Correctly fires at a real boundary and is a no-op when `/wave-start` is re-run within the same phase (idempotent).
2. **Detection key-name mismatch (Defect 2).** Now moot — detection no longer probes any lifecycle-marker key (the old `wave_{M}_completed_at` / `_wrapped_up_at` vs the actually-written `_wrapup_completed_at` mismatch). It keys off phase stamps, which exist regardless of how far the prior wave progressed.
3. **Incomplete RESET_KEYS list (Defect 3).** Reset is **prefix-complete by construction** — every top-level `wave_{M}_*` key is removed, including the dangerous `wave_{M}_branches` (a stale `deployments/phase-4/wave-4` ref would mislead `/wave-kickoff` Step 1). No `wave_4` vs `wave_42` prefix bleed.

## Design notes

- **Removal, not null** — reuses `upsert_status_keys.remove_top_level_key` (the bare-key overwrite convention; phase-prefixing `p{P}_wave_{M}_*` was considered and **rejected in main#611** because it needs a coordinated read-contract change across every wave skill). Preserves the file's mixed compact-inline shape and JSON-validates before AND after.
- The issue suggested durable phase-namespacing as the "real" fix; that conflicts with the accepted main#611 ADR, so this implements the issue's interim path (which is the correct one given that ADR) — mechanized + tested rather than documented-only.
- `/wave-scope` Step 13 now stamps `phase: {P}` into `wave_{M}_scope` so the primary detection signal is reliably present and self-documenting (the orchestrator-built `WAVE_SCOPE_STRUCTURED` did not guarantee it). The `wave_{M}_branches.branch` stamp (always written by `/wave-kickoff`) is the corroborating signal that is reliable at any real phase boundary.

## Tests

`.claude/lib/tests/test_wave_key_reset.py` — 15 tests, one regression per defect (incl. the "current_phase already matches" case the old guard missed, detection without any lifecycle marker, and prefix-completeness with no sibling-wave bleed) plus end-to-end apply / no-op / dry-run.

## Local checks

- ruff-format `--check`, ruff-lint, mypy, cspell: clean on changed files.
- `pre_commit_ci_sync.py .`: `OK: pre-commit config mirrors all CI-enforced checks`.
- Full `.claude/lib/tests/ .claude/hooks/tests/` suite: 1398 passed. The single `test_ontology_tracker` failure is the documented worktree-location false-fail (main#686) — it passes in a normal checkout and in CI; verified `pytest …test_worktrees_segment_not_substring_false_match` passes from the primary checkout.

## Reviewers

Requested: **Aino Virtanen** and **Santiago Ferreira** (per charter 2-reviewer rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
