### PR TITLE
docs(readme): prerequisites, env vars, dev/test workflow, repo map (#773)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,13 @@ by `uv` / `npm` / `pre-commit`):
 | `shellcheck` | **must be on `PATH`** or `actionlint` silently skips shell-lint | `brew install shellcheck` · `apt install shellcheck` |
 | `docker` + compose | build/run the containerized services | <https://docs.docker.com/get-docker/> |
 
-Pinned versions matter: ruff `0.15.11`, actionlint `1.7.12`, gitleaks `8.24.3`,
-cspell `8.4.0`. Matching them keeps local "clean" equal to CI "clean" — org-wide
-local⇄CI parity is mandatory
-([#684](https://github.com/noorinalabs/noorinalabs-main/issues/684)). `pre-commit`
-provisions the pinned `ruff`/`actionlint`/`cspell` for you; `mypy`/`pytest` run
-against your system Python at pre-push, so install those yourself.
+Pinned versions matter: ruff `0.15.11`, actionlint `1.7.12`, cspell `8.4.0` (and,
+across the org's service repos, gitleaks `8.24.3`). Matching them keeps local
+"clean" equal to CI "clean" — org-wide local⇄CI parity is the mandated end-state
+([#684](https://github.com/noorinalabs/noorinalabs-main/issues/684), whose
+rollout — including gitleaks — is still in progress). `pre-commit` provisions the
+pinned `ruff`/`actionlint`/`cspell` for you; `mypy`/`pytest` run against your
+system Python at pre-push, so install those yourself.
 
 **2. Install the git hooks** (one-time per clone — both stages):
 
@@ -65,8 +66,10 @@ fill in real values locally (`cp .env.example .env`). In CI the same names are
 supplied as GitHub Actions secrets. The names below are grouped by purpose — the
 authoritative per-repo list is always that repo's `.env.example`.
 
-> Only **names and purposes** are documented here — no values. The secret
-> scanner (`gitleaks`) gates every diff.
+> Only **names and purposes** are documented here — no values. Across the org's
+> service repos, `gitleaks` scans diffs for leaked secrets; extending that gate
+> to every repo (this one included) is the [#684](https://github.com/noorinalabs/noorinalabs-main/issues/684)
+> end-state.
 
 **Shell-exported for org tooling and package auth** (export in your `zsh`
 profile, or let `gh auth login` manage the token):
@@ -152,7 +155,7 @@ integration/e2e tiers are opt-in and need running services.
 **Org root (`noorinalabs-main`) — hook/lib/skill suites** (pure-Python, offline):
 
 ```bash
-python3 -m pytest .claude/hooks/tests/ .claude/lib/tests/   # or: make test (mirrors pre-push)
+python3 -m pytest .claude/hooks/tests/ .claude/lib/tests/   # same suites the pre-push hook runs
 ```
 
 These also run at the `pre-push` stage and in the `ci.yml` Pytest job, so a
@@ -193,8 +196,11 @@ Per-repo build/test/architecture details live in each repo's own `CLAUDE.md`.
 | [`noorinalabs-isnad-ingest-platform`](https://github.com/noorinalabs/noorinalabs-isnad-ingest-platform) | pipeline processing — Kafka workers (dedup/enrich/normalize/graph-load) | Python · Kafka |
 | [`noorinalabs-deploy`](https://github.com/noorinalabs/noorinalabs-deploy) | deployment orchestration | Terraform · Docker Compose · GH Actions |
 
-Inter-repo dependencies (the source of truth is
-[`dependencies.yml`](dependencies.yml), which CI reads to sequence builds):
+Inter-repo dependencies. The **build/release** edges — npm-package and
+container-image triggers that CI reads to sequence builds — are declared in
+[`dependencies.yml`](dependencies.yml); the **runtime/architectural** edges (the
+user-service auth origin and the data-pipeline flow) are not in that file and are
+shown here for the full picture:
 
 ```text
   design-system ──(npm @noorinalabs/design-system, on release)──► landing-page

--- a/README.md
+++ b/README.md
@@ -9,105 +9,224 @@ ontology.
 
 For the full team/workflow model — roster, charter, wave process, commit
 identity, ontology, and project memory — see [`CLAUDE.md`](CLAUDE.md). This
-README covers only what a fresh clone needs to **install** before it can build,
-test, and pass the local hooks.
+README is the new-clone entry point: what to **install**, what **secrets** to
+provide, how to **develop and test**, and how the seven repos fit together.
 
-## Toolchain / Prerequisites
+## Prerequisites
 
-The repos share one toolchain. Install the tools below once; the per-repo
-`CLAUDE.md` files list which apply to each child repo. Pinned versions are the
-versions our pre-commit and CI enforce — match them so local "clean" equals CI
-"clean" (org-wide local⇄CI parity is mandatory; see
-[#684](https://github.com/noorinalabs/noorinalabs-main/issues/684)).
+The repos share one toolchain. The canonical, version-pinned inventory — every
+tool, who provisions it, the macOS/Linux install line, and the structural-search
+tooling — lives in **[`docs/TOOLCHAIN.md`](docs/TOOLCHAIN.md)**. Read that for the
+full list; this section is just the fast path to a working clone.
 
-After cloning, install the git hooks (both stages):
+> The dev shell — interactive **and** the agent Bash tool — is **`zsh`, not
+> bash**. Write zsh-safe (ideally POSIX-portable) commands; see
+> [`docs/TOOLCHAIN.md` § Shell environment](docs/TOOLCHAIN.md) for the do/don't
+> list.
+
+**1. Install the essentials yourself** (everything else is bootstrapped per repo
+by `uv` / `npm` / `pre-commit`):
+
+| Tool | Why you need it first | Install |
+|------|-----------------------|---------|
+| `git` + `gh` | clone, branch, and drive issues/PRs/the project board | system pkg · `brew install gh` / `apt install gh` |
+| `python3` (3.12+) | runs the `.claude/` hooks, lib, and skills | system · `uv python install` |
+| `uv` | Python package manager for every Python repo | `curl -LsSf https://astral.sh/uv/install.sh \| sh` |
+| `node` (LTS) + `npm` | the JS/TS repos (design-system, isnad-graph frontend, landing-page) | <https://nodejs.org/> · `nvm install --lts` |
+| `pre-commit` | local hook framework that mirrors CI | `uv tool install pre-commit` · `pipx install pre-commit` |
+| `shellcheck` | **must be on `PATH`** or `actionlint` silently skips shell-lint | `brew install shellcheck` · `apt install shellcheck` |
+| `docker` + compose | build/run the containerized services | <https://docs.docker.com/get-docker/> |
+
+Pinned versions matter: ruff `0.15.11`, actionlint `1.7.12`, gitleaks `8.24.3`,
+cspell `8.4.0`. Matching them keeps local "clean" equal to CI "clean" — org-wide
+local⇄CI parity is mandatory
+([#684](https://github.com/noorinalabs/noorinalabs-main/issues/684)). `pre-commit`
+provisions the pinned `ruff`/`actionlint`/`cspell` for you; `mypy`/`pytest` run
+against your system Python at pre-push, so install those yourself.
+
+**2. Install the git hooks** (one-time per clone — both stages):
 
 ```bash
-pre-commit install                          # commit-stage hooks (ruff)
-pre-commit install --hook-type pre-push     # push-stage hooks (mypy, pytest)
+pre-commit install                          # commit-stage: ruff-format, ruff-lint, actionlint, cspell
+pre-commit install --hook-type pre-push     # push-stage:   mypy, pytest suites, memory-budget gate
 ```
 
-### Python
+> The commit stage runs fast linters; the push stage runs the heavier
+> type-check + test suites so nothing red leaves your machine. Never bypass a
+> hook with `--no-verify`, and never push, merge, or commit over a known-failing
+> check without explicit owner permission
+> ([#684](https://github.com/noorinalabs/noorinalabs-main/issues/684)).
 
-The org `.claude/` hooks/lib/skills and the Python child repos (isnad-graph,
-user-service, data-acquisition, isnad-ingest-platform) use this set.
+## Environment variables (external to source control)
 
-| Tool | Purpose | Install |
-|------|---------|---------|
-| Python 3.x | runtime for hooks, lib, skills, and Python services | <https://www.python.org/downloads/> (or `pyenv install`) |
-| uv | fast Python package/venv manager + lockfiles | `curl -LsSf https://astral.sh/uv/install.sh \| sh` |
-| ruff `0.15.11` | Python lint + format (org-canonical pin) | `uv tool install ruff@0.15.11` (or via pre-commit) |
-| mypy | static type-check of hooks/lib and services | `uv tool install mypy` |
-| pytest | hook, lib, skill, and service test suites | `uv tool install pytest` (usually a project dev-dep) |
-| pip-audit | dependency vulnerability scan (isnad-graph, data-acquisition) | `uv tool install pip-audit` |
+Secrets and machine-specific endpoints are **never committed**. Each service
+repo ships a `.env.example` listing the names it expects; copy it to `.env` and
+fill in real values locally (`cp .env.example .env`). In CI the same names are
+supplied as GitHub Actions secrets. The names below are grouped by purpose — the
+authoritative per-repo list is always that repo's `.env.example`.
 
-> ruff is pinned to `0.15.11` org-wide so the same formatter runs locally and in
-> CI. Keep the `rev:` in each repo's `.pre-commit-config.yaml` aligned with it.
+> Only **names and purposes** are documented here — no values. The secret
+> scanner (`gitleaks`) gates every diff.
 
-### JavaScript / TypeScript
+**Shell-exported for org tooling and package auth** (export in your `zsh`
+profile, or let `gh auth login` manage the token):
 
-The frontend and design-system repos (design-system, isnad-graph frontend,
-landing-page) use this set. These tools are declared in each repo's
-`package.json` — installing dependencies pulls the pinned versions in, so prefer
-the project install over global binaries.
+| Name | Purpose |
+|------|---------|
+| `GH_TOKEN` / `GITHUB_TOKEN` | auth for the `gh` CLI — issues, PRs, project-board, and CI's default token |
+| `NODE_AUTH_TOKEN` | npm auth to `npm.pkg.github.com` to install `@noorinalabs/design-system` (project `.npmrc` reads `${NODE_AUTH_TOKEN}`) |
+| `GH_PACKAGES_TOKEN` | GHCR / GitHub Packages auth for pulling & publishing `@noorinalabs/*` images and packages |
+| `GITLEAKS_LICENSE` | optional org license for the `gitleaks` secret-scan gate |
 
-| Tool | Purpose | Install |
-|------|---------|---------|
-| Node.js (LTS) | JS/TS runtime | <https://nodejs.org/> (or `nvm install --lts`) |
-| npm | package manager / script runner | ships with Node.js |
-| pnpm | package manager (used where the repo declares it) | `corepack enable && corepack prepare pnpm@latest --activate` |
-| eslint | JS/TS lint | `npm install` (project dev-dep) |
-| prettier | JS/TS format | `npm install` (project dev-dep) |
-| typescript (`tsc`) | type-check / compile | `npm install` (project dev-dep) |
-| vitest | JS/TS unit tests (design-system, isnad-graph) | `npm install` (project dev-dep) |
-| vite | frontend bundler (isnad-graph, landing-page) | `npm install` (project dev-dep) |
-| astro | static-site generator (landing-page) | `npm install` (project dev-dep) |
-| playwright | E2E browser tests (isnad-graph) | `npm install && npx playwright install` |
+**Per-service `.env` (copied from each repo's `.env.example`):**
 
-### Cross-cutting docs, lint, and security gates
+| Name(s) | Purpose | Repo(s) |
+|---------|---------|---------|
+| `NEO4J_URI`, `NEO4J_USER`, `NEO4J_PASSWORD` | Neo4j graph database connection | isnad-graph, data-acquisition, ingest |
+| `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`, `PG_DSN`, `DATABASE_URL` | PostgreSQL connection / DSN | isnad-graph, user-service, deploy |
+| `USER_POSTGRES_USER`, `USER_POSTGRES_PASSWORD`, `USER_POSTGRES_DB` | user-service's dedicated Postgres in the compose stack | deploy |
+| `REDIS_URL`, `REDIS_PASSWORD`, `USER_REDIS_PASSWORD` | Redis cache / session store | isnad-graph, user-service, deploy |
+| `JWT_PRIVATE_KEY`, `JWT_PUBLIC_KEY`, `JWT_ALGORITHM`, `JWT_SECRET` | JWT signing / verification keypair for auth tokens | user-service, deploy |
+| `AUTH_GOOGLE_CLIENT_ID` / `_SECRET`, `AUTH_GITHUB_CLIENT_ID` / `_SECRET`, `AUTH_APPLE_*`, `AUTH_FACEBOOK_*` | OAuth provider credentials | user-service, deploy |
+| `AUTH_OAUTH_REDIRECT_BASE_URL`, `AUTH_OAUTH_POST_LOGIN_URL`, `AUTH_OAUTH_STATE_TTL_SECONDS` | OAuth redirect / state-cookie configuration | user-service |
+| `VITE_USER_SERVICE_ORIGIN` | frontend → user-service auth origin (build-time) | isnad-graph (frontend) |
+| `SUNNAH_API_KEY` | sunnah.com hadith API key | isnad-graph, data-acquisition, ingest |
+| `KAGGLE_USERNAME`, `KAGGLE_KEY` | Kaggle dataset download credentials | data-acquisition, ingest |
+| `DATA_RAW_DIR`, `DATA_STAGING_DIR`, `DATA_CURATED_DIR` | local data-lake stage paths | data-acquisition, ingest |
+| `PIPELINE_B2_KEY_ID`, `PIPELINE_B2_KEY`, `PIPELINE_B2_BUCKET`, `PIPELINE_B2_ENDPOINT`, `PIPELINE_B2_REGION` | Backblaze B2 object storage for pipeline data | deploy, data-acquisition |
+| `BACKUP_B2_*` | B2 credentials for backups | deploy |
+| `INGEST_CHECKPOINT_BACKEND`, `KAFKA_CLUSTER_ID`, `KAFKA_UI_USER`, `KAFKA_UI_PASSWORD`, `KAFKA_UI_READONLY` | ingest pipeline + Kafka / Kafka-UI configuration | isnad-ingest-platform, deploy |
+| `BASE_DOMAIN`, `CLOUDFLARE_API_TOKEN`, `HCLOUD_TOKEN`, `TF_STATE_B2_*`, `DEPLOY_SSH_PRIVATE_KEY`, `DEPLOY_REPO_PAT`, `SECRETS_ADMIN_TOKEN` | infra: domain, Cloudflare DNS/CDN, Hetzner Cloud, Terraform remote state, deploy SSH + cross-repo dispatch | deploy |
+| `GRAFANA_ADMIN_USER`, `GRAFANA_ADMIN_PASSWORD`, `GRAFANA_ROOT_URL`, `PROM_CONFIG_FILE`, `ALERTMANAGER_CONFIG_FILE`, `SLACK_WEBHOOK_URL` | observability: Grafana, Prometheus/Alertmanager, alert webhook | deploy, isnad-graph |
+| `STG_TEST_EMAIL` / `STG_TEST_PASSWORD`, `STG_TEST_USER_EMAIL` / `STG_TEST_USER_PASSWORD` | staging smoke-test login credentials (CI) | deploy |
 
-These run on every repo via pre-commit and the `docs.yml` / `ci.yml` workflows.
-Most are provisioned by pre-commit (which downloads pinned hook environments),
-so a local `pre-commit run` needs little manual install — the exception is
-`shellcheck`, which must be on `PATH` or `actionlint` silently skips its
-shell-lint integration.
+> Non-secret tunables also live in `.env.example` (e.g. `CORS_ORIGINS`,
+> `LOG_LEVEL`, `LOG_FORMAT`, `RATE_LIMIT_*`, the `AUTH_*_TOKEN_EXPIRE_*` /
+> `*_IMAGE_TAG` values) — safe defaults, override per environment.
 
-| Tool | Purpose | Install |
-|------|---------|---------|
-| pre-commit | local hook framework mirroring CI | `uv tool install pre-commit` (or `pipx install pre-commit`) |
-| actionlint `1.7.12` | GitHub Actions workflow lint | pinned pre-commit rev `v1.7.12`; standalone: download the [1.7.12 release binary](https://github.com/rhysd/actionlint/releases/tag/v1.7.12) |
-| shellcheck | shell lint (also actionlint's shell backend) | `apt install shellcheck` / `brew install shellcheck` |
-| gitleaks `8.24.3` | secret scanning | download the [8.24.3 release binary](https://github.com/gitleaks/gitleaks/releases/tag/v8.24.3) (or via the pinned pre-commit hook) |
-| cspell | docs/prose spellcheck | provisioned by pre-commit (`cspell-cli`); standalone: `npm install -g cspell` |
-| lychee | internal markdown link check | provisioned by CI; standalone: `cargo install lychee` or the [release binary](https://github.com/lycheeverse/lychee/releases) |
-| markdownlint | markdown structure lint | provisioned by the CI action; standalone: `npm install -g markdownlint-cli2` |
+## Development workflow
 
-> New domain vocabulary that trips cspell goes in
-> [`.cspell/project-words.txt`](.cspell/project-words.txt) — add the word, never
-> disable the gate.
+All work runs through the simulated team and its charter
+([`CLAUDE.md`](CLAUDE.md) → `.claude/team/charter.md`). The day-to-day loop:
 
-### Infrastructure
+1. **Pick up the issue.** Work is tracked as GitHub Issues on Project 2 and
+   grouped into waves. Before any edit, run `/ontology-librarian {topic}` — a
+   hook blocks `Edit`/`Write` until you have.
+2. **Branch off a fresh `main`** using the org naming scheme
+   `{FirstInitial}.{LastName}/{IIII}-{issue-name}` (e.g.
+   `N.Khoury/0042-update-charter`).
+3. **Work in a git worktree** — the preferred isolation method, so parallel
+   branches never collide in one checkout:
 
-The deploy repo and the containerized services use this set.
+   ```bash
+   git fetch origin
+   git worktree add ../noor-wt-myfeature -b F.Last/0042-my-feature origin/main
+   ```
 
-| Tool | Purpose | Install |
-|------|---------|---------|
-| docker + compose | build/run service containers | <https://docs.docker.com/get-docker/> |
-| terraform | infrastructure-as-code (deploy) | <https://developer.hashicorp.com/terraform/install> |
-| trivy | container image vulnerability scan (deploy) | `brew install trivy` or the [release binary](https://github.com/aquasecurity/trivy/releases) |
-| cosign | container image signing (deploy) | `brew install cosign` or the [release binary](https://github.com/sigstore/cosign/releases) |
+4. **Commit with per-commit identity** — pass your name/email with `-c` flags;
+   **never** set global or repo `git config`, and never `--no-verify`:
 
-### Note: the `sg` name collision
+   ```bash
+   git -c user.name="First Last" \
+       -c user.email="parametrization+First.Last@gmail.com" \
+       commit -F /tmp/msg.txt
+   ```
 
-On Linux, `command -v sg` resolves to `/usr/bin/sg` — that is **shadow-utils
-`sg`** (run a command with a different group ID), **not** ast-grep. The
-`ast-grep` binary ships an `sg` alias that collides with this. If we adopt
-ast-grep later, invoke it as **`ast-grep`** everywhere (hooks, docs, CI) — a
-script or hook that shells out to `sg ...` would silently run shadow-utils
-instead of the structural search tool.
+5. **Green before push.** `pre-commit run --all-files` locally; a red gate is a
+   stop, not a speed bump.
+6. **Open a PR to `main`** (`gh pr create --base main`), linking the issue with
+   `Closes #NNN`. Charter requires **two reviewers**; reviews use the
+   `/review-pr` format. Wave-branch merges don't auto-close issues — close them
+   when the wave wraps.
 
-> Structural/AST tooling (ast-grep, yq, semgrep, and friends) is **proposed but
-> not yet adopted** — it is tracked as a follow-up in
-> [#748](https://github.com/noorinalabs/noorinalabs-main/issues/748). This
-> README documents only the tools the org already depends on; do not install the
-> proposed set on the strength of this file.
+Hooks under `.claude/` enforce the commit identity, block `--no-verify`, and
+block `git config` user changes, so these conventions fail fast rather than at
+review time.
+
+## Running tests
+
+Match the stack of the repo you touched. The **offline unit tier** — tests that
+need no Docker, network, or browser — is what must stay green on every commit;
+integration/e2e tiers are opt-in and need running services.
+
+**Org root (`noorinalabs-main`) — hook/lib/skill suites** (pure-Python, offline):
+
+```bash
+python3 -m pytest .claude/hooks/tests/ .claude/lib/tests/   # or: make test (mirrors pre-push)
+```
+
+These also run at the `pre-push` stage and in the `ci.yml` Pytest job, so a
+clean push means a clean CI.
+
+**Python services** (isnad-graph, user-service, data-acquisition, ingest) — `uv`
++ `pytest`, with markers separating the tiers:
+
+```bash
+make test                                  # offline unit tier
+pytest -m "not integration and not e2e"    # same, explicit
+make test-integration                      # needs Docker (Neo4j / Postgres / Redis)
+make test-e2e                              # needs the app running (Playwright)
+```
+
+**JS/TS** (design-system, isnad-graph frontend, landing-page) — `npm` + Vitest,
+with Playwright for E2E:
+
+```bash
+npm install
+npm run test          # Vitest unit tests
+npx playwright install && make test-e2e    # isnad-graph E2E
+```
+
+## Repositories & how they depend on each other
+
+Seven repos, each independently versioned and CI'd, cloned beneath this parent.
+Per-repo build/test/architecture details live in each repo's own `CLAUDE.md`.
+
+| Repository | Purpose | Stack |
+|------------|---------|-------|
+| [`noorinalabs-main`](https://github.com/noorinalabs/noorinalabs-main) | org parent — team config, hooks, ontology, cross-repo coordination | Python (`.claude/`) |
+| [`noorinalabs-isnad-graph`](https://github.com/noorinalabs/noorinalabs-isnad-graph) | computational hadith analysis platform | FastAPI · React/Vite · Neo4j · Postgres |
+| [`noorinalabs-user-service`](https://github.com/noorinalabs/noorinalabs-user-service) | user / auth / RBAC — JWT issuer, OAuth, sessions | FastAPI · Postgres · Redis |
+| [`noorinalabs-design-system`](https://github.com/noorinalabs/noorinalabs-design-system) | shared design tokens, components, icons, brand | TS · Vitest · Storybook |
+| [`noorinalabs-landing-page`](https://github.com/noorinalabs/noorinalabs-landing-page) | organization landing / marketing site | Astro |
+| [`noorinalabs-data-acquisition`](https://github.com/noorinalabs/noorinalabs-data-acquisition) | source acquisition — scrapers, API connectors, downloaders | Python · PyArrow · B2 |
+| [`noorinalabs-isnad-ingest-platform`](https://github.com/noorinalabs/noorinalabs-isnad-ingest-platform) | pipeline processing — Kafka workers (dedup/enrich/normalize/graph-load) | Python · Kafka |
+| [`noorinalabs-deploy`](https://github.com/noorinalabs/noorinalabs-deploy) | deployment orchestration | Terraform · Docker Compose · GH Actions |
+
+Inter-repo dependencies (the source of truth is
+[`dependencies.yml`](dependencies.yml), which CI reads to sequence builds):
+
+```text
+  design-system ──(npm @noorinalabs/design-system, on release)──► landing-page
+        │                                                          
+        └────(npm @noorinalabs/design-system, on release)──► isnad-graph (frontend)
+                                                                   ▲
+  user-service ──(JWT/OAuth auth origin, VITE_USER_SERVICE_ORIGIN)─┘
+
+  data-acquisition ──(B2 pipeline data, on manifest-changed)──► isnad-ingest-platform
+        ▲                                                              │
+        └──────(reads Neo4j nodes/edges)───────────────────► isnad-graph (Neo4j)
+                                                                       │
+  isnad-ingest-platform ──(normalized graph load)──────────────────►──┘
+
+  deploy ◄──(ghcr images, on image-pushed)── isnad-graph, landing-page
+         └──(builds/runs all service containers + infra)
+```
+
+In short: **design-system** is the upstream UI dependency for **landing-page**
+and the **isnad-graph** frontend; **user-service** is the auth provider every
+authenticated frontend talks to; **data-acquisition** → **isnad-ingest-platform**
+→ **isnad-graph** is the data pipeline (acquire → process → load into Neo4j); and
+**deploy** consumes the published container images and owns the infrastructure
+for everything.
+
+## Further reading
+
+- [`docs/TOOLCHAIN.md`](docs/TOOLCHAIN.md) — full pinned tool inventory, zsh
+  shell guidance, and structural-search tooling.
+- [`CLAUDE.md`](CLAUDE.md) — team roster, charter, wave process, commit identity,
+  ontology, and project memory.
+- [`ONBOARDING.md`](ONBOARDING.md) — new-teammate setup checklist.
+- New domain vocabulary that trips `cspell` goes in
+  [`.cspell/project-words.txt`](.cspell/project-words.txt) — add the word, never
+  disable the gate.


### PR DESCRIPTION
## What

Makes `README.md` the new-clone entry point and adds the sections #773 asks for, grounded in the actual repo config (`.pre-commit-config.yaml`, `pyproject.toml`, `docs/TOOLCHAIN.md`, the `.env.example` files, workflow secrets, `.npmrc`, and `dependencies.yml`).

## Changes

- **Prerequisites** — slimmed the duplicated full tool inventory down to a fast-path "install yourself first" table and a link to **`docs/TOOLCHAIN.md`** (#762) as the canonical pinned source, removing the two-inventory drift risk. Kept the both-stage hook-install commands and the pinned-version note.
- **Environment variables (external to source control)** — names + one-line purpose only, **no values**. Two tiers: shell-exported org/auth tokens (`GH_TOKEN`, `NODE_AUTH_TOKEN`, `GH_PACKAGES_TOKEN`, `GITLEAKS_LICENSE`) and per-service `.env` families (Neo4j/Postgres/Redis, JWT/OAuth, data-acquisition APIs, B2, Kafka, infra, observability, CI staging creds). Discovered from each repo's `.env.example`, workflow `secrets.*`, and `.npmrc`.
- **Development workflow** — issue → `/ontology-librarian` → branch naming → worktree → per-commit identity → green-before-push → 2-reviewer PR to `main`.
- **Running tests** — org hook/lib/skill suites, the offline unit tier vs Docker-integration vs Playwright-e2e split for Python services, and JS/TS Vitest.
- **Repositories & dependencies** — table of all 7 repos + a dependency diagram grounded in `dependencies.yml`.

## Verification

- cspell, markdownlint-cli2 (0 errors), and all relative-link targets exist (lychee-equivalent manual check).
- Self-audited the diff for value-shaped secrets: **zero** `KEY=value` assignments, **zero** token-like strings — names only.
- Pre-push gates (mypy, pytest, pytest-skills, memory-budget) all green.

Closes #773
Part of #765

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BNK9q1SAds2ZmHQ88oLvxn
