### PR TITLE
fix(hooks): read current_phase/current_wave in session-handoff + session-start (#708)

### DIFF
--- a/.claude/hooks/session_handoff.py
+++ b/.claude/hooks/session_handoff.py
@@ -14,6 +14,7 @@ Exit codes:
 """
 
 import json
+import re
 import subprocess
 import sys
 from datetime import datetime, timezone
@@ -120,17 +121,43 @@ def _get_ontology_staleness() -> str:
         return "Could not read checksums"
 
 
+def _wave_phase_started(data: dict) -> tuple[str, str, str]:
+    """Resolve (phase, wave, started) from a cross-repo-status.json dict.
+
+    Reads the canonical lifecycle keys maintained by the wave skills:
+      - phase   ← ``current_phase``
+      - wave    ← ``current_wave`` (e.g. "wave-5")
+      - started ← ``wave_<N>_started_at`` for N parsed from ``current_wave``,
+                  falling back to ``wave_<N>_kicked_off_at``, then "unknown".
+
+    The flat ``phase``/``wave``/``started``/``last_updated`` keys are NOT used
+    as the source of truth — ``phase`` lags a phase behind (cross-phase key
+    collision, #683) and ``wave``/``started`` do not exist (#708).
+    """
+    phase = data.get("current_phase", "unknown")
+    wave = data.get("current_wave", "unknown")
+    started = "unknown"
+    if isinstance(wave, str):
+        match = re.search(r"(\d+)", wave)
+        if match:
+            n = match.group(1)
+            # `or` chains past both missing keys AND present-but-null values.
+            started = (
+                data.get(f"wave_{n}_started_at") or data.get(f"wave_{n}_kicked_off_at") or "unknown"
+            )
+    return str(phase), str(wave), started
+
+
 def _get_wave_status() -> str:
-    """Read cross-repo status for active wave."""
+    """Read cross-repo status for the active phase/wave."""
     status_file = REPO_ROOT / "cross-repo-status.json"
     if not status_file.exists():
         return "No cross-repo-status.json found"
     try:
         with open(status_file) as f:
             data = json.load(f)
-        wave = data.get("wave", "unknown")
-        started = data.get("started", "unknown")
-        return f"Wave {wave} (started {started})"
+        phase, wave, started = _wave_phase_started(data)
+        return f"Phase {phase}, Wave {wave} (started {started})"
     except (json.JSONDecodeError, OSError):
         return "Could not read status file"
 

--- a/.claude/hooks/session_start.py
+++ b/.claude/hooks/session_start.py
@@ -11,6 +11,7 @@ Exit codes:
 """
 
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -66,14 +67,39 @@ def _handoff_summary() -> str | None:
         return None
 
 
+def _wave_phase_started(data: dict) -> tuple[str, str, str]:
+    """Resolve (phase, wave, started) from a cross-repo-status.json dict.
+
+    Reads the canonical lifecycle keys maintained by the wave skills:
+      - phase   ← ``current_phase``
+      - wave    ← ``current_wave`` (e.g. "wave-5")
+      - started ← ``wave_<N>_started_at`` for N parsed from ``current_wave``,
+                  falling back to ``wave_<N>_kicked_off_at``, then "unknown".
+
+    The flat ``phase``/``wave``/``last_updated`` keys are NOT used as the
+    source of truth — ``phase`` lags a phase behind (cross-phase key
+    collision, #683) and ``wave`` does not exist (#708).
+    """
+    phase = data.get("current_phase", "unknown")
+    wave = data.get("current_wave", "unknown")
+    started = "unknown"
+    if isinstance(wave, str):
+        match = re.search(r"(\d+)", wave)
+        if match:
+            n = match.group(1)
+            # `or` chains past both missing keys AND present-but-null values.
+            started = (
+                data.get(f"wave_{n}_started_at") or data.get(f"wave_{n}_kicked_off_at") or "unknown"
+            )
+    return str(phase), str(wave), started
+
+
 def _wave_status() -> str | None:
-    """Return a brief summary from cross-repo-status.json, or None."""
+    """Return a brief phase/wave summary from cross-repo-status.json, or None."""
     try:
         data = json.loads(_CROSS_REPO_STATUS.read_text(encoding="utf-8"))
-        phase = data.get("phase", "unknown")
-        wave = data.get("wave", "unknown")
-        updated = data.get("last_updated", "unknown")
-        return f"Phase {phase}, Wave {wave} (last updated: {updated})"
+        phase, wave, started = _wave_phase_started(data)
+        return f"Phase {phase}, Wave {wave} (started: {started})"
     except (OSError, json.JSONDecodeError):
         return None
 

--- a/.claude/hooks/tests/test_session_handoff.py
+++ b/.claude/hooks/tests/test_session_handoff.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Tests for the `session_handoff` Stop hook's wave/phase reader (#708).
+
+Regression coverage: `_get_wave_status()` used to read the top-level keys
+`wave` / `started`, neither of which exists in cross-repo-status.json, so it
+always reported "unknown". The fix reads the canonical lifecycle keys
+`current_phase` / `current_wave` / `wave_<N>_started_at`.
+
+Run from the repo root:
+    ENVIRONMENT=test python3 -m pytest \\
+        .claude/hooks/tests/test_session_handoff.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_HOOKS_DIR = _HERE.parent
+sys.path.insert(0, str(_HOOKS_DIR))
+
+import session_handoff as hook  # noqa: E402
+
+
+def _live_shaped(**overrides: object) -> dict:
+    """A dict shaped like the real cross-repo-status.json, incl. stale keys."""
+    data: dict = {
+        "current_phase": 5,
+        "current_wave": "wave-5",
+        "wave_5_started_at": "2026-06-16T22:51:14Z",
+        "wave_5_kicked_off_at": None,
+        # Stale flat keys that the buggy reader trusted:
+        "phase": "phase-4",
+        "wave": None,
+        "started": None,
+        "last_updated": "2026-06-15T01:52:55Z",
+    }
+    data.update(overrides)
+    return data
+
+
+class WavePhaseStartedTests(unittest.TestCase):
+    def test_reads_canonical_keys_not_stale_flat_keys(self) -> None:
+        phase, wave, started = hook._wave_phase_started(_live_shaped())
+        self.assertEqual(phase, "5")
+        self.assertEqual(wave, "wave-5")
+        self.assertEqual(started, "2026-06-16T22:51:14Z")
+        # The stale flat keys must NOT leak through.
+        self.assertNotEqual(phase, "phase-4")
+        self.assertNotEqual(wave, "unknown")
+
+    def test_falls_back_to_kicked_off_at_when_started_missing(self) -> None:
+        data = _live_shaped()
+        del data["wave_5_started_at"]
+        data["wave_5_kicked_off_at"] = "2026-06-16T20:00:00Z"
+        _, _, started = hook._wave_phase_started(data)
+        self.assertEqual(started, "2026-06-16T20:00:00Z")
+
+    def test_falls_back_when_started_present_but_null(self) -> None:
+        data = _live_shaped(wave_5_started_at=None, wave_5_kicked_off_at="2026-06-16T20:00:00Z")
+        _, _, started = hook._wave_phase_started(data)
+        self.assertEqual(started, "2026-06-16T20:00:00Z")
+
+    def test_started_unknown_when_no_timestamps(self) -> None:
+        data = _live_shaped(wave_5_started_at=None, wave_5_kicked_off_at=None)
+        _, _, started = hook._wave_phase_started(data)
+        self.assertEqual(started, "unknown")
+
+    def test_missing_canonical_keys_graceful(self) -> None:
+        phase, wave, started = hook._wave_phase_started({"last_updated": "x"})
+        self.assertEqual(phase, "unknown")
+        self.assertEqual(wave, "unknown")
+        self.assertEqual(started, "unknown")
+
+
+class GetWaveStatusTests(unittest.TestCase):
+    def _write_status(self, tmp: Path, data: dict) -> None:
+        (tmp / "cross-repo-status.json").write_text(json.dumps(data), encoding="utf-8")
+
+    def test_wrapper_reports_phase_and_wave(self) -> None:
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            self._write_status(tmp, _live_shaped())
+            original = hook.REPO_ROOT
+            try:
+                hook.REPO_ROOT = tmp
+                result = hook._get_wave_status()
+            finally:
+                hook.REPO_ROOT = original
+        self.assertEqual(result, "Phase 5, Wave wave-5 (started 2026-06-16T22:51:14Z)")
+        self.assertNotIn("unknown", result)
+        self.assertNotIn("phase-4", result)
+
+    def test_wrapper_missing_file(self) -> None:
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as d:
+            original = hook.REPO_ROOT
+            try:
+                hook.REPO_ROOT = Path(d)
+                result = hook._get_wave_status()
+            finally:
+                hook.REPO_ROOT = original
+        self.assertEqual(result, "No cross-repo-status.json found")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/hooks/tests/test_session_start.py
+++ b/.claude/hooks/tests/test_session_start.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Tests for the `session_start` SessionStart hook's wave/phase reader (#708).
+
+Regression coverage: `_wave_status()` used to read the flat keys `phase`
+(which lags a phase behind — #683 cross-phase collision), `wave` (which does
+not exist), and `last_updated`. The fix reads the canonical lifecycle keys
+`current_phase` / `current_wave` / `wave_<N>_started_at`.
+
+Run from the repo root:
+    ENVIRONMENT=test python3 -m pytest \\
+        .claude/hooks/tests/test_session_start.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_HOOKS_DIR = _HERE.parent
+sys.path.insert(0, str(_HOOKS_DIR))
+
+import session_start as hook  # noqa: E402
+
+
+def _live_shaped(**overrides: object) -> dict:
+    """A dict shaped like the real cross-repo-status.json, incl. stale keys."""
+    data: dict = {
+        "current_phase": 5,
+        "current_wave": "wave-5",
+        "wave_5_started_at": "2026-06-16T22:51:14Z",
+        "wave_5_kicked_off_at": None,
+        # Stale flat keys that the buggy reader trusted:
+        "phase": "phase-4",
+        "wave": None,
+        "last_updated": "2026-06-15T01:52:55Z",
+    }
+    data.update(overrides)
+    return data
+
+
+class WavePhaseStartedTests(unittest.TestCase):
+    def test_reads_canonical_keys_not_stale_flat_keys(self) -> None:
+        phase, wave, started = hook._wave_phase_started(_live_shaped())
+        self.assertEqual(phase, "5")
+        self.assertEqual(wave, "wave-5")
+        self.assertEqual(started, "2026-06-16T22:51:14Z")
+        self.assertNotEqual(phase, "phase-4")
+        self.assertNotEqual(wave, "unknown")
+
+    def test_falls_back_to_kicked_off_at_when_started_missing(self) -> None:
+        data = _live_shaped()
+        del data["wave_5_started_at"]
+        data["wave_5_kicked_off_at"] = "2026-06-16T20:00:00Z"
+        _, _, started = hook._wave_phase_started(data)
+        self.assertEqual(started, "2026-06-16T20:00:00Z")
+
+    def test_falls_back_when_started_present_but_null(self) -> None:
+        data = _live_shaped(wave_5_started_at=None, wave_5_kicked_off_at="2026-06-16T20:00:00Z")
+        _, _, started = hook._wave_phase_started(data)
+        self.assertEqual(started, "2026-06-16T20:00:00Z")
+
+    def test_started_unknown_when_no_timestamps(self) -> None:
+        data = _live_shaped(wave_5_started_at=None, wave_5_kicked_off_at=None)
+        _, _, started = hook._wave_phase_started(data)
+        self.assertEqual(started, "unknown")
+
+    def test_missing_canonical_keys_graceful(self) -> None:
+        phase, wave, started = hook._wave_phase_started({"last_updated": "x"})
+        self.assertEqual(phase, "unknown")
+        self.assertEqual(wave, "unknown")
+        self.assertEqual(started, "unknown")
+
+
+class WaveStatusWrapperTests(unittest.TestCase):
+    def test_wrapper_reports_phase_and_wave(self) -> None:
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as d:
+            status = Path(d) / "cross-repo-status.json"
+            status.write_text(json.dumps(_live_shaped()), encoding="utf-8")
+            original = hook._CROSS_REPO_STATUS
+            try:
+                hook._CROSS_REPO_STATUS = status
+                result = hook._wave_status()
+            finally:
+                hook._CROSS_REPO_STATUS = original
+        self.assertEqual(result, "Phase 5, Wave wave-5 (started: 2026-06-16T22:51:14Z)")
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertNotIn("unknown", result)
+        self.assertNotIn("phase-4", result)
+
+    def test_wrapper_returns_none_on_missing_file(self) -> None:
+        original = hook._CROSS_REPO_STATUS
+        try:
+            hook._CROSS_REPO_STATUS = Path("/nonexistent/cross-repo-status.json")
+            result = hook._wave_status()
+        finally:
+            hook._CROSS_REPO_STATUS = original
+        self.assertIsNone(result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Root cause (#708)

Session-handoff and session-start reported phase/wave as **"unknown"** (and a stale phase) because both reader functions read keys that do not exist or that lag reality in `cross-repo-status.json`:

- `session_handoff.py` `_get_wave_status()` read top-level `wave` + `started` — **neither key exists** (`has("wave")==false`, `has("started")==false`) → always "unknown".
- `session_start.py` `_wave_status()` read the flat `phase` (stale `"phase-4"` via the #683 cross-phase key collision), `wave` (missing), and `last_updated` (stale).

The canonical lifecycle keys actually maintained by the wave skills are `current_phase` (=5), `current_wave` (=`"wave-5"`), and the active wave's `wave_<N>_started_at` (fallback `wave_<N>_kicked_off_at`).

## Fix

Both readers now resolve through a shared `_wave_phase_started(data)` helper:
- phase ← `current_phase`
- wave  ← `current_wave`
- started ← `wave_<N>_started_at` for `N` parsed from `current_wave`, falling back to `wave_<N>_kicked_off_at`, then `"unknown"`. The `or` chain skips both missing keys **and** present-but-null values — note the live `wave_5_kicked_off_at` is `null`.

Stale flat `phase`/`wave`/`last_updated` are no longer the source of truth. Missing canonical keys degrade gracefully to `"unknown"` rather than crashing.

Verified against the live `cross-repo-status.json`: both readers now report **Phase 5, Wave wave-5 (started 2026-06-16T22:51:14Z)**.

## Tests

No tests existed for either reader. Added `test_session_handoff.py` + `test_session_start.py` (14 cases) covering: canonical-keys-over-stale-flat-keys, the `started_at`→`kicked_off_at` fallback (both missing and present-but-null), the no-timestamps `"unknown"` case, missing-keys-graceful, and the file-reading wrappers (incl. missing-file).

## Green-before-push (main#684)

ruff format --check + ruff lint (`.claude/hooks/` + `.claude/lib/`), mypy (CI flags), full pytest (1479 passed), and `pre_commit_ci_sync.py .` (sync-drift gate OK) — all green locally before push.

Closes #708

🤖 Generated with [Claude Code](https://claude.com/claude-code)
