### PR TITLE
refactor(lib): structural yaml.safe_load parse for sync-drift gate (#748 D3)

### DIFF
--- a/.claude/lib/pre_commit_ci_sync.py
+++ b/.claude/lib/pre_commit_ci_sync.py
@@ -8,6 +8,29 @@ a PR is opened. This module is the drift GATE: it parses both sides into a set
 of canonical "check kinds" and reports any check CI enforces that the
 pre-commit config does NOT run locally.
 
+Structural YAML parse (#748 D3)
+===============================
+Both sides are parsed with ``yaml.safe_load`` and classified against the
+STRUCTURAL values that actually carry a check invocation — never raw lines,
+step ``name:`` text, or comments. Concretely:
+
+- CI workflow: only ``jobs[].steps[].run`` (the whole multi-line block scalar,
+  which ``safe_load`` folds for us — no hand-rolled ``run: |`` block emulation)
+  and ``jobs[].steps[].uses`` (action refs).
+- pre-commit config: only ``repos[].hooks[].id``, ``.entry`` and ``.name``.
+
+This deletes the previous line-scanner's false-positive class deterministically:
+a step *named* ``lint with ruff`` or a job *named* ``build-and-validate`` can no
+longer masquerade as a real ``ruff``/``build`` check, because names are never
+classified. A YAML comment cannot match either — the parser strips it.
+
+Robustness: on a YAML parse error, or a document that parses to a bare scalar,
+the classifier RAISES rather than returning an empty set. An empty set would be
+a silent false-green (the gate would report "no drift" for a file it could not
+read), which is the exact failure mode this gate exists to prevent. A genuinely
+empty/whitespace file (``safe_load`` -> ``None``) contributes nothing, which is
+correct — there is no check to mirror.
+
 Drift direction that matters
 ============================
 We gate on **CI-enforced-but-not-local** drift only. That is the harmful
@@ -33,53 +56,60 @@ understand. Closing a blind spot here means ADDING the kind to
 demanding a pre-commit mirror — an un-classified CI check is silently
 un-mirrored, which is the exact divergence this gate exists to prevent.
 
-Input Language
-==============
-- A pre-commit config is parsed for `id:` values AND `entry:`/`name:` text.
-- A CI workflow is parsed for `run:` shell lines AND `uses:` action refs.
-Both are matched against per-kind keyword patterns.
-
 Exit codes (CLI):
     0 — no harmful drift (every CI-enforced kind is mirrored in pre-commit)
     1 — harmful drift (a CI-enforced kind is missing from pre-commit)
-    2 — usage / file-not-found error
+    2 — usage / file-not-found / unparseable-config error
 """
 
 from __future__ import annotations
 
 import argparse
-import re
 import sys
 from pathlib import Path
+from typing import Any, Iterator
 
-# Each kind maps to the keyword patterns that identify it on EITHER side
-# (pre-commit id/entry text or CI run/uses text). Patterns are substrings
-# matched case-insensitively against the relevant lines.
+import yaml
+
+# Each kind maps to the keyword patterns that identify it in a STRUCTURAL value
+# (a pre-commit hook id/entry/name, or a CI step's run/uses string). Patterns
+# are substrings matched case-insensitively against that single value — they are
+# NOT raw-line fragments. So `ruff-lint` keys off the hook id VALUE `ruff` (or a
+# `ruff check` run), not the literal line `id: ruff`; `terraform-fmt` keys off
+# the id VALUE `terraform_fmt`/`terraform-fmt` (or a `terraform fmt` run), not
+# `id: terraform`.
 #
-# `build` matches only real build-QUALITY GATES — a job whose purpose is to
-# fail the PR if the project does not build/compile (`build-and-validate`,
+# `ruff-lint` is `("ruff",)` on purpose: structurally each value is ONE tool, so
+# the bare-`ruff` id (which carries no `-lint`/`check` suffix) must still map to
+# lint. A `ruff format` / `ruff-format` value would also contain `ruff`, so
+# `_classify_value` detects ruff-format FIRST and suppresses ruff-lint on that
+# value — preserving the format-before-lint ordering correctness without the old
+# span-removal hack.
+#
+# `build` matches only real build-QUALITY GATES — a step whose `run:`/`uses:`
+# fails the PR if the project does not build/compile (`build-and-validate`,
 # `build-and-test`, `npm run build`). It deliberately does NOT match bare
 # `docker build` / `docker buildx`: those are runtime image-MOVING (retag,
 # promote, publish to a registry, cold-rebuild dry-runs, digest resolution),
-# which is the deploy/publish job itself, not a quality gate a local
-# pre-commit hook could mirror. A bare `docker build` substring also matches
-# `docker buildx`, so a repo that uses buildx at runtime (deploy, the
-# image-publishing CI in isnad-graph / ingest-platform) would otherwise see a
-# permanent un-mirrorable `build` kind and the drift gate could never exit 0
-# (#576). If a repo ever adds a genuine docker-build-as-quality-gate, name
-# that job `build-and-validate` / `build-and-test` (or add an explicit
-# pattern) so it is mirror-tracked. Tightening lifted verbatim from the
+# which is the deploy/publish job itself, not a quality gate a local pre-commit
+# hook could mirror. A bare `docker build` substring also matches `docker
+# buildx`, so a repo that uses buildx at runtime (deploy, the image-publishing
+# CI in isnad-graph / ingest-platform) would otherwise see a permanent
+# un-mirrorable `build` kind and the drift gate could never exit 0 (#576). If a
+# repo ever adds a genuine docker-build-as-quality-gate, express it as a
+# `run:`/`uses:` matching `build-and-validate` / `build-and-test` (or add an
+# explicit pattern) so it is mirror-tracked. Tightening lifted verbatim from the
 # deploy-rollout form (deploy#391, A.Idrissi) and canonicalized here so all
 # vendored child copies converge.
 _KIND_PATTERNS: dict[str, tuple[str, ...]] = {
     "ruff-format": ("ruff-format", "ruff format"),
-    "ruff-lint": ("ruff check", "id: ruff", "- ruff"),
+    "ruff-lint": ("ruff",),
     "mypy": ("mypy",),
     "pytest": ("pytest",),
     "eslint": ("eslint",),
     "typescript": ("tsc", "typecheck", "type-check", "astro check"),
     "prettier": ("prettier",),
-    "terraform-fmt": ("terraform fmt", "terraform_fmt", "id: terraform"),
+    "terraform-fmt": ("terraform fmt", "terraform_fmt", "terraform-fmt"),
     "gitleaks": ("gitleaks",),
     "actionlint": ("actionlint",),
     "pip-audit": ("pip-audit", "pip audit"),
@@ -93,102 +123,147 @@ _KIND_PATTERNS: dict[str, tuple[str, ...]] = {
     "cspell": ("cspell", "spellcheck", "streetsidesoftware/cspell"),
 }
 
-# `ruff-lint` is a substring of nothing problematic, but `ruff format` also
-# contains `ruff`, so order the lint check to NOT fire on a format-only line.
-# We handle that by classifying format first and removing matched spans.
 
+def _classify_value(value: str) -> set[str]:
+    """Return the canonical kinds a single structural VALUE implies.
 
-def _classify_line(line: str) -> set[str]:
-    """Return the set of canonical kinds a single text line implies."""
-    low = line.lower()
+    A value is one tool now (an `id`, an `entry`, a `uses` ref, or one line of a
+    `run` script), so ruff disambiguation is a precise format-first check rather
+    than the old line-level span removal: a `ruff format` / `ruff-format` value
+    is ruff-format and is NOT also counted as ruff-lint.
+    """
+    low = value.lower()
     kinds: set[str] = set()
-    # Format must be tested before the bare-ruff lint pattern so that a
-    # `ruff format` line is not also counted as `ruff-lint`.
-    if any(p in low for p in _KIND_PATTERNS["ruff-format"]):
+    is_ruff_format = any(p in low for p in _KIND_PATTERNS["ruff-format"])
+    if is_ruff_format:
         kinds.add("ruff-format")
     for kind, patterns in _KIND_PATTERNS.items():
         if kind == "ruff-format":
             continue
-        if kind == "ruff-lint":
-            # Only count ruff-lint when it is not purely the format line.
-            if ("ruff format" in low) and ("ruff check" not in low and "id: ruff" not in low):
-                continue
+        if kind == "ruff-lint" and is_ruff_format:
+            # A ruff-format value (`ruff-format` id / `ruff format` run) must
+            # not also register ruff-lint via the bare `ruff` pattern.
+            continue
         if any(p in low for p in patterns):
             kinds.add(kind)
     return kinds
 
 
-def kinds_from_precommit(config_text: str) -> set[str]:
-    """Canonical check-kinds a `.pre-commit-config.yaml` runs locally."""
+def _classify_run(run: str) -> set[str]:
+    """Classify a (possibly multi-line) `run:` block scalar.
+
+    `safe_load` already folded `run: |` / `run: >` into one string, so we just
+    walk its lines, skipping blank and shell-comment (`#…`) lines so a commented
+    invocation is not mistaken for a real one.
+    """
     kinds: set[str] = set()
-    for raw in config_text.splitlines():
-        line = raw.strip()
-        if not line or line.startswith("#"):
+    for raw in run.splitlines():
+        stripped = raw.strip()
+        if not stripped or stripped.startswith("#"):
             continue
-        # Only lines that name a hook matter: id:, entry:, name:, - repo refs.
-        if re.match(r"^(-\s*)?(id|entry|name|repo):", line) or line.startswith("- "):
-            kinds |= _classify_line(line)
+        kinds |= _classify_value(stripped)
     return kinds
 
 
-# A `run:` (or `- run:`) key opening a YAML block scalar (`|`, `>`, plus the
-# chomping/indentation indicators `-`/`+`/digits, e.g. `|-`, `>2`). The body
-# of such a block is one or more MORE-indented continuation lines that carry
-# the actual shell — tools invoked there (`uv run pip-audit`, a multi-line
-# `ruff check` / `mypy` / `pytest`) must be classified too, else the gate has
-# a blind spot (#577).
-_RUN_BLOCK_OPEN_RE = re.compile(r"^(?P<indent>\s*)-?\s*run:\s*[|>][+\-0-9]*\s*$")
+def _safe_load_or_raise(text: str, what: str) -> Any:
+    """Parse YAML, refusing to degrade a parse failure into a false-green.
+
+    Returns the parsed document (``dict``/``list``), or ``None`` for a genuinely
+    empty document. Raises ``ValueError`` on a YAML syntax error or a document
+    that parses to a bare scalar — either would otherwise yield an empty kind-set
+    and silently hide drift.
+    """
+    try:
+        doc = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise ValueError(f"{what} is not valid YAML: {exc}") from exc
+    if doc is not None and not isinstance(doc, (dict, list)):
+        raise ValueError(
+            f"{what} did not parse to a YAML mapping/sequence "
+            f"(got {type(doc).__name__}); refusing to treat it as 'no checks'."
+        )
+    return doc
+
+
+def _iter_ci_steps(doc: Any) -> Iterator[dict[str, Any]]:
+    """Yield the step mappings of a parsed CI workflow.
+
+    Handles the full workflow shape (``jobs[].steps[]``) and the bare
+    step-list / single-step shapes used by focused unit tests. Only mappings are
+    yielded; ``run``/``uses`` are read off them by the caller.
+    """
+    if isinstance(doc, dict):
+        jobs = doc.get("jobs")
+        if isinstance(jobs, dict):
+            for job in jobs.values():
+                if isinstance(job, dict):
+                    steps = job.get("steps")
+                    if isinstance(steps, list):
+                        for step in steps:
+                            if isinstance(step, dict):
+                                yield step
+            return
+        steps = doc.get("steps")
+        if isinstance(steps, list):
+            for step in steps:
+                if isinstance(step, dict):
+                    yield step
+            return
+        if "run" in doc or "uses" in doc:
+            yield doc
+    elif isinstance(doc, list):
+        for step in doc:
+            if isinstance(step, dict):
+                yield step
 
 
 def kinds_from_ci(workflow_text: str) -> set[str]:
-    """Canonical check-kinds a CI workflow enforces.
+    """Canonical check-kinds a single CI workflow enforces.
 
-    Classifies the line that names a `run:`/`uses:` step AND — for a
-    multi-line `run: |` / `run: >` block scalar — every continuation line in
-    that block's body (#577). Without the block-scan a tool invoked only on a
-    continuation line (e.g. `security-audit`'s `uv run pip-audit` under
-    `run: |`) is invisible to the classifier, so the drift gate silently fails
-    to require it be mirrored. The block ends at the first line whose
-    indentation is less-than-or-equal-to the `run:` key's own indent (a
-    sibling key or list item), matching YAML block-scalar scoping.
+    Classifies ONLY each step's `run:` shell (whole block scalar) and `uses:`
+    action ref. Step/job `name:` and comments are never classified — that
+    exclusion is the #748 false-positive fix.
     """
+    doc = _safe_load_or_raise(workflow_text, "CI workflow")
+    if doc is None:
+        return set()
     kinds: set[str] = set()
-    run_block_indent: int | None = None
-    for raw in workflow_text.splitlines():
-        stripped = raw.strip()
+    for step in _iter_ci_steps(doc):
+        run = step.get("run")
+        if isinstance(run, str):
+            kinds |= _classify_run(run)
+        uses = step.get("uses")
+        if isinstance(uses, str):
+            kinds |= _classify_value(uses)
+    return kinds
 
-        # Inside a multi-line run: block — classify body lines until the block
-        # closes (dedent to <= the run: key indent). Blank lines stay in the
-        # block (YAML block scalars permit interior blank lines).
-        if run_block_indent is not None:
-            if stripped:
-                line_indent = len(raw) - len(raw.lstrip())
-                if line_indent <= run_block_indent:
-                    run_block_indent = None  # block ended; fall through to re-handle
-                else:
-                    if not stripped.startswith("#"):
-                        kinds |= _classify_line(stripped)
-                    continue
 
-        if not stripped or stripped.startswith("#"):
+def kinds_from_precommit(config_text: str) -> set[str]:
+    """Canonical check-kinds a `.pre-commit-config.yaml` runs locally.
+
+    Classifies ONLY each hook's `id`, `entry` and `name` values. Comments and
+    the surrounding YAML structure are never classified.
+    """
+    doc = _safe_load_or_raise(config_text, "pre-commit config")
+    if not isinstance(doc, dict):
+        return set()
+    kinds: set[str] = set()
+    repos = doc.get("repos")
+    if not isinstance(repos, list):
+        return kinds
+    for repo in repos:
+        if not isinstance(repo, dict):
             continue
-
-        # Open a run: block scalar? Record its key indent so the body scan
-        # above can scope the block. The `run:` key line itself carries no
-        # tool text (the `|`/`>` is the only payload), so nothing to classify.
-        block_match = _RUN_BLOCK_OPEN_RE.match(raw)
-        if block_match is not None:
-            run_block_indent = len(block_match.group("indent"))
+        hooks = repo.get("hooks")
+        if not isinstance(hooks, list):
             continue
-
-        # CI expresses checks as `run:` shell or `uses:` actions.
-        if (
-            "run:" in stripped
-            or stripped.startswith("- run:")
-            or "uses:" in stripped
-            or stripped.startswith("-")
-        ):
-            kinds |= _classify_line(stripped)
+        for hook in hooks:
+            if not isinstance(hook, dict):
+                continue
+            for key in ("id", "entry", "name"):
+                value = hook.get(key)
+                if isinstance(value, str):
+                    kinds |= _classify_value(value)
     return kinds
 
 
@@ -204,10 +279,19 @@ def compute_drift(precommit_kinds: set[str], ci_kinds: set[str]) -> tuple[set[st
 
 
 def check_repo(precommit_path: Path, ci_paths: list[Path]) -> tuple[set[str], set[str]]:
-    """Read the files and compute drift. Missing files contribute nothing."""
+    """Read the files and compute drift. Missing files contribute nothing.
+
+    Each CI workflow is parsed independently and the kinds unioned — workflow
+    files are separate YAML documents and must not be concatenated into one
+    parse (duplicate top-level keys would raise).
+    """
     pc_text = precommit_path.read_text(encoding="utf-8") if precommit_path.is_file() else ""
-    ci_text = "\n".join(p.read_text(encoding="utf-8") for p in ci_paths if p.is_file())
-    return compute_drift(kinds_from_precommit(pc_text), kinds_from_ci(ci_text))
+    pc_kinds = kinds_from_precommit(pc_text)
+    ci_kinds: set[str] = set()
+    for path in ci_paths:
+        if path.is_file():
+            ci_kinds |= kinds_from_ci(path.read_text(encoding="utf-8"))
+    return compute_drift(pc_kinds, ci_kinds)
 
 
 def _default_ci_paths(repo_root: Path) -> list[Path]:
@@ -253,7 +337,12 @@ def main(argv: list[str]) -> int:
         )
         return 2
 
-    harmful, stricter = check_repo(precommit_path, ci_paths)
+    try:
+        harmful, stricter = check_repo(precommit_path, ci_paths)
+    except ValueError as exc:
+        # Unparseable config: fail loudly (exit 2), never silently green.
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
 
     if stricter:
         print(f"INFO: pre-commit runs (CI does not): {sorted(stricter)} — stricter local, OK.")

--- a/.claude/lib/tests/test_pre_commit_ci_sync.py
+++ b/.claude/lib/tests/test_pre_commit_ci_sync.py
@@ -10,6 +10,7 @@ Verifies:
 
 from __future__ import annotations
 
+import re
 import sys
 import unittest
 from pathlib import Path
@@ -208,10 +209,14 @@ jobs:
         self.assertNotIn("build", kinds_from_ci("      - run: docker build -t img .\n"))
 
     def test_real_build_quality_gates_still_detected(self) -> None:
-        # The classifier inspects step lines (run:/uses:/`- ` list items), so
-        # the build-quality markers are exercised in those positions.
+        # Structural parse classifies ONLY a step's run:/uses: value, never its
+        # name: — so the build-quality markers are exercised in run position. (A
+        # build gate named purely via `- name: build-and-validate` with an
+        # unrelated run is intentionally NOT a `build` kind now; that name-only
+        # match was the false-positive class #748 removes — see
+        # FalsePositiveDemo below.)
         for line in (
-            "      - name: build-and-validate\n",
+            "      - run: ./scripts/build-and-validate.sh\n",
             "      - run: ./scripts/build-and-test.sh\n",
             "      - run: npm run build\n",
         ):
@@ -389,11 +394,338 @@ class RealParentRepoHasNoDrift(unittest.TestCase):
     def test_parent_ci_enforces_cspell(self) -> None:
         # Guard against the docs.yml cspell job being removed/renamed without the
         # mirror+kind being revisited: the kind must actually appear in CI.
+        # Workflows are independent YAML documents, so we union per-file kinds
+        # (structural parse cannot concatenate them into one parse — duplicate
+        # top-level keys would either raise or silently drop a document).
         wf_dir = _REPO_ROOT / ".github" / "workflows"
-        ci_text = "\n".join(
-            p.read_text(encoding="utf-8") for p in wf_dir.glob("*.y*ml") if p.is_file()
-        )
-        self.assertIn("cspell", kinds_from_ci(ci_text))
+        ci_kinds: set[str] = set()
+        for p in wf_dir.glob("*.y*ml"):
+            if p.is_file():
+                ci_kinds |= kinds_from_ci(p.read_text(encoding="utf-8"))
+        self.assertIn("cspell", ci_kinds)
+
+
+# ---------------------------------------------------------------------------
+# Reference copy of the OLD line-scanner (verbatim from main @ a7d7b2e), kept
+# ONLY so the #748 D3 tests can prove (a) byte-for-byte kind-set parity with the
+# pre-structural-parse classifier across real configs and (b) the precise
+# false-positive class the structural parse removes. Production code no longer
+# contains any of this; do not import it elsewhere.
+# ---------------------------------------------------------------------------
+_OLD_KIND_PATTERNS = {
+    "ruff-format": ("ruff-format", "ruff format"),
+    "ruff-lint": ("ruff check", "id: ruff", "- ruff"),
+    "mypy": ("mypy",),
+    "pytest": ("pytest",),
+    "eslint": ("eslint",),
+    "typescript": ("tsc", "typecheck", "type-check", "astro check"),
+    "prettier": ("prettier",),
+    "terraform-fmt": ("terraform fmt", "terraform_fmt", "id: terraform"),
+    "gitleaks": ("gitleaks",),
+    "actionlint": ("actionlint",),
+    "pip-audit": ("pip-audit", "pip audit"),
+    "build": ("build-and-validate", "build-and-test", "npm run build"),
+    "cspell": ("cspell", "spellcheck", "streetsidesoftware/cspell"),
+}
+_OLD_RUN_BLOCK_OPEN_RE = re.compile(r"^(?P<indent>\s*)-?\s*run:\s*[|>][+\-0-9]*\s*$")
+
+
+def _old_classify_line(line: str) -> set:
+    low = line.lower()
+    kinds: set = set()
+    if any(p in low for p in _OLD_KIND_PATTERNS["ruff-format"]):
+        kinds.add("ruff-format")
+    for kind, patterns in _OLD_KIND_PATTERNS.items():
+        if kind == "ruff-format":
+            continue
+        if kind == "ruff-lint":
+            if ("ruff format" in low) and ("ruff check" not in low and "id: ruff" not in low):
+                continue
+        if any(p in low for p in patterns):
+            kinds.add(kind)
+    return kinds
+
+
+def _old_kinds_from_precommit(text: str) -> set:
+    kinds: set = set()
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if re.match(r"^(-\s*)?(id|entry|name|repo):", line) or line.startswith("- "):
+            kinds |= _old_classify_line(line)
+    return kinds
+
+
+def _old_kinds_from_ci(text: str) -> set:
+    kinds: set = set()
+    run_block_indent = None
+    for raw in text.splitlines():
+        stripped = raw.strip()
+        if run_block_indent is not None:
+            if stripped:
+                line_indent = len(raw) - len(raw.lstrip())
+                if line_indent <= run_block_indent:
+                    run_block_indent = None
+                else:
+                    if not stripped.startswith("#"):
+                        kinds |= _old_classify_line(stripped)
+                    continue
+        if not stripped or stripped.startswith("#"):
+            continue
+        block_match = _OLD_RUN_BLOCK_OPEN_RE.match(raw)
+        if block_match is not None:
+            run_block_indent = len(block_match.group("indent"))
+            continue
+        if (
+            "run:" in stripped
+            or stripped.startswith("- run:")
+            or "uses:" in stripped
+            or stripped.startswith("-")
+        ):
+            kinds |= _old_classify_line(stripped)
+    return kinds
+
+
+# Documented expected per-repo kind-sets (#748 D3 parity proof). Authoritative
+# 8-repo OLD-vs-NEW comparison was run at PR time against the real configs in a
+# full parent checkout: the NEW structural classifier produces an IDENTICAL
+# (pre-commit, CI) kind-set to the OLD line-scanner for ALL 8 repos — no
+# divergence. The false-positive class the structural parse removes is therefore
+# LATENT: no real config exercises a step-name/comment false-match today (proven
+# directly by FalsePositiveDemo). These expectations encode that NEW==expected;
+# ParityAcrossRealConfigs additionally asserts OLD==NEW wherever the config is
+# present (the parent always; sibling child repos only in a full multi-repo
+# checkout — they are independent gitignored repos absent from this repo's CI
+# checkout, so each is skipped when not present rather than false-failing).
+_EXPECTED_KINDS = {
+    ".": {
+        "precommit": {"actionlint", "cspell", "mypy", "pytest", "ruff-format", "ruff-lint"},
+        "ci": {"actionlint", "cspell", "mypy", "pytest", "ruff-format", "ruff-lint"},
+    },
+    "noorinalabs-isnad-graph": {
+        "precommit": {
+            "actionlint",
+            "build",
+            "eslint",
+            "gitleaks",
+            "mypy",
+            "pip-audit",
+            "pytest",
+            "ruff-format",
+            "ruff-lint",
+            "typescript",
+        },
+        "ci": {
+            "actionlint",
+            "build",
+            "cspell",
+            "eslint",
+            "gitleaks",
+            "mypy",
+            "pip-audit",
+            "pytest",
+            "ruff-format",
+            "ruff-lint",
+            "typescript",
+        },
+    },
+    "noorinalabs-user-service": {
+        "precommit": {"actionlint", "mypy", "pytest", "ruff-format", "ruff-lint"},
+        "ci": {"actionlint", "cspell", "pytest", "ruff-format", "ruff-lint"},
+    },
+    "noorinalabs-deploy": {
+        "precommit": {
+            "actionlint",
+            "gitleaks",
+            "mypy",
+            "pytest",
+            "ruff-format",
+            "ruff-lint",
+            "terraform-fmt",
+        },
+        "ci": {
+            "actionlint",
+            "cspell",
+            "mypy",
+            "pytest",
+            "ruff-format",
+            "ruff-lint",
+            "terraform-fmt",
+        },
+    },
+    "noorinalabs-design-system": {
+        "precommit": {"actionlint", "build", "eslint", "gitleaks", "prettier", "typescript"},
+        "ci": {"actionlint", "build", "cspell", "typescript"},
+    },
+    "noorinalabs-data-acquisition": {
+        "precommit": {"actionlint", "gitleaks", "mypy", "pytest", "ruff-format", "ruff-lint"},
+        "ci": {"actionlint", "cspell", "mypy", "pytest", "ruff-format", "ruff-lint"},
+    },
+    "noorinalabs-isnad-ingest-platform": {
+        "precommit": {"actionlint", "mypy", "pytest", "ruff-format", "ruff-lint"},
+        "ci": {
+            "actionlint",
+            "cspell",
+            "mypy",
+            "pip-audit",
+            "pytest",
+            "ruff-format",
+            "ruff-lint",
+        },
+    },
+    "noorinalabs-landing-page": {
+        "precommit": {"build", "eslint", "gitleaks", "prettier", "typescript"},
+        "ci": {"build", "eslint", "prettier", "typescript"},
+    },
+}
+
+
+class ParityAcrossRealConfigs(unittest.TestCase):
+    """(#748 D3 deliverable c) The NEW structural classifier must produce the
+    documented kind-set for every real config, and must equal the OLD line
+    scanner on every config present — proving the refactor is behavior
+    preserving. The parent (`.`) is always present; sibling child repos are
+    independent gitignored repos and are skipped when absent (this repo's CI
+    checkout has none), so this test cannot false-fail in CI."""
+
+    def _present_roots(self):
+        # Child repos live beside the parent tree at <REPO_ROOT>/<repo>/. Present
+        # only in a full multi-repo checkout, never in this repo's CI checkout.
+        for repo, expected in _EXPECTED_KINDS.items():
+            root = _REPO_ROOT if repo == "." else _REPO_ROOT / repo
+            pc = root / ".pre-commit-config.yaml"
+            if pc.is_file():
+                yield repo, root, pc, expected
+
+    def test_new_matches_documented_expectations(self) -> None:
+        seen = []
+        for repo, root, pc, expected in self._present_roots():
+            seen.append(repo)
+            new_pc = kinds_from_precommit(pc.read_text(encoding="utf-8"))
+            new_ci: set = set()
+            wf_dir = root / ".github" / "workflows"
+            for w in sorted(wf_dir.glob("*.y*ml")):
+                new_ci |= kinds_from_ci(w.read_text(encoding="utf-8"))
+            with self.subTest(repo=repo):
+                self.assertEqual(new_pc, expected["precommit"], f"{repo} pre-commit kinds")
+                self.assertEqual(new_ci, expected["ci"], f"{repo} CI kinds")
+        self.assertIn(".", seen, "parent config must always be present and checked")
+
+    def test_new_equals_old_on_present_configs(self) -> None:
+        # Behavior-preservation: identical kind-sets to the retired line scanner
+        # on every config present (no divergence found across all 8 at PR time).
+        for repo, root, pc, _expected in self._present_roots():
+            pc_text = pc.read_text(encoding="utf-8")
+            wf_dir = root / ".github" / "workflows"
+            new_ci: set = set()
+            for w in sorted(wf_dir.glob("*.y*ml")):
+                new_ci |= kinds_from_ci(w.read_text(encoding="utf-8"))
+            # OLD scanner concatenated workflows into one scan (line-based, so
+            # duplicate keys were harmless); reproduce that to compare fairly.
+            old_ci_text = "\n".join(
+                w.read_text(encoding="utf-8") for w in sorted(wf_dir.glob("*.y*ml"))
+            )
+            with self.subTest(repo=repo):
+                self.assertEqual(
+                    kinds_from_precommit(pc_text),
+                    _old_kinds_from_precommit(pc_text),
+                    f"{repo} pre-commit: NEW must equal OLD",
+                )
+                self.assertEqual(
+                    new_ci,
+                    _old_kinds_from_ci(old_ci_text),
+                    f"{repo} CI: NEW must equal OLD",
+                )
+
+
+class FalsePositiveDemo(unittest.TestCase):
+    """(#748 D3 deliverable d) The defect the structural parse fixes: the OLD
+    line scanner classified a tool token appearing in a step `name:` or a YAML
+    `#` comment as a real check; the NEW parser inspects only `run:`/`uses:`
+    values, so it does not. These synthetic configs do not occur in any real
+    repo today (parity proves it), which is why the fix is latent — but they ARE
+    the class of false-positive the structural parse makes impossible."""
+
+    def test_tool_token_in_step_name_is_a_false_positive_old_not_new(self) -> None:
+        # A step NAMED after ruff, doing something unrelated. The classifier must
+        # key off run:, which here is not a ruff invocation.
+        wf = """
+jobs:
+  ci:
+    steps:
+      - name: run ruff check on the changed files
+        run: echo "this step only prints a message"
+"""
+        self.assertIn("ruff-lint", _old_kinds_from_ci(wf))  # OLD false-matches the name
+        self.assertNotIn("ruff-lint", kinds_from_ci(wf))  # NEW ignores name:
+
+    def test_build_token_in_step_name_is_a_false_positive_old_not_new(self) -> None:
+        wf = """
+jobs:
+  deploy:
+    steps:
+      - name: build-and-validate the rendered manifest
+        run: terraform validate
+"""
+        self.assertIn("build", _old_kinds_from_ci(wf))  # OLD false-matches the name
+        self.assertNotIn("build", kinds_from_ci(wf))  # NEW ignores name:
+
+    def test_tool_token_in_yaml_comment_is_a_false_positive_old_not_new(self) -> None:
+        # The `# ruff check ...` is a YAML comment: the parser strips it, so the
+        # run value is just `echo hi`. The OLD line scanner saw the raw line.
+        wf = """
+jobs:
+  ci:
+    steps:
+      - run: echo hi  # ruff check goes here once we wire it up
+"""
+        self.assertIn("ruff-lint", _old_kinds_from_ci(wf))  # OLD false-matches the comment
+        self.assertNotIn("ruff-lint", kinds_from_ci(wf))  # NEW: comment is gone after parse
+
+
+class RobustnessAgainstFalseGreen(unittest.TestCase):
+    """A parse failure or a non-structural document must FAIL LOUDLY, never
+    degrade into an empty kind-set (a silent false-green that hides drift)."""
+
+    def test_malformed_yaml_raises_not_empty(self) -> None:
+        bad = "jobs:\n  ci:\n    steps:\n      - run: x\n  : : bad\n"
+        with self.assertRaises(ValueError):
+            kinds_from_ci(bad)
+
+    def test_scalar_document_raises_not_empty(self) -> None:
+        # A workflow that parses to a bare scalar is malformed; refuse to call it
+        # "no checks".
+        with self.assertRaises(ValueError):
+            kinds_from_ci("just a string, not a mapping or list")
+
+    def test_empty_document_is_genuinely_empty(self) -> None:
+        # A truly empty/whitespace/comment-only file has no checks to mirror.
+        self.assertEqual(kinds_from_ci(""), set())
+        self.assertEqual(kinds_from_ci("\n  \n"), set())
+        self.assertEqual(kinds_from_precommit("# only a comment\n"), set())
+
+    def test_precommit_malformed_yaml_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            kinds_from_precommit("repos:\n  - repo: x\n   bad-indent: y\n")
+
+    def test_main_exits_2_on_unparseable_ci(self) -> None:
+        # End-to-end: the CLI must return 2 (error), not 0 (clean), when a
+        # workflow cannot be parsed — a false-green here would defeat the gate.
+        import tempfile
+
+        from pre_commit_ci_sync import main
+
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            (root / ".pre-commit-config.yaml").write_text(
+                "repos:\n  - repo: local\n    hooks:\n      - id: ruff\n",
+                encoding="utf-8",
+            )
+            wf_dir = root / ".github" / "workflows"
+            wf_dir.mkdir(parents=True)
+            (wf_dir / "ci.yml").write_text("this: is: not: valid: yaml:\n", encoding="utf-8")
+            self.assertEqual(main(["prog", str(root)]), 2)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,11 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: pip install mypy
+      # types-PyYAML: pre_commit_ci_sync.py imports `yaml` (PyYAML, #748 D3).
+      # PyYAML ships no inline types, so without the stubs mypy emits
+      # `import-untyped` — which `--ignore-missing-imports` does NOT suppress
+      # (it only silences `import-not-found`). Stubs keep this job green.
+      - run: pip install mypy types-PyYAML
       - run: mypy .claude/hooks/ .claude/lib/ --ignore-missing-imports --no-error-summary
       # .claude/skills/ added per #326. mypy is run PER-SKILL-DIRECTORY (not as
       # one flat tree) because two skills each ship a `tests/__init__.py`, which
@@ -107,7 +111,11 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: pip install pytest
+      # pyyaml: the .claude/lib test suite imports pre_commit_ci_sync, which now
+      # imports `yaml` (#748 D3). setup-python's interpreter has no PyYAML
+      # preinstalled, so declare it explicitly rather than relying on the
+      # ubuntu-runner system Python.
+      - run: pip install pytest pyyaml
       - name: Run hook and lib tests
         run: pytest .claude/hooks/tests/ .claude/lib/tests/ -q
       # .claude/skills/*/tests/ added per #326. Run PER-SKILL (each from its own
@@ -134,6 +142,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      # pyyaml: the gate now parses both sides structurally with `yaml.safe_load`
+      # (#748 D3). Declared explicitly — setup-python's interpreter has no PyYAML
+      # preinstalled, and the gate must not depend on the runner's system Python.
+      - run: pip install pyyaml
       - name: Verify pre-commit config mirrors CI-enforced checks (#327)
         # Fails if a check CI enforces (ruff/mypy/pytest/…) is missing from
         # .pre-commit-config.yaml, so local hooks can't silently drift behind CI.


### PR DESCRIPTION
Part of #748 (deliverable D3). Does **not** close #748 — the umbrella stays open for the remaining deliverables.

## What

Convert `.claude/lib/pre_commit_ci_sync.py` (the Pre-commit ⇄ CI sync-drift gate) from its hand-rolled YAML line-scanner to a **structural `yaml.safe_load` parse**, eliminating the step-name / comment false-match class deterministically.

- **CI side** classifies **only** `jobs[].steps[].run` (the whole folded block scalar — `safe_load` does the `run: |`/`>` folding, so the #577 `_RUN_BLOCK_OPEN_RE` hand-emulation is deleted) and `jobs[].steps[].uses`. Step `name:` and comments are **never** classified — that exclusion *is* the fix.
- **pre-commit side** classifies `repos[].hooks[].id`, `.entry`, `.name`.
- `_KIND_PATTERNS` re-expressed against **structural values** (e.g. `ruff-lint` keys off the id value `ruff`, not the literal line `id: ruff`; `terraform-fmt` off `terraform_fmt`/`terraform-fmt`, not `id: terraform`). The ruff-format-before-ruff-lint ordering is preserved with a precise per-value guard instead of the old span-removal hack.
- **Robustness:** a YAML parse error or a bare-scalar document now **raises** (CLI exit `2`) instead of degrading to an empty kind-set — no silent false-green. A genuinely empty file still contributes nothing.
- **Semantics preserved:** every kind including `cspell` (#684) and the `build` quality-gate-only tightening that must not match bare `docker build`/`buildx` (#576); `compute_drift` harmful-vs-stricter logic, CLI args, exit codes (0/1/2), missing-file behavior.

## Parity proof (deliverable c)

Ran an OLD-scanner vs NEW-structural comparison across **all 8 real configs** (parent + 7 children). The NEW classifier yields an **identical** `(pre-commit, CI)` kind-set to the retired line scanner for **every** repo — **zero divergence**. The false-positive class is therefore **latent**: no real config exercises a step-name/comment false-match today. `ParityAcrossRealConfigs` encodes the documented per-repo expectations and asserts `NEW == OLD == expected` wherever a config is present (the parent always; sibling child repos only in a full multi-repo checkout, skipped otherwise so CI can't false-fail).

## False-positive demo (deliverable d)

`FalsePositiveDemo` keeps a reference copy of the old line scanner and proves, for a tool token in a step `name:` and in a YAML `#` comment, that the OLD scanner classifies it (`ruff-lint`/`build`) while the NEW structural parser does not.

## Dependency wiring

- **Runtime:** `pyyaml` declared explicitly in the **precommit-ci-sync** job (it now parses YAML) **and** the **pytest** job (the test suite imports the module) — not relying on the ubuntu-runner preinstall.
- **Typecheck:** `types-PyYAML` added to the mypy CI job, since `--ignore-missing-imports` does **not** suppress `import-untyped`.

## Verification

`ruff format --check`, `ruff check`, `mypy`, full `pytest` (1557 passed), the sync gate itself (`OK`, exit 0), and `actionlint` all green locally; pre-commit + pre-push hooks passed on commit/push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BNK9q1SAds2ZmHQ88oLvxn
