### PR TITLE
feat(ontology): code-as-truth + advisory PR doc-freshness gate (#768)

### DIFF
--- a/.claude/lib/doc_freshness.py
+++ b/.claude/lib/doc_freshness.py
@@ -1,0 +1,378 @@
+#!/usr/bin/env python3
+"""Advisory doc-freshness check (#768, part of #765).
+
+When a PR (or a push) changes CODE in a *documented surface*, this gate checks
+that the relevant docs (README / docs/ / ontology / charter) were ALSO touched
+in the same change set — or that an explicit opt-out marker is present. It is the
+machine companion to the project's "code is the final arbiter of truth for the
+ontology" principle (ontology/conventions.md § Ontology: code is the arbiter of
+truth): code drives the docs, so when code moves the docs are expected to move
+with it.
+
+ADVISORY, BY DESIGN — never blocks
+==================================
+This gate **always exits 0**. It prints a clear report and never fails a build
+or blocks a commit/push. A heuristic "the docs probably need updating" signal has
+an irreducible false-positive class — a pure refactor, a typo fix, a comment
+tweak — so hard-gating it would punish legitimate doc-irrelevant changes (cf.
+``feedback_artifact_gate_non_blocking`` and ``feedback_safety_direction_over_ux_friction``:
+a hook that cannot *auto-fix cleanly* either hard-blocks with a precise diagnostic
+or stays advisory; for an unavoidably-heuristic freshness nudge the right call is
+advisory). The signal nudges the author and the reviewer; the human decides.
+
+Because it exits 0 it is non-blocking on BOTH sides of the local⇄CI mirror: the
+pre-commit hook never blocks a push, and the CI job is green-by-construction
+(the job is additionally marked ``continue-on-error`` to make the advisory intent
+explicit even if a future edit makes the script exit non-zero). It is still
+registered as a real check kind in the sync-drift gate
+(``pre_commit_ci_sync.py`` ``doc-freshness``) so local⇄CI parity (#684) holds:
+the CI job and the pre-commit hook must both exist or the drift gate goes red.
+
+How "changed surface" is computed
+=================================
+The change set is the three-dot diff against a base ref (``git diff --name-status
+BASE...HEAD``) — i.e. what this branch changed relative to where it forked from
+``main``, which is exactly a PR's diff. In CI the base is ``origin/<GITHUB_BASE_REF>``
+(falling back to ``origin/main``); at pre-push it is the merge-base with
+``origin/main``. Git failures degrade to an empty change set (advisory: report
+nothing, exit 0) — the gate never crashes a commit because git was in an odd
+state.
+
+Surface rules (``SURFACE_RULES``)
+=================================
+Each rule pairs CODE path patterns with the DOC path patterns expected to move
+with them. A rule fires when the change set touches a code path (with a status in
+the rule's ``statuses``) but touches NONE of the rule's doc paths. The rules are
+deliberately CONSERVATIVE and high-signal — a few mappings whose false-positive
+rate is low — not an exhaustive code↔doc map (which would drown the signal). The
+clearest case is ``statuses={"A"}``: a brand-new hook/lib module or skill almost
+always needs a registry/index doc entry, whereas editing an existing module's
+internals usually does not. Child repos vendor this file and extend
+``SURFACE_RULES`` with their own documented surfaces.
+
+Opt-out
+=======
+A change that legitimately needs no doc update declares it with an opt-out
+TRAILER (case-insensitive) in any commit message of the range or in an
+explicitly-passed opt-out text (the PR body, via ``--opt-out-text`` or
+``DOC_FRESHNESS_OPT_OUT_TEXT``): a ``Docs-N/A:`` or ``Skip-Doc-Check:`` line,
+optionally followed by a reason (e.g. ``Docs-N/A: pure refactor``). When present,
+the gate reports the opt-out and emits no findings.
+
+The trailing COLON is load-bearing: it is what distinguishes a deliberate opt-out
+from prose that merely *names* the marker (a commit, doc, or this very module that
+discusses ``Docs-N/A`` would otherwise self-trigger the opt-out). Matching the
+colon form also keeps it distinct from the charter's ``TechDebt:`` / review
+``Requestor:`` line shapes so it can never be mistaken for a review verdict by
+Hook 4 (cf. feedback_hook4_regex_prose_false_match).
+
+Exit code: always 0 (advisory). CLI usage errors print to stderr but still 0,
+because this gate must never be the reason a push or build stops.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess  # noqa: S404 - git invocations are fixed, no shell, args are literals
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# Opt-out trailers (matched case-insensitively). The trailing colon is REQUIRED
+# so prose that merely names the marker does not self-trigger the opt-out (see
+# the module docstring § Opt-out). Documented spellings: ``Docs-N/A:`` and
+# ``Skip-Doc-Check:``, each optionally followed by a reason.
+OPT_OUT_MARKERS: tuple[str, ...] = ("docs-n/a:", "skip-doc-check:")
+
+
+@dataclass(frozen=True)
+class Surface:
+    """A documented code surface and the docs expected to move with it.
+
+    ``code`` / ``docs`` are regex patterns matched against repo-relative POSIX
+    paths. A rule FIRES (is reported) when the change set contains a path that
+    matches any ``code`` pattern with a status in ``statuses`` AND contains NO
+    path matching any ``docs`` pattern. ``hint`` is the human guidance printed.
+    """
+
+    name: str
+    code: tuple[str, ...]
+    docs: tuple[str, ...]
+    hint: str
+    statuses: frozenset[str] = field(default_factory=lambda: frozenset({"A", "M"}))
+
+
+# Conservative, high-signal rules for noorinalabs-main. Child repos extend this.
+#
+# Rule 1 (new module): a brand-new org hook/lib module (status A, direct child
+#   of .claude/hooks/ or .claude/lib/ — `tests/` and `__pycache__/` live in
+#   subdirs so the `[^/]+` segment excludes them) is expected to be registered
+#   in the Automation-hooks table in ontology/conventions.md and/or in
+#   docs/TOOLCHAIN.md. Editing an existing module's internals is status M and
+#   does NOT fire — that is the false-positive this status scoping removes.
+# Rule 2 (new skill): a new skill (its SKILL.md is added) is expected to be
+#   listed in CLAUDE.md / README.md / conventions.
+# Rule 3 (CI / pre-commit topology): any change to a CI workflow or the
+#   pre-commit config is expected to be reflected in the local⇄CI parity docs
+#   (CLAUDE.md § Local Hooks, conventions § Pre-commit hooks, docs/TOOLCHAIN.md).
+SURFACE_RULES: tuple[Surface, ...] = (
+    Surface(
+        name="new-org-hook-or-lib-module",
+        code=(r"^\.claude/(hooks|lib)/[^/]+\.py$",),
+        docs=(r"^ontology/conventions\.md$", r"^docs/TOOLCHAIN\.md$"),
+        hint=(
+            "New org hook/lib module — register it in ontology/conventions.md "
+            "(§ Automation hooks) and/or docs/TOOLCHAIN.md."
+        ),
+        statuses=frozenset({"A"}),
+    ),
+    Surface(
+        name="new-skill",
+        code=(r"^\.claude/skills/[^/]+/SKILL\.md$",),
+        docs=(r"^CLAUDE\.md$", r"^README\.md$", r"^ontology/conventions\.md$"),
+        hint="New skill — list it in CLAUDE.md / README.md so it is discoverable.",
+        statuses=frozenset({"A"}),
+    ),
+    Surface(
+        name="ci-or-precommit-topology",
+        code=(r"^\.github/workflows/.*\.ya?ml$", r"^\.pre-commit-config\.yaml$"),
+        docs=(
+            r"^CLAUDE\.md$",
+            r"^ontology/conventions\.md$",
+            r"^docs/TOOLCHAIN\.md$",
+        ),
+        hint=(
+            "CI / pre-commit topology changed — reflect it in the local⇄CI "
+            "parity docs (CLAUDE.md § Local Hooks, conventions § Pre-commit hooks)."
+        ),
+    ),
+)
+
+
+@dataclass(frozen=True)
+class Finding:
+    surface: str
+    code_paths: tuple[str, ...]
+    expected_docs: tuple[str, ...]
+    hint: str
+
+
+def _normalize_status(raw: str) -> str:
+    """First letter of a git name-status code, renames/copies folded to M.
+
+    ``git diff --name-status`` emits ``A``/``M``/``D`` and similarity-scored
+    ``R100``/``C075`` for renames/copies. A rename keeps the file existing under
+    a new path, so for surface purposes it is a modification (``M``), not a fresh
+    addition — folding R/C to M avoids spuriously firing an ``A``-scoped rule on
+    a path that already had its docs written.
+    """
+    if not raw:
+        return ""
+    first = raw[0].upper()
+    return "M" if first in ("R", "C") else first
+
+
+def has_opt_out(texts: list[str]) -> bool:
+    """True if any opt-out marker appears (case-insensitive) in any text."""
+    blob = "\n".join(texts).lower()
+    return any(marker in blob for marker in OPT_OUT_MARKERS)
+
+
+def evaluate(
+    changed: list[tuple[str, str]],
+    rules: tuple[Surface, ...] = SURFACE_RULES,
+) -> list[Finding]:
+    """Return findings: surfaces whose code changed without a corresponding doc.
+
+    ``changed`` is a list of ``(status, path)`` pairs (status is a git
+    name-status code; only its first letter, with R/C folded to M, is used).
+    Paths are repo-relative POSIX strings.
+    """
+    findings: list[Finding] = []
+    for rule in rules:
+        code_pats = [re.compile(p) for p in rule.code]
+        doc_pats = [re.compile(p) for p in rule.docs]
+
+        touched_code = [
+            path
+            for status, path in changed
+            if _normalize_status(status) in rule.statuses and any(p.match(path) for p in code_pats)
+        ]
+        if not touched_code:
+            continue
+
+        # A doc counts as "updated" on ANY change status (add or modify).
+        doc_touched = any(any(p.match(path) for p in doc_pats) for _status, path in changed)
+        if doc_touched:
+            continue
+
+        findings.append(
+            Finding(
+                surface=rule.name,
+                code_paths=tuple(sorted(set(touched_code))),
+                expected_docs=rule.docs,
+                hint=rule.hint,
+            )
+        )
+    return findings
+
+
+# --------------------------------------------------------------------------- #
+# Git layer — best-effort, never raises out of these helpers.
+# --------------------------------------------------------------------------- #
+def _run_git(args: list[str], cwd: Path) -> str | None:
+    """Run ``git <args>`` in ``cwd``; return stdout, or None on any failure."""
+    try:
+        result = subprocess.run(  # noqa: S603 - fixed argv, no shell
+            ["git", *args],
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except (OSError, ValueError):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout
+
+
+def resolve_base(repo_root: Path, explicit: str | None) -> str | None:
+    """Resolve the diff base ref for the three-dot diff.
+
+    Precedence: explicit ``--base`` > ``origin/$GITHUB_BASE_REF`` (CI pull_request)
+    > ``origin/main``. Returns None if no usable base resolves (advisory: then
+    there is nothing to compare against and the gate reports nothing).
+    """
+    candidates: list[str] = []
+    if explicit:
+        candidates.append(explicit)
+    base_ref = os.environ.get("GITHUB_BASE_REF", "").strip()
+    if base_ref:
+        candidates.append(f"origin/{base_ref}")
+    candidates.append("origin/main")
+
+    for ref in candidates:
+        if (
+            _run_git(["rev-parse", "--verify", "--quiet", f"{ref}^{{commit}}"], repo_root)
+            is not None
+        ):
+            return ref
+    return None
+
+
+def changed_files(repo_root: Path, base: str, head: str = "HEAD") -> list[tuple[str, str]]:
+    """``git diff --name-status base...head`` parsed to ``(status, path)`` pairs.
+
+    Three-dot (merge-base) diff = the branch's own changes relative to where it
+    forked from base, i.e. a PR's diff. Returns [] on any git failure.
+    """
+    out = _run_git(["diff", "--name-status", f"{base}...{head}"], repo_root)
+    if out is None:
+        return []
+    pairs: list[tuple[str, str]] = []
+    for line in out.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split("\t")
+        if len(parts) < 2:
+            continue
+        status = parts[0]
+        # Rename/copy lines are "R100\told\tnew" — the new path is the last field.
+        path = parts[-1]
+        pairs.append((status, path))
+    return pairs
+
+
+def collect_opt_out_texts(repo_root: Path, base: str, extra: str | None) -> list[str]:
+    """Commit messages in base..HEAD plus any explicit opt-out text (PR body)."""
+    texts: list[str] = []
+    log = _run_git(["log", "--format=%B", f"{base}..HEAD"], repo_root)
+    if log:
+        texts.append(log)
+    if extra:
+        texts.append(extra)
+    env_text = os.environ.get("DOC_FRESHNESS_OPT_OUT_TEXT", "")
+    if env_text:
+        texts.append(env_text)
+    return texts
+
+
+def render(findings: list[Finding]) -> str:
+    """Human-readable advisory report."""
+    if not findings:
+        return "doc-freshness: no documented code surface changed without a matching doc update."
+    lines = [
+        "doc-freshness (advisory): code changed in a documented surface, but no "
+        "matching doc was updated in this change set.",
+        "",
+    ]
+    for f in findings:
+        lines.append(f"  surface: {f.surface}")
+        for p in f.code_paths:
+            lines.append(f"    changed: {p}")
+        lines.append(f"    expected one of: {', '.join(f.expected_docs)}")
+        lines.append(f"    -> {f.hint}")
+        lines.append("")
+    lines.append(
+        "If this change legitimately needs no doc update, add an opt-out trailer "
+        "(a `Docs-N/A:` or `Skip-Doc-Check:` line) to a commit message or the PR body."
+    )
+    return "\n".join(lines)
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Advisory doc-freshness check (#768).")
+    parser.add_argument("repo_root", nargs="?", default=".", help="Repo root (default: cwd).")
+    parser.add_argument(
+        "--base", help="Diff base ref (default: origin/$GITHUB_BASE_REF or origin/main)."
+    )
+    parser.add_argument(
+        "--opt-out-text",
+        help="Extra text to scan for an opt-out marker (e.g. the PR body).",
+    )
+    parser.add_argument(
+        "--changed",
+        action="append",
+        metavar="STATUS:PATH",
+        help="Inject a changed entry instead of reading git (repeatable; for tests).",
+    )
+    args = parser.parse_args(argv[1:])
+    repo_root = Path(args.repo_root).resolve()
+
+    # Injected change set (tests) bypasses the git layer entirely.
+    if args.changed:
+        injected: list[tuple[str, str]] = []
+        for item in args.changed:
+            status, _, path = item.partition(":")
+            if path:
+                injected.append((status, path))
+        opt_texts = [args.opt_out_text] if args.opt_out_text else []
+        if has_opt_out(opt_texts):
+            print("doc-freshness: opt-out marker present — skipping.")
+            return 0
+        print(render(evaluate(injected)))
+        return 0
+
+    base = resolve_base(repo_root, args.base)
+    if base is None:
+        print("doc-freshness: no diff base resolved (origin/main not fetched?) — skipping.")
+        return 0
+
+    if has_opt_out(collect_opt_out_texts(repo_root, base, args.opt_out_text)):
+        print("doc-freshness: opt-out marker present — skipping.")
+        return 0
+
+    print(render(evaluate(changed_files(repo_root, base))))
+    return 0
+
+
+if __name__ == "__main__":
+    # Advisory: even an unexpected error must not stop a push/build.
+    try:
+        sys.exit(main(sys.argv))
+    except Exception as exc:  # noqa: BLE001
+        print(f"doc-freshness: skipped (internal error: {exc})", file=sys.stderr)
+        sys.exit(0)

--- a/.claude/lib/pre_commit_ci_sync.py
+++ b/.claude/lib/pre_commit_ci_sync.py
@@ -128,6 +128,14 @@ _KIND_PATTERNS: dict[str, tuple[str, ...]] = {
     # Patterns cover the hook `id`/`name` token (`memory-budget`) and the CI
     # `run` invocation token (`memory_budget`).
     "memory-budget": ("memory-budget", "memory_budget"),
+    # `doc-freshness` is the advisory PR-time doc-freshness gate
+    # (`.claude/lib/doc_freshness.py`, #768). It is ADVISORY (always exits 0), but
+    # it is still a real CI check, so it must be mirrored in pre-commit for
+    # local⇄CI parity (#684) — classifying it makes the drift gate DEMAND that
+    # mirror rather than silently ignoring an un-classified kind. Patterns cover
+    # the hook `id`/`name` token (`doc-freshness`) and the CI `run` invocation
+    # token (`doc_freshness`).
+    "doc-freshness": ("doc-freshness", "doc_freshness"),
 }
 
 

--- a/.claude/lib/tests/test_doc_freshness.py
+++ b/.claude/lib/tests/test_doc_freshness.py
@@ -1,0 +1,182 @@
+"""Tests for doc_freshness — the advisory PR-time doc-freshness gate (#768).
+
+Verifies the pure decision core (no git): surface firing, status scoping
+(new-module rules fire on A, not M), doc-satisfaction, opt-out detection,
+rename folding, and that the CLI always exits 0 (advisory).
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from doc_freshness import (  # noqa: E402
+    Surface,
+    _normalize_status,
+    evaluate,
+    has_opt_out,
+    main,
+    render,
+)
+
+_RULES = (
+    Surface(
+        name="new-module",
+        code=(r"^\.claude/(hooks|lib)/[^/]+\.py$",),
+        docs=(r"^ontology/conventions\.md$", r"^docs/TOOLCHAIN\.md$"),
+        hint="register it",
+        statuses=frozenset({"A"}),
+    ),
+    Surface(
+        name="ci-topology",
+        code=(r"^\.github/workflows/.*\.ya?ml$", r"^\.pre-commit-config\.yaml$"),
+        docs=(r"^CLAUDE\.md$", r"^ontology/conventions\.md$"),
+        hint="reflect it",
+    ),
+)
+
+
+class StatusNormalization(unittest.TestCase):
+    def test_plain_codes(self) -> None:
+        self.assertEqual(_normalize_status("A"), "A")
+        self.assertEqual(_normalize_status("M"), "M")
+        self.assertEqual(_normalize_status("D"), "D")
+
+    def test_rename_and_copy_fold_to_m(self) -> None:
+        self.assertEqual(_normalize_status("R100"), "M")
+        self.assertEqual(_normalize_status("C075"), "M")
+
+    def test_empty(self) -> None:
+        self.assertEqual(_normalize_status(""), "")
+
+
+class SurfaceFiring(unittest.TestCase):
+    def test_new_module_without_doc_fires(self) -> None:
+        findings = evaluate([("A", ".claude/lib/foo.py")], _RULES)
+        names = {f.surface for f in findings}
+        self.assertIn("new-module", names)
+
+    def test_new_module_with_conventions_update_is_satisfied(self) -> None:
+        findings = evaluate(
+            [("A", ".claude/lib/foo.py"), ("M", "ontology/conventions.md")],
+            _RULES,
+        )
+        self.assertNotIn("new-module", {f.surface for f in findings})
+
+    def test_modified_module_does_not_fire_new_module_rule(self) -> None:
+        # Status M on an existing module must NOT trip the A-scoped rule.
+        findings = evaluate([("M", ".claude/lib/foo.py")], _RULES)
+        self.assertNotIn("new-module", {f.surface for f in findings})
+
+    def test_test_file_in_subdir_does_not_fire(self) -> None:
+        # .claude/lib/tests/x.py has a `/tests/` segment, so [^/]+ excludes it.
+        findings = evaluate([("A", ".claude/lib/tests/test_x.py")], _RULES)
+        self.assertEqual(findings, [])
+
+    def test_ci_topology_fires_on_modify(self) -> None:
+        findings = evaluate([("M", ".github/workflows/ci.yml")], _RULES)
+        self.assertIn("ci-topology", {f.surface for f in findings})
+
+    def test_ci_topology_satisfied_by_claude_md(self) -> None:
+        findings = evaluate([("M", ".github/workflows/ci.yml"), ("M", "CLAUDE.md")], _RULES)
+        self.assertNotIn("ci-topology", {f.surface for f in findings})
+
+    def test_precommit_change_fires_ci_topology(self) -> None:
+        findings = evaluate([("M", ".pre-commit-config.yaml")], _RULES)
+        self.assertIn("ci-topology", {f.surface for f in findings})
+
+    def test_unrelated_change_no_findings(self) -> None:
+        self.assertEqual(evaluate([("M", "README.md")], _RULES), [])
+
+    def test_finding_carries_code_paths_and_docs(self) -> None:
+        findings = evaluate([("A", ".claude/hooks/bar.py")], _RULES)
+        f = next(x for x in findings if x.surface == "new-module")
+        self.assertIn(".claude/hooks/bar.py", f.code_paths)
+        # expected_docs carries the rule's doc patterns verbatim.
+        self.assertIn(r"^ontology/conventions\.md$", f.expected_docs)
+
+
+class OptOut(unittest.TestCase):
+    def test_docs_na_marker(self) -> None:
+        self.assertTrue(has_opt_out(["chore: refactor\n\nDocs-N/A: pure rename"]))
+
+    def test_skip_token_case_insensitive(self) -> None:
+        self.assertTrue(has_opt_out(["fix bug\n\nSKIP-DOC-CHECK: trivial"]))
+
+    def test_no_marker(self) -> None:
+        self.assertFalse(has_opt_out(["feat: add a hook"]))
+
+    def test_bare_token_without_colon_is_not_optout(self) -> None:
+        # Prose that merely NAMES the marker must not self-trigger the opt-out —
+        # the colon is required. This is the footgun the colon form closes (a
+        # commit that documents the gate mentions "Docs-N/A" / "[skip-doc-check]").
+        self.assertFalse(
+            has_opt_out(["docs: explain the Docs-N/A and [skip-doc-check] opt-out markers"])
+        )
+
+    def test_empty(self) -> None:
+        self.assertFalse(has_opt_out([]))
+
+
+class Render(unittest.TestCase):
+    def test_clean_message_when_no_findings(self) -> None:
+        self.assertIn("no documented code surface", render([]))
+
+    def test_report_lists_surface_and_optout_hint(self) -> None:
+        out = render(evaluate([("A", ".claude/lib/foo.py")], _RULES))
+        self.assertIn("new-module", out)
+        self.assertIn("Docs-N/A", out)
+
+
+class CliAlwaysExitsZero(unittest.TestCase):
+    def test_injected_findings_exit_zero(self) -> None:
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = main(["doc_freshness.py", "--changed", "A:.claude/lib/foo.py"])
+        self.assertEqual(rc, 0)
+
+    def test_injected_optout_exit_zero_and_skips(self) -> None:
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = main(
+                [
+                    "doc_freshness.py",
+                    "--changed",
+                    "A:.claude/lib/foo.py",
+                    "--opt-out-text",
+                    "Docs-N/A: scaffolding only",
+                ]
+            )
+        self.assertEqual(rc, 0)
+        self.assertIn("opt-out", buf.getvalue())
+
+
+class RealRules(unittest.TestCase):
+    """The shipped SURFACE_RULES classify this repo's own paths sensibly."""
+
+    def test_real_rules_fire_on_new_lib_without_doc(self) -> None:
+        from doc_freshness import SURFACE_RULES
+
+        findings = evaluate([("A", ".claude/lib/doc_freshness.py")], SURFACE_RULES)
+        self.assertIn("new-org-hook-or-lib-module", {f.surface for f in findings})
+
+    def test_real_rules_satisfied_when_conventions_also_changed(self) -> None:
+        from doc_freshness import SURFACE_RULES
+
+        findings = evaluate(
+            [
+                ("A", ".claude/lib/doc_freshness.py"),
+                ("M", "ontology/conventions.md"),
+            ],
+            SURFACE_RULES,
+        )
+        self.assertEqual(findings, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/lib/tests/test_pre_commit_ci_sync.py
+++ b/.claude/lib/tests/test_pre_commit_ci_sync.py
@@ -429,6 +429,7 @@ _OLD_KIND_PATTERNS = {
     # Kept in lock-step with the production _KIND_PATTERNS so the OLD-vs-NEW
     # parity proof stays valid as new kinds are added (cf. memory-budget, #733).
     "memory-budget": ("memory-budget", "memory_budget"),
+    "doc-freshness": ("doc-freshness", "doc_freshness"),
 }
 _OLD_RUN_BLOCK_OPEN_RE = re.compile(r"^(?P<indent>\s*)-?\s*run:\s*[|>][+\-0-9]*\s*$")
 
@@ -506,6 +507,7 @@ _EXPECTED_KINDS = {
         "precommit": {
             "actionlint",
             "cspell",
+            "doc-freshness",
             "memory-budget",
             "mypy",
             "pytest",
@@ -515,6 +517,7 @@ _EXPECTED_KINDS = {
         "ci": {
             "actionlint",
             "cspell",
+            "doc-freshness",
             "memory-budget",
             "mypy",
             "pytest",

--- a/.claude/skills/ontology-rebuild/SKILL.md
+++ b/.claude/skills/ontology-rebuild/SKILL.md
@@ -17,6 +17,10 @@ The ontology system has three roles:
 
 A file is "dirty" when `last_tracked != last_resolved` in `checksums.json`.
 
+### Code is the final arbiter of truth
+
+This skill derives the ontology and the auto-updatable docs **FROM the code**. When the code and a doc/ontology entry disagree, **the code wins**: update the ontology/doc to match the code — never edit the code to match a stale doc. Source code (`.py`/`.ts`/`.tf`/`.yaml` config/schemas/…) is read first (step 2 orders code → docs → high-level-docs precisely so code is resolved before anything derived from it); READMEs, CLAUDE.md, inline docs, and the ontology files are downstream artifacts that must be brought into agreement with it. Recommend-only docs (high-level-docs/, architecture diagrams) are flagged for human review rather than auto-rewritten, but the conflict is still reported with code as the reference. This is the canonical statement of the org convention in `ontology/conventions.md` § Ontology: code is the arbiter of truth, enforced PR-side by the advisory `doc-freshness` gate (`.claude/lib/doc_freshness.py`, #768).
+
 ## Instructions
 
 ### 1. Read checksums and identify dirty files

--- a/.claude/team/charter/pull-requests.md
+++ b/.claude/team/charter/pull-requests.md
@@ -298,6 +298,7 @@ Closes #<issue-number>
 - [ ] Reviewed by another team member
 - [ ] Must-fix items resolved
 - [ ] Tech debt items filed as GitHub Issues (if any)
+- [ ] Docs updated for the code change (README / docs/ / ontology), or a `Docs-N/A:` opt-out trailer is justified
 
 Co-Authored-By: Firstname Lastname <parametrization+Firstname.Lastname@gmail.com>
 Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
@@ -308,6 +309,10 @@ EOF
 - PR title should be concise (under 70 characters).
 - The body must reference the related GitHub Issue(s) with `Closes #N`.
 - The submitting team member is responsible for creating the PR immediately upon branch completion.
+
+### Documentation freshness (advisory gate — #768)
+
+Code is the arbiter of truth for the docs: when a PR changes a **documented code surface**, the docs it implies (README / `docs/` / ontology / CLAUDE.md) are expected to move with it. The advisory `doc-freshness` gate (`.claude/lib/doc_freshness.py`, mirrored as the `Doc-freshness gate (advisory)` CI job and the `doc-freshness` pre-push hook) reports surfaces changed without a matching doc update. It is **advisory — never blocks** (it always exits 0; a heuristic freshness signal has unavoidable false-positives). When a change legitimately needs no doc update, declare it with a `Docs-N/A:` or `Skip-Doc-Check:` trailer line (the trailing colon is required) in a commit message or the PR body. Canonical rule: `ontology/conventions.md` § Ontology: code is the arbiter of truth.
 
 ## Closes-vs-Refs Disposition — Decided at Brief Time, Never Flipped <!-- promotion-target: none -->
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,3 +174,30 @@ jobs:
         # byte size exceed the budget in memory_budget.py. Mirrored locally by the
         # `memory-budget` pre-push hook; the sync-drift gate classifies the kind.
         run: python3 .claude/lib/memory_budget.py .
+
+  doc-freshness:
+    name: Doc-freshness gate (advisory)
+    runs-on: ubuntu-latest
+    # ADVISORY (#768): doc_freshness.py always exits 0, so this job is green by
+    # construction; continue-on-error makes the advisory intent explicit so a
+    # future edit can't silently turn a heuristic freshness nudge into a hard
+    # gate. The report still surfaces in the job log. Mirrored locally by the
+    # `doc-freshness` pre-push hook; the sync-drift gate classifies the kind
+    # (#684 parity) — the advisory check is mirrored, not exempt.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history so the merge-base three-dot diff against the PR base
+          # resolves (the default shallow checkout has no merge-base).
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Report code surfaces changed without a matching doc update (#768)
+        # Base ref comes from origin/$GITHUB_BASE_REF on a pull_request, falling
+        # back to origin/main. The PR body is passed so a `Docs-N/A` opt-out in
+        # the body (not just a commit message) is honored.
+        env:
+          DOC_FRESHNESS_OPT_OUT_TEXT: ${{ github.event.pull_request.body }}
+        run: python3 .claude/lib/doc_freshness.py .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -140,3 +140,19 @@ repos:
         pass_filenames: false
         always_run: true
         stages: [pre-push]
+      # doc-freshness mirrors the `Doc-freshness gate (advisory)` CI job in
+      # ci.yml (the sync-drift gate classifies the `doc-freshness` kind — #768/#684
+      # — so the CI advisory check must be mirrored here or the gate goes red).
+      # ADVISORY: doc_freshness.py always exits 0, so this hook never blocks a
+      # push — it prints which code surfaces changed without a matching doc
+      # update so the author sees the nudge before the PR opens. `always_run`
+      # because it computes its own three-dot diff against origin/main, not the
+      # staged file list; pre-push (not pre-commit) so the base/merge-base
+      # resolves and incremental in-progress commits aren't each flagged.
+      - id: doc-freshness
+        name: doc-freshness (pre-push, advisory)
+        entry: python3 .claude/lib/doc_freshness.py .
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-push]

--- a/ontology/conventions.md
+++ b/ontology/conventions.md
@@ -241,6 +241,11 @@ Existing 3-digit ADRs are not merge-blockers; renames are mechanical and reversi
 | `suggest_generic_prompt.py` | PostToolUse (Edit/Write) | Suggest generic prompts for `.claude/` changes |
 | `session_handoff.py` | Stop | Auto-generate handoff on session exit |
 
+### Ontology: code is the arbiter of truth (#768)
+
+- **Code wins on conflict.** `/ontology-rebuild` derives the ontology (`ontology/*.yaml`, this file) AND the auto-updatable docs (READMEs, CLAUDE.md, inline docs) **FROM the code**. When code and a doc/ontology entry disagree, the doc/ontology is wrong and is updated to match the code — the code is never edited to match a stale doc. The resolver processes files code → docs → high-level-docs (`ontology-rebuild` SKILL.md § Code is the final arbiter of truth) precisely so code is resolved before anything derived from it. Recommend-only docs (high-level-docs/, architecture diagrams, mermaid) are flagged for human review rather than auto-rewritten, but the conflict is still reported with code as the reference.
+- **PR doc-freshness (advisory).** Every PR is expected to carry the doc updates its code changes imply. The advisory gate `.claude/lib/doc_freshness.py` (#768) computes the three-dot diff against the PR base and reports any **documented code surface** (`SURFACE_RULES`: a new org hook/lib module, a new skill, a CI-workflow/pre-commit-config change) touched without a matching README/`docs/`/ontology/CLAUDE.md update. It is **advisory — always exits 0**, never blocking (a heuristic freshness signal has an irreducible false-positive class — pure refactors, typo fixes). It runs as the `Doc-freshness gate (advisory)` CI job (`continue-on-error`) and the `doc-freshness` pre-push hook; the sync-drift gate classifies the `doc-freshness` kind so the local⇄CI mirror is enforced (#684). A legitimately doc-irrelevant change opts out with a `Docs-N/A:` or `Skip-Doc-Check:` trailer line (the trailing colon is required, so prose that merely names the marker does not self-trigger) in a commit message or the PR body. The charter PR Review Checklist carries the human-side reminder (`charter/pull-requests.md`).
+
 ## Shared tooling
 
 ### Package management


### PR DESCRIPTION
## Summary

Implements #768 (part of #765): makes **code the final arbiter of truth for the ontology**, and adds an **advisory PR-time doc-freshness gate**.

### Code-as-truth (documentation)
- `ontology/conventions.md` — new rule **"Ontology: code is the arbiter of truth"**: `/ontology-rebuild` derives the ontology + auto-updatable docs FROM code; on conflict the doc/ontology is updated to match the code, never the reverse.
- `.claude/skills/ontology-rebuild/SKILL.md` — explicit **"Code is the final arbiter of truth"** subsection (code wins; code is never edited to match a stale doc).
- `.claude/team/charter/pull-requests.md` — Review-Checklist doc-update item + a doc-freshness subsection.

### Doc-freshness gate (advisory, modeled on the sync-drift gate)
- `.claude/lib/doc_freshness.py` — computes the three-dot diff against the PR base and reports **documented code surfaces** (a new hook/lib module, a new skill, a CI-workflow / pre-commit-config change) touched with **no matching README / docs/ / ontology update**.
- **Advisory by design — always exits 0.** A heuristic freshness signal has an irreducible false-positive class (pure refactors, typo fixes), so it nudges rather than blocks. Non-blocking on both sides of the mirror.
- A legitimately doc-irrelevant change opts out with a colon-terminated trailer line (`Docs` + `-N/A:` reason, or `Skip-Doc-Check:` reason) in a commit message or the PR body. The colon is required so prose that merely names the marker does not self-trigger.
- `.github/workflows/ci.yml` — `Doc-freshness gate (advisory)` job (`continue-on-error`, `fetch-depth: 0`).
- `.pre-commit-config.yaml` — `doc-freshness` pre-push hook (the mirror).
- `.claude/lib/pre_commit_ci_sync.py` — classifies the `doc-freshness` kind so the local⇄CI mirror is enforced (#684); the OLD reference patterns + expected-kinds table updated in lock-step.
- `.claude/lib/tests/test_doc_freshness.py` — surface firing, status scoping (new-module rules fire on `A`, not `M`), opt-out trailer, advisory exit-0.

### Verification
- Full `pre-commit run --hook-stage push --all-files`: all green (ruff-format/lint, actionlint, cspell, mypy, pytest, pytest-skills, memory-budget, doc-freshness).
- The gate run on this PR's own diff reports cleanly ("no documented code surface changed without a matching doc update").

## Related Issues

Closes #768
Part of #765

Co-Authored-By: Aino Virtanen <parametrization+Aino.Virtanen@gmail.com>
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
