### PR TITLE
refactor(hooks): bashlex AST shell-parse for commit-identity (#748 D3b)

### DIFF
--- a/.claude/hooks/_shell_parse.py
+++ b/.claude/hooks/_shell_parse.py
@@ -39,6 +39,31 @@ Public API
         inside quotes), strips leading `KEY=value` env-var assignments from
         each segment, and yields the surviving tokens.
 
+    iter_command_segments_ast(command) -> list[list[str]] | None
+        Structural (bashlex) alternative to tokenize + iter_command_segments:
+        parses `command` into a real Bash AST and returns every
+        command-position token segment, walking `&&`/`;`/`||` lists, `|`
+        pipelines, `$(...)`/backtick command substitutions, and compound
+        bodies. Each segment is the command's word tokens (env-var
+        AssignmentNode prefixes excluded) in the SAME shape the shlex path
+        emits — so `find_git_subcommand` / `extract_dash_c_pairs` consume AST
+        segments unchanged. Returns None when bashlex is unavailable (degraded
+        mode) OR the command fails to parse; callers MUST fall back to the
+        shlex/regex path and must never treat None as "allow" for a
+        security-relevant matcher. A real grammar removes the regex/shlex
+        confusion between a command-position `git commit` and the literal
+        phrase inside a heredoc body, a quoted arg, or a `--body` value — the
+        root of the #118/#134/#144/#188/#189/#216/#223/#226/#227 bug trail
+        (#748 D3b).
+
+    bashlex_available() -> bool
+        True iff the optional `bashlex` dependency imported successfully at
+        module load. The commit-identity hook checks this to decide whether
+        the structural path is active or it must warn + run in degraded
+        regex-fallback mode. bashlex is the ENFORCED parser in CI + pre-commit
+        (where the dependency is declared); a bare checkout without it still
+        works via the shlex/regex fallback (zero-setup-on-pull is preserved).
+
     find_git_subcommand(segment) -> tuple[list[str], list[str]] | None
         Given a single segment's tokens, returns (global_opts, [subcommand,
         ...rest]) if it's a `git ...` invocation, else None. Skips git
@@ -155,6 +180,23 @@ import shlex
 import subprocess
 from typing import Iterator
 
+# Optional structural dependency (#748 D3b). bashlex gives a real Bash-AST
+# parse for the commit-identity matcher. It is imported defensively so a
+# freshly-pulled checkout's hooks keep working with ZERO install step (the same
+# zero-setup-on-pull guarantee as the git-transferable memory) — if bashlex is
+# absent the parser silently degrades to the shlex/regex path and the consuming
+# hook surfaces a single stderr warning. bashlex.* missing stubs are handled by
+# the `[[tool.mypy.overrides]]` entry in pyproject.toml.
+try:
+    import bashlex
+    from bashlex import ast as bashlex_ast
+
+    _BASHLEX_AVAILABLE = True
+except ImportError:  # pragma: no cover - degraded mode is exercised via monkeypatch
+    bashlex = None
+    bashlex_ast = None
+    _BASHLEX_AVAILABLE = False
+
 # Shell control tokens that segment a compound command. Any of these,
 # appearing as their OWN token after shlex.split, separates one pipeline
 # segment from the next.
@@ -252,6 +294,65 @@ def _strip_leading_env_assignments(segment: list[str]) -> list[str]:
     while i < len(segment) and _ENV_ASSIGN_RE.match(segment[i]):
         i += 1
     return segment[i:]
