### PR TITLE
fix(skills): zsh-safe rewrites of bash-only idioms in executed skill blocks (#759)

### DIFF
--- a/.claude/skills/board-audit/SKILL.md
+++ b/.claude/skills/board-audit/SKILL.md
@@ -202,10 +202,15 @@ The user MUST type `y` to proceed. Any other answer aborts with `BLOCK: user dec
 ### 6. Bulk-add orphans
 
 ```bash
-for url in $ORPHANS; do
+# `while read` over the newline-list, NOT `for url in $ORPHANS` — zsh does not
+# word-split an unquoted scalar, so the whole list would collapse into one bogus
+# iteration (#759, same class as main#688). The `[ -n ]` guard preserves the
+# zero-iteration-on-empty behaviour `for` gives when $ORPHANS is empty.
+while IFS= read -r url; do
+  [ -n "$url" ] || continue
   gh project item-add 2 --owner noorinalabs --url "$url" || \
     echo "WARN: failed to add $url"
-done
+done <<< "$ORPHANS"
 ```
 
 Per memory `feedback_gh_pr_edit_silent_noop` family, `gh project item-add` can silently no-op — `gh` is being deprecated for project-classic operations (see `pull-requests.md § gh pr edit projects-classic deprecation`). If the bulk-add appears to succeed but the orphan count doesn't drop on the next audit run, fall back to the GraphQL `addProjectV2ItemById` mutation:
@@ -244,7 +249,12 @@ query {
 WAVE_FIELD_ID=$(jq -r '.data.organization.projectV2.field.id' /tmp/wave-options.json)
 declare -A WAVE_OPTION_IDS
 while IFS=$'\t' read -r name id; do
-  WAVE_OPTION_IDS["$name"]="$id"
+  # Unquoted subscript on assignment — zsh keeps quotes *inside* a subscript as
+  # part of the key (`WAVE_OPTION_IDS["$name"]=` would store key `"P6W1"`, with
+  # the quotes, so later `${WAVE_OPTION_IDS[$expected]}` lookups miss). Bash
+  # strips them; the unquoted form is correct in both. Keys are wave names
+  # (no spaces), so no word-split risk. (zsh-safety, #759)
+  WAVE_OPTION_IDS[$name]=$id
 done < <(jq -r '.data.organization.projectV2.field.options[] | "\(.name)\t\(.id)"' /tmp/wave-options.json)
 
 # Project node ID — same response.

--- a/.claude/skills/phase-review/SKILL.md
+++ b/.claude/skills/phase-review/SKILL.md
@@ -52,12 +52,17 @@ Extract tracking issue numbers from the phase plan and pull live state for each:
 ```bash
 TRACKING_ISSUES=$(grep -oE 'noorinalabs-main#[0-9]+' "$PHASE_DOC" | sort -u)
 
-for issue in $TRACKING_ISSUES; do
+# `while read`, NOT `for issue in $TRACKING_ISSUES` — zsh does not word-split an
+# unquoted scalar, so the multi-line list would collapse into one bogus iteration
+# (#759, same class as main#688). The `[ -n ]` guard keeps the no-op-on-empty
+# behaviour `for` gives when no tracking issues are found.
+while IFS= read -r issue; do
+  [ -n "$issue" ] || continue
   num=${issue#noorinalabs-main#}
-  gh issue view $num --repo noorinalabs/noorinalabs-main \
+  gh issue view "$num" --repo noorinalabs/noorinalabs-main \
     --json number,title,state,labels,closedAt \
     --jq '"\(.state)\t#\(.number)\t[\(.labels|map(.name)|join(","))]\t\(.title)"'
-done
+done <<< "$TRACKING_ISSUES"
 ```
 
 Categorize each criterion:

--- a/.claude/skills/session-start/SKILL.md
+++ b/.claude/skills/session-start/SKILL.md
@@ -213,7 +213,14 @@ REPOS=$(jq -r '
   (.current_wave // "" | ltrimstr("wave-")) as $n
   | .["wave_\($n)_repos_in_scope"][]? // empty
 ' "$REPO_ROOT/cross-repo-status.json" 2>/dev/null)
-[ -n "$REPOS" ] || REPOS="noorinalabs-main noorinalabs-isnad-graph noorinalabs-user-service noorinalabs-deploy noorinalabs-design-system noorinalabs-data-acquisition noorinalabs-isnad-ingest-platform noorinalabs-landing-page"
+# Newline-separated fallback (one repo per line) so the `while read` loop below
+# is correct under zsh — a space-separated string would be read as ONE line
+# (zsh does not word-split an unquoted scalar; #759 / main#688). jq above already
+# emits newlines, so both sources share the same shape.
+[ -n "$REPOS" ] || REPOS=$(printf '%s\n' \
+  noorinalabs-main noorinalabs-isnad-graph noorinalabs-user-service \
+  noorinalabs-deploy noorinalabs-design-system noorinalabs-data-acquisition \
+  noorinalabs-isnad-ingest-platform noorinalabs-landing-page)
 
 # Best-effort cause classification for a red run (main#647). Echoes "base-image-drift"
 # when the failed job log carries a base-image-CVE signal, else "code/other". Never fatal:
@@ -229,7 +236,11 @@ classify_red() {  # $1=repo  $2=run_id
 }
 
 RED=()
-for repo in $REPOS; do
+# `while read` over the newline-list, NOT `for repo in $REPOS` — zsh does not
+# word-split an unquoted scalar (#759 / main#688). A here-string (not a `|` pipe)
+# keeps the loop in the current shell so the RED array survives past `done`.
+while IFS= read -r repo; do
+  [ -n "$repo" ] || continue
   branch=$(gh api "repos/noorinalabs/$repo" --jq '.default_branch' 2>/dev/null || echo main)
   # Latest run per workflow on the default branch; keep only publish/deploy/release-class names with a non-success conclusion.
   while IFS=$'\t' read -r name conclusion url run_id; do
@@ -244,7 +255,7 @@ for repo in $REPOS; do
             | group_by(.workflow_id) | map(max_by(.run_started_at))
             | .[] | [(.name // .display_title), .conclusion, .html_url, .id] | @tsv' 2>/dev/null
   )
-done
+done <<< "$REPOS"
 if [ ${#RED[@]} -gt 0 ]; then
   printf 'RED default-branch publish/deploy run(s) — investigate before relying on staging:\n'
   printf '  %s\n' "${RED[@]}"

--- a/.claude/skills/wave-start/SKILL.md
+++ b/.claude/skills/wave-start/SKILL.md
@@ -144,8 +144,10 @@ This reset runs BEFORE the § 6 PUT-contents write so the only `wave_{M}_*` valu
 Set the active-wave fields for this repo in `cross-repo-status.json`. This is a **main-targeting** status write, so use the **`gh api` PUT-contents recipe** — the atomic, no-local-orphan pattern documented in `/wave-kickoff` Step 1a (added P3W6 retro, supersedes local-commit-then-push). Do **not** `git add/commit/push` the file from the local tree: a local commit here re-introduces the orphan / stale-tree hazard this issue (#653) closes, and the local `main` parked in § 2 races the remote after the PUT lands.
 
 ```bash
-# Read current status (for reference / field-setting)
-gh api repos/noorinalabs/noorinalabs-main/contents/cross-repo-status.json?ref=main \
+# Read current status (for reference / field-setting). Quote the URL: the
+# unquoted `?` is a zsh glob metacharacter and, with NOMATCH on by default, zsh
+# aborts the command with "no matches found" before gh ever runs (#759).
+gh api "repos/noorinalabs/noorinalabs-main/contents/cross-repo-status.json?ref=main" \
   --jq '.content' | base64 -d
 ```
 


### PR DESCRIPTION
## Bash-ism audit of committed parent tooling (#759 code portion)

The owner's shell and the Bash tool are **zsh 5.9**. This sweeps `.claude/hooks/**`, `.claude/lib/**`, and the executed bash blocks inside `.claude/skills/**/*.md` for bash-only idioms that break or silently misbehave under zsh. Every finding below was reproduced under the live zsh before fixing, and each rewrite is mechanically behaviour-preserving (re-verified post-fix).

### Findings fixed (all in skill bash blocks)

| File | Bash-ism | zsh failure mode | Fix |
|------|----------|------------------|-----|
| `board-audit/SKILL.md` | `WAVE_OPTION_IDS["$name"]="$id"` | zsh keeps the quotes *inside* the subscript as part of the key (`"P6W1"`), so later `${WAVE_OPTION_IDS[$expected]}` lookups MISS | unquoted `[$name]=$id` (correct in both shells; keys are space-free) |
| `board-audit/SKILL.md` | `for url in $ORPHANS` | zsh does not word-split an unquoted scalar → whole newline-list collapses into ONE bogus iteration (same class as main#688) | `while IFS= read -r url … done <<< "$ORPHANS"` + `[ -n ]` guard |
| `phase-review/SKILL.md` | `for issue in $TRACKING_ISSUES` | same scalar-collapse | `while read` here-string + guard |
| `session-start/SKILL.md` | `for repo in $REPOS` (+ space-separated fallback) | same scalar-collapse; fallback string read as one line | normalized fallback to newline-separated; `while read` via **here-string** (not a pipe, so the `RED` array survives `done`) |
| `wave-start/SKILL.md` | `gh api …/cross-repo-status.json?ref=main` (unquoted) | unquoted `?` is a zsh glob; with NOMATCH-on-by-default zsh aborts with "no matches found" before gh runs | quote the URL |

### Audited, already zsh-safe — deliberately NOT changed

- **`wave-kickoff/SKILL.md`** `declare -A BRANCH_SHA/BRANCH_STATUS` — already uses unquoted subscripts and a here-string loop (explicitly main#688-hardened). Works in zsh.
- **Process substitution** `done < <(…)` / `comm -23 <(…) <(…)` across session-start/board-audit/wave-wrapup/wave-scope — zsh fully supports `<(…)`; not a bash-ism.
- **All Python `.claude/hooks/**` + `.claude/lib/**`** — run via `python3`, not the shell. The single `shell=True` (`session_handoff.py`) uses `/bin/sh` (POSIX), is insulated from zsh, and only runs plain `git`/`gh` strings.
- The `for … in $VAR` hits in `wave-wrapup`/`wave-scope` are **comments** documenting the anti-pattern; the code there already uses the safe `while read` form.

### Verification
- Each broken construct reproduced under zsh 5.9, then each rewrite re-run under zsh (3 iterations not 1; zero-iteration-on-empty preserved; quoted URL no longer globs; assoc lookup hits).
- `pre-commit run --all-files` (commit + `--hook-stage pre-push`): ruff-format, ruff-lint, actionlint, cspell, mypy, pytest, pytest-skills, memory-budget — all **Passed**.
- No hook/lib code touched, so the hook test suites pass unchanged.

### Left for human judgment
- Prose/inline-code mentions of `…json?ref=main` in `wave-start` (lines 154/158) and `wave-kickoff` (line 224) are **documentation**, not executed blocks, so they were left as-is. If we want copy-paste-safety from prose too, they could be quoted in a follow-up — flagging rather than guessing.

Part of #759
