### PR TITLE
tech-debt(tooling): pr_review_state.py — deterministic review-state query over check_comment_reviews() (#707)

### DIFF
--- a/.claude/lib/pr_review_state.py
+++ b/.claude/lib/pr_review_state.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Deterministic PR review-state query over the merge gate's own logic (#707).
+
+`validate_pr_review.py` (Hook 4) is the canonical authority on whether a PR
+satisfies the 2-reviewer / TechDebt / wave-bootstrap-exception requirements
+before `gh pr merge`. But that authority only runs AT merge time, as a
+PreToolUse block. There was no way to ASK the same question ahead of time:
+
+  - before spawning reviewers — is this PR already reviewed, and by whom?
+  - before `gh pr merge`   — will the gate pass, or who is missing TechDebt?
+
+This CLI answers that question by REUSING the hook's functions verbatim —
+`get_pr_data`, `extract_branch_author_lastname`, `check_comment_reviews`,
+`_load_roster_names`, and `is_single_reviewer_exception`. It deliberately does
+NOT reimplement the charter-comment parsing: a fork would silently drift from
+the gate, and that drift is the exact failure #707 exists to prevent. The
+PASS/FAIL verdict computed here mirrors `validate_pr_review.check()` step for
+step (formal + roster-filtered comment reviewers, the wave-merge head-ref
+sentinel, the single-reviewer exception, and the missing-TechDebt block).
+
+Usage:
+    python3 .claude/lib/pr_review_state.py <pr_number> --repo <owner/repo>
+    python3 .claude/lib/pr_review_state.py <pr_number> --repo <owner/repo> --json
+
+Exit codes:
+    0 — the merge gate would PASS (>=2 distinct Approved reviewers, or exactly
+        one with the wave-bootstrap exception, and no verdict missing TechDebt)
+    1 — the merge gate would BLOCK (too few reviewers, or a verdict missing the
+        TechDebt line)
+    2 — review state could not be determined (PR fetch failed, or a named child
+        repo's roster could not be resolved — mirrors the hook's hard-block)
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import sys
+from pathlib import Path
+
+# Reuse the merge gate's canonical logic. The hook lives at
+# .claude/hooks/validate_pr_review.py; this driver lives at .claude/lib/. Put
+# the hooks dir on sys.path and import the gate functions directly (same
+# reader/writer-share-one-module pattern annunaki_parse.py uses for
+# annunaki_log). There is intentionally NO local fallback copy: a vendored fork
+# of check_comment_reviews would drift from the gate, which is the whole bug
+# #707 closes. If the import fails the tool should fail loudly, not guess.
+_HOOKS_DIR = Path(__file__).resolve().parent.parent / "hooks"
+sys.path.insert(0, str(_HOOKS_DIR))
+
+import validate_pr_review as gate  # noqa: E402
+
+# The two-distinct-reviewer threshold the gate enforces (charter line 36).
+REVIEW_THRESHOLD = 2
+
+
+@dataclasses.dataclass
+class ReviewState:
+    """Computed review state for a single PR — the gate's verdict, surfaced."""
+
+    pr_number: str
+    repo: str | None
+    head_ref: str
+    branch_author_lastname: str | None
+    # Distinct Approved reviewers (full names, lowercased — the gate's dedup key).
+    formal_reviewers: list[str]
+    comment_reviewers: list[str]  # roster-valid comment-based Approved reviewers
+    non_roster_requestors: list[str]  # Approved Requestors filtered out as non-roster
+    distinct_reviewer_count: int  # formal | roster comment, the gate's count
+    wave_bootstrap_exception: bool
+    reviews_missing_tech_debt: list[str]
+    tech_debt_issue_numbers: list[str]
+
+    def passes(self) -> bool:
+        """True iff `validate_pr_review` would ALLOW the merge.
+
+        Mirrors `check()`: pass when there are >=2 distinct reviewers, OR
+        exactly one reviewer who qualifies for the wave-bootstrap single-
+        reviewer exception — AND no verdict is missing its TechDebt line.
+        """
+        if self.reviews_missing_tech_debt:
+            return False
+        if self.distinct_reviewer_count >= REVIEW_THRESHOLD:
+            return True
+        return self.distinct_reviewer_count == 1 and self.wave_bootstrap_exception
+
+
+class ReviewStateError(Exception):
+    """Review state could not be determined (maps to CLI exit code 2)."""
+
+
+def compute_review_state(pr_number: str, repo: str | None = None) -> ReviewState:
+    """Compute a PR's review state by replaying the merge gate's own logic.
+
+    Reuses `gate.get_pr_data`, `gate.extract_branch_author_lastname`,
+    `gate.check_comment_reviews`, `gate._load_roster_names`, and
+    `gate.is_single_reviewer_exception` so this driver and Hook 4 cannot drift.
+
+    Raises `ReviewStateError` when the PR cannot be fetched or a named child
+    repo's roster cannot be resolved — the determinate-failure cases the gate
+    hard-blocks on (exit code 2), distinct from a gate FAIL (exit code 1).
+    """
+    pr_data = gate.get_pr_data(pr_number, repo=repo)
+    if pr_data is None:
+        raise ReviewStateError(
+            f"could not fetch PR #{pr_number}"
+            + (f" in {repo}" if repo else "")
+            + " — check the PR number, --repo value, and `gh auth status`."
+        )
+
+    author = pr_data["author"]
+    reviews = pr_data["reviews"]
+    head_ref = pr_data["headRefName"]
+    number = pr_data["number"]
+    labels = pr_data["labels"]
+
+    # Formal GitHub reviews from non-authors (not roster-filtered — these are
+    # platform-authenticated identities, exactly as the gate treats them).
+    formal_reviewers: set[str] = set()
+    for review in reviews:
+        login = review.get("author", {}).get("login", "")
+        if login and login != author:
+            formal_reviewers.add(login.lower())
+
+    # Resolve head ref -> branch-author lastname, then fetch comment reviews.
+    # Mirrors check() lines 845-854: a normal feature branch yields a lastname;
+    # a wave-merge head (deployments/phase-N/wave-M) has no implementer author,
+    # so the gate passes an empty sentinel that admits any non-empty reviewer.
+    comment_result = gate.CommentReviewResult()
+    branch_author_lastname = None
+    if head_ref:
+        branch_author_lastname = gate.extract_branch_author_lastname(head_ref)
+        if branch_author_lastname:
+            comment_result = gate.check_comment_reviews(number, branch_author_lastname, repo=repo)
+        elif head_ref.startswith("deployments/") and "/wave-" in head_ref:
+            comment_result = gate.check_comment_reviews(number, "", repo=repo)
+
+    # Filter comment-based Approved reviewers against the roster (gate #498):
+    # only real roster personas count toward the threshold. A missing child
+    # roster is a hard-block in the gate, surfaced here as ReviewStateError.
+    try:
+        roster_names = gate._load_roster_names(repo=repo)
+    except gate.RosterResolutionError as exc:
+        raise ReviewStateError(
+            f"child-repo roster could not be resolved for --repo '{repo}': {exc}"
+        ) from exc
+
+    non_roster = {r for r in comment_result.reviewers if r not in roster_names}
+    roster_comment_reviewers = comment_result.reviewers - non_roster
+
+    distinct = formal_reviewers | roster_comment_reviewers
+
+    wave_bootstrap = gate.is_single_reviewer_exception(labels, distinct, repo=repo)
+
+    return ReviewState(
+        pr_number=str(number),
+        repo=repo,
+        head_ref=head_ref,
+        branch_author_lastname=branch_author_lastname,
+        formal_reviewers=sorted(formal_reviewers),
+        comment_reviewers=sorted(roster_comment_reviewers),
+        non_roster_requestors=sorted(non_roster),
+        distinct_reviewer_count=len(distinct),
+        wave_bootstrap_exception=wave_bootstrap,
+        reviews_missing_tech_debt=list(comment_result.reviews_missing_tech_debt),
+        tech_debt_issue_numbers=list(comment_result.tech_debt_issue_numbers),
+    )
+
+
+def _render_text(state: ReviewState) -> str:
+    """Human-readable review-state report."""
+    lines: list[str] = []
+    pr_label = f"PR #{state.pr_number}" + (f" ({state.repo})" if state.repo else "")
+    verdict = "PASS" if state.passes() else "BLOCK"
+    lines.append(f"{pr_label} — merge gate would {verdict}")
+    lines.append(f"  head ref: {state.head_ref or '(unknown)'}")
+    lastname = state.branch_author_lastname or "(none — wave-merge / unmatched)"
+    lines.append(f"  branch-author lastname: {lastname}")
+
+    approved = state.comment_reviewers + state.formal_reviewers
+    lines.append(
+        f"  distinct Approved reviewers: {state.distinct_reviewer_count}/{REVIEW_THRESHOLD}"
+        f" required — {', '.join(approved) if approved else '(none)'}"
+    )
+    if state.comment_reviewers:
+        lines.append(f"    comment-based: {', '.join(state.comment_reviewers)}")
+    if state.formal_reviewers:
+        lines.append(f"    formal GitHub: {', '.join(state.formal_reviewers)}")
+    if state.non_roster_requestors:
+        lines.append(
+            "    excluded (non-roster Approved Requestors): "
+            + ", ".join(state.non_roster_requestors)
+        )
+
+    lines.append(
+        "  wave-bootstrap single-reviewer exception: "
+        + ("APPLIES" if state.wave_bootstrap_exception else "no")
+    )
+
+    if state.reviews_missing_tech_debt:
+        lines.append(
+            "  verdicts MISSING the TechDebt line: " + ", ".join(state.reviews_missing_tech_debt)
+        )
+    else:
+        lines.append("  verdicts missing TechDebt line: none")
+
+    if state.tech_debt_issue_numbers:
+        lines.append(
+            "  TechDebt issue numbers: " + ", ".join(f"#{n}" for n in state.tech_debt_issue_numbers)
+        )
+    else:
+        lines.append("  TechDebt issue numbers: none")
+
+    return "\n".join(lines)
+
+
+def _render_json(state: ReviewState) -> str:
+    payload = dataclasses.asdict(state)
+    payload["passes"] = state.passes()
+    payload["threshold"] = REVIEW_THRESHOLD
+    return json.dumps(payload, indent=2, sort_keys=True)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="pr_review_state",
+        description=(
+            "Query a PR's review state using the merge gate's own logic "
+            "(validate_pr_review.check_comment_reviews). Exit 0 if the gate "
+            "would pass, 1 if it would block, 2 if undeterminable."
+        ),
+    )
+    p.add_argument("pr_number", help="PR number to query")
+    p.add_argument(
+        "--repo",
+        default=None,
+        help="target repo as OWNER/NAME (e.g. noorinalabs/noorinalabs-main); "
+        "default uses the cwd-resolved repo",
+    )
+    p.add_argument(
+        "--json",
+        action="store_true",
+        help="emit machine-readable JSON instead of the text report",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        state = compute_review_state(args.pr_number, repo=args.repo)
+    except ReviewStateError as exc:
+        print(f"pr_review_state: {exc}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(_render_json(state))
+    else:
+        print(_render_text(state))
+    return 0 if state.passes() else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/lib/tests/test_pr_review_state.py
+++ b/.claude/lib/tests/test_pr_review_state.py
@@ -1,0 +1,216 @@
+"""Tests for pr_review_state — the deterministic review-state query CLI (#707).
+
+The driver REUSES validate_pr_review's functions, so these tests mock those
+gate functions (never the network). Coverage:
+  1. 0 distinct Approved -> gate would BLOCK (exit 1).
+  2. 1 distinct Approved (no exception) -> BLOCK (exit 1).
+  3. 2 distinct Approved, all TechDebt present -> PASS (exit 0).
+  4. A verdict missing the TechDebt line -> BLOCK even with 2 reviewers (exit 1).
+  5. wave-bootstrap single-reviewer exception -> PASS with one reviewer (exit 0).
+  6. branch-author self-review exclusion: the lastname parsed from the head ref
+     is the one passed into check_comment_reviews (the gate excludes a same-
+     lastname Requestor).
+  7. non-roster Approved Requestor is filtered out of the reviewer count.
+  8. a PR-fetch failure -> ReviewStateError -> CLI exit 2.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+# Helper lives at .claude/lib/pr_review_state.py; test is at
+# .claude/lib/tests/test_*.py. parent.parent reaches the lib root.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import pr_review_state as prs  # noqa: E402
+
+
+def _comment_result(
+    reviewers=(), missing_tech_debt=(), tech_debt_issues=()
+) -> "prs.gate.CommentReviewResult":
+    """Build a CommentReviewResult like check_comment_reviews would return.
+
+    `reviewers` are full names (any case); they are stored lowercased, matching
+    the gate's dedup key.
+    """
+    result = prs.gate.CommentReviewResult()
+    result.reviewers = {r.lower() for r in reviewers}
+    result.reviews_missing_tech_debt = list(missing_tech_debt)
+    result.tech_debt_issue_numbers = list(tech_debt_issues)
+    return result
+
+
+def _pr_data(
+    *, author="someauthor", head_ref="S.Ferreira/0707-pr-review-state", labels=(), reviews=()
+) -> dict:
+    return {
+        "author": author,
+        "number": "707",
+        "reviews": list(reviews),
+        "headRefName": head_ref,
+        "labels": list(labels),
+    }
+
+
+class ComputeReviewStateTests(unittest.TestCase):
+    def _run(
+        self,
+        *,
+        pr_data,
+        comment_result,
+        roster_names,
+        single_reviewer_exception=False,
+    ) -> prs.ReviewState:
+        with (
+            mock.patch.object(prs.gate, "get_pr_data", return_value=pr_data),
+            mock.patch.object(prs.gate, "check_comment_reviews", return_value=comment_result),
+            mock.patch.object(prs.gate, "_load_roster_names", return_value=roster_names),
+            mock.patch.object(
+                prs.gate, "is_single_reviewer_exception", return_value=single_reviewer_exception
+            ),
+        ):
+            return prs.compute_review_state("707", repo="noorinalabs/noorinalabs-main")
+
+    def test_zero_approved_blocks(self):
+        state = self._run(
+            pr_data=_pr_data(),
+            comment_result=_comment_result(reviewers=()),
+            roster_names=set(),
+        )
+        self.assertEqual(state.distinct_reviewer_count, 0)
+        self.assertFalse(state.passes())
+
+    def test_one_approved_blocks_without_exception(self):
+        state = self._run(
+            pr_data=_pr_data(),
+            comment_result=_comment_result(reviewers=("Aino Virtanen",)),
+            roster_names={"aino virtanen"},
+        )
+        self.assertEqual(state.distinct_reviewer_count, 1)
+        self.assertFalse(state.passes())
+
+    def test_two_approved_passes(self):
+        state = self._run(
+            pr_data=_pr_data(),
+            comment_result=_comment_result(
+                reviewers=("Aino Virtanen", "Nadia Khoury"),
+                tech_debt_issues=("808",),
+            ),
+            roster_names={"aino virtanen", "nadia khoury"},
+        )
+        self.assertEqual(state.distinct_reviewer_count, 2)
+        self.assertEqual(state.tech_debt_issue_numbers, ["808"])
+        self.assertTrue(state.passes())
+
+    def test_two_approved_but_missing_tech_debt_blocks(self):
+        state = self._run(
+            pr_data=_pr_data(),
+            comment_result=_comment_result(
+                reviewers=("Aino Virtanen", "Nadia Khoury"),
+                missing_tech_debt=("Nadia Khoury",),
+            ),
+            roster_names={"aino virtanen", "nadia khoury"},
+        )
+        self.assertEqual(state.distinct_reviewer_count, 2)
+        self.assertEqual(state.reviews_missing_tech_debt, ["Nadia Khoury"])
+        self.assertFalse(state.passes())
+
+    def test_wave_bootstrap_single_reviewer_passes(self):
+        state = self._run(
+            pr_data=_pr_data(labels=("wave-bootstrap",)),
+            comment_result=_comment_result(reviewers=("Aino Virtanen",)),
+            roster_names={"aino virtanen"},
+            single_reviewer_exception=True,
+        )
+        self.assertEqual(state.distinct_reviewer_count, 1)
+        self.assertTrue(state.wave_bootstrap_exception)
+        self.assertTrue(state.passes())
+
+    def test_branch_author_lastname_passed_to_check(self):
+        """The lastname parsed from the head ref drives the gate's self-review
+        exclusion, so it must be the value handed to check_comment_reviews."""
+        captured = {}
+
+        def fake_check(number, lastname, repo=None):
+            captured["number"] = number
+            captured["lastname"] = lastname
+            return _comment_result(reviewers=())
+
+        with (
+            mock.patch.object(
+                prs.gate,
+                "get_pr_data",
+                return_value=_pr_data(head_ref="S.Ferreira/0707-pr-review-state"),
+            ),
+            mock.patch.object(prs.gate, "check_comment_reviews", side_effect=fake_check),
+            mock.patch.object(prs.gate, "_load_roster_names", return_value=set()),
+            mock.patch.object(prs.gate, "is_single_reviewer_exception", return_value=False),
+        ):
+            state = prs.compute_review_state("707", repo="noorinalabs/noorinalabs-main")
+
+        self.assertEqual(captured["lastname"], "Ferreira")
+        self.assertEqual(state.branch_author_lastname, "Ferreira")
+
+    def test_non_roster_requestor_excluded_from_count(self):
+        """An Approved Requestor not in the roster is filtered out (#498) and
+        does not count toward the threshold."""
+        state = self._run(
+            pr_data=_pr_data(),
+            comment_result=_comment_result(
+                reviewers=("Aino Virtanen", "Imelda Santos"),
+            ),
+            roster_names={"aino virtanen"},  # Imelda is NOT a roster persona
+        )
+        self.assertEqual(state.comment_reviewers, ["aino virtanen"])
+        self.assertEqual(state.non_roster_requestors, ["imelda santos"])
+        self.assertEqual(state.distinct_reviewer_count, 1)
+        self.assertFalse(state.passes())
+
+    def test_fetch_failure_raises(self):
+        with mock.patch.object(prs.gate, "get_pr_data", return_value=None):
+            with self.assertRaises(prs.ReviewStateError):
+                prs.compute_review_state("707", repo="noorinalabs/noorinalabs-main")
+
+
+class CliExitCodeTests(unittest.TestCase):
+    def _main(self, state_or_exc):
+        if isinstance(state_or_exc, Exception):
+            cm = mock.patch.object(prs, "compute_review_state", side_effect=state_or_exc)
+        else:
+            cm = mock.patch.object(prs, "compute_review_state", return_value=state_or_exc)
+        with cm:
+            return prs.main(["707", "--repo", "noorinalabs/noorinalabs-main"])
+
+    def _state(self, *, count, missing=(), exception=False):
+        return prs.ReviewState(
+            pr_number="707",
+            repo="noorinalabs/noorinalabs-main",
+            head_ref="S.Ferreira/0707-pr-review-state",
+            branch_author_lastname="Ferreira",
+            formal_reviewers=[],
+            comment_reviewers=[],
+            non_roster_requestors=[],
+            distinct_reviewer_count=count,
+            wave_bootstrap_exception=exception,
+            reviews_missing_tech_debt=list(missing),
+            tech_debt_issue_numbers=[],
+        )
+
+    def test_exit_zero_on_pass(self):
+        self.assertEqual(self._main(self._state(count=2)), 0)
+
+    def test_exit_one_on_too_few_reviewers(self):
+        self.assertEqual(self._main(self._state(count=1)), 1)
+
+    def test_exit_one_on_missing_tech_debt(self):
+        self.assertEqual(self._main(self._state(count=2, missing=("Nadia Khoury",))), 1)
+
+    def test_exit_two_on_undeterminable(self):
+        self.assertEqual(self._main(prs.ReviewStateError("boom")), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds `.claude/lib/pr_review_state.py` — a deterministic CLI that answers "what is this PR's review state?" using **the merge gate's own logic**, so the question can be asked *before* merge time (Hook 4 only runs as a PreToolUse block at `gh pr merge`).

```
python3 .claude/lib/pr_review_state.py <pr_number> --repo <owner/repo> [--json]
```

Two intended use points:
- **before spawning reviewers** — is this PR already reviewed, and by whom?
- **before `gh pr merge`** — will the gate pass, or who is missing TechDebt?

## Reuse, not fork (the reason #707 exists)

The driver **imports** the canonical functions from `validate_pr_review.py` — `get_pr_data`, `extract_branch_author_lastname`, `check_comment_reviews`, `_load_roster_names`, `is_single_reviewer_exception` — and replays `check()`'s verdict step for step:
- formal GitHub reviewers ∪ roster-filtered comment reviewers (the #498 non-roster filter),
- the wave-merge head-ref empty sentinel (`deployments/phase-N/wave-M`),
- the wave-bootstrap single-reviewer exception,
- the missing-TechDebt block.

No charter-comment parsing is reimplemented, so the CLI and the gate **cannot drift** — a fork is exactly the failure #707 is about. Import uses the same hooks-dir `sys.path` pattern as `annunaki_parse.py`, with intentionally **no** local fallback copy (a vendored copy would be the drift).

## Output / exit codes

Reports: distinct Approved reviewers + count vs the 2-reviewer threshold; whether the wave-bootstrap exception applies; any verdicts missing the TechDebt line; extracted TechDebt issue numbers. `--json` for machine use.

- `0` — gate would PASS (≥2 distinct Approved, or 1 with wave-bootstrap, and no verdict missing TechDebt)
- `1` — gate would BLOCK (too few reviewers, or a verdict missing TechDebt)
- `2` — undeterminable (PR fetch failed / child-roster resolution failed — mirrors the hook's hard-block)

## Tests

`.claude/lib/tests/test_pr_review_state.py` mocks the gate functions (no network): 0/1/2 distinct Approved, a verdict missing TechDebt, the wave-bootstrap single-reviewer pass, branch-author self-review-exclusion wiring, non-roster Requestor filtering, and the CLI exit codes. Full suite: 1477 passed. ruff/mypy/sync-drift gate all green.

Note: because the reused hook derives `_PARENT_REPO_ROOT` from `__file__`, passing an explicit `--repo noorinalabs/noorinalabs-main` while running the script *from a worktree dir not named `noorinalabs-main`* is misread as a missing child repo (exit 2) — inherited worktree-location behavior of the gate (cf. `project_ontology_tracker_test_worktree_location_fragile`); resolves correctly on `main`. The cwd-resolved form works from anywhere.

Closes #707

🤖 Generated with [Claude Code](https://claude.com/claude-code)
