### PR TITLE
test: isolate temp-repo git tests from inherited GIT_* env (#719)

### DIFF
--- a/.claude/lib/tests/conftest.py
+++ b/.claude/lib/tests/conftest.py
@@ -1,0 +1,27 @@
+"""Isolate temp-repo git tests from an inherited git environment (main#719).
+
+git exports ``GIT_DIR``/``GIT_WORK_TREE``/``GIT_INDEX_FILE`` (and friends) into
+hook subprocesses — notably the pre-push ``pytest`` hook. Tests in this package
+build throwaway repos and run git against them via ``git -C <tmp>``, which sets
+the working directory but does **not** override an inherited ``GIT_DIR``. Without
+this fixture those commits target the *parent* repo (whose pre-commit hook then
+fires with the wrong cwd → "No .pre-commit-config.yaml found"), so the whole
+suite fails when run as a git hook even though it passes standalone and in CI.
+
+Stripping the ``GIT_*`` namespace before every test makes temp-repo git hermetic
+regardless of how the suite was launched. ``monkeypatch`` restores the real
+environment afterwards.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_git_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in list(os.environ):
+        if key.startswith("GIT_"):
+            monkeypatch.delenv(key, raising=False)

--- a/.claude/skills/promotion-audit/tests/conftest.py
+++ b/.claude/skills/promotion-audit/tests/conftest.py
@@ -1,0 +1,25 @@
+"""Isolate temp-repo git tests from an inherited git environment (main#719).
+
+git exports ``GIT_DIR``/``GIT_WORK_TREE``/``GIT_INDEX_FILE`` into hook
+subprocesses (notably the pre-push ``pytest`` hook). ``test_run.py`` builds a
+throwaway repo and runs ``git -C <tmp> commit`` — which sets cwd but does not
+override an inherited ``GIT_DIR`` — so without this the commit targets the
+parent repo and fails ("No .pre-commit-config.yaml found") whenever the suite
+is run as a git hook, even though it passes standalone and in CI.
+
+Stripping the ``GIT_*`` namespace before every test makes temp-repo git
+hermetic regardless of launch context. ``monkeypatch`` restores afterwards.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_git_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in list(os.environ):
+        if key.startswith("GIT_"):
+            monkeypatch.delenv(key, raising=False)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -90,7 +90,11 @@ repos:
         language: system
         types: [python]
         files: ^\.claude/(hooks|lib|skills)/.*\.py$
-        exclude: ^\.claude/worktrees/
+        # Skip worktree copies, and conftest.py — two test dirs each ship a
+        # `conftest.py`, which collide under one flat mypy invocation ("Duplicate
+        # module named conftest"). CI type-checks them safely via its per-dir
+        # mypy loop (ci.yml); this file-list hook would pass both at once (#719).
+        exclude: (^\.claude/worktrees/|(^|/)conftest\.py$)
         pass_filenames: true
         stages: [pre-push]
       - id: pytest


### PR DESCRIPTION
## Summary

Installing the org-wide pre-push hooks surfaced a latent test bug that **breaks every push**. git exports `GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE` into hook subprocesses; temp-repo tests run `git -C <tmp>` which sets cwd but does **not** override the inherited `GIT_DIR`, so under the pre-push hook those commits target the parent `.git` (now carrying a pre-commit hook) and fail with *"No .pre-commit-config.yaml found."* Dormant until now only because the hooks were never installed.

## Change

- Autouse `conftest.py` in `.claude/lib/tests/` and `.claude/skills/promotion-audit/tests/` that strips the `GIT_*` namespace per test (monkeypatch-restored) → temp-repo git is hermetic regardless of launch context. Also auto-covers the auto-sync PR's `test_sync_main.py` once it rebases.
- pre-commit mypy hook `exclude` extended to skip `conftest.py`: two same-named conftest modules collide under one flat mypy invocation. CI already type-checks them safely via its **per-directory** mypy loop (ci.yml), so this is local-hook-only — no CI/parity change.

## Verification

- The previously-failing suites (`test_verify_commit_identity`, promotion-audit `test_run`) and the full `pytest .claude/hooks/tests .claude/lib/tests` (1491 passed) now pass **with `GIT_DIR` set** — the exact hook environment.
- **This PR pushed cleanly through the real pre-push hook** (mypy + pytest + pytest-skills all green) — the end-to-end proof.
- CI-style per-dir mypy green for `.claude/hooks .claude/lib` and `promotion-audit`; sync-drift gate OK.

## Reviewer brief

- **Scope:** test infrastructure only — two conftest fixtures + one pre-commit `exclude` regex. No production code.
- **Check:** the `GIT_*` strip is monkeypatch-scoped (restored after each test); confirm the mypy `exclude` regex `(^\.claude/worktrees/|(^|/)conftest\.py$)` still matches worktrees.
- **TechDebt:** none.

Closes #719. Unblocks the pre-push hooks installed for the org-wide hook rollout; PR #717 and #715's `test_sync_main` depend on this landing.
