### PR TITLE
tech-debt(hooks): classifier docstring A/B + extract_repo segment-scoping (#704)

### DIFF
--- a/.claude/hooks/_repo_flag_parse.py
+++ b/.claude/hooks/_repo_flag_parse.py
@@ -39,6 +39,17 @@ Public API
         a conservative regex when shlex tokenization fails (e.g. command
         contains a malformed quote). Both paths recognize all four forms.
 
+    extract_repo_from_tokens(tokens: list[str]) -> str | None
+        Same extraction over an ALREADY-tokenized command segment. Use this
+        when the caller has tokenized + segment-scoped the command itself
+        (e.g. via `iter_command_segments` / `find_gh_subcommand`) and wants
+        repo extraction confined to that one segment rather than re-parsing
+        the whole command string. Confining to the segment avoids a
+        cross-segment mis-pick in a compound multi-`gh` command such as
+        `gh issue create … --repo A && gh pr view … --repo B`, where
+        `extract_repo` over the raw string would return whichever `--repo`
+        appears first regardless of which segment is the one being acted on.
+
 Design notes
 ============
 
@@ -75,11 +86,23 @@ _REPO_FLAGS = {"--repo", "-R"}
 _REPO_FALLBACK_RE = re.compile(r"(?:^|\s)(?:--repo|-R)(?:=|\s+)(\S+)")
 
 
+def extract_repo_from_tokens(tokens: list[str]) -> str | None:
+    """Extract the `--repo` / `-R` `OWNER/NAME` value from already-tokenized
+    command tokens, or None if absent.
+
+    For callers that have already tokenized (and, ideally, segment-scoped) the
+    command — see the module `Public API` note on cross-segment mis-pick. Both
+    the space form (`--repo X` / `-R X`) and the equals form (`--repo=X` /
+    `-R=X`) are recognized via the shared `walk_flag_values` walker.
+    """
+    values = walk_flag_values(tokens, _REPO_FLAGS)
+    return values[0] if values else None
+
+
 def extract_repo(command: str) -> str | None:
     """Extract the `--repo` / `-R` `OWNER/NAME` value, or None if absent."""
     tokens = tokenize(command)
     if tokens is None:
         match = _REPO_FALLBACK_RE.search(command)
         return match.group(1) if match else None
-    values = walk_flag_values(tokens, _REPO_FLAGS)
-    return values[0] if values else None
+    return extract_repo_from_tokens(tokens)

--- a/.claude/hooks/tests/test_gh_command_parser_invariant.py
+++ b/.claude/hooks/tests/test_gh_command_parser_invariant.py
@@ -29,7 +29,7 @@ shape. For each such hook assert BOTH:
      the line-continuation #287 and heredoc fixes a private reimplementation
      would miss).
 
-  C. It contains no ad-hoc flag-value-capturing regex literal (a regex that
+  B. It contains no ad-hoc flag-value-capturing regex literal (a regex that
      captures the value following `--repo`/`--label`/`--add-label`/
      `--remove-label`/`-R`/`-l`). Such extraction is the #650/#659/#661 bug
      class — it leaks label-shaped tokens out of `--body` content. Pure

--- a/.claude/hooks/tests/test_repo_flag_parse.py
+++ b/.claude/hooks/tests/test_repo_flag_parse.py
@@ -26,6 +26,11 @@ _HOOKS_DIR = _HERE.parent
 sys.path.insert(0, str(_HOOKS_DIR))
 
 import _repo_flag_parse as parser  # noqa: E402
+from _shell_parse import (  # noqa: E402
+    find_gh_subcommand,
+    iter_command_segments,
+    tokenize,
+)
 
 
 class FourFormsTests(unittest.TestCase):
@@ -157,6 +162,67 @@ class IssueOrigin503ReproTests(unittest.TestCase):
             'RequestOrReplied: Approved\nTechDebt: none"'
         )
         self.assertEqual(parser.extract_repo(cmd), "noorinalabs/noorinalabs-deploy")
