### PR TITLE
docs(memory): capture GitHub negated close-keyword auto-close footgun (#748)

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -46,6 +46,7 @@
 - [actionlint needs shellcheck on PATH](feedback_actionlint_needs_shellcheck.md) — actionlint silently skips shellcheck if binary absent; local "clean" diverges from CI.
 - [Verify third-party integrity claims against source](feedback_verify_3p_integrity.md) — don't claim a downloader verifies SHA/GPG without grepping its source.
 - [Wave-branch merges don't auto-close issues](feedback_wave_branch_issue_close.md) — Closes #N only fires on default-branch merges; after wave-branch merge, manually close.
+- [Negated close-keyword still closes](feedback_github_negated_close_keyword.md) — "does not close #N" matches `close #N` substring → auto-closes on merge; use Part of/Re #N only, never close/fix/resolve adjacent.
 - [Review against artifact, not PR-body framing](feedback_review_against_artifact.md) — read diff/code at PR head via gh api contents, not PR body / commit msgs / line numbers.
 - [Full-read over tail for memory files](feedback_full_read_over_tail.md) — memory-file state-claims need full Read or grep -n, not tail; memory dir is outside repo.
 - [Run ruff format --check before pushing hook tests](feedback_ruff_format_check_before_push.md) — uvx ruff@<pin> format --check .claude/hooks/ pre-push catches what hooks-lint CI blocks.

--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -46,7 +46,7 @@
 - [actionlint needs shellcheck on PATH](feedback_actionlint_needs_shellcheck.md) — actionlint silently skips shellcheck if binary absent; local "clean" diverges from CI.
 - [Verify third-party integrity claims against source](feedback_verify_3p_integrity.md) — don't claim a downloader verifies SHA/GPG without grepping its source.
 - [Wave-branch merges don't auto-close issues](feedback_wave_branch_issue_close.md) — Closes #N only fires on default-branch merges; after wave-branch merge, manually close.
-- [Negated close-keyword still closes](feedback_github_negated_close_keyword.md) — "does not close #N" matches `close #N` substring → auto-closes on merge; use Part of/Re #N only, never close/fix/resolve adjacent.
+- [Negated close-keyword still closes](feedback_github_negated_close_keyword.md) — "does not close #N" still matches `close #N` → auto-closes on merge; use Part of/Re #N, not close/fix adjacent.
 - [Review against artifact, not PR-body framing](feedback_review_against_artifact.md) — read diff/code at PR head via gh api contents, not PR body / commit msgs / line numbers.
 - [Full-read over tail for memory files](feedback_full_read_over_tail.md) — memory-file state-claims need full Read or grep -n, not tail; memory dir is outside repo.
 - [Run ruff format --check before pushing hook tests](feedback_ruff_format_check_before_push.md) — uvx ruff@<pin> format --check .claude/hooks/ pre-push catches what hooks-lint CI blocks.

--- a/.claude/memory/feedback_github_negated_close_keyword.md
+++ b/.claude/memory/feedback_github_negated_close_keyword.md
@@ -1,0 +1,12 @@
+---
+name: feedback_github_negated_close_keyword
+description: GitHub's PR/commit closing-keyword parser ignores negation — "does not close #N" still closes #N on default-branch merge.
+metadata:
+  type: feedback
+---
+
+GitHub's auto-close parser matches `close|fix|resolve` (+ variants) immediately followed by `#N` **anywhere in a PR body or a commit/squash message**, and it does **NOT** understand negation. A PR body reading `Does **not** close #748` contains the substring `close #748` → GitHub closed #748 on squash-merge to the default branch. This bit **twice** in one session on #748 (PR #749 via a stray commit link, then PR #753 via the negation).
+
+**Why:** the parser is a dumb regex over `(keyword)\s+#?\d+`; "not", markdown bold, and surrounding prose are invisible to it. It fires only on **default-branch** merges (cf. [[feedback_wave_branch_issue_close]] — wave-branch merges don't auto-close at all).
+
+**How to apply:** for an umbrella/multi-deliverable issue you want to KEEP open while merging one deliverable, never place the word close/fix/resolve adjacent to that issue number in any PR body or commit/squash message — **even negated, even to disclaim it**. Use neutral refs only: `Part of #N`, `Re #N`, `relates to #N`, `deliverable D3 of #N`. If it auto-closes anyway, `gh issue reopen #N` and scrub the keyword. Pre-merge, grep the PR body + squash subject/body for `(close|fix|resolve)[sd]?\s+#N` before merging.


### PR DESCRIPTION
Captures the GitHub auto-close footgun that bit this issue **twice** in one session: GitHub's PR/commit closing-keyword parser matches the bare `close|fix|resolve #N` substring **even when negated**, so a PR body reading "Does not close #N" still closes #N on default-branch merge.

- New memory `feedback_github_negated_close_keyword.md` + `MEMORY.md` index line.
- Links `[[feedback_wave_branch_issue_close]]` (the adjacent rule: closing keywords only fire on default-branch merges at all).

Process hygiene follow-up surfaced while delivering D3. Re #748 — does not touch the umbrella's open deliverables (D2/D3b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
