### PR TITLE
fix(session-start §5a): key repo-scope picker off current_wave, not max_by(wave-number) (#712)

### DIFF
--- a/.claude/skills/session-start/SKILL.md
+++ b/.claude/skills/session-start/SKILL.md
@@ -192,14 +192,16 @@ For each org repo, list the latest default-branch run of each workflow and flag 
 ```bash
 REPO_ROOT="$(cd "$(git rev-parse --git-common-dir 2>/dev/null)/.." 2>/dev/null && pwd)"
 [ -f "$REPO_ROOT/cross-repo-status.json" ] || REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
-# Primary: the most-recent `wave_<N>_repos_in_scope` array (the canonical org repo set;
-# there is no top-level `.repos` key). Falls through to the hardcoded list if the file is
-# missing/unparseable or has no such key.
+# Primary: resolve the repo set from the canonical `current_wave` lifecycle
+# pointer (e.g. "wave-5" -> `wave_5_repos_in_scope`), NOT `max_by` over the
+# wave NUMBER. Completed *prior-phase* waves (e.g. `wave_7_repos_in_scope` from
+# the P4 close-out) are legitimately retained, so "highest number" structurally
+# picks a stale 2-repo scope over the live one — main#712 (same defect class as
+# the current_wave reader fix #708/#709). `ltrimstr` is null-safe: a missing/
+# malformed `current_wave` yields an absent key -> empty -> the hardcoded list.
 REPOS=$(jq -r '
-  [to_entries[]
-   | select(.key | test("^wave_[0-9]+_repos_in_scope$"))
-   | {n: (.key | capture("^wave_(?<n>[0-9]+)_repos_in_scope$").n | tonumber), v: .value}]
-  | max_by(.n) | .v[]? // empty
+  (.current_wave // "" | ltrimstr("wave-")) as $n
+  | .["wave_\($n)_repos_in_scope"][]? // empty
 ' "$REPO_ROOT/cross-repo-status.json" 2>/dev/null)
 [ -n "$REPOS" ] || REPOS="noorinalabs-main noorinalabs-isnad-graph noorinalabs-user-service noorinalabs-deploy noorinalabs-design-system noorinalabs-data-acquisition noorinalabs-isnad-ingest-platform noorinalabs-landing-page"
 

--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -149,3 +149,4 @@ lastname
 Luciana
 Ferreyra
 Okonkwo
+ltrimstr


### PR DESCRIPTION
## Summary

Step 5a of `/session-start` resolved its red-default-branch repo set with `max_by(.n)` over `wave_<N>_repos_in_scope` keys — i.e. the **highest-numbered** key. Completed *prior-phase* waves (e.g. `wave_7_repos_in_scope` from the Phase-4 close-out, a 2-repo set) are legitimately retained in `cross-repo-status.json`, so the picker selected a **stale 2-repo scope over the live wave-5 8-repo set**. The publish/deploy red-run scan therefore silently covered only main + deploy — observed this session.

Same defect class as #708/#709 (a reader keying off the wrong signal instead of the canonical `current_wave`).

## Change

Resolve the set from `current_wave` (`"wave-5"` → `ltrimstr("wave-")` → `5` → `wave_5_repos_in_scope`), null-safe, falling back to the hardcoded 8-repo list. One jq block in `session-start/SKILL.md`; no behavioral change to the rest of the step.

## Verification

Against the live status file the new picker yields all 8 wave-5 repos (was 2 under `max_by`). `current_wave` confirmed `wave-5`.

## Reviewer brief

- **Scope:** documentation/skill only — a jq selector in a bash block in `session-start/SKILL.md`. No hook/lib code, no tests touched.
- **Check:** the `ltrimstr` null-safety (missing/malformed `current_wave` → absent key → empty → hardcoded fallback), and that no other call site relied on the old `max_by` block (grep confirms `max_by` remains only at the `run_started_at` line, which is correct and untouched).
- **TechDebt:** none — net simplification (removes the to_entries/capture/max_by pipeline for a direct keyed lookup).

Closes #712.
