### PR TITLE
tech-debt(ci): align cspell mirror .md regex with CI **/*.md glob (#706)

### DIFF
--- a/.claude/lib/tests/test_pre_commit_ci_sync.py
+++ b/.claude/lib/tests/test_pre_commit_ci_sync.py
@@ -10,6 +10,7 @@ Verifies:
 
 from __future__ import annotations
 
+import re
 import sys
 import unittest
 from pathlib import Path
@@ -184,6 +185,70 @@ repos:
 """
         harmful, _ = compute_drift(kinds_from_precommit(cfg), kinds_from_ci(wf))
         self.assertNotIn("cspell", harmful)
+
+
+class CspellMirrorGlobParity(unittest.TestCase):
+    r"""#706 (from #698 review): the pre-commit cspell `files` regex must mirror
+    the CI cspell-action `dir/**/*.md` globs EXACTLY across directory depth.
+    `**` is zero-or-more path segments, so each scoped directory must match a
+    `.md` file at its top level AND at any nesting depth; a narrowing edit (e.g.
+    a single-level `dir/[^/]+\.md`) would skip a nested `dir/a/b.md` that the CI
+    `**/*.md` glob still checks — a local-skip-but-CI-catches divergence. These
+    tests read the REAL config + workflow and lock the depth-agnostic behavior
+    so the two sides cannot silently drift."""
+
+    @staticmethod
+    def _precommit_cspell_files_regex() -> re.Pattern[str]:
+        # The cspell hook's `files:` is the only `files:` whose pattern targets
+        # .md (ruff/mypy scope .py), so pick the .md one out of the real config.
+        text = (_REPO_ROOT / ".pre-commit-config.yaml").read_text(encoding="utf-8")
+        for raw in text.splitlines():
+            m = re.match(r"\s*files:\s*(\^.*\$)\s*$", raw)
+            if m and r"\.md" in m.group(1):
+                return re.compile(m.group(1))
+        raise AssertionError("no cspell .md `files:` regex in .pre-commit-config.yaml")
+
+    def setUp(self) -> None:
+        self.pattern = self._precommit_cspell_files_regex()
+
+    def _matches(self, path: str) -> bool:
+        # pre-commit applies `files` with re.search against the repo-relative path.
+        return self.pattern.search(path) is not None
+
+    def test_scoped_dirs_match_at_every_depth(self) -> None:
+        # CI `dir/**/*.md` matches a .md at the top level and at ANY depth — the
+        # exact divergence #706 guards: top-level must match AND nested must match.
+        for d in (".claude/team/charter", ".claude/skills", "ontology", "docs"):
+            for rel in ("top.md", "sub/nested.md", "a/b/deep.md"):
+                p = f"{d}/{rel}"
+                with self.subTest(path=p):
+                    self.assertTrue(self._matches(p), f"{p} must be spell-checked")
+
+    def test_root_docs_match(self) -> None:
+        self.assertTrue(self._matches("CLAUDE.md"))
+        self.assertTrue(self._matches("ONBOARDING.md"))
+
+    def test_out_of_scope_paths_not_matched(self) -> None:
+        for p in (
+            "README.md",  # root file, not CLAUDE/ONBOARDING
+            ".claude/team/feedback_log.md",  # under .claude/team but not charter/
+            ".claude/team/roster/standards_lead_aino.md",  # roster excluded by CI
+            "docs/notes.txt",  # not a .md file
+            ".claude/skills/helper.py",  # not a .md file
+            "noorinalabs-isnad-graph/docs/x.md",  # child-repo docs, out of parent scope
+            "src/docs/guide.md",  # `docs/` only scoped at the repo root
+        ):
+            with self.subTest(path=p):
+                self.assertFalse(self._matches(p), f"{p} must NOT be spell-checked")
+
+    def test_ci_still_uses_doublestar_md_globs(self) -> None:
+        # Guard the OTHER side: the mirror + the depth expectations above are only
+        # correct while CI globs each scoped dir as `dir/**/*.md`. If a CI edit
+        # changes that, this fails so the mirror is revisited (parity is bilateral).
+        docs = (_REPO_ROOT / ".github" / "workflows" / "docs.yml").read_text(encoding="utf-8")
+        for d in (".claude/team/charter", ".claude/skills", "ontology", "docs"):
+            with self.subTest(dir=d):
+                self.assertIn(f"{d}/**/*.md", docs)
 
 
 class BuildKindTightening(unittest.TestCase):

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,13 +71,21 @@ repos:
   # (charter, skills, ontology, root docs); `--config .cspell.json` reuses the
   # same dictionaries + ignore rules CI loads, so a word that passes locally
   # passes in CI and vice-versa.
+  #
+  # Each scoped directory uses `(?:[^/]+/)*[^/]+\.md` — the exact regex
+  # translation of the CI action's `dir/**/*.md` glob: `(?:[^/]+/)*` is the `**`
+  # (zero or more path segments), `[^/]+\.md` is the `*.md` leaf. This is the
+  # earlier `dir/.*\.md` form made depth-explicit (#706, from #698 review): a
+  # later edit that narrowed a directory to a single-level `dir/[^/]+\.md` would
+  # then SKIP a nested `dir/a/b.md` that the CI `**/*.md` glob still checks — a
+  # local-skip-but-CI-catches divergence the depth-coverage test now locks.
   - repo: https://github.com/streetsidesoftware/cspell-cli
     rev: v8.4.0
     hooks:
       - id: cspell
         name: cspell
         args: ["--no-must-find-files", "--no-progress", "--no-summary", "--config", ".cspell.json"]
-        files: ^(\.claude/team/charter/.*\.md|\.claude/skills/.*\.md|ontology/.*\.md|CLAUDE\.md|ONBOARDING\.md|docs/.*\.md)$
+        files: ^((\.claude/team/charter|\.claude/skills|ontology|docs)/(?:[^/]+/)*[^/]+\.md|(CLAUDE|ONBOARDING)\.md)$
 
   # Heavier checks run at pre-push (mirror CI's mypy + pytest jobs). Running as
   # `local`/`system` hooks so we use the system tools and don't drift from


### PR DESCRIPTION
## Summary

Aligns the pre-commit cspell mirror's `.md` `files` regex with the CI cspell-action `dir/**/*.md` globs so the two stay provably in parity across directory depth. Non-blocking review finding from PR #698 (#684), raised by Wanjiku Mwangi.

The mirror previously used a per-directory `.*\.md` form. It agreed with the CI `**/*.md` globs for the present tree, but it was depth-*implicit*: a later narrowing edit to a single-level `dir/[^/]+\.md` would silently skip a nested `dir/a/b.md` that CI's `**/*.md` still spell-checks — the local-skip-but-CI-catches divergence the sync-drift gate exists to prevent.

## Changes

- `.pre-commit-config.yaml`: each scoped directory now uses `(?:[^/]+/)*[^/]+\.md` — the exact regex translation of `dir/**/*.md` (`(?:[^/]+/)*` = the `**` zero-or-more segments, `[^/]+\.md` = the `*.md` leaf). Comment updated to explain the mirror and the divergence it guards. Behavior is unchanged for real files; intent and parity are now explicit.
- `.claude/lib/tests/test_pre_commit_ci_sync.py`: new `CspellMirrorGlobParity` class that reads the REAL config + `docs.yml` and locks bilateral parity — every scoped dir must match a `.md` at the top level AND at any nesting depth, out-of-scope paths must not match, and CI must still glob each dir as `dir/**/*.md` (a CI-side change forces a revisit).

## Verification (green-before-push, in worktree)

- `pytest .claude/hooks/tests/ .claude/lib/tests/` — 1546 passed (33 in the sync-gate suite incl. 4 new)
- `ruff check` / `ruff format --check` — clean
- `mypy .claude/hooks/ .claude/lib/` — rc=0
- `pre_commit_ci_sync.py .` — OK (no drift)
- `pre-commit run cspell --all-files` — Passed with the new regex

## Tech debt

Pure CI-parity tech-debt; no runtime/product behavior change. No new tech debt introduced.

Closes #706