+
+
+class FromTokensTests(unittest.TestCase):
+    """`extract_repo_from_tokens` operates on already-tokenized command
+    tokens — the segment-scoped sibling of `extract_repo` (#704)."""
+
+    def test_space_form_over_tokens(self):
+        tokens = tokenize("gh pr comment 314 --repo owner/repo --body x")
+        self.assertEqual(parser.extract_repo_from_tokens(tokens), "owner/repo")
+
+    def test_equals_form_over_tokens(self):
+        tokens = tokenize("gh pr comment 314 --repo=owner/repo --body x")
+        self.assertEqual(parser.extract_repo_from_tokens(tokens), "owner/repo")
+
+    def test_short_form_over_tokens(self):
+        tokens = tokenize("gh pr comment 314 -R owner/repo --body x")
+        self.assertEqual(parser.extract_repo_from_tokens(tokens), "owner/repo")
+
+    def test_absent_returns_none(self):
+        tokens = tokenize("gh pr comment 314 --body x")
+        self.assertIsNone(parser.extract_repo_from_tokens(tokens))
+
+    def test_empty_tokens_returns_none(self):
+        self.assertIsNone(parser.extract_repo_from_tokens([]))
+
+    def test_body_token_does_not_leak(self):
+        """A `--repo` substring INSIDE a quoted `--body` value arrives as a
+        single token and must not be extracted (same protection as the
+        string-form parser, preserved over the token-list path)."""
+        tokens = tokenize('gh pr comment 99 --body "discussed --repo owner/repo in #123"')
+        self.assertIsNone(parser.extract_repo_from_tokens(tokens))
+
+    def test_segment_scoping_avoids_cross_segment_mispick(self):
+        """The motivating #704 case: a compound command whose FIRST `gh`
+        segment carries a different `--repo` than the segment being acted on.
+
+        `extract_repo` over the raw string returns the first `--repo` in
+        source order (the WRONG segment's). Scoping to the located segment's
+        tokens returns the right one. This test pins that the token-scoped
+        path disagrees with the whole-string path exactly where it should."""
+        command = (
+            "gh pr view 5 --repo noorinalabs/WRONG && "
+            "gh issue create --repo noorinalabs/CORRECT --title T --body B"
+        )
+        # Whole-string parse picks the first --repo (the leading pr-view segment).
+        self.assertEqual(parser.extract_repo(command), "noorinalabs/WRONG")
+
+        # Segment-scoped parse over the located `gh issue create` segment picks
+        # the segment's own --repo.
+        tokens = tokenize(command)
+        issue_segment_rest = None
+        for segment in iter_command_segments(tokens):
+            gh = find_gh_subcommand(segment)
+            if gh and gh[1][:2] == ["issue", "create"]:
+                issue_segment_rest = gh[1]
+                break
+        self.assertIsNotNone(issue_segment_rest)
+        self.assertEqual(
+            parser.extract_repo_from_tokens(issue_segment_rest),
+            "noorinalabs/CORRECT",
+        )
 
 
 if __name__ == "__main__":

--- a/.claude/hooks/tests/test_validate_wave_label_evidence.py
+++ b/.claude/hooks/tests/test_validate_wave_label_evidence.py
@@ -338,6 +338,44 @@ class BodyOverMatchScopingTests(unittest.TestCase):
             run.assert_not_called()
 
 
+class CompoundCommandRepoScopingTests(unittest.TestCase):
+    """#704: repo extraction is scoped to the LOCATED `gh issue` segment, so a
+    leading sibling `gh` segment carrying a different `--repo` cannot be
+    mis-picked. Pre-fix, `extract_repo` over the raw command returned the first
+    `--repo` in source order (the leading segment's)."""
+
+    def test_repo_taken_from_issue_segment_not_leading_segment(self):
+        # `gh issue edit` resolves the body via `gh issue view <num> --repo R`,
+        # so the extracted repo flows straight into a subprocess arg we can
+        # observe. The leading `gh pr view` segment carries a DIFFERENT --repo;
+        # pre-fix, the whole-string `extract_repo` returned that (first in
+        # source order). The fix scopes extraction to the edit segment.
+        calls: list[list[str]] = []
+
+        class _Result:
+            def __init__(self, returncode: int, stdout: str = ""):
+                self.returncode = returncode
+                self.stdout = stdout
+                self.stderr = ""
+
+        def fake_run(args, capture_output, text, timeout):
+            calls.append(args)
+            return _Result(0, "")  # empty body → hook allows after observing repo
+
+        cmd = (
+            "gh pr view 5 --repo noorinalabs/WRONG && "
+            "gh issue edit 42 --repo noorinalabs/CORRECT --add-label 'p3-wave-9'"
+        )
+        with mock.patch.object(hook.subprocess, "run", side_effect=fake_run):
+            hook.check(_bash_input(cmd))
+
+        view_calls = [a for a in calls if "issue" in a and "view" in a]
+        self.assertTrue(view_calls, "expected a `gh issue view` body fetch")
+        view = view_calls[0]
+        repo_idx = view.index("--repo") + 1
+        self.assertEqual(view[repo_idx], "noorinalabs/CORRECT")
+
+
 class LineContinuationTests(unittest.TestCase):
     """main#663: shared tokenizer normalizes backslash-newline continuations
     (#287) — the old private `shlex.split` reimplementation did not."""

