### PR TITLE
docs: org toolchain README (#748 D1)

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -23,6 +23,7 @@
     "ontology/**/*.md",
     "CLAUDE.md",
     "ONBOARDING.md",
+    "README.md",
     "docs/**/*.md"
   ],
   "ignorePaths": [

--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -153,3 +153,7 @@ ltrimstr
 wikilinks
 grype
 upsert
+
+# --- toolchain README (#748): contributor-facing tool/installer names ---
+corepack
+semgrep

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -86,6 +86,7 @@ jobs:
             ontology/**/*.md
             CLAUDE.md
             ONBOARDING.md
+            README.md
             docs/**/*.md
           incremental_files_only: false
           strict: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,7 +77,7 @@ repos:
       - id: cspell
         name: cspell
         args: ["--no-must-find-files", "--no-progress", "--no-summary", "--config", ".cspell.json"]
-        files: ^(\.claude/team/charter/.*\.md|\.claude/skills/.*\.md|ontology/.*\.md|CLAUDE\.md|ONBOARDING\.md|docs/.*\.md)$
+        files: ^(\.claude/team/charter/.*\.md|\.claude/skills/.*\.md|ontology/.*\.md|CLAUDE\.md|ONBOARDING\.md|README\.md|docs/.*\.md)$
 
   # Heavier checks run at pre-push (mirror CI's mypy + pytest jobs). Running as
   # `local`/`system` hooks so we use the system tools and don't drift from

--- a/README.md
+++ b/README.md
@@ -1,0 +1,113 @@
+# noorinalabs
+
+**NoorinALabs** is a platform for Islamic scholarly research, computational
+hadith analysis, and community tools. This repository — `noorinalabs-main` — is
+the org-level parent that orchestrates the child repos (isnad-graph,
+user-service, deploy, design-system, data-acquisition, isnad-ingest-platform,
+landing-page) and version-controls the shared team configuration, hooks, and
+ontology.
+
+For the full team/workflow model — roster, charter, wave process, commit
+identity, ontology, and project memory — see [`CLAUDE.md`](CLAUDE.md). This
+README covers only what a fresh clone needs to **install** before it can build,
+test, and pass the local hooks.
+
+## Toolchain / Prerequisites
+
+The repos share one toolchain. Install the tools below once; the per-repo
+`CLAUDE.md` files list which apply to each child repo. Pinned versions are the
+versions our pre-commit and CI enforce — match them so local "clean" equals CI
+"clean" (org-wide local⇄CI parity is mandatory; see
+[#684](https://github.com/noorinalabs/noorinalabs-main/issues/684)).
+
+After cloning, install the git hooks (both stages):
+
+```bash
+pre-commit install                          # commit-stage hooks (ruff)
+pre-commit install --hook-type pre-push     # push-stage hooks (mypy, pytest)
+```
+
+### Python
+
+The org `.claude/` hooks/lib/skills and the Python child repos (isnad-graph,
+user-service, data-acquisition, isnad-ingest-platform) use this set.
+
+| Tool | Purpose | Install |
+|------|---------|---------|
+| Python 3.x | runtime for hooks, lib, skills, and Python services | <https://www.python.org/downloads/> (or `pyenv install`) |
+| uv | fast Python package/venv manager + lockfiles | `curl -LsSf https://astral.sh/uv/install.sh \| sh` |
+| ruff `0.15.11` | Python lint + format (org-canonical pin) | `uv tool install ruff@0.15.11` (or via pre-commit) |
+| mypy | static type-check of hooks/lib and services | `uv tool install mypy` |
+| pytest | hook, lib, skill, and service test suites | `uv tool install pytest` (usually a project dev-dep) |
+| pip-audit | dependency vulnerability scan (isnad-graph, data-acquisition) | `uv tool install pip-audit` |
+
+> ruff is pinned to `0.15.11` org-wide so the same formatter runs locally and in
+> CI. Keep the `rev:` in each repo's `.pre-commit-config.yaml` aligned with it.
+
+### JavaScript / TypeScript
+
+The frontend and design-system repos (design-system, isnad-graph frontend,
+landing-page) use this set. These tools are declared in each repo's
+`package.json` — installing dependencies pulls the pinned versions in, so prefer
+the project install over global binaries.
+
+| Tool | Purpose | Install |
+|------|---------|---------|
+| Node.js (LTS) | JS/TS runtime | <https://nodejs.org/> (or `nvm install --lts`) |
+| npm | package manager / script runner | ships with Node.js |
+| pnpm | package manager (used where the repo declares it) | `corepack enable && corepack prepare pnpm@latest --activate` |
+| eslint | JS/TS lint | `npm install` (project dev-dep) |
+| prettier | JS/TS format | `npm install` (project dev-dep) |
+| typescript (`tsc`) | type-check / compile | `npm install` (project dev-dep) |
+| vitest | JS/TS unit tests (design-system, isnad-graph) | `npm install` (project dev-dep) |
+| vite | frontend bundler (isnad-graph, landing-page) | `npm install` (project dev-dep) |
+| astro | static-site generator (landing-page) | `npm install` (project dev-dep) |
+| playwright | E2E browser tests (isnad-graph) | `npm install && npx playwright install` |
+
+### Cross-cutting docs, lint, and security gates
+
+These run on every repo via pre-commit and the `docs.yml` / `ci.yml` workflows.
+Most are provisioned by pre-commit (which downloads pinned hook environments),
+so a local `pre-commit run` needs little manual install — the exception is
+`shellcheck`, which must be on `PATH` or `actionlint` silently skips its
+shell-lint integration.
+
+| Tool | Purpose | Install |
+|------|---------|---------|
+| pre-commit | local hook framework mirroring CI | `uv tool install pre-commit` (or `pipx install pre-commit`) |
+| actionlint `1.7.12` | GitHub Actions workflow lint | pinned pre-commit rev `v1.7.12`; standalone: download the [1.7.12 release binary](https://github.com/rhysd/actionlint/releases/tag/v1.7.12) |
+| shellcheck | shell lint (also actionlint's shell backend) | `apt install shellcheck` / `brew install shellcheck` |
+| gitleaks `8.24.3` | secret scanning | download the [8.24.3 release binary](https://github.com/gitleaks/gitleaks/releases/tag/v8.24.3) (or via the pinned pre-commit hook) |
+| cspell | docs/prose spellcheck | provisioned by pre-commit (`cspell-cli`); standalone: `npm install -g cspell` |
+| lychee | internal markdown link check | provisioned by CI; standalone: `cargo install lychee` or the [release binary](https://github.com/lycheeverse/lychee/releases) |
+| markdownlint | markdown structure lint | provisioned by the CI action; standalone: `npm install -g markdownlint-cli2` |
+
+> New domain vocabulary that trips cspell goes in
+> [`.cspell/project-words.txt`](.cspell/project-words.txt) — add the word, never
+> disable the gate.
+
+### Infrastructure
+
+The deploy repo and the containerized services use this set.
+
+| Tool | Purpose | Install |
+|------|---------|---------|
+| docker + compose | build/run service containers | <https://docs.docker.com/get-docker/> |
+| terraform | infrastructure-as-code (deploy) | <https://developer.hashicorp.com/terraform/install> |
+| trivy | container image vulnerability scan (deploy) | `brew install trivy` or the [release binary](https://github.com/aquasecurity/trivy/releases) |
+| cosign | container image signing (deploy) | `brew install cosign` or the [release binary](https://github.com/sigstore/cosign/releases) |
+
+### Note: the `sg` name collision
+
+On Linux, `command -v sg` resolves to `/usr/bin/sg` — that is **shadow-utils
+`sg`** (run a command with a different group ID), **not** ast-grep. The
+`ast-grep` binary ships an `sg` alias that collides with this. If we adopt
+ast-grep later, invoke it as **`ast-grep`** everywhere (hooks, docs, CI) — a
+script or hook that shells out to `sg ...` would silently run shadow-utils
+instead of the structural search tool.
+
+> Structural/AST tooling (ast-grep, yq, semgrep, and friends) is **proposed but
+> not yet adopted** — it is tracked as a follow-up in
+> [#748](https://github.com/noorinalabs/noorinalabs-main/issues/748). This
+> README documents only the tools the org already depends on; do not install the
+> proposed set on the strength of this file.


### PR DESCRIPTION
## Summary

Deliverable **D1** of #748: a contributor-facing toolchain doc so a fresh clone
knows what to install. No org-root README existed before — this is net-new.

- **`README.md`** (new) — short org overview that points to `CLAUDE.md` for the
  full team/workflow model (no duplication), then a `## Toolchain /
  Prerequisites` section documenting the tools the org **already** depends on,
  grouped: Python (uv/ruff/mypy/pytest/pip-audit), JS/TS
  (npm/pnpm/eslint/prettier/tsc/vitest/vite/astro/playwright), cross-cutting
  docs+lint+security (pre-commit/actionlint/shellcheck/gitleaks/cspell/lychee/markdownlint),
  and infra (docker/compose/terraform/trivy/cosign). Each tool has a one-line
  purpose + an install command; pins recorded where the repos pin them (ruff
  0.15.11, actionlint 1.7.12, gitleaks 8.24.3).
- The `### Note: the sg name collision` callout: `command -v sg` resolves to
  `/usr/bin/sg` (shadow-utils, run-with-group-id), **not** ast-grep — anyone
  adopting ast-grep later must invoke it as `ast-grep`.
- A one-line `pre-commit install && pre-commit install --hook-type pre-push`
  quickstart.

### Scope guard

Documents only tools we **already use**. The proposed structural tooling
(ast-grep/yq/semgrep/…) is explicitly called out as not-yet-adopted with a
pointer to #748 — that is follow-up D3, not this PR.

### Spell-gate wiring (so the new doc is genuinely covered)

`README.md` was added to the cspell `files` list in three places that must stay
in lockstep — `.cspell.json`, the `docs.yml` cspell step, and the pre-commit
cspell `files:` regex — so local pre-commit and CI both spellcheck it (local⇄CI
parity, #684). `corepack` and `semgrep` were added to
`.cspell/project-words.txt` — the only legitimate terms the gate flagged.

## Local verification (all green)

- cspell (v8.4.0, via `.cspell.json`) on README — clean
- markdownlint-cli2 — 0 errors
- actionlint on `docs.yml` — clean
- `pre-commit run --files` over all 5 changed files — cspell runs on README and
  Passes (not skipped)
- `pre_commit_ci_sync.py .` — OK, config mirrors all CI-enforced checks
- lychee not on PATH locally; the only relative links in README
  (`CLAUDE.md`, `.cspell/project-words.txt`) both exist; all other links are
  full external URLs (excluded by `.lychee.toml`)

## Reviewer brief

- **Requestee:** Aino Virtanen (author).
- **Reviewers:** to be assigned by the orchestrator (2 org-team reviewers per
  charter).
- This is a docs + lint-config change; no runtime code. Verify the toolchain
  table matches what the repos actually invoke, the pins are correct, and the
  `sg`-collision note is accurate.
- **Verdict-format reminder:** each reviewer's approval comment MUST carry the
  tech-debt accounting line (the `TechDebt` line) that the merge gate (Hook 4)
  requires — a verdict that omits it blocks merge wave-wide. Write `none` on
  that line if the PR introduces no tech debt; do not omit the line.

Part of #748 (deliverable D1). Does **not** close #748 — D2 (analysis, done in
the issue body), D3 (Tier-1 proof-of-pattern), and D4 (deploy ruff bump) remain.
