### PR TITLE
fix(memory): repoint handoff hooks to in-repo .claude/memory/ (closes #741)

### DIFF
--- a/.claude/hooks/session_handoff.py
+++ b/.claude/hooks/session_handoff.py
@@ -22,12 +22,19 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
-# Project memory path — Claude auto-loads this at session start
-MEMORY_DIR = (
-    Path.home() / ".claude" / "projects" / "-home-parameterization-code-noorinalabs-main" / "memory"
-)
+# Project memory is version-controlled in-repo (#732 relocation) so it travels
+# with a git pull. The handoff file itself stays gitignored — it's per-session
+# machine-local churn — but it MUST live alongside the corpus so the SessionStart
+# hook (session_start.py) and the /session-start skill read the same file. When
+# this lived under the user-space ~/.claude/projects/ auto-memory dir while the
+# skill read in-repo, the two diverged (split-brain, #741).
+#
+# We deliberately do NOT auto-rewrite the tracked MEMORY.md index line from this
+# Stop hook: mutating a version-controlled file on every session exit is exactly
+# the churn the gitignore on the handoff file avoids. The /handoff skill owns the
+# committed index line (a deliberate, intentional write).
+MEMORY_DIR = REPO_ROOT / ".claude" / "memory"
 HANDOFF_FILE = MEMORY_DIR / "session_handoff.md"
-MEMORY_INDEX = MEMORY_DIR / "MEMORY.md"
 
 
 def _run(cmd: str, cwd: str | None = None, timeout: int = 10) -> str:
@@ -174,7 +181,6 @@ def main() -> None:
 
     now = datetime.now(timezone.utc)
     date_str = now.strftime("%Y-%m-%d %H:%M UTC")
-    date_short = now.strftime("%Y-%m-%d")
 
     git = _get_git_state()
     prs = _get_open_prs()
@@ -237,28 +243,9 @@ def main() -> None:
     except OSError:
         sys.exit(0)
 
-    # Update memory index — replace existing handoff entry or add new one
-    handoff_entry = (
-        f"- [Session handoff](session_handoff.md)"
-        f" — Pickup from {date_short}: auto-generated project state snapshot"
-    )
-    try:
-        if MEMORY_INDEX.exists():
-            index_content = MEMORY_INDEX.read_text(encoding="utf-8")
-            index_lines = index_content.splitlines()
-            new_lines = []
-            found = False
-            for line in index_lines:
-                if "session_handoff.md" in line.lower() or "Session handoff" in line:
-                    new_lines.append(handoff_entry)
-                    found = True
-                else:
-                    new_lines.append(line)
-            if not found:
-                new_lines.append(handoff_entry)
-            MEMORY_INDEX.write_text("\n".join(new_lines) + "\n", encoding="utf-8")
-    except OSError:
-        pass
+    # Note: the tracked MEMORY.md index line is intentionally NOT updated here —
+    # see the MEMORY_DIR comment above. The committed index line is owned by the
+    # /handoff skill so this Stop hook never dirties a version-controlled file.
 
     # Build a compact display version for the conversation
     display_lines = [

--- a/.claude/hooks/session_start.py
+++ b/.claude/hooks/session_start.py
@@ -19,9 +19,10 @@ _PROJECT = Path(__file__).resolve().parent.parent.parent
 _CHECKSUMS = _PROJECT / "ontology" / "checksums.json"
 _ERRORS_LOG = _PROJECT / ".claude" / "annunaki" / "errors.jsonl"
 _CROSS_REPO_STATUS = _PROJECT / "cross-repo-status.json"
-# Claude Code encodes project paths by replacing / with - (leading slash becomes leading -)
-_ENCODED_PROJECT = str(_PROJECT).replace("/", "-")
-_HANDOFF = Path.home() / ".claude" / "projects" / _ENCODED_PROJECT / "memory" / "session_handoff.md"
+# Handoff lives in-repo alongside the version-controlled memory corpus (#732, #741)
+# so this SessionStart hook and the /session-start skill read the SAME gitignored
+# file — no split-brain between the user-space auto-memory dir and the in-repo one.
+_HANDOFF = _PROJECT / ".claude" / "memory" / "session_handoff.md"
 
 
 def _ontology_staleness() -> tuple[int, int]:

--- a/.claude/hooks/tests/test_session_handoff.py
+++ b/.claude/hooks/tests/test_session_handoff.py
@@ -109,5 +109,25 @@ class GetWaveStatusTests(unittest.TestCase):
         self.assertEqual(result, "No cross-repo-status.json found")
 
 
+class HandoffPathLocationTests(unittest.TestCase):
+    """#741: the Stop hook must write the handoff into the in-repo,
+    version-controlled .claude/memory/ — NOT the user-space auto-memory dir —
+    so it and the /session-start skill agree on one file (no split-brain).
+    """
+
+    def test_handoff_file_is_in_repo_memory(self) -> None:
+        expected = hook.REPO_ROOT / ".claude" / "memory" / "session_handoff.md"
+        self.assertEqual(hook.HANDOFF_FILE, expected)
+
+    def test_handoff_not_in_user_space(self) -> None:
+        self.assertNotIn("/.claude/projects/", hook.HANDOFF_FILE.as_posix())
+        self.assertFalse(hook.HANDOFF_FILE.is_relative_to(Path.home() / ".claude" / "projects"))
+
+    def test_tracked_memory_index_autochurn_removed(self) -> None:
+        # The Stop hook no longer auto-rewrites the tracked MEMORY.md index line
+        # (#741); ensure the constant is gone so the churn can't silently return.
+        self.assertFalse(hasattr(hook, "MEMORY_INDEX"))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.claude/hooks/tests/test_session_start.py
+++ b/.claude/hooks/tests/test_session_start.py
@@ -103,5 +103,21 @@ class WaveStatusWrapperTests(unittest.TestCase):
         self.assertIsNone(result)
 
 
+class HandoffPathLocationTests(unittest.TestCase):
+    """#741: the SessionStart hook must read the handoff from the in-repo,
+    version-controlled .claude/memory/ — NOT the user-space
+    ~/.claude/projects/<encoded>/memory/ auto-memory dir. Reading user-space
+    while the /session-start skill reads in-repo is the split-brain this fixes.
+    """
+
+    def test_handoff_is_in_repo_memory(self) -> None:
+        expected = hook._PROJECT / ".claude" / "memory" / "session_handoff.md"
+        self.assertEqual(hook._HANDOFF, expected)
+
+    def test_handoff_not_in_user_space(self) -> None:
+        self.assertNotIn("/.claude/projects/", hook._HANDOFF.as_posix())
+        self.assertFalse(hook._HANDOFF.is_relative_to(Path.home() / ".claude" / "projects"))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Finishes the #732 memory relocation. That work repointed the **skill** handoff pair (`/handoff` writer, `/session-start` Step 0 reader) to the in-repo `.claude/memory/` corpus but left the **hook** pair on the user-space `~/.claude/projects/…/memory/` auto-memory dir — a half-migration that produced a **split-brain**: a fresh session can surface a stale user-space handoff via the `session_start.py` SessionStart hook while `/session-start` reads the fresh in-repo file. (Both `session_handoff.md` files exist on disk right now with different content/timestamps.)

After this PR all four touchpoints agree on **one** gitignored file:

| Touchpoint | Path before | Path after |
|---|---|---|
| `session_handoff.py` (Stop hook, writes) | user-space | `.claude/memory/` |
| `session_start.py` (SessionStart hook, reads) | user-space | `.claude/memory/` |
| `/handoff` skill (writes) | `.claude/memory/` | `.claude/memory/` |
| `/session-start` SKILL.md Step 0 (reads) | `.claude/memory/` | `.claude/memory/` |

Changes:
- **`session_handoff.py`** — `MEMORY_DIR` → `REPO_ROOT/.claude/memory`. Also **dropped the auto-rewrite of the tracked `MEMORY.md` index line** on every Stop: mutating a version-controlled file on every session exit is exactly the churn the `.gitignore` on the handoff file avoids. The `/handoff` skill owns the committed index line (a deliberate write).
- **`session_start.py`** — `_HANDOFF` → in-repo; removed the now-unused `_ENCODED_PROJECT`.
- **tests** — `test_session_handoff.py` + `test_session_start.py` each get a `HandoffPathLocationTests` class asserting the path resolves **inside the repo**, not under `~/.claude/projects/`, plus a guard that the `MEMORY_INDEX` auto-churn constant stays gone.

This is a **consistency** fix, not a transferability one: the handoff file stays gitignored (per-session, machine-local churn), so a teammate pulling the branch is unaffected. The committed 137-file corpus + `MEMORY.md` already transfer via the `CLAUDE.md` `@import`.

**Base = `main`** (not the wave branch): the #732 relocation commits (`bd68b8a`/`842a0fe`/`df9821a`) landed directly on `main`, so this completion belongs on the same base, and the fix must be live on `main` for the next session's auto-hook to behave.

## Related Issues

Closes #741

## Review Checklist

- [ ] Both hooks resolve the handoff under `.claude/memory/`, not `~/.claude/projects/`
- [ ] Dropping the tracked-`MEMORY.md` auto-rewrite is correct (avoids per-Stop churn on a version-controlled file; `/handoff` retains ownership of the index line)
- [ ] `_ENCODED_PROJECT` removal leaves no dangling references
- [ ] Regression tests lock the in-repo path in both test files
- [ ] Full local⇄CI parity green (ruff/mypy/pytest/pytest-skills/sync-drift)

Co-Authored-By: Aino Virtanen <parametrization+Aino.Virtanen@gmail.com>
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