+
+
+def bashlex_available() -> bool:
+    """True iff the optional bashlex Bash-AST parser imported successfully.
+
+    Read at call time so tests can monkeypatch `_BASHLEX_AVAILABLE` to simulate
+    a bare checkout. The commit-identity hook uses this to decide between the
+    structural (bashlex) parse and the shlex/regex degraded fallback.
+    """
+    return _BASHLEX_AVAILABLE
+
+
+def iter_command_segments_ast(command: str) -> list[list[str]] | None:
+    """Structural (bashlex) extraction of command-position token segments.
+
+    Parses `command` into a real Bash AST and walks every CommandNode —
+    descending through `&&`/`;`/`||` lists, `|` pipelines, `$(...)`/backtick
+    command substitutions, and compound (`{ }`, `( )`, if/while/for) bodies.
+    Each yielded segment is the command's WordNode values in source order;
+    `KEY=value` env-var prefixes arrive as AssignmentNodes and are naturally
+    excluded because only `word`-kind parts are collected — matching the
+    leading-env-strip behaviour of the shlex-based `iter_command_segments`.
+
+    Token shape is identical to the shlex path: `-c user.name="A B"` yields
+    `["-c", "user.name=A B"]`, so the existing `find_git_subcommand` /
+    `extract_dash_c_pairs` consumers work unchanged on AST segments.
+
+    Returns:
+      list[list[str]] — the segments (an empty list when the input parsed but
+                        held no command, e.g. a bare comment).
+      None            — bashlex is unavailable (degraded mode) OR the command
+                        failed to parse. The caller MUST fall back to the
+                        shlex/regex path; per the tokenize() security contract
+                        a None here is NEVER treated as "allow".
+    """
+    if not _BASHLEX_AVAILABLE:
+        return None
+    try:
+        trees = bashlex.parse(command)
+    except Exception:
+        # Any bashlex failure — unbalanced quotes, an unsupported construct,
+        # etc. — signals the caller to fall back. Fallback is always safe, so a
+        # broad catch matches the resilience posture of `tokenize` returning
+        # None on a parse error (never crash the hook).
+        return None
+
+    segments: list[list[str]] = []
+
+    class _SegmentCollector(bashlex_ast.nodevisitor):
+        def visitcommand(self, n, parts):
+            tokens = [p.word for p in parts if p.kind == "word"]
+            if tokens:
+                segments.append(tokens)
+            return True  # keep descending into command substitutions, compounds, ...
+
+    collector = _SegmentCollector()
+    for tree in trees:
+        collector.visit(tree)
+    return segments
 
 
 def _is_equals_form_global(tok: str) -> bool:

--- a/.claude/hooks/fixtures/validate_commit_identity/ast_chain_missing_identity_blocks.json
+++ b/.claude/hooks/fixtures/validate_commit_identity/ast_chain_missing_identity_blocks.json
@@ -1,0 +1,5 @@
+{
+  "description": "AST/#748 D3b negative: a bare `git commit` (no -c identity) as the second command in an && chain must still be blocked in both modes",
+  "command": "git status && git commit -m \"no identity flags in a chain\"",
+  "expect": "block:missing user.name"
+}

--- a/.claude/hooks/fixtures/validate_commit_identity/ast_command_sub_in_message_valid.json
+++ b/.claude/hooks/fixtures/validate_commit_identity/ast_command_sub_in_message_valid.json
@@ -1,0 +1,5 @@
+{
+  "description": "AST/#748 D3b: valid identity commit whose -m message contains a $(...) command substitution — the outer git commit is validated, the inner command is irrelevant (allow in both AST and shlex-fallback modes)",
+  "command": "git -c user.name=\"Aino Virtanen\" -c user.email=\"parametrization+Aino.Virtanen@gmail.com\" commit -m \"$(echo done)\"",
+  "expect": "allow"
+}

--- a/.claude/hooks/fixtures/validate_commit_identity/ast_env_prefix_and_chain_valid.json
+++ b/.claude/hooks/fixtures/validate_commit_identity/ast_env_prefix_and_chain_valid.json
@@ -1,0 +1,5 @@
+{
+  "description": "AST/#748 D3b: env-var prefix (GIT_PAGER=cat) on a valid-identity commit inside an && chain — the env assignment must be stripped (AssignmentNode in AST; leading KEY=val in shlex) and the commit allowed",
+  "command": "cd /repo && GIT_PAGER=cat git -c user.name=\"Aino Virtanen\" -c user.email=\"parametrization+Aino.Virtanen@gmail.com\" commit -m \"env prefixed\"",
+  "expect": "allow"
+}

