### PR TITLE
feat(lib): MEMORY.md size/count-budget enforcement gate (#733)

### DIFF
--- a/.claude/lib/memory_budget.py
+++ b/.claude/lib/memory_budget.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Enforce a size/count budget on the project-memory corpus (#733, P6 W1).
+
+Second deliverable of P6 criterion #1 (memory leanness, epic #725): the
+*enforcement* half. After the corpus was consolidated (sibling audit issue),
+this check keeps it lean going forward — it caps how large the version-controlled
+memory corpus (``.claude/memory/MEMORY.md`` + the topic files beside it) may grow
+so that growth is a deliberate, surfaced decision rather than silent drift.
+
+Per the enforcement hierarchy (``feedback_enforcement_hierarchy.md`` — hook >
+skill > charter > memory), a budget expressed only as prose decays; it has to be
+machine-enforced. This module is that machine: a CLI that exits non-zero when the
+corpus is over budget, mirrored into ``.pre-commit-config.yaml`` and wired as a
+CI job (``Memory budget gate``) so local and CI agree (the full local⇄CI parity
+rule, ``feedback_local_ci_parity_no_force.md`` / #684).
+
+Three dimensions, one threshold each (single source of truth)
+=============================================================
+The budget is the three module constants below — the ONLY place a limit is
+defined. Each is enforced independently; the corpus is over budget if ANY one is
+exceeded.
+
+- ``MAX_INDEX_ENTRIES`` — index lines in ``MEMORY.md`` (``^- \\[`` rows, one per
+  recallable memory). This is the primary, most meaningful dimension: it counts
+  the things a session has to scan at startup.
+- ``MAX_MEMORY_FILES`` — topic ``*.md`` files in ``.claude/memory/`` excluding
+  ``MEMORY.md`` itself and the gitignored, machine-local ``session_handoff.md``
+  (see below). Roughly tracks the index-entry count and catches an orphaned
+  file that was added without an index row.
+- ``MAX_MEMORY_BYTES`` — byte size of ``MEMORY.md``. A backstop against the
+  pathological "few but enormous" index lines that the entry count alone would
+  not catch.
+
+Why the index count (102) and the file count (101) differ by one
+================================================================
+``MEMORY.md`` carries a committed pointer line for ``session_handoff.md``, but
+that file is gitignored (per-session machine-local churn — see ``.gitignore``)
+and is absent in a CI checkout. To keep the *file* count identical on a
+developer machine (where the handoff exists) and in CI (where it does not), the
+handoff is excluded from the file count. The index therefore legitimately counts
+one more (the committed handoff pointer line) than the file count. Both budgets
+have independent headroom, so the off-by-one is harmless.
+
+Threshold calibration (headroom rationale — owner directive 2026-06-19 "tighten")
+=================================================================================
+Measured against the *post-consolidation* corpus at #733 time:
+    index entries = 102,  topic files = 101,  MEMORY.md = 17,989 bytes (~17.6 KiB).
+
+    MAX_INDEX_ENTRIES = 120  → ~18 entries / ~18% headroom over 102.
+    MAX_MEMORY_FILES  = 120  → ~19 files   / ~19% headroom over 101.
+    MAX_MEMORY_BYTES  = 24576 (24 KiB)  → ~37% headroom over 17,989 bytes; sits
+        just under the ~24.4 KB ceiling a prior retro cited for MEMORY.md before
+        the consolidation (it had bloated to ~38 KB). The byte cap is the loosest
+        of the three on purpose — the entry/file caps bind first in the common
+        growth pattern (adding memories); the byte cap only catches the rare
+        case of fewer-but-bloated index lines.
+
+The headroom is deliberately modest: enough that a normal wave's memory intake
+does not trip the gate, but tight enough that it forces a consolidate/retire
+decision before the corpus drifts back toward its pre-audit bloat. Raising a cap
+is a one-line, reviewed change here — which is exactly the "deliberate, surfaced
+decision" #725 wants, rather than silent growth.
+
+Block, not advisory (``feedback_safety_direction_over_ux_friction.md``)
+=======================================================================
+A budget overflow CANNOT be auto-fixed — it needs a human consolidate/retire
+judgment about which memories to merge or drop. So the right posture is a HARD
+BLOCK with an actionable diagnostic (current vs. budget, by how much it is over,
+and that the fix is to consolidate/retire in ``.claude/memory/``), never a silent
+advisory that scrolls past. Exit 1 on overflow; the pre-commit/CI gate then stops
+the push.
+
+Exit codes (CLI):
+    0 — corpus is within budget on all three dimensions.
+    1 — over budget on at least one dimension (HARD BLOCK).
+    2 — usage / corpus directory or MEMORY.md not found (cannot evaluate).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import NamedTuple
+
+# --- Budget: the single source of truth. Edit a number here and nowhere else. ---
+MAX_INDEX_ENTRIES = 120
+MAX_MEMORY_FILES = 120
+MAX_MEMORY_BYTES = 24_576  # 24 KiB
+
+# Files under .claude/memory/ that are NOT counted as topic files: the index
+# itself, and the gitignored per-session handoff (absent in CI — see module
+# docstring). Compared case-sensitively against the file name.
+_NON_TOPIC_FILES = frozenset({"MEMORY.md", "session_handoff.md"})
+
+# An index entry is a top-level list row linking a memory: `- [Title](file.md) …`.
+_INDEX_ENTRY_RE = re.compile(r"^- \[")
+
+
+class Metric(NamedTuple):
+    """One budgeted dimension and its current reading."""
+
+    label: str  # human label, e.g. "index entries"
+    current: int
+    limit: int
+    unit: str  # "" for counts, "bytes" for the size metric
+
+    @property
+    def over(self) -> bool:
+        return self.current > self.limit
+
+    @property
+    def overage(self) -> int:
+        return max(0, self.current - self.limit)
+
+
+def count_index_entries(memory_md: Path) -> int:
+    """Count `- [...]` index rows in MEMORY.md."""
+    text = memory_md.read_text(encoding="utf-8")
+    return sum(1 for line in text.splitlines() if _INDEX_ENTRY_RE.match(line))
+
+
+def count_memory_files(memory_dir: Path) -> int:
+    """Count topic `*.md` files in the memory dir, excluding non-topic files."""
+    return sum(1 for p in memory_dir.glob("*.md") if p.name not in _NON_TOPIC_FILES)
+
+
+def memory_md_bytes(memory_md: Path) -> int:
+    """Byte size of MEMORY.md on disk."""
+    return memory_md.stat().st_size
+
+
+def gather_metrics(memory_dir: Path) -> list[Metric]:
+    """Read the corpus and return the three budgeted metrics.
+
+    Raises FileNotFoundError if the memory dir or MEMORY.md is absent — the
+    caller turns that into exit 2 (cannot evaluate), never a silent pass.
+    """
+    if not memory_dir.is_dir():
+        raise FileNotFoundError(f"memory directory not found: {memory_dir}")
+    memory_md = memory_dir / "MEMORY.md"
+    if not memory_md.is_file():
+        raise FileNotFoundError(f"MEMORY.md not found: {memory_md}")
+    return [
+        Metric("index entries", count_index_entries(memory_md), MAX_INDEX_ENTRIES, ""),
+        Metric("memory files", count_memory_files(memory_dir), MAX_MEMORY_FILES, ""),
+        Metric("MEMORY.md size", memory_md_bytes(memory_md), MAX_MEMORY_BYTES, "bytes"),
+    ]
+
+
+def _fmt(metric: Metric) -> str:
+    unit = f" {metric.unit}" if metric.unit else ""
+    status = f"OVER by {metric.overage}{unit}" if metric.over else "ok"
+    return f"  {metric.label:<14}: {metric.current} / {metric.limit}{unit}  ({status})"
+
+
+def format_report(metrics: list[Metric]) -> str:
+    """Render the metric table; identical shape whether over or under budget."""
+    return "\n".join(_fmt(m) for m in metrics)
+
+
+def over_budget_message(metrics: list[Metric]) -> str:
+    """The HARD-BLOCK diagnostic printed when over budget."""
+    over = [m for m in metrics if m.over]
+    dims = ", ".join(m.label for m in over)
+    return (
+        "MEMORY BUDGET EXCEEDED — the project-memory corpus is over budget "
+        f"on: {dims}.\n\n"
+        f"{format_report(metrics)}\n\n"
+        "A budget overflow cannot be auto-fixed: it needs a human "
+        "consolidate/retire decision about which memories to merge or drop.\n"
+        "To get back under budget, CONSOLIDATE related entries or RETIRE stale "
+        "ones under .claude/memory/ (delete the file AND its line in MEMORY.md), "
+        "then re-run.\n"
+        "See CLAUDE.md § Project Memory and the /wave-retro memory curation step. "
+        "If the corpus has genuinely outgrown the budget, raise the cap "
+        "deliberately in .claude/lib/memory_budget.py (one reviewed line) — that "
+        "is the surfaced decision this gate exists to force."
+    )
+
+
+def evaluate(memory_dir: Path) -> int:
+    """Evaluate the corpus and print a report. Return the process exit code."""
+    metrics = gather_metrics(memory_dir)
+    if any(m.over for m in metrics):
+        print(over_budget_message(metrics), file=sys.stderr)
+        return 1
+    print("OK: project-memory corpus is within budget.")
+    print(format_report(metrics))
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "repo_root",
+        nargs="?",
+        default=".",
+        help="Repo root to check (default: cwd). The corpus is <repo_root>/.claude/memory.",
+    )
+    parser.add_argument(
+        "--memory-dir",
+        help="Path to the memory dir directly (overrides <repo_root>/.claude/memory).",
+    )
+    args = parser.parse_args(argv[1:])
+
+    memory_dir = (
+        Path(args.memory_dir)
+        if args.memory_dir
+        else Path(args.repo_root).resolve() / ".claude" / "memory"
+    )
+
+    try:
+        return evaluate(memory_dir)
+    except FileNotFoundError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.claude/lib/pre_commit_ci_sync.py
+++ b/.claude/lib/pre_commit_ci_sync.py
@@ -121,6 +121,13 @@ _KIND_PATTERNS: dict[str, tuple[str, ...]] = {
     # domain vocabulary then failed only after push. Patterns cover the action
     # ref, the bundled-CLI step name, and the generic job/step word.
     "cspell": ("cspell", "spellcheck", "streetsidesoftware/cspell"),
+    # `memory-budget` is the project-memory corpus size/count gate
+    # (`.claude/lib/memory_budget.py`, #733). Classifying it makes the drift gate
+    # actively DEMAND the local⇄CI mirror (#684): a `memory_budget.py` CI run
+    # with no pre-commit hook is harmful drift, not a silently-ignored unknown.
+    # Patterns cover the hook `id`/`name` token (`memory-budget`) and the CI
+    # `run` invocation token (`memory_budget`).
+    "memory-budget": ("memory-budget", "memory_budget"),
 }
 
 

--- a/.claude/lib/tests/test_memory_budget.py
+++ b/.claude/lib/tests/test_memory_budget.py
@@ -1,0 +1,182 @@
+"""Tests for memory_budget -- the project-memory corpus size/count budget (#733).
+
+Verifies:
+  1. Under budget on all three dimensions -> exit 0, "within budget".
+  2. Exactly AT each cap -> exit 0 (the cap is inclusive; at-limit is allowed).
+  3. One-over on EACH dimension independently -> exit 1, names that dimension.
+  4. The over-budget diagnostic is a HARD BLOCK with actionable content
+     (current/limit, "OVER by N", consolidate/retire guidance).
+  5. session_handoff.md and MEMORY.md are excluded from the file count.
+  6. Missing memory dir / missing MEMORY.md -> exit 2 (cannot evaluate).
+  7. The budget lives in ONE place: the three module constants drive the caps.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import memory_budget  # noqa: E402
+from memory_budget import (  # noqa: E402
+    MAX_INDEX_ENTRIES,
+    MAX_MEMORY_BYTES,
+    MAX_MEMORY_FILES,
+    count_index_entries,
+    count_memory_files,
+    evaluate,
+    gather_metrics,
+    main,
+)
+
+
+def _build_corpus(
+    root: Path,
+    *,
+    entries: int,
+    files: int,
+    extra_md_bytes: int = 0,
+    include_handoff: bool = False,
+) -> Path:
+    """Create a .claude/memory corpus with the requested shape; return its dir.
+
+    `entries` index rows are written to MEMORY.md; `files` topic *.md files are
+    created beside it. `extra_md_bytes` pads MEMORY.md to exercise the byte cap.
+    `include_handoff` adds the gitignored session_handoff.md (must NOT count).
+    """
+    memory_dir = root / ".claude" / "memory"
+    memory_dir.mkdir(parents=True)
+
+    lines = [f"- [Entry {i}](topic_{i}.md) — hook line {i}." for i in range(entries)]
+    body = "\n".join(lines) + ("\n" if lines else "")
+    if extra_md_bytes > 0:
+        body += "x" * extra_md_bytes
+    (memory_dir / "MEMORY.md").write_text(body, encoding="utf-8")
+
+    for i in range(files):
+        (memory_dir / f"topic_{i}.md").write_text(f"topic {i}\n", encoding="utf-8")
+    if include_handoff:
+        (memory_dir / "session_handoff.md").write_text("handoff\n", encoding="utf-8")
+    return memory_dir
+
+
+class CountingTests(unittest.TestCase):
+    def test_index_entries_count_only_list_link_rows(self) -> None:
+        with TemporaryDirectory() as d:
+            md = Path(d) / "MEMORY.md"
+            md.write_text(
+                "# heading (not an entry)\n"
+                "- [A](a.md) — x\n"
+                "- [B](b.md) — y\n"
+                "  - nested (not top-level)\n"
+                "plain line\n",
+                encoding="utf-8",
+            )
+            self.assertEqual(count_index_entries(md), 2)
+
+    def test_file_count_excludes_memory_md_and_handoff(self) -> None:
+        with TemporaryDirectory() as d:
+            memory_dir = _build_corpus(Path(d), entries=3, files=3, include_handoff=True)
+            # 3 topic files; MEMORY.md and session_handoff.md must NOT count.
+            self.assertEqual(count_memory_files(memory_dir), 3)
+
+
+class UnderAndAtBudgetTests(unittest.TestCase):
+    def test_well_under_budget_exits_zero(self) -> None:
+        with TemporaryDirectory() as d:
+            memory_dir = _build_corpus(Path(d), entries=10, files=10)
+            self.assertEqual(evaluate(memory_dir), 0)
+
+    def test_exactly_at_caps_is_allowed(self) -> None:
+        # At-limit on entries AND files simultaneously; size left well under.
+        with TemporaryDirectory() as d:
+            memory_dir = _build_corpus(Path(d), entries=MAX_INDEX_ENTRIES, files=MAX_MEMORY_FILES)
+            metrics = gather_metrics(memory_dir)
+            by_label = {m.label: m for m in metrics}
+            self.assertEqual(by_label["index entries"].current, MAX_INDEX_ENTRIES)
+            self.assertFalse(by_label["index entries"].over)
+            self.assertFalse(by_label["memory files"].over)
+            self.assertEqual(evaluate(memory_dir), 0)
+
+
+class OverBudgetTests(unittest.TestCase):
+    def test_one_over_entries_blocks(self) -> None:
+        with TemporaryDirectory() as d:
+            # Push files down so ONLY the entry dimension is over.
+            memory_dir = _build_corpus(Path(d), entries=MAX_INDEX_ENTRIES + 1, files=5)
+            self.assertEqual(evaluate(memory_dir), 1)
+
+    def test_one_over_files_blocks(self) -> None:
+        with TemporaryDirectory() as d:
+            # Keep entries low so ONLY the file dimension is over.
+            memory_dir = _build_corpus(Path(d), entries=5, files=MAX_MEMORY_FILES + 1)
+            self.assertEqual(evaluate(memory_dir), 1)
+
+    def test_one_over_bytes_blocks(self) -> None:
+        with TemporaryDirectory() as d:
+            # Few entries/files, but pad MEMORY.md past the byte cap.
+            memory_dir = _build_corpus(
+                Path(d), entries=3, files=3, extra_md_bytes=MAX_MEMORY_BYTES + 1
+            )
+            metrics = gather_metrics(memory_dir)
+            size = next(m for m in metrics if m.label == "MEMORY.md size")
+            self.assertTrue(size.over)
+            self.assertEqual(evaluate(memory_dir), 1)
+
+    def test_over_budget_diagnostic_is_actionable(self) -> None:
+        with TemporaryDirectory() as d:
+            memory_dir = _build_corpus(Path(d), entries=MAX_INDEX_ENTRIES + 3, files=5)
+            metrics = gather_metrics(memory_dir)
+            msg = memory_budget.over_budget_message(metrics)
+            self.assertIn("MEMORY BUDGET EXCEEDED", msg)
+            self.assertIn("index entries", msg)
+            self.assertIn("OVER by 3", msg)
+            self.assertIn(str(MAX_INDEX_ENTRIES), msg)
+            # Must tell the human the fix is consolidate/retire, not auto-fixable.
+            self.assertIn("cannot be auto-fixed", msg)
+            self.assertIn("CONSOLIDATE", msg)
+            self.assertIn("RETIRE", msg)
+
+
+class CliAndErrorTests(unittest.TestCase):
+    def test_main_repo_root_arg_resolves_corpus(self) -> None:
+        with TemporaryDirectory() as d:
+            _build_corpus(Path(d), entries=4, files=4)
+            self.assertEqual(main(["memory_budget.py", d]), 0)
+
+    def test_main_memory_dir_override(self) -> None:
+        with TemporaryDirectory() as d:
+            memory_dir = _build_corpus(Path(d), entries=4, files=4)
+            self.assertEqual(main(["memory_budget.py", "--memory-dir", str(memory_dir)]), 0)
+
+    def test_missing_memory_dir_exits_two(self) -> None:
+        with TemporaryDirectory() as d:
+            # No .claude/memory created.
+            self.assertEqual(main(["memory_budget.py", d]), 2)
+
+    def test_missing_memory_md_exits_two(self) -> None:
+        with TemporaryDirectory() as d:
+            memory_dir = Path(d) / ".claude" / "memory"
+            memory_dir.mkdir(parents=True)
+            (memory_dir / "topic_0.md").write_text("x\n", encoding="utf-8")
+            self.assertEqual(main(["memory_budget.py", d]), 2)
+
+
+class RealCorpusWithinBudgetTests(unittest.TestCase):
+    """The check must PASS on the very corpus that ships it — i.e. the caps sit
+    above the current consolidated size with headroom (else the gate red-blocks
+    the PR adding it)."""
+
+    def test_parent_memory_corpus_is_within_budget(self) -> None:
+        repo_root = Path(__file__).resolve().parents[3]
+        memory_dir = repo_root / ".claude" / "memory"
+        if not (memory_dir / "MEMORY.md").is_file():
+            self.skipTest("parent memory corpus not present in this checkout")
+        self.assertEqual(evaluate(memory_dir), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/lib/tests/test_pre_commit_ci_sync.py
+++ b/.claude/lib/tests/test_pre_commit_ci_sync.py
@@ -426,6 +426,9 @@ _OLD_KIND_PATTERNS = {
     "pip-audit": ("pip-audit", "pip audit"),
     "build": ("build-and-validate", "build-and-test", "npm run build"),
     "cspell": ("cspell", "spellcheck", "streetsidesoftware/cspell"),
+    # Kept in lock-step with the production _KIND_PATTERNS so the OLD-vs-NEW
+    # parity proof stays valid as new kinds are added (cf. memory-budget, #733).
+    "memory-budget": ("memory-budget", "memory_budget"),
 }
 _OLD_RUN_BLOCK_OPEN_RE = re.compile(r"^(?P<indent>\s*)-?\s*run:\s*[|>][+\-0-9]*\s*$")
 
@@ -500,8 +503,24 @@ def _old_kinds_from_ci(text: str) -> set:
 # checkout, so each is skipped when not present rather than false-failing).
 _EXPECTED_KINDS = {
     ".": {
-        "precommit": {"actionlint", "cspell", "mypy", "pytest", "ruff-format", "ruff-lint"},
-        "ci": {"actionlint", "cspell", "mypy", "pytest", "ruff-format", "ruff-lint"},
+        "precommit": {
+            "actionlint",
+            "cspell",
+            "memory-budget",
+            "mypy",
+            "pytest",
+            "ruff-format",
+            "ruff-lint",
+        },
+        "ci": {
+            "actionlint",
+            "cspell",
+            "memory-budget",
+            "mypy",
+            "pytest",
+            "ruff-format",
+            "ruff-lint",
+        },
     },
     "noorinalabs-isnad-graph": {
         "precommit": {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
       - ".claude/hooks/**"
       - ".claude/lib/**"
       - ".claude/skills/**"
+      # The memory-budget gate (#733) caps the project-memory corpus, so a
+      # change that only touches memory must still run CI to enforce it.
+      - ".claude/memory/**"
       - ".github/workflows/ci.yml"
       - ".pre-commit-config.yaml"
       - "pyproject.toml"
@@ -16,6 +19,7 @@ on:
       - ".claude/hooks/**"
       - ".claude/lib/**"
       - ".claude/skills/**"
+      - ".claude/memory/**"
       - ".github/workflows/ci.yml"
       - ".pre-commit-config.yaml"
       - "pyproject.toml"
@@ -150,3 +154,17 @@ jobs:
         # Fails if a check CI enforces (ruff/mypy/pytest/…) is missing from
         # .pre-commit-config.yaml, so local hooks can't silently drift behind CI.
         run: python3 .claude/lib/pre_commit_ci_sync.py .
+
+  memory-budget:
+    name: Memory budget gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Enforce the project-memory corpus size/count budget (#733)
+        # HARD-BLOCKS if MEMORY.md index entries / memory-file count / MEMORY.md
+        # byte size exceed the budget in memory_budget.py. Mirrored locally by the
+        # `memory-budget` pre-push hook; the sync-drift gate classifies the kind.
+        run: python3 .claude/lib/memory_budget.py .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -114,3 +114,18 @@ repos:
         pass_filenames: false
         always_run: true
         stages: [pre-push]
+      # memory-budget mirrors the `Memory budget gate` CI job in ci.yml (the
+      # sync-drift gate classifies the `memory-budget` kind — #733/#684 — so a
+      # CI-enforced budget not mirrored here turns the gate red, same contract as
+      # mypy/pytest above). HARD-BLOCKS a commit/push that grows the project
+      # memory corpus past its size/count budget (a budget overflow can't be
+      # auto-fixed — it needs a human consolidate/retire decision). `always_run`
+      # because the budget is over the whole corpus, not the changed files; this
+      # is a project-level check so it lives at pre-push alongside mypy/pytest.
+      - id: memory-budget
+        name: memory-budget (pre-push)
+        entry: python3 .claude/lib/memory_budget.py .
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-push]


### PR DESCRIPTION
## Summary

Enforcement half of **P6 W1 / criterion #1** (memory leanness, epic #725): a machine-enforced budget on the version-controlled project-memory corpus, so growth is a deliberate, surfaced decision rather than silent drift. Per the enforcement hierarchy, a budget expressed only as prose decays — it has to be a gate.

`Closes #733`

## What it does

`.claude/lib/memory_budget.py` (stdlib-only) caps three dimensions, with the budget defined in **one place** (three module constants):

| Dimension | Current (post-audit) | Cap | Headroom |
|---|---|---|---|
| `MEMORY.md` index entries (`^- \[` rows) | 102 | **120** | ~18% |
| memory `*.md` files (excl. `MEMORY.md` + gitignored `session_handoff.md`) | 101 | **120** | ~19% |
| `MEMORY.md` byte size | 17,989 | **24,576 (24 KiB)** | ~37% |

The byte cap is the loosest on purpose (the count caps bind first in the common growth pattern; bytes is a backstop against few-but-bloated lines) and sits just under the ~24.4 KB ceiling a prior retro cited. Headroom is deliberately modest per the owner "tighten" directive — enough that a normal wave's intake doesn't trip it, tight enough to force a consolidate/retire decision before the corpus drifts back toward its pre-audit bloat.

## Block, not advisory

A budget overflow **cannot** be auto-fixed (it needs a human consolidate/retire judgment), so it **HARD-BLOCKS** (exit 1) with an actionable diagnostic — current vs. budget, by how much it's over, and that the fix is to consolidate/retire under `.claude/memory/`. Exit 2 when the corpus can't be evaluated; exit 0 within budget. (`feedback_safety_direction_over_ux_friction`.)

## Local⇄CI parity (#684)

- Mirrored into `.pre-commit-config.yaml` as the `memory-budget` pre-push hook.
- Wired as a CI job (`Memory budget gate`) in `ci.yml`; added `.claude/memory/**` to the trigger paths so a memory-only change still runs the gate.
- Classified the `memory-budget` kind in `pre_commit_ci_sync.py` so the sync-drift gate **actively demands** the mirror (an un-mirrored CI budget job is harmful drift, not a silently-ignored unknown). Frozen OLD-reference patterns + `_EXPECTED_KINDS["."]` kept in lock-step (cspell precedent) so the OLD↔NEW parity proof stays valid. `python3 .claude/lib/pre_commit_ci_sync.py .` → **0 drift**.

## Tests

`.claude/lib/tests/test_memory_budget.py` covers under/at/over budget on each dimension, exit codes, diagnostic content, the file-count exclusions, and a guard that the **real shipped corpus is within budget**. Full hooks+lib suite: 1570 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BNK9q1SAds2ZmHQ88oLvxn
