### PR TITLE
tech-debt(promotion-audit): canonical CLI driver wiring classify_* once (closes #690)

### DIFF
--- a/.claude/skills/promotion-audit/SKILL.md
+++ b/.claude/skills/promotion-audit/SKILL.md
@@ -24,37 +24,51 @@ Skill-to-hook **ALWAYS** produces a DECIDE-tier draft issue — never auto-appli
 
 ## Instructions
 
-### 1. Resolve wave name
+> **Do NOT hand-roll the `classify_*` call sequence.** Run the canonical
+> driver (`run.py`) — it wires the helper calls, slug resolution, and
+> thresholds in exactly one place. Hand-rolling the sequence inline is what
+> produced the P5W4 24-spurious-AUTO mis-fire (main#690): the section→skill
+> tier called `count_skill_invocations(section.promoted_to, …)` over an
+> empty `promoted_to` slug, and `git log --grep=/` matched ~every commit,
+> crossing the threshold for 24 not-yet-promoted sections. The driver
+> derives the candidate-skill slug from the heading for not-yet-promoted sections,
+> and `helpers.count_skill_invocations` now returns 0 for a blank slug.
 
-If invoked with no argument, read `cross-repo-status.json` for `current_wave`. Use that slug (e.g., `wave-9`) as the audit wave name. If the arg is provided, trust it.
+### 1. Run the canonical driver
 
-### 2. Gather inputs (all deterministic — helpers.py)
+```bash
+# Human-readable audit table + summary line:
+python3 .claude/skills/promotion-audit/run.py [wave]
 
-```python
-from helpers import (
-    read_all_memories,
-    read_all_charter_sections,
-    read_all_skills,
-    find_already_promoted_in_charter,
-    count_retro_citations,
-    count_skill_invocations,
-    classify_memory,
-    classify_section,
-    classify_skill,
-    render_audit_table,
-)
-
-memories  = read_all_memories(memory_dir)                  # list[Memory]
-sections  = read_all_charter_sections(charter_parent)      # list[Section] — only sections with a promotion-target marker
-skills    = read_all_skills(skills_dir)                    # list[Skill]
-already   = find_already_promoted_in_charter(charter_parent)  # set[str] — aggregates Promotion provenance: blocks AND <!-- Promoted from memory: X --> markers across all charter sub-docs (#283)
-# NOTE: `charter_parent` is the directory CONTAINING `charter/` (e.g. `.claude/team`),
-# NOT the `charter/` directory itself. Passing `.claude/team/charter` raises ValueError (#418).
+# Machine-readable decisions, to drive artifact emission in step 4:
+python3 .claude/skills/promotion-audit/run.py [wave] --json
 ```
 
-### 3. Classify each candidate (pure function)
+- **Wave resolution.** With no `wave` argument the driver reads
+  `current_phase` + `current_wave` from `cross-repo-status.json` and emits
+  the canonical phase-prefixed form `p{N}-wave-{M}` (e.g. `p5-wave-5`). A
+  bare `wave-{M}` or `{M}` arg is auto-prefixed; an already-canonical
+  `p{N}-wave-{M}` passes through. Bare `wave-{M}` output is forbidden (#442).
+- **Audit date** is pinned to the wave boundary (`wave_{M}_kicked_off_at`,
+  else `_started_at`, else `_scope_reconciled_at`) — never `datetime.now()`,
+  so re-runs on unchanged state are byte-identical. Override with `--date`.
+- The driver performs ONLY the deterministic classification + rendering. It
+  makes no `gh` calls and emits no artifacts — that is step 4, which reads
+  the driver's `--json` output.
 
-There is no single `classify()` entry point — each tier transition has its own classifier with a distinct signature, because the signal sources differ (retro citations for memory → charter; invocation counts for charter → skill and skill → hook) and `classify_section` has no `already_promoted` analogue (sections carry their own `promoted_to` back-reference instead).
+The `--json` payload is `{wave_name, audit_date, threshold, counts,
+decisions[]}` where each decision carries `kind, item_id, from_tier,
+to_tier, signal, reason, artifact_ref, extra`. Drive step 4 off the
+`AUTO` and `DECIDE` decisions in that list.
+
+### 2. How the driver classifies (reference — do not re-implement)
+
+The driver reads inputs via `read_all_memories` / `read_all_charter_sections`
+/ `read_all_skills` / `find_already_promoted_in_charter` (the latter
+aggregates `Promotion provenance:` blocks AND `<!-- Promoted from memory: X -->`
+markers across all charter sub-docs, #283), then routes each candidate to
+its tier-specific classifier. There is no single `classify()` entry point —
+each transition has a distinct signature because the signal sources differ:
 
 | Function | Signature | `signals` keys consumed |
 |---|---|---|
@@ -62,36 +76,18 @@ There is no single `classify()` entry point — each tier transition has its own
 | `classify_section(section, signals)` | `(CharterSection, dict[str,int]) -> Decision` | `skill_invocations`, `threshold` |
 | `classify_skill(skill, signals, already_promoted)` | `(Skill, dict[str,int], set[str]) -> Decision` | `skill_invocations`, `threshold` |
 
-Worked example (one item per tier):
+Signal derivation (wired once in `run.py`): memory→charter uses
+`count_retro_citations`; charter→skill counts invocations of the section's
+candidate-skill slug (`promoted_to` with the `skills/` prefix stripped if
+already promoted, else `_slugify(heading)` — never an empty slug);
+skill→hook counts invocations of the skill name (always DECIDE, D6).
 
-```python
-mem_decision = classify_memory(
-    memories[0],
-    signals={"retro_citations": count_retro_citations(memories[0], feedback_log_path)},
-    already_promoted=already,
-)
+> `charter_parent` is the directory CONTAINING `charter/` (e.g.
+> `.claude/team`), NOT `charter/` itself — passing `.claude/team/charter`
+> raises ValueError (#418). The driver resolves this correctly; this note
+> matters only if you call the helpers directly in a one-off.
 
-sec_decision = classify_section(
-    sections[0],
-    signals={
-        "skill_invocations": count_skill_invocations(sections[0].promoted_to_slug or "", repo_root),
-        "threshold": 5,
-    },
-)
-
-skill_decision = classify_skill(
-    skills[0],
-    signals={
-        "skill_invocations": count_skill_invocations(skills[0].name, repo_root),
-        "threshold": 5,
-    },
-    already_promoted=already,
-)
-```
-
-Common failure mode: passing the citation/invocation count as a bare int (`classify_memory(mem, cite, already)`) rather than wrapping it in the `signals` dict (`classify_memory(mem, {"retro_citations": cite}, already)`). The classifiers all do `signals.get(...)` and will raise `AttributeError: 'int' object has no attribute 'get'` on a bare int. Always pass a dict.
-
-Each call returns a `Decision` in one of these kinds:
+Each `Decision` has one of these kinds:
 
 - **AUTO** — thresholds met, promotion target is charter or skill, NOT already promoted
 - **DECIDE** — thresholds met, target is hook (always DECIDE), OR `requires_decision: true` override, OR signals ambiguous
@@ -106,7 +102,7 @@ Resolve the **current wave label** once at the top of this step from `cross-repo
 
 #### AUTO artifacts
 
-For each AUTO decision:
+For each `AUTO` decision in the driver's `--json` output (step 1):
 - **memory → charter:** apply `templates/charter-section.md` to the memory, append to the appropriate charter file, mark memory `superseded_by: charter:{file} § {section}`. Stage the diff.
 - **charter → skill:** apply `templates/skill-scaffold.md` to the section, write `.claude/skills/{slug}/SKILL.md`, add a back-reference comment `<!-- promoted-to: skills/{slug} -->` after the section's `promotion-target` marker. Stage.
 
@@ -172,7 +168,7 @@ Q3 decision: auto-promote artifacts land via PR (2-reviewer gate), not direct co
 
 #### DECIDE artifacts
 
-For each DECIDE decision:
+For each `DECIDE` decision in the driver's `--json` output (step 1):
 - Apply `templates/hook-draft.md` to generate an issue title + body. Write the body to `.claude/scratch/promotion-audit-{wave}-decide-{slug}.md`.
 - Create the issue with the **same three-label set** as AUTO PRs (`tech-debt` + `enhancement` + current-wave label) and the same project-board treatment:
 
@@ -205,7 +201,10 @@ The `gh` calls in this step (PR/issue creation, project-board adds, label/board 
 
 ### 5. Render the audit table
 
-Use `render_audit_table(decisions)` to produce deterministic markdown with four subsections:
+The driver already renders this table — its default (non-`--json`) stdout
+**is** the audit table followed by the summary line. Capture that stdout
+for steps 6–7 rather than calling `render_audit_table` by hand. The table
+has four subsections:
 
 ```
 ## Promotion Audit — {wave_name}
@@ -246,13 +245,14 @@ Log: .claude/team/promotion_audit_log/p{N}-wave-{M}.md
 
 ## Determinism
 
-The audit MUST produce byte-identical output when re-run on unchanged repo state. To guarantee this:
-- Sort every list by a stable key before iteration (memory name, charter path+heading, skill name).
-- Use UTC dates pinned to the wave boundary (read from `cross-repo-status.json`), never `datetime.now()`.
+The audit MUST produce byte-identical output when re-run on unchanged repo state. The canonical driver (`run.py`) is what guarantees this — it wires the helpers exactly once so the classification logic cannot drift between runs or operators:
+- Sort every list by a stable key before iteration (memory name, charter path+heading, skill name) — done inside the helpers the driver calls.
+- Use UTC dates pinned to the wave boundary (`run.py` reads `wave_{M}_kicked_off_at`/`_started_at`/`_scope_reconciled_at` from `cross-repo-status.json`), never `datetime.now()`.
+- Never count invocations for an empty/blank slug (`count_skill_invocations` guards this; `--grep=/` would otherwise match ~every commit — the main#690 mis-fire).
 - Never read transcript files (per D4(i)).
 - Never invoke external tools with nondeterministic output (no `gh api` except for issue creation at the end).
 
-Tests in `.claude/skills/promotion-audit/tests/` cover each helper and a smoke test that verifies the first-run expected outcome (zero AUTO, zero DECIDE on current repo state).
+Tests in `.claude/skills/promotion-audit/tests/` cover each helper (`test_helpers.py`), a smoke test verifying the first-run expected outcome (zero AUTO, zero DECIDE on current repo state — `test_smoke.py`), and the driver itself including the empty-slug regression and steady-state-through-the-driver (`test_run.py`).
 
 ## Integration
 

--- a/.claude/skills/promotion-audit/helpers.py
+++ b/.claude/skills/promotion-audit/helpers.py
@@ -413,7 +413,17 @@ def count_skill_invocations(skill_name: str, repo_root: str) -> int:
     D4 lightweight: we do NOT scan transcripts. `git log --grep="/{skill}"`
     finds commit messages that reference the skill, which is a stable and
     durable signal for "this skill got invoked during real work."
+
+    An empty or whitespace-only `skill_name` returns 0 — never the full
+    commit count. `git log --grep=/` matches (nearly) every commit because
+    almost all commit messages contain a slash, so a blank slug would
+    report a huge invocation count and spuriously cross any threshold.
+    This guard is the root-cause fix for the P5W4 24-spurious-AUTO mis-fire
+    (main#690): hand-rolled callers passed an empty `section.promoted_to`
+    slug straight through to this counter.
     """
+    if not skill_name or not skill_name.strip():
+        return 0
     try:
         result = subprocess.run(
             [

--- a/.claude/skills/promotion-audit/run.py
+++ b/.claude/skills/promotion-audit/run.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+"""Canonical CLI driver for the /promotion-audit skill.
+
+This is the single, deterministic entrypoint that wires the `helpers.py`
+pure functions + thresholds together exactly once. The SKILL.md invokes
+this driver instead of describing the classify_* call sequence in prose.
+
+Background (main#690)
+=====================
+The skill historically shipped `helpers.py` but no driver. The orchestrator
+hand-rolled the classify_* call sequence inline each retro. At the P5W4
+retro that hand-rolling mis-fired: the section→skill / skill→hook tiers
+derived the invocation signal by calling
+`count_skill_invocations(section.promoted_to, repo_root)` over an EMPTY
+`promoted_to` slug. `git log --grep=/` matches (nearly) every commit, so
+each not-yet-promoted section reported ~600 invocations and crossed the
+threshold — producing 24 spurious AUTO decisions that would have opened 24
+bogus charter/skill PRs. The more-carefully-called memory→charter tier
+returned the correct 0 AUTO.
+
+The fix is determinism-over-hand-rolling (same principle as main#688's
+`wave_status.py`): wire the signal derivation in ONE place, with the
+correct slug resolution, so the same repo state always yields the same
+decisions.
+
+Signal derivation, fixed in this driver
+=======================================
+- memory → charter: `count_retro_citations(memory, feedback_log)`.
+- charter → skill: the candidate skill slug is `section.promoted_to`
+  (with the `skills/` prefix stripped) when the section is already
+  promoted, else `_slugify(section.heading)` — the *prospective* skill
+  name. A not-yet-existent skill never appears in commit messages, so its
+  invocation count is naturally ~0. The empty-slug footgun is also closed
+  at the root in `helpers.count_skill_invocations` (blank slug → 0).
+- skill → hook: `count_skill_invocations(skill.name, repo_root)`
+  (always DECIDE per D6, never AUTO).
+
+Usage
+=====
+    python3 .claude/skills/promotion-audit/run.py [wave] [--json] [--date YYYY-MM-DD]
+    python3 -m run [wave] ...        # when CWD is the skill dir
+
+With no `wave` argument the driver reads `current_phase` / `current_wave`
+from `cross-repo-status.json` and emits the phase-prefixed canonical form
+`p{N}-wave-{M}` (bare `wave-{M}` is forbidden per #442 to avoid
+cross-phase collisions).
+
+The driver performs ONLY the deterministic classification + rendering.
+Artifact emission (PR/issue creation, project-board adds) stays in the
+SKILL.md prose because it makes nondeterministic `gh` calls — but it now
+drives off this driver's `--json` output rather than re-deriving signals.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+# Make `helpers` importable whether run as a script or via `python -m`.
+_HERE = Path(__file__).resolve().parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
+import helpers as h  # noqa: E402
+
+# Walk up from .claude/skills/promotion-audit/run.py to the repo root.
+_REPO_ROOT = _HERE.parent.parent.parent
+_DEFAULT_MEMORY_DIR = os.path.expanduser(
+    "~/.claude/projects/-home-parameterization-code-noorinalabs-main/memory"
+)
+
+DEFAULT_THRESHOLD = 5
+
+
+@dataclasses.dataclass(frozen=True)
+class AuditPaths:
+    """Resolved input locations for one audit run."""
+
+    repo_root: str
+    memory_dir: str
+    charter_parent: str  # dir CONTAINING charter/ (e.g. .claude/team), NOT charter/ itself
+    skills_dir: str
+    feedback_log: str
+    status_path: str
+
+
+def resolve_paths(
+    repo_root: str | os.PathLike[str] | None = None,
+    *,
+    memory_dir: str | None = None,
+) -> AuditPaths:
+    """Resolve every input path from the repo root.
+
+    `memory_dir` defaults to the project's user-level memory area, which
+    lives OUTSIDE the repo (under ~/.claude/projects/...). It can be
+    overridden for tests against a fixture tree.
+    """
+    root = Path(repo_root) if repo_root is not None else _REPO_ROOT
+    team = root / ".claude" / "team"
+    return AuditPaths(
+        repo_root=str(root),
+        memory_dir=memory_dir if memory_dir is not None else _DEFAULT_MEMORY_DIR,
+        charter_parent=str(team),
+        skills_dir=str(root / ".claude" / "skills"),
+        feedback_log=str(team / "feedback_log.md"),
+        status_path=str(root / "cross-repo-status.json"),
+    )
+
+
+_WAVE_M_RE = re.compile(r"(?:wave-)?(?P<m>\d+)\s*$")
+_PHASE_PREFIXED_RE = re.compile(r"^p(?P<n>\d+)-wave-(?P<m>\d+)$")
+
+
+def resolve_wave_name(arg: str | None, status_path: str) -> str:
+    """Return the canonical phase-prefixed wave name `p{N}-wave-{M}`.
+
+    - Already-canonical `p{N}-wave-{M}` args pass through unchanged.
+    - Bare `wave-{M}` or `{M}` args are prefixed with `current_phase`
+      from `cross-repo-status.json`.
+    - No arg reads `current_phase` + `current_wave` from the status file.
+
+    Bare `wave-{M}` output is forbidden (#442): every consumer of this name
+    (audit logs, feedback-log headers) must be phase-namespaced to avoid the
+    cross-phase collision documented in the P2W10/P3W10 overwrite.
+    """
+    data: dict = {}
+    if os.path.isfile(status_path):
+        data = json.loads(Path(status_path).read_text())
+
+    if arg:
+        arg = arg.strip()
+        if _PHASE_PREFIXED_RE.match(arg):
+            return arg
+        m = _WAVE_M_RE.search(arg)
+        if not m:
+            raise ValueError(f"Cannot parse wave from {arg!r} (expected p5-wave-5 or wave-5 or 5)")
+        wave_m = m.group("m")
+    else:
+        current_wave = str(data.get("current_wave", "")).strip()
+        m = _WAVE_M_RE.search(current_wave)
+        if not m:
+            raise ValueError(f"cross-repo-status.json current_wave={current_wave!r} is unparseable")
+        wave_m = m.group("m")
+
+    phase = data.get("current_phase")
+    if phase is None:
+        raise ValueError("cross-repo-status.json is missing current_phase")
+    return f"p{int(phase)}-wave-{wave_m}"
+
+
+def resolve_audit_date(wave_name: str, status_path: str) -> str:
+    """Pin the audit date to the wave boundary (UTC, `YYYY-MM-DD`).
+
+    Determinism requires we never use `datetime.now()` — the date is read
+    from the wave's boundary timestamp in `cross-repo-status.json`. Tries,
+    in order: `wave_{M}_kicked_off_at`, `wave_{M}_started_at`,
+    `wave_{M}_scope_reconciled_at`. Returns "unknown-date" only if the
+    status file or every boundary key is absent (callers may override with
+    `--date`).
+    """
+    m = _PHASE_PREFIXED_RE.match(wave_name)
+    wave_m = m.group("m") if m else _WAVE_M_RE.search(wave_name).group("m")  # type: ignore[union-attr]
+    if not os.path.isfile(status_path):
+        return "unknown-date"
+    data = json.loads(Path(status_path).read_text())
+    for key in (
+        f"wave_{wave_m}_kicked_off_at",
+        f"wave_{wave_m}_started_at",
+        f"wave_{wave_m}_scope_reconciled_at",
+    ):
+        val = data.get(key)
+        if val:
+            return str(val)[:10]
+    return "unknown-date"
+
+
+def _section_signal_slug(section: h.CharterSection) -> str:
+    """The skill slug whose invocations gate this section's charter→skill move.
+
+    For an already-promoted section, that's the existing skill slug recorded
+    in the `promoted-to: skills/{slug}` back-reference. For a not-yet-promoted
+    section, it's the *prospective* skill name derived from the heading —
+    which, because the skill does not exist yet, naturally yields ~0
+    invocations rather than the all-commits count an empty slug produced
+    in the P5W4 mis-fire (main#690).
+    """
+    if section.promoted_to:
+        return section.promoted_to.split("/")[-1]
+    return h._slugify(section.heading)
+
+
+@dataclasses.dataclass(frozen=True)
+class AuditResult:
+    wave_name: str
+    audit_date: str
+    threshold: int
+    decisions: list[h.Decision]
+
+    def counts(self) -> dict[str, int]:
+        out = {"AUTO": 0, "DECIDE": 0, "KEPT": 0, "SUPERSEDED": 0, "ALREADY-PROMOTED": 0}
+        for d in self.decisions:
+            out[d.kind] = out.get(d.kind, 0) + 1
+        return out
+
+    def table(self) -> str:
+        return h.render_audit_table(self.decisions, self.wave_name, self.audit_date)
+
+    def summary_line(self) -> str:
+        c = self.counts()
+        supers = c["SUPERSEDED"] + c["ALREADY-PROMOTED"]
+        return (
+            f"Promotion audit {self.wave_name} complete: "
+            f"{c['AUTO']} AUTO · {c['DECIDE']} DECIDE · {c['KEPT']} KEPT · {supers} SUPERSEDED"
+        )
+
+
+def run_audit(
+    paths: AuditPaths,
+    *,
+    wave_name: str,
+    audit_date: str,
+    threshold: int = DEFAULT_THRESHOLD,
+) -> AuditResult:
+    """Drive the full deterministic classification pipeline exactly once.
+
+    Re-running on unchanged repo state yields byte-identical decisions —
+    every input list is read in sorted order by the helpers, and signals
+    are derived from git history + on-disk files only (no clock, no
+    transcripts, no network).
+    """
+    memories = h.read_all_memories(paths.memory_dir)
+    sections = h.read_all_charter_sections(paths.charter_parent)
+    skills = h.read_all_skills(paths.skills_dir)
+    already = h.find_already_promoted_in_charter(paths.charter_parent)
+
+    decisions: list[h.Decision] = []
+
+    # memory → charter
+    for mem in memories:
+        cites = h.count_retro_citations(mem, paths.feedback_log)
+        decisions.append(h.classify_memory(mem, {"retro_citations": cites}, already))
+
+    # charter → skill
+    for sec in sections:
+        slug = _section_signal_slug(sec)
+        invocations = h.count_skill_invocations(slug, paths.repo_root)
+        decisions.append(
+            h.classify_section(sec, {"skill_invocations": invocations, "threshold": threshold})
+        )
+
+    # skill → hook (always DECIDE)
+    for sk in skills:
+        invocations = h.count_skill_invocations(sk.name, paths.repo_root)
+        decisions.append(
+            h.classify_skill(
+                sk, {"skill_invocations": invocations, "threshold": threshold}, already
+            )
+        )
+
+    return AuditResult(
+        wave_name=wave_name,
+        audit_date=audit_date,
+        threshold=threshold,
+        decisions=decisions,
+    )
+
+
+def _decisions_as_json(result: AuditResult) -> str:
+    payload = {
+        "wave_name": result.wave_name,
+        "audit_date": result.audit_date,
+        "threshold": result.threshold,
+        "counts": result.counts(),
+        "decisions": [dataclasses.asdict(d) for d in result.decisions],
+    }
+    return json.dumps(payload, indent=2, sort_keys=True)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="promotion-audit",
+        description="Canonical deterministic driver for the /promotion-audit skill.",
+    )
+    p.add_argument(
+        "wave",
+        nargs="?",
+        default=None,
+        help="wave name (p5-wave-5, wave-5, or 5); default reads cross-repo-status.json",
+    )
+    p.add_argument(
+        "--json",
+        action="store_true",
+        help="emit machine-readable decisions (for artifact-emission drivers)",
+    )
+    p.add_argument(
+        "--date",
+        default=None,
+        help="override the audit date (YYYY-MM-DD); default reads the wave boundary",
+    )
+    p.add_argument(
+        "--repo-root",
+        default=None,
+        help="repo root (default: inferred from this file's location)",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    paths = resolve_paths(args.repo_root)
+    wave_name = resolve_wave_name(args.wave, paths.status_path)
+    audit_date = args.date or resolve_audit_date(wave_name, paths.status_path)
+    result = run_audit(paths, wave_name=wave_name, audit_date=audit_date)
+
+    if args.json:
+        print(_decisions_as_json(result))
+    else:
+        print(result.table())
+        print()
+        print(result.summary_line())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/promotion-audit/tests/test_run.py
+++ b/.claude/skills/promotion-audit/tests/test_run.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Tests for the canonical promotion-audit CLI driver (run.py, main#690).
+
+Two layers:
+  - hermetic fixture tests (a synthetic repo tree built in a tempdir) that
+    pin the driver's wiring + the empty-slug regression that caused the
+    P5W4 24-spurious-AUTO mis-fire, with no dependency on the live repo;
+  - a steady-state test against the real working tree asserting the driver
+    still yields ~0 AUTO / 0 DECIDE (the same invariant test_smoke.py
+    asserts for the hand-driven path, now asserted THROUGH the driver).
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import subprocess
+import sys
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE.parent))
+
+import helpers as h  # noqa: E402
+import run  # noqa: E402
+
+_REPO_ROOT = _HERE.parent.parent.parent.parent
+_MEMORY_DIR = os.path.expanduser(
+    "~/.claude/projects/-home-parameterization-code-noorinalabs-main/memory"
+)
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _make_fixture_repo(tmp: Path) -> tuple[run.AuditPaths, str]:
+    """Build a minimal repo tree + git history; return (paths, repo_root)."""
+    repo = tmp / "repo"
+    mem = tmp / "memory"
+    mem.mkdir(parents=True)
+
+    # A charter with one skill-target section that has NOT been promoted
+    # (no `promoted-to` back-reference). Under the old hand-rolled path this
+    # section's empty `promoted_to` slug reached count_skill_invocations and
+    # matched every commit -> spurious AUTO. The driver must keep it KEPT.
+    _write(
+        repo / ".claude" / "team" / "charter.md",
+        "# Charter\n\n"
+        "## Some Procedure <!-- promotion-target: skill -->\n\n"
+        "Body of a procedure that has not been promoted yet.\n",
+    )
+    # One skill, not opted into hook promotion.
+    _write(
+        repo / ".claude" / "skills" / "demo-skill" / "SKILL.md",
+        "---\nname: demo-skill\ndescription: demo\n---\n\nbody\n",
+    )
+    _write(repo / ".claude" / "team" / "feedback_log.md", "# Feedback Log\n")
+    _write(
+        repo / "cross-repo-status.json",
+        '{"current_phase": 5, "current_wave": "wave-5", '
+        '"wave_5_started_at": "2026-06-16T22:51:14Z"}\n',
+    )
+    # A memory that opts out of promotion -> KEPT.
+    _write(
+        mem / "project_demo.md",
+        "---\nname: demo\ndescription: d\nmetadata:\n  type: project\n"
+        "promotion_target: none\n---\n\nbody\n",
+    )
+
+    # Real git history whose commit messages contain slashes, so an empty
+    # `--grep=/` slug WOULD match them (the bug condition).
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "t@t")
+    _git(repo, "config", "user.name", "t")
+    (repo / "f.txt").write_text("x\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "feat: run /some-thing and a/b path")
+
+    paths = run.resolve_paths(repo, memory_dir=str(mem))
+    return paths, str(repo)
+
+
+class WaveNameResolution(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = TemporaryDirectory()
+        self.status = Path(self._tmp.name) / "status.json"
+        self.status.write_text('{"current_phase": 5, "current_wave": "wave-5"}')
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def test_phase_prefixed_passthrough(self) -> None:
+        self.assertEqual(run.resolve_wave_name("p3-wave-11", str(self.status)), "p3-wave-11")
+
+    def test_bare_wave_is_prefixed(self) -> None:
+        self.assertEqual(run.resolve_wave_name("wave-5", str(self.status)), "p5-wave-5")
+
+    def test_bare_number_is_prefixed(self) -> None:
+        self.assertEqual(run.resolve_wave_name("7", str(self.status)), "p5-wave-7")
+
+    def test_no_arg_reads_status(self) -> None:
+        self.assertEqual(run.resolve_wave_name(None, str(self.status)), "p5-wave-5")
+
+    def test_output_is_never_bare(self) -> None:
+        # #442: output must always be phase-prefixed, never bare wave-{M}.
+        self.assertRegex(run.resolve_wave_name(None, str(self.status)), r"^p\d+-wave-\d+$")
+
+    def test_missing_phase_raises(self) -> None:
+        self.status.write_text('{"current_wave": "wave-5"}')
+        with self.assertRaises(ValueError):
+            run.resolve_wave_name("wave-5", str(self.status))
+
+
+class AuditDateResolution(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = TemporaryDirectory()
+        self.status = Path(self._tmp.name) / "status.json"
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def test_prefers_kicked_off_at(self) -> None:
+        self.status.write_text(
+            '{"wave_5_kicked_off_at": "2026-06-10T00:00:00Z", '
+            '"wave_5_started_at": "2026-06-16T00:00:00Z"}'
+        )
+        self.assertEqual(run.resolve_audit_date("p5-wave-5", str(self.status)), "2026-06-10")
+
+    def test_falls_back_to_started_at(self) -> None:
+        self.status.write_text('{"wave_5_started_at": "2026-06-16T22:51:14Z"}')
+        self.assertEqual(run.resolve_audit_date("p5-wave-5", str(self.status)), "2026-06-16")
+
+    def test_unknown_when_no_keys(self) -> None:
+        self.status.write_text("{}")
+        self.assertEqual(run.resolve_audit_date("p5-wave-5", str(self.status)), "unknown-date")
+
+
+class EmptySlugRegression(unittest.TestCase):
+    """The P5W4 root cause: an empty slug must never count all commits."""
+
+    def setUp(self) -> None:
+        self._tmp = TemporaryDirectory()
+        self.tmp = Path(self._tmp.name)
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def test_empty_slug_counts_zero(self) -> None:
+        self.assertEqual(h.count_skill_invocations("", str(_REPO_ROOT)), 0)
+        self.assertEqual(h.count_skill_invocations("   ", str(_REPO_ROOT)), 0)
+
+    def test_section_signal_slug_is_heading_when_unpromoted(self) -> None:
+        sec = h.CharterSection(
+            path="charter.md",
+            heading="Some Procedure",
+            promotion_target="skill",
+            body="b",
+            promoted_to="",
+        )
+        # Never empty -> never the all-commits count.
+        self.assertEqual(run._section_signal_slug(sec), "some-procedure")
+
+    def test_section_signal_slug_strips_skills_prefix(self) -> None:
+        sec = h.CharterSection(
+            path="charter.md",
+            heading="X",
+            promotion_target="skill",
+            body="b",
+            promoted_to="skills/my-skill",
+        )
+        self.assertEqual(run._section_signal_slug(sec), "my-skill")
+
+    def test_unpromoted_section_is_kept_not_auto(self) -> None:
+        # The end-to-end regression: in a repo whose commits contain
+        # slashes, the unpromoted skill-target section must be KEPT.
+        paths, _ = _make_fixture_repo(self.tmp)
+        result = run.run_audit(paths, wave_name="p5-wave-5", audit_date="2026-06-16")
+        sec_decisions = [d for d in result.decisions if d.from_tier == "charter"]
+        self.assertEqual(len(sec_decisions), 1)
+        self.assertEqual(sec_decisions[0].kind, "KEPT")
+        self.assertEqual(result.counts()["AUTO"], 0)
+        self.assertEqual(result.counts()["DECIDE"], 0)
+
+
+class FixtureAuditShape(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = TemporaryDirectory()
+        self.tmp = Path(self._tmp.name)
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def test_audit_covers_all_three_tiers(self) -> None:
+        paths, _ = _make_fixture_repo(self.tmp)
+        result = run.run_audit(paths, wave_name="p5-wave-5", audit_date="2026-06-16")
+        tiers = {d.from_tier for d in result.decisions}
+        self.assertEqual(tiers, {"memory", "charter", "skill"})
+
+    def test_run_audit_is_deterministic(self) -> None:
+        paths, _ = _make_fixture_repo(self.tmp)
+        a = run.run_audit(paths, wave_name="p5-wave-5", audit_date="2026-06-16")
+        b = run.run_audit(paths, wave_name="p5-wave-5", audit_date="2026-06-16")
+        self.assertEqual(a.table(), b.table())
+        self.assertEqual(a.counts(), b.counts())
+
+    def test_summary_line_groups_superseded_and_already(self) -> None:
+        paths, _ = _make_fixture_repo(self.tmp)
+        result = run.run_audit(paths, wave_name="p5-wave-5", audit_date="2026-06-16")
+        self.assertIn("Promotion audit p5-wave-5 complete:", result.summary_line())
+
+
+class MainEntrypoint(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = TemporaryDirectory()
+        self.tmp = Path(self._tmp.name)
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def test_main_returns_zero_and_prints_summary(self) -> None:
+        # Exercise the argparse wiring + table path against the real repo
+        # root (the default memory dir lives outside any tempdir).
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = run.main(["p5-wave-5", "--repo-root", str(_REPO_ROOT), "--date", "2026-06-16"])
+        self.assertEqual(rc, 0)
+        self.assertIn("Promotion audit p5-wave-5 complete:", buf.getvalue())
+
+    def test_json_flag_emits_parseable_payload(self) -> None:
+        import json
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = run.main(
+                ["p5-wave-5", "--json", "--repo-root", str(_REPO_ROOT), "--date", "2026-06-16"]
+            )
+        self.assertEqual(rc, 0)
+        payload = json.loads(buf.getvalue())
+        self.assertEqual(payload["wave_name"], "p5-wave-5")
+        self.assertIn("counts", payload)
+        self.assertIn("decisions", payload)
+
+
+@unittest.skipUnless(
+    os.path.isdir(_MEMORY_DIR),
+    "steady-state test requires the project's memory directory",
+)
+class SteadyStateThroughDriver(unittest.TestCase):
+    """The driver must reproduce the smoke-test invariant: 0 AUTO / 0 DECIDE
+    on the real working tree — proving the canonical wiring matches the
+    hand-driven expectation while closing the empty-slug mis-fire."""
+
+    def test_zero_auto_zero_decide(self) -> None:
+        paths = run.resolve_paths(_REPO_ROOT)
+        result = run.run_audit(paths, wave_name="p5-wave-5", audit_date="2026-06-16")
+        counts = result.counts()
+        auto = [d.item_id for d in result.decisions if d.kind == "AUTO"]
+        decide = [d.item_id for d in result.decisions if d.kind == "DECIDE"]
+        self.assertEqual(counts["AUTO"], 0, f"unexpected AUTO: {auto}")
+        self.assertEqual(counts["DECIDE"], 0, f"unexpected DECIDE: {decide}")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Adds a canonical CLI driver for the `/promotion-audit` skill so the
`classify_*` call sequence is wired in exactly one deterministic place
instead of being hand-rolled inline each retro.

**Why:** At the P5W4 retro the hand-rolled sequence mis-fired. The
section→skill tier derived its signal via
`count_skill_invocations(section.promoted_to, repo_root)` over an **empty**
`promoted_to` slug, and `git log --grep=/` matches ~every commit — so 24
not-yet-promoted skill-target sections each reported ~600 invocations,
crossed the threshold, and produced **24 spurious AUTO** decisions that
would have opened 24 bogus charter/skill PRs. The carefully-called
memory→charter tier correctly returned 0 AUTO. Same
determinism-over-hand-rolling principle as main#688 (`wave_status.py`).

## Changes

- **`run.py`** — single deterministic entrypoint. Wires `read_*` +
  `classify_*` + thresholds once; resolves the wave to canonical
  `p{N}-wave-{M}` (#442); pins the audit date to the wave boundary (never
  `datetime.now()`); renders the table + summary. `--json` emits
  machine-readable decisions to drive the skill's artifact-emission step.
  Makes no `gh` calls.
- **Correct slug resolution** — section→skill candidate slug is
  `promoted_to` (with `skills/` stripped) when already promoted, else
  `_slugify(heading)` (the prospective skill name, naturally ~0
  invocations). Never an empty slug.
- **Root-cause guard** in `helpers.count_skill_invocations`: blank slug → 0
  instead of the all-commits count.
- **SKILL.md** invokes the driver and adds a no-hand-roll directive instead
  of describing the call sequence in prose.
- **`tests/test_run.py`** — wave/date resolution, the empty-slug regression,
  the end-to-end "not-yet-promoted section stays KEPT" regression,
  determinism, and steady-state-through-the-driver (0 AUTO / 0 DECIDE).

## Verification

- `ruff format --check` + `ruff check` clean; `mypy` clean.
- Full skill suite: **99 passed** (`ENVIRONMENT=test pytest tests/`).
- Driver on current `p5-wave-5` state: **0 AUTO · 0 DECIDE · 242 KEPT · 18
  SUPERSEDED/ALREADY-PROMOTED** — re-run byte-identical.
- cspell clean on the edited `SKILL.md`.

## Related Issues

Closes #690.

## Review Checklist

- [ ] Driver wiring matches the SKILL.md tier table (signatures + signals)
- [ ] Empty-slug guard + heading-slug fallback correctly prevent the 24-AUTO mis-fire
- [ ] Wave-name + audit-date resolution stay deterministic (#442)

Co-Authored-By: Santiago Ferreira <parametrization+Santiago.Ferreira@gmail.com>
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
