### PR TITLE
feat(tooling): auto-sync local main after push/merge to origin/main (#713)

### DIFF
--- a/.claude/hooks/auto_sync_main.py
+++ b/.claude/hooks/auto_sync_main.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""PostToolUse(Bash): fast-forward the local default branch immediately after a
+successful push/merge to ``origin/main`` (main#713).
+
+Owner request 2026-06-19: after any push/merge to ``origin/main``, the local
+``main`` checkout should pick up the change *now*, not lag — a stale local main
+silently runs pre-fix hooks/skills off disk (this session opened 22 commits
+behind and ran the pre-#709 session-start reader). This hook covers the
+*self-push* case: when the session itself merges/pushes to main, sync the
+working copy right after. (Others' pushes are picked up at session boundaries
+by session-start Step 0, which calls the same helper.)
+
+Detection is intentionally narrow-but-safe: a ``git push`` whose refspec names
+``main`` against ``origin``, or any ``gh pr merge`` (the org's wave-branch→main
+merges go through it). The actual fast-forward is delegated to
+:func:`sync_main.sync_main`, which is itself fully guarded — it only moves a
+clean, strictly-behind ``main`` and refuses (no-op) on a diverged/ahead/dirty
+tree — so an over-broad match here can never corrupt state; the worst case is a
+wasted ``git fetch``. A failed push/merge (non-zero exit) is ignored: main did
+not move, so there is nothing to sync.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+_HOOKS_DIR = Path(__file__).resolve().parent
+_PROJECT = _HOOKS_DIR.parent.parent  # .claude/hooks -> .claude -> repo root
+_LIB = _PROJECT / ".claude" / "lib"
+
+# A push whose refspec targets main against origin, or any PR merge.
+_TRIGGERS = (
+    re.compile(r"\bgit\s+push\b[^|&;]*\borigin\b[^|&;]*\bmain\b"),
+    re.compile(r"\bgit\s+push\b[^|&;]*:main\b"),
+    re.compile(r"\bgh\s+pr\s+merge\b"),
+)
+
+
+def _targets_main(command: str) -> bool:
+    return any(p.search(command) for p in _TRIGGERS)
+
+
+def check(input_data: dict) -> dict | None:
+    if input_data.get("tool_name", "") != "Bash":
+        return None
+    command = (input_data.get("tool_input") or {}).get("command", "")
+    if not _targets_main(command):
+        return None
+
+    # Only sync if the push/merge itself succeeded — otherwise main did not move.
+    tool_output = input_data.get("tool_response") or input_data.get("tool_output") or {}
+    if isinstance(tool_output, dict) and tool_output.get("exit_code", 0) != 0:
+        return None
+
+    if str(_LIB) not in sys.path:
+        sys.path.insert(0, str(_LIB))
+    try:
+        from sync_main import sync_main
+    except ImportError:
+        return None
+
+    result = sync_main(_PROJECT)
+    if result.status == "fast-forwarded":
+        return {"systemMessage": f"🔄 auto-sync: local {result.detail}"}
+    if result.status == "error":
+        return {
+            "systemMessage": f"⚠ auto-sync (main#713) could not fast-forward main: {result.detail}"
+        }
+    # up-to-date / skipped-not-on-branch / refused-* — safe, silent no-op.
+    return None
+
+
+def main() -> None:
+    import json
+
+    try:
+        input_data = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        sys.exit(0)
+    result = check(input_data)
+    if result and result.get("systemMessage"):
+        print(json.dumps({"systemMessage": result["systemMessage"]}))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/post_dispatcher.py
+++ b/.claude/hooks/post_dispatcher.py
@@ -77,6 +77,7 @@ _EDIT_WRITE_MODULES = [
 _REGISTRY: dict[str, list[str]] = {
     "Bash": [
         "annunaki_monitor",  # local: regex over stdout/stderr, JSONL append
+        "auto_sync_main",  # local: ff local main after a push/merge to origin/main (#713)
         "auto_add_issue_to_board",  # network: runs `gh project item-add`
         "post_wave_kickoff_comment",  # network: gh fetch + post comment
         "post_label_change_wave_field_sync",  # network: GraphQL updateProjectV2ItemFieldValue

--- a/.claude/hooks/tests/test_auto_sync_main.py
+++ b/.claude/hooks/tests/test_auto_sync_main.py
@@ -1,0 +1,115 @@
+"""Tests for auto_sync_main — the PostToolUse(Bash) hook that fast-forwards local
+main after a successful push/merge to origin/main (main#713).
+
+The fast-forward mechanics live in (and are tested by) ``sync_main``; here we
+test the hook's *trigger discrimination* and *gating*: which commands fire it,
+that a failed push is ignored, and that only a real move surfaces a message.
+``sync_main`` is replaced with a fake so these stay hermetic (no git, no repo).
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+# Hook lives at .claude/hooks/auto_sync_main.py; test at .claude/hooks/tests/.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import auto_sync_main  # noqa: E402
+
+
+def _evt(command: str, *, tool="Bash", exit_code=0) -> dict:
+    return {
+        "tool_name": tool,
+        "tool_input": {"command": command},
+        "tool_response": {"exit_code": exit_code},
+    }
+
+
+class TargetsMainTest(unittest.TestCase):
+    def test_matches_push_to_main_and_pr_merge(self) -> None:
+        for cmd in (
+            "git push origin main",
+            "git push -u origin main",
+            "git push origin HEAD:main",
+            "gh pr merge 714 --squash",
+            "cd /repo && gh pr merge 714 --merge",
+        ):
+            self.assertTrue(auto_sync_main._targets_main(cmd), cmd)
+
+    def test_ignores_non_main_pushes_and_reads(self) -> None:
+        for cmd in (
+            "git push origin feature/x",
+            "git push origin deployments/phase-5/wave-5",
+            "gh pr view 714",
+            "git status",
+            "ls -la",
+        ):
+            self.assertFalse(auto_sync_main._targets_main(cmd), cmd)
+
+
+class CheckTest(unittest.TestCase):
+    def setUp(self) -> None:
+        # Replace the lazily-imported sync_main module with a fake.
+        self._calls: list[object] = []
+        self._fake = types.ModuleType("sync_main")
+        self._real = sys.modules.get("sync_main")
+        sys.modules["sync_main"] = self._fake
+
+        def _restore() -> None:
+            if self._real is not None:
+                sys.modules["sync_main"] = self._real
+            else:
+                sys.modules.pop("sync_main", None)
+
+        self.addCleanup(_restore)
+
+    def _set_result(self, status: str, detail: str = "main aaa->bbb (+1)") -> None:
+        def fake_sync(root: object) -> object:
+            self._calls.append(root)
+            return SimpleNamespace(status=status, detail=detail)
+
+        self._fake.sync_main = fake_sync  # type: ignore[attr-defined]
+
+    def test_non_bash_is_ignored(self) -> None:
+        self._set_result("fast-forwarded")
+        self.assertIsNone(auto_sync_main.check(_evt("git push origin main", tool="Edit")))
+        self.assertEqual(self._calls, [])
+
+    def test_non_matching_command_is_ignored(self) -> None:
+        self._set_result("fast-forwarded")
+        self.assertIsNone(auto_sync_main.check(_evt("git status")))
+        self.assertEqual(self._calls, [])
+
+    def test_failed_push_is_ignored(self) -> None:
+        self._set_result("fast-forwarded")
+        self.assertIsNone(auto_sync_main.check(_evt("git push origin main", exit_code=1)))
+        self.assertEqual(self._calls, [], "must not sync when the push itself failed")
+
+    def test_fast_forward_emits_message(self) -> None:
+        self._set_result("fast-forwarded", "main aaa->bbb (+2)")
+        out = auto_sync_main.check(_evt("gh pr merge 714 --squash"))
+        self.assertIsNotNone(out)
+        assert out is not None
+        self.assertIn("auto-sync", out["systemMessage"])
+        self.assertIn("aaa->bbb", out["systemMessage"])
+        self.assertEqual(len(self._calls), 1)
+
+    def test_up_to_date_is_silent(self) -> None:
+        self._set_result("up-to-date")
+        self.assertIsNone(auto_sync_main.check(_evt("git push origin main")))
+        self.assertEqual(len(self._calls), 1, "still consults sync_main, just no message")
+
+    def test_error_surfaces_warning(self) -> None:
+        self._set_result("error", "git fetch failed: boom")
+        out = auto_sync_main.check(_evt("git push origin main"))
+        self.assertIsNotNone(out)
+        assert out is not None
+        self.assertIn("could not fast-forward", out["systemMessage"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/lib/sync_main.py
+++ b/.claude/lib/sync_main.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Fast-forward the local default branch to its remote when provably safe.
+
+Owner request (main#713): after any push/merge to ``origin/main``, the local
+``main`` checkout should pick up the change *immediately* rather than silently
+lag. A stale local ``main`` runs pre-fix hooks/skills off disk — this session
+opened 22 commits behind origin and ran the pre-#709 session-start reader,
+producing false orientation (phase/wave "unknown", a 2-of-8-repo scan).
+
+This module is the deterministic, side-effect-guarded core. It fast-forwards
+local ``branch`` to ``remote/branch`` ONLY when:
+
+  * the checkout is currently on ``branch`` (never moves a feature branch),
+  * local is strictly behind the remote (``behind > 0`` and ``ahead == 0`` —
+    it never rewrites a divergence and never touches an already-current tree),
+  * the working tree carries no real local modifications — tracked changes
+    outside :data:`GENERATED_ALLOWLIST` abort the sync.
+
+It NEVER force-updates, NEVER creates a merge commit (``--ff-only``), and NEVER
+discards real local work. Generated, append-only files (the annunaki error log)
+are stashed around the fast-forward and restored, so a perpetually-dirty log
+does not block the sync. Anything it cannot do safely it reports and refuses
+(``ok=False``) rather than guessing.
+
+CLI: ``python3 .claude/lib/sync_main.py [REPO_ROOT]`` — prints a one-line status
+and exits non-zero on a hard failure (``status == "error"``). A refusal
+(diverged/ahead/dirty) is a *safe* outcome and exits 0 with a diagnostic, so a
+caller wiring this into a hook or session-start never breaks on a normal
+"can't fast-forward right now" state.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# Tracked, machine-generated, append-only files that are safe to stash around a
+# fast-forward. They are perpetually dirty in an active session and would
+# otherwise block every sync. Repo-root-relative POSIX paths.
+GENERATED_ALLOWLIST: frozenset[str] = frozenset({".claude/annunaki/errors.jsonl"})
+
+
+@dataclass
+class SyncResult:
+    """Outcome of a :func:`sync_main` call.
+
+    ``ok`` is False only for a *hard* failure (git plumbing error). A refusal to
+    fast-forward (diverged / ahead / real dirty tree) is a safe, expected state:
+    ``ok`` stays True and ``status`` carries the machine-readable reason.
+    """
+
+    ok: bool
+    status: str  # fast-forwarded | up-to-date | skipped-not-on-branch
+    #            | refused-ahead | refused-diverged | refused-dirty | error
+    detail: str
+    behind: int = 0
+    ahead: int = 0
+    from_sha: str = ""
+    to_sha: str = ""
+    dirty: list[str] = field(default_factory=list)
+
+
+def _git(args: Sequence[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _count(runner: "GitRunner", cwd: Path, rev_range: str) -> int:
+    res = runner(["rev-list", "--count", rev_range], cwd)
+    if res.returncode != 0:
+        return -1
+    try:
+        return int(res.stdout.strip())
+    except ValueError:
+        return -1
+
+
+def _parse_dirty(porcelain: str) -> list[str]:
+    """Return paths of *tracked* modifications in ``git status --porcelain``.
+
+    Untracked (``??``) and ignored (``!!``) entries are excluded — they never
+    block a fast-forward merge. Rename entries (``R  old -> new``) report the
+    new path.
+    """
+    out: list[str] = []
+    for line in porcelain.splitlines():
+        if len(line) < 4:
+            continue
+        if line[:2] in ("??", "!!"):
+            continue
+        path = line[3:]
+        if " -> " in path:
+            path = path.split(" -> ", 1)[1]
+        out.append(path.strip().strip('"'))
+    return out
+
+
+# Typing alias for the injected git runner (real git by default; a fake in tests
+# only for the rare unit that does not want a real temp repo).
+GitRunner = Callable[[Sequence[str], Path], "subprocess.CompletedProcess[str]"]
+
+
+def sync_main(
+    repo_root: str | Path,
+    *,
+    branch: str = "main",
+    remote: str = "origin",
+    fetch: bool = True,
+    runner: GitRunner = _git,
+) -> SyncResult:
+    """Fast-forward ``branch`` to ``remote/branch`` when safe. See module docs."""
+    root = Path(repo_root)
+
+    cur = runner(["rev-parse", "--abbrev-ref", "HEAD"], root)
+    if cur.returncode != 0:
+        return SyncResult(False, "error", f"git rev-parse failed: {cur.stderr.strip()}")
+    current_branch = cur.stdout.strip()
+    if current_branch != branch:
+        return SyncResult(
+            True,
+            "skipped-not-on-branch",
+            f"on '{current_branch}', not '{branch}' — no sync",
+        )
+
+    if fetch:
+        fres = runner(["fetch", remote, branch], root)
+        if fres.returncode != 0:
+            return SyncResult(
+                False, "error", f"git fetch {remote} {branch} failed: {fres.stderr.strip()}"
+            )
+
+    behind = _count(runner, root, f"{branch}..{remote}/{branch}")
+    ahead = _count(runner, root, f"{remote}/{branch}..{branch}")
+    if behind < 0 or ahead < 0:
+        return SyncResult(False, "error", f"could not compare {branch} with {remote}/{branch}")
+
+    from_sha = runner(["rev-parse", "--short", "HEAD"], root).stdout.strip()
+    to_sha = runner(["rev-parse", "--short", f"{remote}/{branch}"], root).stdout.strip()
+
+    if ahead > 0:
+        status = "refused-diverged" if behind > 0 else "refused-ahead"
+        return SyncResult(
+            True,
+            status,
+            f"{branch} ahead {ahead}/behind {behind} — refusing (no force/merge commit)",
+            behind,
+            ahead,
+            from_sha,
+            to_sha,
+        )
+    if behind == 0:
+        return SyncResult(
+            True,
+            "up-to-date",
+            f"{branch} already at {remote}/{branch} ({to_sha})",
+            behind,
+            ahead,
+            from_sha,
+            to_sha,
+        )
+
+    # behind > 0, ahead == 0 — a clean fast-forward is possible if the tree allows.
+    dirty = _parse_dirty(runner(["status", "--porcelain"], root).stdout)
+    blocking = [p for p in dirty if p not in GENERATED_ALLOWLIST]
+    if blocking:
+        return SyncResult(
+            True,
+            "refused-dirty",
+            f"local tracked changes block ff: {', '.join(blocking)} — commit/stash first",
+            behind,
+            ahead,
+            from_sha,
+            to_sha,
+            dirty=dirty,
+        )
+
+    stashed = bool(dirty)  # only generated-allowlist paths remain
+    if stashed:
+        st = runner(["stash", "push", "--", *dirty], root)
+        if st.returncode != 0:
+            return SyncResult(
+                False, "error", f"git stash of generated files failed: {st.stderr.strip()}"
+            )
+
+    ff = runner(["merge", "--ff-only", f"{remote}/{branch}"], root)
+    if ff.returncode != 0:
+        if stashed:
+            runner(["stash", "pop"], root)  # best-effort restore before bailing
+        return SyncResult(False, "error", f"git merge --ff-only failed: {ff.stderr.strip()}")
+
+    new_sha = runner(["rev-parse", "--short", "HEAD"], root).stdout.strip()
+
+    if stashed:
+        pop = runner(["stash", "pop"], root)
+        if pop.returncode != 0:
+            # Fast-forward landed but the generated file could not be restored
+            # cleanly (e.g. origin also changed it). Leave the stash for manual
+            # recovery; the ff itself succeeded, which is the load-bearing part.
+            return SyncResult(
+                True,
+                "fast-forwarded",
+                f"{branch} {from_sha} -> {new_sha} (generated file left in stash)",
+                behind,
+                ahead,
+                from_sha,
+                new_sha,
+                dirty=dirty,
+            )
+
+    return SyncResult(
+        True,
+        "fast-forwarded",
+        f"{branch} {from_sha} -> {new_sha} (+{behind})",
+        behind,
+        ahead,
+        from_sha,
+        new_sha,
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    repo_root = args[0] if args else "."
+    result = sync_main(repo_root)
+    print(f"sync_main: {result.status} — {result.detail}")
+    return 1 if result.status == "error" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/lib/tests/test_sync_main.py
+++ b/.claude/lib/tests/test_sync_main.py
@@ -1,0 +1,175 @@
+"""Tests for sync_main — the deterministic, side-effect-guarded fast-forward of
+the local default branch to its remote (main#713).
+
+Each test drives REAL git against throwaway temp repos (a bare "remote" plus
+working clones) so the plumbing is exercised end-to-end. Coverage:
+
+  * behind + clean              -> fast-forwarded
+  * already current             -> up-to-date (no-op)
+  * not on the target branch    -> skipped-not-on-branch
+  * local ahead only            -> refused-ahead (never force-pushes/rewrites)
+  * local + remote diverged     -> refused-diverged
+  * real tracked local change   -> refused-dirty (never discards work)
+  * only generated-allowlist     -> stashed around ff and restored
+  * _parse_dirty                -> excludes untracked/ignored, follows renames
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import unittest
+from collections.abc import Sequence
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+# Helper lives at .claude/lib/sync_main.py; this test is at .claude/lib/tests/.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from sync_main import GENERATED_ALLOWLIST, _parse_dirty, sync_main  # noqa: E402
+
+_IDENT = [
+    "-c",
+    "user.name=Test",
+    "-c",
+    "user.email=test@example.com",
+    "-c",
+    "commit.gpgsign=false",
+]
+
+
+def _git(args: Sequence[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *_IDENT, *args],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+def _commit(repo: Path, name: str, content: str, msg: str) -> None:
+    (repo / name).write_text(content)
+    _git(["add", name], repo)
+    _git(["commit", "-m", msg], repo)
+
+
+class SyncMainTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = TemporaryDirectory()
+        base = Path(self._tmp.name)
+        self.remote = base / "remote.git"
+        self.local = base / "local"
+        self.other = base / "other"
+        _git(["init", "--bare", "-b", "main", str(self.remote)], base)
+
+        _git(["clone", str(self.remote), str(self.local)], base)
+        _git(["checkout", "-b", "main"], self.local)
+        _commit(self.local, "README.md", "v1\n", "init")
+        _git(["push", "-u", "origin", "main"], self.local)
+
+        _git(["clone", str(self.remote), str(self.other)], base)
+        _git(["checkout", "main"], self.other)
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def _advance_remote(self) -> None:
+        """Push a new commit to the remote via the 'other' clone."""
+        _commit(self.other, "README.md", "v2\n", "remote advance")
+        _git(["push", "origin", "main"], self.other)
+
+    # ----- happy paths --------------------------------------------------
+
+    def test_fast_forward_when_behind_and_clean(self) -> None:
+        self._advance_remote()
+        before = _git(["rev-parse", "HEAD"], self.local).stdout.strip()
+        res = sync_main(self.local)
+        self.assertTrue(res.ok)
+        self.assertEqual(res.status, "fast-forwarded")
+        self.assertEqual(res.behind, 1)
+        self.assertEqual(res.ahead, 0)
+        after = _git(["rev-parse", "HEAD"], self.local).stdout.strip()
+        self.assertNotEqual(before, after)
+        self.assertEqual((self.local / "README.md").read_text(), "v2\n")
+
+    def test_up_to_date_noop(self) -> None:
+        res = sync_main(self.local)
+        self.assertTrue(res.ok)
+        self.assertEqual(res.status, "up-to-date")
+        self.assertEqual(res.behind, 0)
+
+    def test_skipped_when_not_on_branch(self) -> None:
+        _git(["checkout", "-b", "feature/x"], self.local)
+        self._advance_remote()
+        res = sync_main(self.local)
+        self.assertTrue(res.ok)
+        self.assertEqual(res.status, "skipped-not-on-branch")
+        # Did NOT move the feature branch.
+        self.assertEqual((self.local / "README.md").read_text(), "v1\n")
+
+    # ----- refusals -----------------------------------------------------
+
+    def test_refused_when_ahead(self) -> None:
+        _commit(self.local, "local.txt", "local\n", "local-only commit")
+        res = sync_main(self.local)
+        self.assertTrue(res.ok)  # refusal is a safe outcome
+        self.assertEqual(res.status, "refused-ahead")
+        self.assertGreaterEqual(res.ahead, 1)
+
+    def test_refused_when_diverged(self) -> None:
+        self._advance_remote()
+        _commit(self.local, "local.txt", "local\n", "local-only commit")
+        res = sync_main(self.local)
+        self.assertTrue(res.ok)
+        self.assertEqual(res.status, "refused-diverged")
+        self.assertGreaterEqual(res.ahead, 1)
+        self.assertGreaterEqual(res.behind, 1)
+
+    def test_refused_when_real_dirty(self) -> None:
+        self._advance_remote()
+        (self.local / "README.md").write_text("uncommitted edit\n")
+        res = sync_main(self.local)
+        self.assertTrue(res.ok)
+        self.assertEqual(res.status, "refused-dirty")
+        self.assertIn("README.md", res.dirty)
+        # Fast-forward did NOT happen — local content preserved.
+        self.assertEqual((self.local / "README.md").read_text(), "uncommitted edit\n")
+
+    def test_generated_allowlist_stashed_and_restored(self) -> None:
+        # Track an allowlisted generated file, then dirty it while behind.
+        gen = next(iter(GENERATED_ALLOWLIST))
+        gpath = self.local / gen
+        gpath.parent.mkdir(parents=True, exist_ok=True)
+        gpath.write_text("line1\n")
+        _git(["add", gen], self.local)
+        _git(["commit", "-m", "track generated log"], self.local)
+        _git(["push", "origin", "main"], self.local)
+        # other must catch up so a later remote advance is a clean ff for local.
+        _git(["pull", "origin", "main"], self.other)
+
+        self._advance_remote()
+        gpath.write_text("line1\nlocal-append\n")  # dirty the generated file
+
+        res = sync_main(self.local)
+        self.assertTrue(res.ok)
+        self.assertEqual(res.status, "fast-forwarded")
+        # Remote change landed AND the local generated append was restored.
+        self.assertEqual((self.local / "README.md").read_text(), "v2\n")
+        self.assertEqual(gpath.read_text(), "line1\nlocal-append\n")
+
+    # ----- _parse_dirty unit -------------------------------------------
+
+    def test_parse_dirty_excludes_untracked_and_follows_rename(self) -> None:
+        porcelain = (
+            " M src/a.py\n?? new_untracked.py\n!! ignored.log\n"
+            "R  old.py -> renamed.py\nA  added.py\n"
+        )
+        self.assertEqual(
+            _parse_dirty(porcelain),
+            ["src/a.py", "renamed.py", "added.py"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/skills/session-start/SKILL.md
+++ b/.claude/skills/session-start/SKILL.md
@@ -57,6 +57,16 @@ resolve_repo_root() {
 }
 REPO_ROOT="$(resolve_repo_root)"
 
+# Pick up any merges/pushes to origin/main since last session (main#713) so the
+# session never runs pre-fix hooks/skills off a stale checkout (the failure this
+# session hit: opened 22 commits behind, ran the pre-#709 reader). The helper is
+# fully guarded — it fast-forwards only a clean, strictly-behind main and refuses
+# (no-op) on a diverged/ahead/dirty tree; it never forces or discards local work.
+# Non-fatal: a refusal or error must never block session-start.
+if [ -f "$REPO_ROOT/.claude/lib/sync_main.py" ]; then
+  python3 "$REPO_ROOT/.claude/lib/sync_main.py" "$REPO_ROOT" || true
+fi
+
 # Parent repo + the 7 canonical child repos (CLAUDE.md Repository Map).
 REPOS=("$REPO_ROOT")
 for child in \


### PR DESCRIPTION
## Summary

A stale local `main` silently runs **pre-fix hooks/skills off disk**. This session opened **22 commits behind** `origin/main` and ran the pre-#709 session-start reader → false orientation (phase/wave "unknown", a 2-of-8-repo scan). Owner request 2026-06-19: after any push/merge to `origin/main`, the local `main` checkout should pick up the change immediately.

## Change

**`.claude/lib/sync_main.py`** — deterministic, side-effect-guarded fast-forward of local `main` to `origin/main`. Fast-forwards **only** when on `main`, strictly behind (`behind>0`, `ahead==0`), and the tree has no real local changes. Refuses (safe no-op) on diverged/ahead/dirty. **Never** force-updates, **never** creates a merge commit (`--ff-only`), **never** discards work. The perpetually-dirty generated annunaki log (`GENERATED_ALLOWLIST`) is stashed around the ff and restored. CLI exits non-zero only on a hard git error; a refusal exits 0.

**`.claude/hooks/auto_sync_main.py`** — PostToolUse(Bash) handler. After a successful `git push … origin … main` / `git push …:main` / `gh pr merge`, it calls the helper (the *self-push* case). Registered in `post_dispatcher.py`. Detection is narrow-but-safe; because the helper is fully guarded, an over-broad match can at worst cost a wasted `git fetch`. A failed push (non-zero exit) is ignored.

**`session-start/SKILL.md` Step 0** — calls the helper at session start (the *others'-push* case), non-fatal.

## Verification

- `sync_main`: 8 tests over **real** temp git repos — ff / up-to-date / not-on-branch / refused-ahead / refused-diverged / refused-dirty / generated-allowlist-stash-restore / `_parse_dirty`.
- `auto_sync_main`: 8 tests — trigger discrimination, non-Bash/non-match/failed-exit gating, message-on-move, silent-when-current.
- Full suite: **1507 passed**. ruff (format+lint), `mypy --ignore-missing-imports`, cspell, and the **pre-commit ⇄ CI sync-drift gate** all green. New `.claude/lib|hooks/*.py` are auto-covered by the existing pre-commit globs — no config change needed.

## Reviewer brief

- **Safety is the crux:** confirm `sync_main` can never lose work — the `ahead>0` and `blocking` (non-allowlist dirty) guards both return *before* any stash/merge, and the only mutating path is `stash push` → `merge --ff-only` → `stash pop` with a best-effort restore on ff failure.
- **Trigger scope:** `auto_sync_main._targets_main` — confirm wave-branch pushes (`origin deployments/phase-5/wave-5`) and `gh pr view` do **not** match, while `gh pr merge` / push-to-main do.
- **Shared-file note:** the `session-start/SKILL.md` edit is in Step 0 (~line 58); PR #714 (#712) edits Step 5a (~line 198) of the same file. Disjoint regions, auto-mergeable — if #714 lands first this may need a trivial rebase.
- **TechDebt:** none.

Closes #713.