--- a/.claude/hooks/validate_wave_label_evidence.py
+++ b/.claude/hooks/validate_wave_label_evidence.py
@@ -20,9 +20,11 @@ Algorithm:
   1. Tokenize command via the shared `_shell_parse` tokenizer (segment-aware,
      line-continuation-normalized, heredoc-stripped) — NOT a private shlex
      reimplementation. Flag VALUES are extracted via `walk_flag_values` and
-     `_repo_flag_parse.extract_repo`, so label-shaped / repo-shaped tokens in
-     `--body`/`--body-file` content cannot leak into extraction (main#663
-     gh-command parser invariant — see `charter/hooks.md`).
+     `_repo_flag_parse.extract_repo_from_tokens` (the latter scoped to the
+     located issue segment's tokens, not the raw command), so label-shaped /
+     repo-shaped tokens in `--body`/`--body-file` content cannot leak into
+     extraction and a second `gh` segment's `--repo` cannot be mis-picked
+     (main#663 gh-command parser invariant — see `charter/hooks.md`).
   2. Detect wave-label application (regex `p\\d+-wave-\\d+` in any --label /
      --add-label value).
   3. Resolve the target repo. When `--repo`/`-R` is OMITTED (in-repo
@@ -61,7 +63,7 @@ import subprocess
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from _repo_flag_parse import extract_repo  # noqa: E402
+from _repo_flag_parse import extract_repo_from_tokens  # noqa: E402
 from _shell_parse import (  # noqa: E402
     find_gh_subcommand,
     iter_command_segments,
@@ -217,7 +219,14 @@ def check(input_data: dict) -> dict | None:
     # origin (main#663 invariant MUST #2) instead of the old empty-default
     # `noorinalabs/` slug. If the ambient repo is unresolvable, log a skip
     # diagnostic and fail-open (allow) — never a silent drop.
-    repo = extract_repo(command)
+    #
+    # Scope extraction to the LOCATED issue segment's tokens (`rest`), not the
+    # raw command: in a compound `gh issue create … --repo A && gh pr view …
+    # --repo B`, parsing the whole string could pick the wrong segment's
+    # `--repo`. `rest` is already tokenized (tokenize() succeeded in
+    # `_find_issue_command`), so the regex-fallback in `extract_repo` is not
+    # needed here.
+    repo = extract_repo_from_tokens(rest)
     if not repo:
         short = resolve_repo_short_name(input_data)
         if not short:


### PR DESCRIPTION
## What & why

Two non-blocking review findings from PR #702 (issue #663), filed as #704 to complete the review's attestation per charter § Comment-Based Reviews. Tight TD nits, not a refactor.

## Changes

**`.claude/hooks/tests/test_gh_command_parser_invariant.py`** — the gh-command parser classifier docstring enumerated checks **A** and **C** with no **B** (cosmetic leftover). Relabel `C → B` so the docstring matches the two checks actually asserted (no shlex; no ad-hoc flag-value regex).

**`.claude/hooks/_repo_flag_parse.py`** — add `extract_repo_from_tokens(tokens)`, a segment-scoped sibling of `extract_repo`, and refactor `extract_repo` to reuse it. Documents the cross-segment mis-pick it guards against.

**`.claude/hooks/validate_wave_label_evidence.py`** — `extract_repo(command)` ran over the **full** command string, so a compound `gh ... --repo A && gh issue create/edit ... --repo B` could mis-pick the leading segment's `--repo` (first in source order) instead of the located issue segment's. Now extracts from the already-tokenized issue segment `rest` via `extract_repo_from_tokens` — also drops a redundant re-tokenize. Theoretical/low-risk as flagged, but now correct.

## Tests

- `test_repo_flag_parse.py`: +7 `extract_repo_from_tokens` cases — space/equals/short forms, absence, empty tokens, `--body`-no-leak, and the cross-segment mis-pick (asserts whole-string vs segment-scoped disagree exactly where they should).
- `test_validate_wave_label_evidence.py`: +1 hook-level test — a leading `gh pr view --repo WRONG` segment must not override the `gh issue edit --repo CORRECT` segment; the `gh issue view` body fetch is asserted to use `CORRECT`.

## Verification

- ruff format + lint (pinned 0.15.11), mypy: clean.
- Full `.claude/hooks/tests/` + `.claude/lib/tests/` suite: **1550 passed, 56 subtests**.
- sync-drift gate: `OK: pre-commit config mirrors all CI-enforced checks`.
- pre-commit + pre-push hooks: all passed on commit + push.

## Reviewers (charter: 2)
- Aino Virtanen
- Santiago Ferreira

Closes #704
Refs #702 #663

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AkRwPuak1q336WSwR6CJ6n