--- a/.claude/hooks/fixtures/validate_commit_identity/ast_nested_double_quotes_valid.json
+++ b/.claude/hooks/fixtures/validate_commit_identity/ast_nested_double_quotes_valid.json
@@ -1,0 +1,5 @@
+{
+  "description": "AST/#748 D3b: valid-identity commit whose -m message contains escaped nested double quotes — quoting must be parsed correctly and the commit allowed in both modes",
+  "command": "git -c user.name=\"Aino Virtanen\" -c user.email=\"parametrization+Aino.Virtanen@gmail.com\" commit -m \"fix: handle \\\"quoted\\\" path segment\"",
+  "expect": "allow"
+}

--- a/.claude/hooks/fixtures/validate_commit_identity/ast_pipe_chain_valid.json
+++ b/.claude/hooks/fixtures/validate_commit_identity/ast_pipe_chain_valid.json
@@ -1,0 +1,5 @@
+{
+  "description": "AST/#748 D3b: valid-identity commit piped into another command — the commit is in the first pipeline segment and must be allowed (both modes split on |)",
+  "command": "git -c user.name=\"Aino Virtanen\" -c user.email=\"parametrization+Aino.Virtanen@gmail.com\" commit -m \"piped\" | cat",
+  "expect": "allow"
+}

--- a/.claude/hooks/fixtures/validate_commit_identity/ast_semicolon_chain_valid.json
+++ b/.claude/hooks/fixtures/validate_commit_identity/ast_semicolon_chain_valid.json
@@ -1,0 +1,5 @@
+{
+  "description": "AST/#748 D3b: a `;`-separated chain where the second command is a valid-identity commit — must be allowed (both modes split on ;)",
+  "command": "git status ; git -c user.name=\"Aino Virtanen\" -c user.email=\"parametrization+Aino.Virtanen@gmail.com\" commit -m \"after status\"",
+  "expect": "allow"
+}

