### PR TITLE
charter+hooks(#663): gh-command parser invariant + machine-enforcement gate

### DIFF
--- a/.claude/hooks/tests/test_gh_command_parser_invariant.py
+++ b/.claude/hooks/tests/test_gh_command_parser_invariant.py
@@ -1,0 +1,254 @@
+r"""Smoke/lint gate for the main#663 gh-command parser invariant.
+
+Charter rule: `charter/hooks.md` § Hook Authorship Requirements
+              "7. gh-command Parser Invariant".
+
+> Any hook that parses a `gh issue`/`gh pr` command MUST scope label/repo
+> extraction to the actual flag VALUES (via the shared `_shell_parse` /
+> `_wave_label_parse` / `_repo_flag_parse` tokenizer) and resolve the
+> flag-omitted (ambient git-context) case — never reimplement the shell
+> tokenizer privately, and never match flag-shaped / label-shaped strings
+> elsewhere in the command (especially `--body`/`--body-file` content).
+
+This gate is the machine-enforcement of that invariant (per
+`feedback_enforcement_hierarchy.md`: "Charter rules without enforcement
+decay"). It is the gh-command analogue of the deferred grep-gate noted in
+§5a, scoped to the `gh issue`/`gh pr` parser class the invariant governs.
+
+Mechanics
+=========
+
+For every top-level hook in `.claude/hooks/*.py` (excluding the three
+sanctioned shared parsers, which ARE the canonical tokenizer/flag-walker),
+classify whether it is a **gh-command parser** — i.e. it reads the incoming
+Bash command (`tool_input` / `command`) AND matches a `gh issue`/`gh pr`
+shape. For each such hook assert BOTH:
+
+  A. It does NOT call `shlex.split` / `shlex.shlex` directly — all shell
+     tokenization must route through `_shell_parse.tokenize` (which carries
+     the line-continuation #287 and heredoc fixes a private reimplementation
+     would miss).
+
+  C. It contains no ad-hoc flag-value-capturing regex literal (a regex that
+     captures the value following `--repo`/`--label`/`--add-label`/
+     `--remove-label`/`-R`/`-l`). Such extraction is the #650/#659/#661 bug
+     class — it leaks label-shaped tokens out of `--body` content. Pure
+     shape-detection regexes (`\bgh\s+issue\s+create\b`) are allowed.
+
+Scope: `gh issue`/`gh pr` per the invariant text. `gh workflow`/`gh api`
+parsers (e.g. `warn_ghcr_image` extracting `-R` from `gh workflow run`) are
+the same latent class but out of the invariant's stated scope — tracked as a
+follow-up, not enforced here.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import re
+import unittest
+
+_HOOKS_DIR = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
+
+# The canonical shared parsers — they ARE the tokenizer / flag-walker /
+# ambient-repo resolver. They are allowed to call shlex and carry the
+# sanctioned regex fallbacks, so they are exempt from the gate.
+_SHARED_PARSERS = {"_shell_parse.py", "_wave_label_parse.py", "_repo_flag_parse.py"}
+
+# gh value/identity flags whose VALUE a parser might (wrongly) regex out.
+_FLAG_ALT = r"--repo|--add-label|--remove-label|--label|-R|-l"
+
+# Heuristic: a regex SOURCE literal that captures the value FOLLOWING a gh
+# value-flag — `--flag( |=|\s)*( capture | \S | . | [ )`. Validated against the
+# live corpus: matches the `-R\s+[\"']?(\S+)` ad-hoc shape; does NOT match the
+# sanctioned `(?:--repo|-R)(?:=|\s+)(\S+)` form in `_repo_flag_parse` (a `)`
+# follows the flag there, outside the allowed separator run) — and that module
+# is exempt anyway.
+_FORBIDDEN_FLAG_REGEX = re.compile(r"(?:%s)(?:\\?=|\\s|\\ |\s|=)*\(?\\?[Ss.\[(]" % _FLAG_ALT)
+
+# re.* functions whose FIRST positional arg is a regex pattern source.
+_RE_PATTERN_FUNCS = {
+    "compile",
+    "search",
+    "match",
+    "fullmatch",
+    "findall",
+    "finditer",
+    "split",
+    "sub",
+}
+
+# Minimum gh-command parsers the classifier must find. Guards against a
+# refactor that silently breaks the classifier into matching nothing (which
+# would make this gate vacuously green).
+_MIN_GH_HOOKS = 6
+
+
+def _iter_hook_files() -> list[str]:
+    return sorted(
+        f
+        for f in os.listdir(_HOOKS_DIR)
+        if f.endswith(".py") and not f.startswith("_consultation") and f not in {"__init__.py"}
+    )
+
+
+def _read(name: str) -> str:
+    with open(os.path.join(_HOOKS_DIR, name), encoding="utf-8") as fh:
+        return fh.read()
+
+
+def _docstring_constant_ids(tree: ast.AST) -> set[int]:
+    """ids() of string Constant nodes that are module/func/class docstrings."""
+    out: set[int] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            body = getattr(node, "body", None)
+            if (
+                body
+                and isinstance(body[0], ast.Expr)
+                and isinstance(body[0].value, ast.Constant)
+                and isinstance(body[0].value.value, str)
+            ):
+                out.add(id(body[0].value))
+    return out
+
+
+def _code_signal_text(src: str) -> str:
+    """Join code identifiers + non-docstring string constants into one blob.
+
+    Used only for cheap substring/regex SIGNAL checks (classification), not for
+    semantics. Docstrings are excluded so a hook that merely *documents* a gh
+    command in its module docstring is not misclassified as a parser of one.
+    """
+    tree = ast.parse(src)
+    doc_ids = _docstring_constant_ids(tree)
+    parts: list[str] = []
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Constant)
+            and isinstance(node.value, str)
+            and id(node) not in doc_ids
+        ):
+            parts.append(node.value)
+        elif isinstance(node, ast.Attribute):
+            parts.append(node.attr)
+        elif isinstance(node, ast.Name):
+            parts.append(node.id)
+    return " ".join(parts)
+
+
+def _is_gh_command_parser(src: str) -> bool:
+    """True if the hook reads the incoming command AND matches a gh issue/pr shape."""
+    code = _code_signal_text(src)
+    reads_command = ("tool_input" in code) and ("command" in code)
+    if not reads_command:
+        return False
+    gh_shape = (
+        re.search(r"gh\s+(?:issue|pr)\b", code) is not None
+        or "is_gh_subcommand" in code
+        or "find_gh_subcommand" in code
+        or "--add-label" in code
+        or "--remove-label" in code
+    )
+    return gh_shape
+
+
+def _calls_shlex_directly(src: str) -> bool:
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            base = node.func.value
+            if (
+                isinstance(base, ast.Name)
+                and base.id == "shlex"
+                and node.func.attr in {"split", "shlex"}
+            ):
+                return True
+        if isinstance(node, ast.ImportFrom) and node.module == "shlex":
+            if any(a.name in {"split", "shlex"} for a in node.names):
+                return True
+    return False
+
+
+def _adhoc_flag_value_regexes(src: str) -> list[str]:
+    """Regex SOURCE literals (re.* first arg) that capture a gh flag VALUE."""
+    tree = ast.parse(src)
+    hits: list[str] = []
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr in _RE_PATTERN_FUNCS
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "re"
+            and node.args
+            and isinstance(node.args[0], ast.Constant)
+            and isinstance(node.args[0].value, str)
+        ):
+            pat = node.args[0].value
+            if _FORBIDDEN_FLAG_REGEX.search(pat):
+                hits.append(pat)
+    return hits
+
+
+def _gh_command_parser_hooks() -> list[str]:
+    out = []
+    for name in _iter_hook_files():
+        if name in _SHARED_PARSERS:
+            continue
+        if _is_gh_command_parser(_read(name)):
+            out.append(name)
+    return out
+
+
+class GhCommandParserInvariantTests(unittest.TestCase):
+    def test_classifier_finds_the_gh_parser_class(self):
+        hooks = _gh_command_parser_hooks()
+        self.assertGreaterEqual(
+            len(hooks),
+            _MIN_GH_HOOKS,
+            f"Classifier found only {len(hooks)} gh-command parsers ({hooks}); "
+            f"expected >= {_MIN_GH_HOOKS}. The classifier likely regressed — "
+            "this gate would be vacuously green.",
+        )
+
+    def test_migrated_hook_is_classified(self):
+        # Regression guard: the hook migrated for main#663 must stay in scope.
+        self.assertIn("validate_wave_label_evidence.py", _gh_command_parser_hooks())
+
+    def test_shared_parsers_present(self):
+        for name in _SHARED_PARSERS:
+            self.assertTrue(
+                os.path.exists(os.path.join(_HOOKS_DIR, name)),
+                f"sanctioned shared parser missing: {name}",
+            )
+
+    def test_no_gh_parser_calls_shlex_directly(self):
+        offenders = []
+        for name in _gh_command_parser_hooks():
+            if _calls_shlex_directly(_read(name)):
+                offenders.append(name)
+        self.assertEqual(
+            offenders,
+            [],
+            "gh-command parser hooks must tokenize via `_shell_parse.tokenize`, "
+            f"not call shlex directly (main#663 invariant): {offenders}",
+        )
+
+    def test_no_gh_parser_has_adhoc_flag_value_regex(self):
+        offenders = {}
+        for name in _gh_command_parser_hooks():
+            hits = _adhoc_flag_value_regexes(_read(name))
+            if hits:
+                offenders[name] = hits
+        self.assertEqual(
+            offenders,
+            {},
+            "gh-command parser hooks must extract flag values via the shared "
+            "tokenizer (walk_flag_values / extract_repo), not a private "
+            f"flag-value-capturing regex (main#663 invariant): {offenders}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/hooks/tests/test_validate_wave_label_evidence.py
+++ b/.claude/hooks/tests/test_validate_wave_label_evidence.py
@@ -269,5 +269,91 @@ class WaveBranchFallbackTests(unittest.TestCase):
             self.assertIsNone(hook.check(_bash_input(cmd)))
 
 
+class AmbientRepoResolutionTests(unittest.TestCase):
+    """main#663 MUST #2: `--repo`/`-R` omitted (in-repo create/edit) resolves
+    the ambient repo from the cwd origin (mirroring gh) instead of the old
+    empty-default `noorinalabs/` slug. Without resolution the hook would skip
+    (allow); these cases prove it reaches verification and blocks on a 404."""
+
+    def test_ambient_create_resolves_repo_and_blocks_on_404(self):
+        # No `--repo`: resolution must succeed for the hook to reach body
+        # verification at all (else it skips+allows). Cited path 404s → block.
+        body = "File at noorinalabs-main/.claude/hooks/missing.py is gone."
+        cmd = f"gh issue create --title T --body {body!r} --label 'p3-wave-9'"
+        fake = _fake_subprocess_factory(main_exists=set())
+        with (
+            mock.patch.object(hook, "resolve_repo_short_name", return_value="noorinalabs-main"),
+            mock.patch.object(hook.subprocess, "run", side_effect=fake),
+        ):
+            result = hook.check(_bash_input(cmd))
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+        self.assertIn("noorinalabs-main/.claude/hooks/missing.py", result["reason"])
+
+    def test_ambient_edit_resolves_repo_and_blocks_on_404(self):
+        # `gh issue edit` WITHOUT --repo: body fetched via `gh issue view`, the
+        # cited path 404s → block. Resolution feeds the ambient case.
+        body = "File at noorinalabs-main/.claude/hooks/old.py is gone."
+        cmd = "gh issue edit 100 --add-label 'p3-wave-9'"
+        fake = _fake_subprocess_factory(main_exists=set(), issue_body=body)
+        with (
+            mock.patch.object(hook, "resolve_repo_short_name", return_value="noorinalabs-main"),
+            mock.patch.object(hook.subprocess, "run", side_effect=fake),
+        ):
+            result = hook.check(_bash_input(cmd))
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+        self.assertIn("noorinalabs-main/.claude/hooks/old.py", result["reason"])
+
+    def test_ambient_unresolvable_logs_skip_and_allows(self):
+        # No `--repo` AND cwd origin unresolvable → skip diagnostic + fail-open
+        # (allow), never a silent drop and never a bogus-slug false-block.
+        body = "See .claude/hooks/gone.py."
+        cmd = f"gh issue create --title T --body {body!r} --label 'p3-wave-9'"
+        with (
+            mock.patch.object(hook, "resolve_repo_short_name", return_value=None),
+            mock.patch.object(hook, "log_pretooluse_diagnostic") as diag,
+            mock.patch.object(hook.subprocess, "run") as run,
+        ):
+            self.assertIsNone(hook.check(_bash_input(cmd)))
+            run.assert_not_called()
+            diag.assert_called_once()
+
+
+class BodyOverMatchScopingTests(unittest.TestCase):
+    """main#663: label-shaped tokens in `--body` must NOT be parsed as labels;
+    extraction is scoped to the actual `--label`/`--add-label` flag values."""
+
+    def test_wave_label_shape_in_body_not_treated_as_label(self):
+        # Real label is non-wave (`tech-debt`); the body documents a
+        # `--add-label 'p3-wave-9'` pattern. The hook must NOT fire — no real
+        # wave label is applied, so it never reaches body verification.
+        body = "Documents the --add-label 'p3-wave-9' wave-label sync flow."
+        cmd = (
+            "gh issue create --repo noorinalabs/noorinalabs-main --title T "
+            f"--body {body!r} --label 'tech-debt'"
+        )
+        with mock.patch.object(hook.subprocess, "run") as run:
+            self.assertIsNone(hook.check(_bash_input(cmd)))
+            run.assert_not_called()
+
+
+class LineContinuationTests(unittest.TestCase):
+    """main#663: shared tokenizer normalizes backslash-newline continuations
+    (#287) — the old private `shlex.split` reimplementation did not."""
+
+    def test_backslash_newline_create_still_detected(self):
+        body = "noorinalabs-main/.claude/hooks/missing.py"
+        cmd = (
+            "gh issue create --repo noorinalabs/noorinalabs-main \\\n"
+            f"  --title T --body {body!r} --label 'p3-wave-9'"
+        )
+        fake = _fake_subprocess_factory(main_exists=set())
+        with mock.patch.object(hook.subprocess, "run", side_effect=fake):
+            result = hook.check(_bash_input(cmd))
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.claude/hooks/validate_wave_label_evidence.py
+++ b/.claude/hooks/validate_wave_label_evidence.py
@@ -17,10 +17,22 @@ Input Language:
   Does NOT match: gh issue list/view, gh label create, gh pr create.
 
 Algorithm:
-  1. Tokenize command via shlex.
+  1. Tokenize command via the shared `_shell_parse` tokenizer (segment-aware,
+     line-continuation-normalized, heredoc-stripped) — NOT a private shlex
+     reimplementation. Flag VALUES are extracted via `walk_flag_values` and
+     `_repo_flag_parse.extract_repo`, so label-shaped / repo-shaped tokens in
+     `--body`/`--body-file` content cannot leak into extraction (main#663
+     gh-command parser invariant — see `charter/hooks.md`).
   2. Detect wave-label application (regex `p\\d+-wave-\\d+` in any --label /
      --add-label value).
-  3. Resolve issue body:
+  3. Resolve the target repo. When `--repo`/`-R` is OMITTED (in-repo
+     invocation, gh's ambient-git-context resolution), recover it from the
+     invocation cwd's `origin` via `resolve_repo_short_name` (mirroring gh)
+     instead of falling through to the old empty-default-repo `noorinalabs/`
+     slug (the #650/#659 ambient-omitted class — MUST #2 of the invariant).
+     If the ambient repo is unresolvable, log a `skip_no_repo_context`
+     diagnostic and ALLOW (fail-open) — never a silent drop.
+  4. Resolve issue body:
        - gh issue create: from --body, --body-file, or stdin (skip if neither)
        - gh issue edit:   from `gh api repos/{repo}/issues/{num} --jq .body`
   4. If body contains `Origin-Verification:` line → ALLOW (override).
@@ -45,12 +57,20 @@ Exit codes:
 import json
 import os
 import re
-import shlex
 import subprocess
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from annunaki_log import log_pretooluse_block  # noqa: E402
+from _repo_flag_parse import extract_repo  # noqa: E402
+from _shell_parse import (  # noqa: E402
+    find_gh_subcommand,
+    iter_command_segments,
+    resolve_repo_short_name,
+    strip_heredocs,
+    tokenize,
+    walk_flag_values,
+)
+from annunaki_log import log_pretooluse_block, log_pretooluse_diagnostic  # noqa: E402
 
 _WAVE_LABEL_RE = re.compile(r"p\d+-wave-\d+")
 _PHASE_WAVE_RE = re.compile(r"p(\d+)-wave-(\d+)")
@@ -67,64 +87,53 @@ _CITED_PATH_RE = re.compile(
 _OVERRIDE_RE = re.compile(r"^Origin-Verification:\s*\S", re.MULTILINE)
 
 
-def _tokenize(command: str) -> list[str] | None:
-    try:
-        return shlex.split(command, posix=True)
-    except ValueError:
+def _find_issue_command(command: str) -> tuple[str, str | None, list[str]] | None:
+    """Locate the first `gh issue create` / `gh issue edit <NUM>` segment.
+
+    Routes through the shared `_shell_parse` primitives (heredoc-strip,
+    line-continuation-aware tokenize, segment split, gh-subcommand locate)
+    rather than a private shlex reimplementation (main#663 invariant). This
+    also gains the #287 backslash-line-continuation fix the old private
+    `_tokenize` lacked.
+
+    Returns `(kind, issue_number, rest_tokens)` where `kind` is `"create"` or
+    `"edit"`, `issue_number` is the bare positional after `edit` (else None),
+    and `rest_tokens` is the post-`gh` token tail (e.g.
+    `["issue", "create", "--label", ...]`). Returns None when no matching
+    segment is present or the command does not tokenize.
+    """
+    tokens = tokenize(strip_heredocs(command))
+    if tokens is None:
         return None
-
-
-def _is_gh_issue_create(tokens: list[str]) -> bool:
-    for i in range(len(tokens) - 2):
-        if tokens[i] == "gh" and tokens[i + 1] == "issue" and tokens[i + 2] == "create":
-            return True
-    return False
-
-
-def _is_gh_issue_edit(tokens: list[str]) -> tuple[bool, str | None]:
-    """Detect `gh issue edit <NUM>` and return the issue number."""
-    for i in range(len(tokens) - 3):
-        if tokens[i] == "gh" and tokens[i + 1] == "issue" and tokens[i + 2] == "edit":
-            num = tokens[i + 3]
-            if num.isdigit():
-                return True, num
-    return False, None
-
-
-def _walk_flag_values(tokens: list[str], wanted: set[str]) -> list[str]:
-    """Collect values for any flag in `wanted`. Supports `--flag value` and
-    `--flag=value`. Comma-separated values are split (gh's list-flag style)."""
-    out: list[str] = []
-    i = 0
-    while i < len(tokens):
-        tok = tokens[i]
-        if tok in wanted and i + 1 < len(tokens):
-            out.extend(p for p in tokens[i + 1].split(",") if p)
-            i += 2
+    for segment in iter_command_segments(tokens):
+        gh = find_gh_subcommand(segment)
+        if gh is None:
             continue
-        matched = False
-        for flag in wanted:
-            if flag.startswith("--") and tok.startswith(flag + "="):
-                out.extend(p for p in tok[len(flag) + 1 :].split(",") if p)
-                matched = True
-                break
-        i += 1 if not matched else 1
+        _globals, rest = gh
+        if len(rest) >= 2 and rest[0] == "issue" and rest[1] == "create":
+            return "create", None, rest
+        if len(rest) >= 3 and rest[0] == "issue" and rest[1] == "edit" and rest[2].isdigit():
+            return "edit", rest[2], rest
+    return None
+
+
+def _collect_labels(rest: list[str], flags: set[str]) -> list[str]:
+    """Return label values for `flags`, splitting gh's comma-separated form.
+
+    `walk_flag_values` scopes extraction to the actual flag VALUES (never
+    label-shaped tokens inside `--body`); gh additionally accepts a single
+    `--label a,b,c` token, so each value is comma-split here.
+    """
+    out: list[str] = []
+    for raw in walk_flag_values(rest, flags):
+        out.extend(p for p in raw.split(",") if p)
     return out
 
 
-def _walk_first_value(tokens: list[str], wanted: set[str]) -> str | None:
-    """Return the FIRST value for any flag in `wanted` (single-value flags
-    like --body or --body-file)."""
-    i = 0
-    while i < len(tokens):
-        tok = tokens[i]
-        if tok in wanted and i + 1 < len(tokens):
-            return tokens[i + 1]
-        for flag in wanted:
-            if flag.startswith("--") and tok.startswith(flag + "="):
-                return tok[len(flag) + 1 :]
-        i += 1
-    return None
+def _first_value(rest: list[str], flags: set[str]) -> str | None:
+    """First value for any single-value flag in `flags`, or None."""
+    values = walk_flag_values(rest, flags)
+    return values[0] if values else None
 
 
 def _read_body_file(path: str) -> str | None:
@@ -187,17 +196,14 @@ def check(input_data: dict) -> dict | None:
     if not command:
         return None
 
-    tokens = _tokenize(command)
-    if tokens is None:
+    found = _find_issue_command(command)
+    if found is None:
         return None
+    kind, issue_num, rest = found
+    is_create = kind == "create"
 
-    is_create = _is_gh_issue_create(tokens)
-    is_edit, issue_num = _is_gh_issue_edit(tokens)
-    if not is_create and not is_edit:
-        return None
-
-    label_flag = {"--label", "-l"} if is_create else {"--add-label"}
-    labels = _walk_flag_values(tokens, label_flag)
+    label_flags = {"--label", "-l"} if is_create else {"--add-label"}
+    labels = _collect_labels(rest, label_flags)
     wave_label = next(
         (lbl for lbl in labels if _WAVE_LABEL_RE.search(lbl)),
         None,
@@ -205,18 +211,34 @@ def check(input_data: dict) -> dict | None:
     if not wave_label:
         return None
 
-    repo_default = _walk_first_value(tokens, {"--repo", "-R"}) or ""
+    # Resolve the target repo. `--repo`/`-R` is OPTIONAL: an in-repo
+    # `gh issue create/edit` relies on gh's ambient-git-context resolution and
+    # carries no `--repo` token. Recover that case from the invocation cwd's
+    # origin (main#663 invariant MUST #2) instead of the old empty-default
+    # `noorinalabs/` slug. If the ambient repo is unresolvable, log a skip
+    # diagnostic and fail-open (allow) — never a silent drop.
+    repo = extract_repo(command)
+    if not repo:
+        short = resolve_repo_short_name(input_data)
+        if not short:
+            log_pretooluse_diagnostic(
+                "validate_wave_label_evidence",
+                command,
+                {"skip": "skip_no_repo_context", "wave_label": wave_label},
+            )
+            return None
+        repo = f"noorinalabs/{short}"
 
     # Resolve issue body
     body: str | None = None
     if is_create:
-        body = _walk_first_value(tokens, {"--body"})
+        body = _first_value(rest, {"--body"})
         if body is None:
-            bf = _walk_first_value(tokens, {"--body-file", "-F"})
+            bf = _first_value(rest, {"--body-file", "-F"})
             if bf:
                 body = _read_body_file(bf)
-    elif is_edit and issue_num is not None:
-        body = _resolve_issue_body_for_edit(issue_num, repo_default)
+    elif issue_num is not None:
+        body = _resolve_issue_body_for_edit(issue_num, repo)
 
     if not body:
         return None  # Nothing to verify against
@@ -240,10 +262,10 @@ def check(input_data: dict) -> dict | None:
     # Verify each cited path at origin
     unverified: list[str] = []
     for path in cited_paths:
-        repo, inner_path = _extract_repo_for_path(path, repo_default)
-        exists_at_main = _path_exists_at_ref(repo, inner_path, "main")
+        path_repo, inner_path = _extract_repo_for_path(path, repo)
+        exists_at_main = _path_exists_at_ref(path_repo, inner_path, "main")
         exists_at_wave = (
-            _path_exists_at_ref(repo, inner_path, wave_branch) if wave_branch else False
+            _path_exists_at_ref(path_repo, inner_path, wave_branch) if wave_branch else False
         )
         if not (exists_at_main or exists_at_wave):
             unverified.append(path)

--- a/.claude/team/charter/hooks.md
+++ b/.claude/team/charter/hooks.md
@@ -412,7 +412,21 @@ Every hook MUST have exactly one backward-claim sentence. The parser's `_PROVENA
 
 **Rationale:** PR #155 added the reactive `_FORWARD_REFERENCE_MARKERS` filter to handle Hook 15's own provenance block — which had narrative referencing a future skill mixed in with the backward citation. The filter is the runtime safety net; this guidance is the preempt-at-author-time fix that reduces future filter-edits. Sibling of #393 (HTML-marker convention) — this section catalogues the parse keys; the authoritative shape-selection rule (when to use HTML-comment vs. bold-prose) lives at [`charter/skills.md` § Promotion Pipeline Marker Convention](skills.md#promotion-pipeline-marker-convention).
 
-**Enforcement:** The Standards & Quality Lead (Aino) verifies these requirements during hook PR review. A hook missing any of the six requirements must not be approved. For segment-parser hooks specifically, §5a's six-class test matrix is part of that verification.
+### 7. gh-command Parser Invariant (flag-value scoping + ambient-repo resolution)
+
+**Any hook that parses a `gh issue` / `gh pr` command MUST:**
+
+1. **Scope label/repo extraction to the actual flag VALUES** — the tokens that follow `--label`/`-l`/`--add-label`/`--remove-label`/`--repo`/`-R` — via the shared tokenizer (`_shell_parse.walk_flag_values` / `first_flag_value`, `_repo_flag_parse.extract_repo`, or the domain-shape `_wave_label_parse` helpers). It MUST NOT regex flag-shaped or label-shaped strings out of arbitrary command text, and MUST NOT reimplement shell tokenization privately (`shlex.split(...)` in the hook body). Routing through `_shell_parse.tokenize` is mandatory because it carries fixes a private copy silently loses — line-continuation normalization (#287), heredoc stripping, and segment splitting — and because a private regex over the raw command leaks label-shaped tokens out of `--body`/`--body-file` content (the #661 false-block).
+
+2. **Resolve the flag-omitted (ambient git-context) case** — a `gh issue create/edit` run *inside* the target repo carries no `--repo` and relies on gh's ambient resolution. The hook MUST recover the repo from the invocation cwd's `origin` via `_shell_parse.resolve_repo_short_name` (mirroring gh), or log a `skip_no_repo_context`-style diagnostic and fail-open — **never silently drop the command** (the #650 EDIT-path drop) and never fall through to a malformed default repo (the #659 CREATE-path twin).
+
+**Backing class:** #650 (EDIT path required `--repo`, dropped in-repo label edits — fixed PR #658), #659 (CREATE path same gate — fixed PR, commit `9ab5c37`), #661 (`validate_labels` matched a label-shaped token in `--body` — fixed `9ab5c37`), and `validate_wave_label_evidence` (private `shlex`/flag-walker reimplementation + empty-default `noorinalabs/` slug — migrated under #663). Lineage: cwd-anchor #144/#521 → multi-cmd #455 → #650 → #659/#661.
+
+**Machine-enforcement:** `.claude/hooks/tests/test_gh_command_parser_invariant.py` is the gate (runs in the pytest suite CI already mirrors in `.pre-commit-config.yaml`, so no new CI job / no `ci.yml` edit). It classifies every top-level hook that reads the incoming command and matches a `gh issue`/`gh pr` shape, then asserts each (A) does not call `shlex.split`/`shlex.shlex` directly and (C) carries no ad-hoc flag-value-capturing regex. The three sanctioned shared parsers (`_shell_parse`, `_wave_label_parse`, `_repo_flag_parse`) are exempt — they ARE the tokenizer/flag-walker/ambient-resolver. **Scope** is `gh issue`/`gh pr` per this invariant; `gh workflow`/`gh api` value-flag extractors (e.g. `warn_ghcr_image`'s `-R` from `gh workflow run`) are the same latent class but out of the stated scope — an enumerated follow-up, not yet enforced.
+
+<!-- Promoted from charter feedback `feedback_enforcement_hierarchy.md` (hook > skill > charter) and the convergent #650/#659/#661 class — owner-adopted P4W7 retro Proposed Change #1 (2026-06-13), actioned in P5 via issue #663. Charter rule + pytest gate; the gh-command analogue of the deferred grep-gate noted in §5a. -->
+
+**Enforcement:** The Standards & Quality Lead (Aino) verifies these requirements during hook PR review. A hook missing any of the seven requirements must not be approved. For segment-parser hooks specifically, §5a's six-class test matrix is part of that verification; for `gh issue`/`gh pr` parsers, §7's flag-value-scoping + ambient-repo resolution (and its gate) are part of it.
 
 ## Hook Audit Protocol
 


### PR DESCRIPTION
## What & why

Actions the owner-adopted **P4W7 retro Proposed Change #1** (2026-06-13) under **#663**: promote the convergent #650/#659/#661 gh-command-parser class into a **charter invariant + a machine-enforcement gate**, and migrate the one open instance the gate catches.

`#659` and `#661` were already fixed (commit `9ab5c37`). This PR delivers the parts that remained: the charter codification, the gate, and the third (parser-reimplementation) instance.

## Changes

**`charter/hooks.md` § Hook Authorship Requirements**
- New **§7 gh-command Parser Invariant**: any hook parsing a `gh issue`/`gh pr` command MUST (1) scope label/repo extraction to the actual flag VALUES via the shared `_shell_parse`/`_wave_label_parse`/`_repo_flag_parse` tokenizer (no private `shlex.split`, no flag-value regex over raw command text — that leaks label-shaped tokens out of `--body`), and (2) resolve the `--repo`-omitted ambient case via `resolve_repo_short_name` or log a `skip_no_repo_context` event — never silently drop. Bumps the Enforcement count "six → seven".

**`.claude/hooks/tests/test_gh_command_parser_invariant.py`** (new gate)
- Classifies every top-level hook that reads the incoming command and matches a `gh issue`/`gh pr` shape, then asserts (A) no direct `shlex.split`/`shlex.shlex` and (C) no ad-hoc flag-value-capturing regex. Shared parsers are exempt (they ARE the tokenizer). Includes a `_MIN_GH_HOOKS` guard so a classifier regression can't make the gate vacuously green.
- Runs in the **existing pytest suite** that CI already mirrors in `.pre-commit-config.yaml` — **no `ci.yml` / `.pre-commit-config.yaml` edit**, so no serialization needed with #684.
- Scope is `gh issue`/`gh pr` per the invariant; `gh workflow`/`gh api` value-flag extractors (`warn_ghcr_image`'s `-R`) are the same latent class but an enumerated follow-up, not enforced here.

**`.claude/hooks/validate_wave_label_evidence.py`** (the instance the gate caught)
- Replaces the private `_tokenize` (raw `shlex.split`, missing the #287 line-continuation fix), `_walk_flag_values`, `_walk_first_value`, `_is_gh_issue_*` with the shared `tokenize`/`strip_heredocs`/`iter_command_segments`/`find_gh_subcommand`/`walk_flag_values` + `extract_repo`.
- Resolves the ambient repo via `resolve_repo_short_name` instead of the old empty-default `noorinalabs/` slug; logs `skip_no_repo_context` (traces.jsonl) + fails open when unresolvable.
- +6 tests: ambient create/edit resolution, skip-on-unresolvable, `--body` over-match scoping, backslash-line-continuation. Existing 14 behavior-preserved.

## Verification

- ruff format + lint (pinned 0.15.11), mypy: clean.
- Full pytest from a CI-equivalent path (no `.worktrees`/`/tmp` component): **1384 passed, 49 subtests, 0 failures**. (Two location-sensitive pre-existing tests — `test_ontology_tracker` #686 and a `/tmp`-sibling in `test_block_stale_tmp_message_file` — false-fail only when run from inside `.worktrees`//`tmp`; green in CI's clean checkout.)
- sync-drift gate: `OK: pre-commit config mirrors all CI-enforced checks`.
- cspell: not a CI check on this branch (sync-gate confirms parity; #684 not yet merged here) and binary not installed locally — not gating.

## Reviewers (charter: 2)
- Wanjiku Mwangi
- Nadia Khoury

Refs #663
