### PR TITLE
fix(hook): scope block_git_config to the user.* identity namespace (#717)

### DIFF
--- a/.claude/hooks/block_git_config.py
+++ b/.claude/hooks/block_git_config.py
@@ -23,17 +23,21 @@ Does NOT match:
 Flag pass-through:
     --get / --get-all / --get-regexp / --list / -l / --show-origin /
     --show-scope → read-only, allowed.
-    Anything else on `git config` → write, blocked.
+    A write to a `user.*` identity key → blocked.
+    A write to any other (operational) key — core.hooksPath, commit.gpgsign,
+    … → allowed (#717: the charter rule is identity-specific; over-blocking
+    all keys prevented legitimate local-hook setup).
 
 Exit codes:
-  0 — allow (not a git config command, or a read-only operation)
-  2 — block (git config write detected)
+  0 — allow (not a git config command, a read-only op, or a non-identity write)
+  2 — block (git config write to the user.* identity namespace)
 """
 
 from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
@@ -44,6 +48,14 @@ from _shell_parse import (  # noqa: E402
     tokenize,
 )
 from annunaki_log import log_pretooluse_block  # noqa: E402
+
+# Config keys the charter actually protects (§ Commit Identity — "block git
+# config *user* changes"). The whole `user.` namespace is treated as identity
+# (user.name / user.email / user.signingkey). Non-identity / operational keys
+# (core.hooksPath, commit.gpgsign, …) are NOT blocked — they were over-blocked
+# before #717, which prevented legitimate `git config --unset core.hooksPath`
+# needed to install local pre-commit hooks.
+_IDENTITY_KEY_RE = re.compile(r"^user\.", re.IGNORECASE)
 
 # Read-only flags that mark a `git config` invocation as harmless.
 _READ_ONLY_FLAGS = {
@@ -58,10 +70,13 @@ _READ_ONLY_FLAGS = {
 
 
 def _is_git_config_write(segment: list[str]) -> bool:
-    """True if `segment` is a `git config <write>` invocation.
+    """True if `segment` is a `git config` write to the protected identity
+    (`user.*`) namespace.
 
     A read-only invocation (any token in `_READ_ONLY_FLAGS` present) returns
-    False; everything else with subcommand `config` returns True.
+    False. A write to a non-identity / operational key (core.hooksPath,
+    commit.gpgsign, …) also returns False — the charter rule is identity-
+    specific (#717). Only a write naming a `user.*` key returns True.
     """
     decoded = find_git_subcommand(segment)
     if decoded is None:
@@ -77,7 +92,10 @@ def _is_git_config_write(segment: list[str]) -> bool:
         for ro in _READ_ONLY_FLAGS:
             if arg.startswith(ro + "="):
                 return False
-    return True
+    # A write — block ONLY if it targets the identity namespace. Any arg naming
+    # a `user.*` key (the value position never looks like a config key, so a
+    # plain key-token scan is sufficient and avoids mis-parsing flag values).
+    return any(_IDENTITY_KEY_RE.match(arg) for arg in args)
 
 
 def check(input_data: dict) -> dict | None:
@@ -105,11 +123,11 @@ def check(input_data: dict) -> dict | None:
     result = {
         "decision": "block",
         "reason": (
-            "BLOCKED: `git config` writes are prohibited by the charter (§ Commit Identity). "
-            "Never modify global or repo-level git config. "
+            "BLOCKED: writes to the `user.*` identity namespace are prohibited by the "
+            "charter (§ Commit Identity). Never set repo/global git identity. "
             "Use per-commit `-c` flags instead:\n"
             '  git -c user.name="Name" -c user.email="email@example.com" commit -m "..."\n'
-            "Read-only operations (--get, --list, -l) are allowed.\n"
+            "Non-identity config (e.g. core.hooksPath) and read-only ops are allowed.\n"
             "See .claude/team/charter.md § Commit Identity for the full identity table."
         ),
     }

--- a/.claude/hooks/tests/test_block_git_config.py
+++ b/.claude/hooks/tests/test_block_git_config.py
@@ -38,6 +38,27 @@ class PositiveMatchTests(unittest.TestCase):
         result = hook.check(_input("git -C /repo config user.name foo"))
         self.assertIsNotNone(result)
 
+    def test_unset_identity_blocked(self):
+        self.assertIsNotNone(hook.check(_input("git config --unset user.email")))
+
+    def test_user_namespace_blocked(self):
+        # The whole user.* identity namespace is protected, not just name/email.
+        self.assertIsNotNone(hook.check(_input("git config user.signingkey ABC123")))
+
+
+class OperationalKeyTests(unittest.TestCase):
+    """#717: non-identity (operational) config writes MUST be allowed."""
+
+    def test_core_hookspath_write_allowed(self):
+        self.assertIsNone(hook.check(_input("git config core.hooksPath .git/hooks")))
+
+    def test_core_hookspath_unset_allowed(self):
+        # The exact command #717 was filed for.
+        self.assertIsNone(hook.check(_input("git -C /repo config --unset core.hooksPath")))
+
+    def test_commit_gpgsign_allowed(self):
+        self.assertIsNone(hook.check(_input("git config commit.gpgsign false")))
+
 
 class NegativeMatchTests(unittest.TestCase):
     """#216: prose / --body / --body-file content must NOT trigger.


### PR DESCRIPTION
## Summary

`block_git_config.py` blocked **every** `git config` write. The charter rule (§ Commit Identity) — and CLAUDE.md's own wording, "block git config **user** changes" — is identity-specific. The over-block prevented a legitimate `git config --unset core.hooksPath` needed to install local pre-commit/pre-push hooks in a child repo whose `hooksPath` was a stale leftover from a repo rename.

## Change

`_is_git_config_write` now blocks a write **only** when it names a `user.*` key (the identity namespace). Operational keys — `core.hooksPath`, `commit.gpgsign`, … — and all read-only ops are allowed. Block message + docstrings updated.

## Verification

19 tests pass: identity (`user.name`/`user.email`/`user.signingkey`/`--unset user.email`, any scope) blocked; `core.hooksPath` write+unset and `commit.gpgsign` allowed; read-only still allowed.

## Reviewer brief

- **Scope:** one hook + its tests. Confirm the `user.*` regex can't be evaded (e.g. a `--file` value that looks like `user.x` is a non-issue — values aren't keys) and that no legitimate identity write slips through.
- **TechDebt:** none.
- **Stacking:** based on `A.Virtanen/0719-test-git-env-isolation` (the GIT_DIR test-isolation fix) because the pre-push hook can't pass without it. Retarget to `main` once #720 (#719) merges.

Closes #717.