--- a/.claude/hooks/tests/test_validate_commit_identity_ast.py
+++ b/.claude/hooks/tests/test_validate_commit_identity_ast.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""bashlex Bash-AST parse path for validate_commit_identity (#748 D3b).
+
+Splits into three concerns:
+
+1. AST extraction (`_shell_parse.iter_command_segments_ast`) — structural
+   segment extraction across quoting, backslash continuation, `$(...)`,
+   `&&`/`;`/`|` chains, and env-var prefixes. These assert the AST path
+   specifically, so they are skipped when bashlex is not installed.
+
+2. AST-superiority over the shlex fallback — a `git commit` hidden inside a
+   `$(...)` command substitution is a REAL invocation the shlex path cannot see
+   (the substitution is one quoted token) but the AST surfaces. Skipped without
+   bashlex.
+
+3. Degraded-mode safety (ALWAYS runs) — with bashlex forced unavailable (or its
+   parse forced to fail), the hook must not crash and must return the SAME
+   verdict via the shlex/regex fallback.
+
+Run: ENVIRONMENT=test python3 -m pytest \
+        .claude/hooks/tests/test_validate_commit_identity_ast.py -v
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+from unittest import mock
+
+_HERE = Path(__file__).resolve().parent
+_HOOKS_DIR = _HERE.parent
+sys.path.insert(0, str(_HOOKS_DIR))
+
+import _shell_parse as sp  # noqa: E402
+import validate_commit_identity as hook  # noqa: E402
+
+_AINO = "Aino Virtanen"
+_AINO_EMAIL = "parametrization+Aino.Virtanen@gmail.com"
+_VALID = f'git -c user.name="{_AINO}" -c user.email="{_AINO_EMAIL}"'
+
+
+def _input(command: str) -> dict:
+    return {"tool_name": "Bash", "tool_input": {"command": command}}
+
+
+def _find_git_commit(segments: list[list[str]]) -> list[str] | None:
+    """Return the first `git ... commit ...` segment from AST output, else None."""
+    for segment in segments:
+        decoded = sp.find_git_subcommand(segment)
+        if decoded is None:
+            continue
+        _globals, rest = decoded
+        if rest and rest[0] == "commit":
+            return segment
+    return None
+
+
+@unittest.skipUnless(sp.bashlex_available(), "bashlex not installed — AST path inactive")
+class AstExtractionTests(unittest.TestCase):
+    """`iter_command_segments_ast` structural extraction (bashlex present)."""
+
+    def test_quoted_value_kept_whole(self):
+        segs = sp.iter_command_segments_ast(f'{_VALID} commit -m "multi word msg"')
+        self.assertIsNotNone(segs)
+        commit = _find_git_commit(segs)
+        self.assertIsNotNone(commit)
+        self.assertIn("user.name=Aino Virtanen", commit)
+        self.assertIn("multi word msg", commit)
+
+    def test_backslash_line_continuation(self):
+        """#287: backslash-newline continuation resolves to one git commit."""
+        cmd = (
+            f'git -c user.name="{_AINO}" \\\n'
+            f'    -c user.email="{_AINO_EMAIL}" \\\n'
+            f'    commit -m "continued"'
+        )
+        segs = sp.iter_command_segments_ast(cmd)
+        self.assertIsNotNone(segs)
+        self.assertIsNotNone(_find_git_commit(segs))
+
+    def test_env_prefix_stripped(self):
+        """A leading KEY=value AssignmentNode is excluded from the segment."""
+        segs = sp.iter_command_segments_ast(f"FOO=bar {_VALID} commit -m x")
+        self.assertIsNotNone(segs)
+        commit = _find_git_commit(segs)
+        self.assertIsNotNone(commit)
+        self.assertEqual(commit[0], "git")
+        self.assertNotIn("FOO=bar", commit)
+
+    def test_chains_and_pipes_split(self):
+        for cmd in (
+            f"{_VALID} commit -m a ; ls",
+            f"{_VALID} commit -m a && ls",
+            f"{_VALID} commit -m a | cat",
+        ):
+            with self.subTest(cmd=cmd):
+                segs = sp.iter_command_segments_ast(cmd)
+                self.assertIsNotNone(segs)
+                self.assertIsNotNone(_find_git_commit(segs))
+
+    def test_heredoc_body_is_not_a_command(self):
+        """`cat <<EOF ... git commit ... EOF` — body is data, not a command."""
+        cmd = "cat <<EOF\ngit commit -m sneaky\nEOF"
+        segs = sp.iter_command_segments_ast(cmd)
+        self.assertIsNotNone(segs)
+        self.assertIsNone(_find_git_commit(segs))
+
+    def test_commit_in_branch_name_not_a_subcommand(self):
+        cmd = "git worktree add /tmp/wt -b feature/commit-identity origin/main"
+        segs = sp.iter_command_segments_ast(cmd)
+        self.assertIsNotNone(segs)
+        self.assertIsNone(_find_git_commit(segs))
+
+    def test_parse_error_returns_none(self):
+        """Unbalanced quote → None so the caller falls back."""
+        self.assertIsNone(sp.iter_command_segments_ast('git commit -m "unbalanced'))
+
+
+@unittest.skipUnless(sp.bashlex_available(), "bashlex not installed — AST path inactive")
+class AstSupersedesShlexTests(unittest.TestCase):
+    """Cases the AST handles that the shlex fallback cannot."""
+
+    def test_command_sub_with_valid_identity_allowed(self):
+        result = hook.check(_input(f'{_VALID} commit -m "$(echo done)"'))
+        self.assertIsNone(result)
+
+    def test_commit_hidden_in_substitution_is_blocked(self):
+        """A real `git commit` inside $(...) is surfaced by the AST and blocked.
+
+        The shlex fallback keeps the whole `$(...)` as one quoted token and so
+        cannot see this commit — this is the AST-superiority case, hence the
+        skipUnless guard.
+        """
+        result = hook.check(_input('echo "$(git commit -m sneaky)"'))
+        self.assertIsNotNone(result)
+        assert result is not None  # for mypy
+        self.assertEqual(result.get("decision"), "block")
+
+
+class DegradedModeTests(unittest.TestCase):
+    """bashlex forced unavailable — fallback must give the same verdict, no crash.
+
+    Always runs (independent of whether bashlex is actually installed) by
+    monkeypatching `_shell_parse._BASHLEX_AVAILABLE`, since both
+    `bashlex_available()` and `iter_command_segments_ast()` read that module
+    global at call time.
+    """
+
+    def setUp(self):
+        # Reset the once-per-process warning latch so the warning test is
+        # deterministic regardless of test ordering.
+        hook._DEGRADED_WARNED = False
+
+    def test_valid_commit_allowed_in_degraded_mode(self):
+        with mock.patch.object(sp, "_BASHLEX_AVAILABLE", False):
+            with redirect_stderr(io.StringIO()):
+                result = hook.check(_input(f'{_VALID} commit -m "fallback ok"'))
+        self.assertIsNone(result)
+
+    def test_missing_identity_blocked_in_degraded_mode(self):
+        with mock.patch.object(sp, "_BASHLEX_AVAILABLE", False):
+            with redirect_stderr(io.StringIO()):
+                result = hook.check(_input('git commit -m "no identity"'))
+        self.assertIsNotNone(result)
+        assert result is not None  # for mypy
+        self.assertEqual(result.get("decision"), "block")
+
+    def test_degraded_mode_emits_single_warning(self):
+        with mock.patch.object(sp, "_BASHLEX_AVAILABLE", False):
+            buf = io.StringIO()
+            with redirect_stderr(buf):
+                hook.check(_input(f'{_VALID} commit -m "one"'))
+                hook.check(_input(f'{_VALID} commit -m "two"'))
+            stderr = buf.getvalue()
+        self.assertEqual(stderr.count("degraded regex mode"), 1, stderr)
+        self.assertIn("bashlex not installed", stderr)
+
+    def test_no_crash_on_messy_command_in_degraded_mode(self):
+        """A heredoc-in-$() shape must not crash the fallback path."""
+        cmd = f"{_VALID} commit -m \"$(cat <<'EOF'\nmulti\nline\nEOF\n)\""
+        with mock.patch.object(sp, "_BASHLEX_AVAILABLE", False):
+            with redirect_stderr(io.StringIO()):
+                result = hook.check(_input(cmd))
+        self.assertIsNone(result)
+
+
+class BashlexParseFailureFallthroughTests(unittest.TestCase):
+    """bashlex present but its parse returns None → fall through to shlex path."""
+
+    def test_parse_failure_falls_through_to_shlex(self):
+        # Patch the name in the HOOK module namespace (it `from _shell_parse
+        # import iter_command_segments_ast`s a bound reference), not in sp.
+        with mock.patch.object(hook, "iter_command_segments_ast", return_value=None):
+            # bashlex_available() stays True, so no degraded warning; the hook
+            # must still validate via the shlex tokenizer.
+            valid = hook.check(_input(f'{_VALID} commit -m "shlex path"'))
+            self.assertIsNone(valid)
+            blocked = hook.check(_input('git commit -m "no id"'))
+            self.assertIsNotNone(blocked)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/hooks/validate_commit_identity.py
+++ b/.claude/hooks/validate_commit_identity.py
@@ -70,6 +70,20 @@ Substring-bug history fixed by tokenization:
     #188 — nested $(cat <<'EOF' ... EOF) no longer mangles the parser
     Both root in regex-against-raw-string parsing; switched to shlex tokens.
 
+Structural Bash-AST parse (#748 D3b):
+    The direct `git commit` detector now prefers a real Bash AST parse via
+    bashlex (`_shell_parse.iter_command_segments_ast`) over the shlex
+    tokenizer. A true grammar distinguishes a command-position `git commit`
+    from the literal phrase inside a heredoc body / quoted arg / `--body`
+    value, and surfaces commits hidden inside `$(...)` substitutions — closing
+    the long regex/shlex bug trail #118/#134/#144/#188/#189/#216/#223/#226/
+    #227. bashlex is an OPTIONAL dependency: when it is absent (a bare
+    zero-setup checkout) the hook prints one stderr warning and falls back to
+    the existing shlex/regex path, so a freshly-pulled checkout's hooks keep
+    working with no install step. The indirect-exec bypass layer below is
+    unchanged — bashlex does not re-parse a shell's own `-c '...'` string arg,
+    so those wrappers are still caught by the regex detectors that run first.
+
 Exit codes:
   0 — allow (not a git commit, or identity is valid)
   2 — block (missing or invalid identity flags, OR indirect-exec wrapper
@@ -85,14 +99,40 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _shell_parse import (  # noqa: E402
+    bashlex_available,
     extract_dash_c_pairs,
     find_git_subcommand,
     iter_command_segments,
+    iter_command_segments_ast,
     resolve_tool_cwd,
     strip_heredocs,
     tokenize,
 )
 from annunaki_log import log_pretooluse_block  # noqa: E402
+
+# Emitted at most once per process when bashlex is unavailable so the degraded
+# parse mode is visible rather than silent. Each PreToolUse invocation is its
+# own short-lived process, so this is effectively once per checked command.
+_DEGRADED_WARNED = False
+
+
+def _warn_degraded_mode_once() -> None:
+    """Print a single concise stderr warning that the structural parse is off.
+
+    bashlex is the enforced parser in CI + pre-commit (where the dependency is
+    declared); on a bare checkout without it the hook still validates identity
+    via the shlex/regex fallback, but we surface that a parser-correctness gap
+    exists rather than letting it pass silently.
+    """
+    global _DEGRADED_WARNED
+    if _DEGRADED_WARNED:
+        return
+    _DEGRADED_WARNED = True
+    print(
+        "warning: bashlex not installed — shell-identity check running in degraded "
+        "regex mode (install bashlex for structural Bash-AST parsing).",
+        file=sys.stderr,
+    )
 
 
 def _read_roster(roster_path: Path) -> dict[str, str]:
@@ -423,9 +463,34 @@ def _find_commit_segment(command: str) -> list[str] | None | object:
       - _PARSE_FAILURE — tokenize failed (unbalanced quotes); caller must use
                          regex fallback
 
-    Strips heredocs first so a heredoc body containing the literal phrase
-    "git commit" cannot be confused with a real invocation.
+    Resolution order (#748 D3b):
+      1. Structural bashlex AST parse — a real grammar treats a heredoc body
+         as redirect data (not commands), keeps quoted args as data, and
+         surfaces commits hidden in `$(...)` substitutions. When bashlex parses
+         the command we trust its result completely (including "no commit
+         found" → allow).
+      2. bashlex unavailable (degraded mode) → warn once, fall through.
+      3. bashlex present but parse failed → fall through.
+      4. shlex tokenize + segment split (the prior path). Strips heredocs first
+         so a heredoc body containing the literal phrase "git commit" cannot be
+         confused with a real invocation.
+      5. shlex parse failure → _PARSE_FAILURE (caller's regex fail-closed path).
     """
+    if bashlex_available():
+        ast_segments = iter_command_segments_ast(command)
+        if ast_segments is not None:
+            for segment in ast_segments:
+                decoded = find_git_subcommand(segment)
+                if decoded is None:
+                    continue
+                _globals, rest = decoded
+                if rest and rest[0] == "commit":
+                    return segment
+            return None
+        # bashlex present but could not parse → fall through to shlex/regex.
+    else:
+        _warn_degraded_mode_once()
+
     cleaned = strip_heredocs(command)
     tokens = tokenize(cleaned)
     if tokens is None:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,10 @@ jobs:
       # PyYAML ships no inline types, so without the stubs mypy emits
       # `import-untyped` — which `--ignore-missing-imports` does NOT suppress
       # (it only silences `import-not-found`). Stubs keep this job green.
-      - run: pip install mypy types-PyYAML
+      # bashlex (#748 D3b): the commit-identity hooks import it for the Bash-AST
+      # parse. Installed here so mypy resolves the real module; its missing
+      # stubs are handled by the `bashlex.*` override in pyproject.toml.
+      - run: pip install mypy types-PyYAML bashlex
       - run: mypy .claude/hooks/ .claude/lib/ --ignore-missing-imports --no-error-summary
       # .claude/skills/ added per #326. mypy is run PER-SKILL-DIRECTORY (not as
       # one flat tree) because two skills each ship a `tests/__init__.py`, which
@@ -119,7 +122,10 @@ jobs:
       # imports `yaml` (#748 D3). setup-python's interpreter has no PyYAML
       # preinstalled, so declare it explicitly rather than relying on the
       # ubuntu-runner system Python.
-      - run: pip install pytest pyyaml
+      # bashlex (#748 D3b): required so the commit-identity tests exercise the
+      # ENFORCED structural Bash-AST parse path (the bashlex-specific cases
+      # skip when it is absent; this install makes CI run them, not skip them).
+      - run: pip install pytest pyyaml bashlex
       - name: Run hook and lib tests
         run: pytest .claude/hooks/tests/ .claude/lib/tests/ -q
       # .claude/skills/*/tests/ added per #326. Run PER-SKILL (each from its own

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,17 @@
 #     the commit loop snappy while still catching everything before it leaves
 #     the machine.
 #
+# Optional hook dependency — bashlex (#748 D3b): the commit-identity hooks
+# import bashlex for a structural Bash-AST parse, falling back to a shlex/regex
+# path when it is absent (runtime zero-setup-on-pull is preserved). The
+# mypy/pytest hooks below are `language: system`, so `additional_dependencies`
+# does NOT apply to them — install bashlex into the same system Python that runs
+# mypy/pytest (`pip install bashlex`) so local pre-push exercises the SAME
+# enforced AST path CI does. Without it, the bashlex-specific tests skip and
+# pre-push validates only the fallback path (still green, but not the enforced
+# path). bashlex is NOT a new sync-gate check kind — it is a library dependency
+# of an existing hook, so .pre-commit-config ⇄ CI kind parity is unaffected.
+#
 # Scope: `.claude/hooks/` + `.claude/lib/` + `.claude/skills/` — the Python that
 # CI checks (CI runs ruff/mypy/pytest on all three; the pre_commit_ci_sync gate
 # enforces this mirror). `.claude/skills/` was added per #326 (criterion #5 —

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,3 +13,18 @@ select = ["E", "F", "W", "I"]
 
 [tool.ruff.lint.isort]
 known-first-party = []
+
+[tool.mypy]
+# Intentionally minimal — the CI/pre-commit invocations still pass their own
+# CLI flags (--ignore-missing-imports --no-error-summary). This section exists
+# only to host the per-module override below.
+
+[[tool.mypy.overrides]]
+# bashlex (the Bash-AST shell parser the commit-identity hooks use, #748 D3b)
+# ships no type stubs. `--ignore-missing-imports` silences import-not-found
+# (degraded / uninstalled) but NOT import-untyped (installed-but-untyped — the
+# CI typecheck job installs bashlex, so mypy would otherwise emit import-untyped
+# there; same situation the ci.yml comment documents for PyYAML). This
+# per-module override suppresses both, keeping mypy green in either mode.
+module = "bashlex.*"
+ignore_missing_imports = true


### PR DESCRIPTION
## Summary

Replaces the regex/line-scan shell parsing in the commit-identity matcher with a real Bash AST parse via the **bashlex** library, closing the long bug trail #118/#134/#144/#188/#189/#216/#223/#226/#227 (mis-handled quoting, line-continuations, command substitution, chaining).

Part of noorinalabs/noorinalabs-main#748 (D3b — structural-vs-regex tooling).

## What changed

- **`_shell_parse.py`** — new `iter_command_segments_ast(command)` walks the bashlex AST to extract every command-position token segment across `&&`/`;`/`||` lists, `|` pipelines, `$(...)`/backtick substitutions, and compound bodies. Env-var `AssignmentNode` prefixes are excluded. Token shape is **identical** to the shlex path (`-c user.name="A B"` → `["-c", "user.name=A B"]`), so `find_git_subcommand` / `extract_dash_c_pairs` consume AST segments unchanged. Plus `bashlex_available()`.
- **`validate_commit_identity.py`** — `_find_commit_segment()` now prefers the AST parse. A heredoc body is treated as redirect data natively (no `strip_heredocs` needed on that path), and a `git commit` hidden inside `$(...)` is now surfaced and validated.

## Regex fallback kept + degraded-mode tested

bashlex is imported in a `try/except ImportError`. **Zero-setup-on-pull is preserved**: when bashlex is absent, the hook prints **one** concise stderr warning (`bashlex not installed — shell-identity check running in degraded regex mode`) and falls back to the existing shlex/regex path, never crashing. The indirect-exec bypass layer (`bash -c '...'`, `eval`, heredoc-to-shell, etc.) is **unchanged** — bashlex does not re-parse a shell's own `-c` string arg, so those wrappers are still caught by the regex detectors that run first.

Degraded mode is tested by monkeypatching `_BASHLEX_AVAILABLE` to `False` (and separately forcing the AST parse to return `None`): the hook does not crash, returns the **same verdict** via fallback, and warns exactly once.

## Enforced-path dependency declaration

- **`.github/workflows/ci.yml`** — `pip install bashlex` added to the **typecheck** and **pytest** jobs. The bashlex AST path is the enforced one in CI; the bashlex-specific tests run there (not skip).
- **`pyproject.toml`** — `[[tool.mypy.overrides]] module = "bashlex.*"` `ignore_missing_imports = true`. bashlex ships no stubs, and `--ignore-missing-imports` silences `import-not-found` but **not** `import-untyped` (the installed-but-untyped case in CI) — the same situation the ci.yml comment documents for PyYAML.
- **`.pre-commit-config.yaml`** — header note: the code-importing hooks (mypy/pytest) are `language: system`, so `additional_dependencies` does **not** apply to them; the dependency is declared via CI and a system-Python install instruction so local pre-push exercises the same AST path.

## mypy handling of missing stubs

Via the `bashlex.*` per-module override in `pyproject.toml` (config override preferred over inline `# type: ignore`, and robust in both installed/uninstalled modes). `mypy .claude/hooks/ .claude/lib/ --ignore-missing-imports` → **0 errors**.

## Sync-gate decision

**No sync-gate change.** bashlex is a *library dependency of an existing hook*, not a new CI check kind — no new `run:`/`uses:` quality gate is added, so `pre_commit_ci_sync.py`'s `_KIND_PATTERNS` is untouched and `.pre-commit-config ⇄ CI` kind parity is unaffected. Verified locally: `python3 .claude/lib/pre_commit_ci_sync.py .` → `OK`.

## Tests

- 6 mode-agnostic fixtures (`ast_*.json`) that pass under **both** the AST and shlex-fallback paths: command-sub in `-m` message, `;`/`&&`/`|` chains, env-var prefix, nested quotes, negative missing-identity chain.
- `test_validate_commit_identity_ast.py`: AST extraction unit tests (skipUnless bashlex) covering quoting, `\`-continuation, `$(...)`, chains, heredoc-body-is-data, branch-name `commit`, parse-error → None; an AST-superiority test (a `git commit` hidden in `$(...)` is blocked, which the shlex path cannot see); and the always-on degraded-mode + parse-failure-fallthrough tests.

## Local check results (all green)

| Check | Result |
|---|---|
| `ruff@0.15.11 format --check` (hooks/lib/skills) | clean |
| `ruff@0.15.11 check` (hooks/lib/skills) | All checks passed |
| `mypy .claude/hooks/ .claude/lib/ --ignore-missing-imports` | 0 errors |
| `pytest .claude/hooks/tests/ .claude/lib/tests/` | 1590 passed, 61 subtests |
| `pre_commit_ci_sync.py .` | OK |
| `memory_budget.py .` | OK |
| `actionlint .github/workflows/ci.yml` | ok |
| pre-commit + pre-push hooks (on commit/push) | all Passed |

Degraded mode independently verified by blocking the bashlex import at runtime: valid commit allowed, missing-identity blocked, single warning emitted, no crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BNK9q1SAds2ZmHQ88oLvxn
