### PR TITLE
fix(ontology): reconcile services.yaml to compose ground truth (#783) + resolve lifecycle.md cross-ref (#782)

### DIFF
--- a/ontology/lifecycle.md
+++ b/ontology/lifecycle.md
@@ -240,7 +240,7 @@ with drafts, writes a per-wave audit log. Driven by a byte-deterministic
 errors (excluding benign traces) and surfaces recent ones; suggests
 `/annunaki-attack` at 5+ unprocessed errors. Does not fix anything.
 
-- **(a) code/repo actions:** `grep` for `annunaki_monitor` in `.claude/settings.json` (hook-active check); reads `.claude/annunaki/errors.jsonl` via `.claude/lib/annunaki_parse.py` (skips blanks/corrupt lines and benign `traces.jsonl`-class records). No writes.
+- **(a) code/repo actions:** hook-active check — confirms `post_dispatcher.py` is wired on `PostToolUse` Bash in `.claude/settings.json` **and** `annunaki_monitor` is registered in its `_REGISTRY` (post-#625 the monitor is dispatched, not wired directly — see #788); reads `.claude/annunaki/errors.jsonl` via `.claude/lib/annunaki_parse.py` (skips blanks/corrupt lines and benign `traces.jsonl`-class records). No writes.
 - **(b) GitHub API:** none.
 - **(c) MCP calls:** none.
 - **(d) other external services:** none.
@@ -260,6 +260,23 @@ errors (excluding benign traces) and surfaces recent ones; suggests
 > pass") — driving the deployed UI through the operator's already-authenticated
 > session and filing findings per the bug→issue→PR workflow. That pass is not a
 > slash command and not part of the lifecycle happy path.
+
+### Exploratory / E2E live-app pass
+
+**Purpose:** the one on-demand, non-command step in the org workflow that uses
+the **Chrome MCP** (`claude-in-chrome`). An operator-initiated pass that drives
+the **deployed** app's UI (staging or prod) through the operator's
+already-authenticated browser session — clicking through real flows, reading the
+rendered DOM/console/network, and spotting behaviour a unit/integration test
+would not (visual regressions, broken auth redirects, empty-state rendering,
+500s behind a button). Findings are filed through the normal bug→issue→PR
+workflow. It is **not** a slash command and **not** part of the linear happy
+path — it is invoked only when a human wants eyes on the live product.
+
+- **(a) code/repo actions:** none directly; any fix lands as a normal issue→PR.
+- **(b) GitHub API:** only via the downstream bug→issue→PR workflow (`gh issue`/PR).
+- **(c) MCP calls:** the Chrome MCP (`claude-in-chrome`) — the sole MCP usage anywhere in the org workflow.
+- **(d) other external services:** the deployed app under test (staging/prod URL).
 
 ---
 

--- a/ontology/services.yaml
+++ b/ontology/services.yaml
@@ -203,6 +203,34 @@ data_stores:
     consumers: [user-service]
     purpose: [session_state, rate_limiting, verification_tracking]
 
+# --- Deploy runtime topology (compose-derived ground truth) ---
+# The `services:` block above is the SEMANTIC app model (logical names, APIs).
+# This section is the LITERAL container roster + network split, derived from the
+# deploy compose at origin HEAD, so the semantic model and the running stack do
+# not silently drift (#783). Re-derive via /ontology-rebuild when compose changes.
+deploy_runtime_topology:
+  source:
+    repo: noorinalabs-deploy
+    path: compose/docker-compose.prod.yml
+    ref: 273f2201e54e82ca2bf9527c9a092c45bb988ec5
+  service_count: 30
+  networks:
+    backend:      { driver: bridge, internal: true,  purpose: "internal mesh — DBs, app, observability, kafka (25 attachments)" }
+    frontend:     { driver: bridge, internal: false, purpose: "caddy-facing edge — api, frontend, landing, blackbox probes" }
+    user-backend: { driver: bridge, internal: true,  purpose: "user-service ↔ user-postgres / user-redis isolation" }
+    egress:       { driver: bridge, internal: false, purpose: "outbound-only — alertmanager notify, embed model pulls, ingest workers" }
+  long_running:   # restart: unless-stopped (26)
+    [neo4j, postgres, redis, api, frontend, landing, caddy, user-service, user-postgres,
+     user-redis, prometheus, alertmanager, grafana, loki, alloy, node-exporter,
+     postgres-exporter, user-postgres-exporter, blackbox-exporter, kafka, kafka-exporter,
+     kafka-ui, dedup-worker, enrich-worker, normalize-worker, graph-load-worker]
+  init_one_shot:  # restart: "no" — run once then exit (3)
+    kafka-init:           { image: apache/kafka:3.9.2,  purpose: "create kafka topics before workers connect" }
+    user-service-migrate: { image: "ghcr.io/noorinalabs/noorinalabs-user-service:${USER_SERVICE_IMAGE_TAG:-latest}", network: user-backend, purpose: "alembic migrations before user-service starts" }
+    loki-runtime-init:    { image: busybox:1.37,        purpose: "prepare loki runtime dirs/permissions" }
+  optional_profiles:  # not started by default (1)
+    isnad-graph-embed: { profile: embed, image: "${EMBED_IMAGE:-ghcr.io/noorinalabs/noorinalabs-isnad-graph-embed:stg-latest}", networks: [backend, egress], purpose: "on-demand semantic-search re-embed job" }
+
 # --- Cross-repo repository_dispatch contracts ---
 # Each entry pairs a sender workflow (`peter-evans/repository-dispatch` step) with the
 # listener workflow whose `on.repository_dispatch.types` accepts the literal `event_type`
@@ -305,7 +333,7 @@ infrastructure:
     # per main#212 owner direction), DNS-flip, decommission old prod (#86 retitle pending).
     servers:
       stg:  { hetzner_name: noorinalabs-1box-stg,  system_hostname: noorinalabs-1box-stg,  ipv4: 87.99.137.225, type: CPX21, specs: { vcpu: 3, ram_gb: 4 }, state_key: hetzner/stg.tfstate,  notes: "Cloned from prod template — same package set incl. openssh-server + fail2ban. deploy#82 provisioned VPSes via TF but did NOT inject cloud-init SSH keys (real gap, 2026-04-24); first-access required Hetzner password reset + manual key paste. Cloning artifacts: /home/deploy was root-owned with deploy-owned subdirs (chown -R recovered 2026-04-24); old system hostname was 'noorinalabs-isnad-graph-prod' (renamed). Option C cutover plan retires this clone and rebuilds via clean cloud-init." }
-      prod: { hetzner_name: noorinalabs-1box-prod, system_hostname: noorinalabs-1box-prod, ipv4: 87.99.134.161, type: CPX41, specs: { vcpu: 8, ram_gb: 16 }, state_key: hetzner/prod.tfstate, notes: "Full stack: caddy + landing + isnad-graph (api+frontend) + user-service + neo4j + 2x postgres + 2x redis + kafka (bitnamilegacy, deploy#100 owner-decision pending) + kafka-ui + prometheus + grafana + loki + promtail + alertmanager + 2x postgres-exporter + node-exporter." }
+      prod: { hetzner_name: noorinalabs-1box-prod, system_hostname: noorinalabs-1box-prod, ipv4: 87.99.134.161, type: CPX41, specs: { vcpu: 8, ram_gb: 16 }, state_key: hetzner/prod.tfstate, notes: "Full stack: caddy + landing + isnad-graph (api+frontend) + user-service + neo4j + 2x postgres + 2x redis + kafka (apache/kafka:3.9.2) + kafka-ui + prometheus + grafana + loki + alloy + alertmanager + 2x postgres-exporter + node-exporter + blackbox-exporter + kafka-exporter. Full compose-derived roster (30 services incl. init/one-shot + embed profile, 4 networks) in deploy_runtime_topology below." }
 
   dns:
     provider: Cloudflare
@@ -332,9 +360,9 @@ infrastructure:
   observability:
     metrics: { tool: Prometheus v3.4.0, retention: 30d }
     dashboards: { tool: Grafana 11.6.0, path: /grafana }
-    logs: { tool: Loki 2.9.10, shipper: Promtail 2.9.10, retention: 7d }
+    logs: { tool: Loki 2.9.10, shipper: Grafana Alloy v1.16.1, retention: 7d }  # alloy replaced promtail in the live stack (#783)
     alerting: { tool: Alertmanager v0.28.1 }
-    exporters: [node-exporter v1.9.1, postgres-exporter v0.16.0]
+    exporters: [node-exporter v1.9.1, postgres-exporter v0.16.0, user-postgres-exporter v0.16.0, blackbox-exporter v0.25.0, kafka-exporter v1.9.0]
 
   ci_cd:
     platform: GitHub Actions


### PR DESCRIPTION
## Summary

Two P6W1 doc-truth follow-ups under meta #765, reconciling ontology artifacts against ground truth.

### #783 — `services.yaml` ⇄ deploy compose reconciliation
`ontology/services.yaml` had drifted from the authoritative deploy compose (`noorinalabs-deploy compose/docker-compose.prod.yml` @ origin **273f220** — 30 services, 4 networks). Derived directly from that source (origin HEAD, per the canonical-source lesson):
- **alloy-not-promtail:** `observability.logs` shipper Promtail → **Grafana Alloy v1.16.1**; prod-box notes updated.
- **missing exporters added:** `user-postgres-exporter v0.16.0`, `blackbox-exporter v0.25.0`, `kafka-exporter v1.9.0`.
- **new `deploy_runtime_topology` section** — the literal **30-service roster** (26 long-running + 3 init/one-shot `kafka-init`/`user-service-migrate`/`loki-runtime-init` + 1 `embed`-profile `isnad-graph-embed`) and the **4-network split** incl. the previously-missing outbound-only **`egress`** network. Kept distinct from the existing *semantic* app model so the two don't silently re-drift.
- prod-box note kafka image corrected (`bitnamilegacy` → `apache/kafka:3.9.2`).

### #782 — `lifecycle.md` dangling cross-ref
- Added the **"Exploratory / E2E live-app pass"** Mid-wave subsection that lifecycle.md's Chrome-MCP note already pointed at (the prose cross-ref was dangling — lychee can't catch prose refs).
- Also corrected lifecycle.md's `/annunaki` hook-active-check description to the post-#625 **dispatcher indirection** — it still described the old broken `grep annunaki_monitor settings.json`, the exact thing the just-merged **#788** fixed.

## Verification
- `services.yaml` parses; `deploy_runtime_topology.service_count == 30 == len(long_running)+len(init_one_shot)+len(optional_profiles)`; 4 networks present.
- All image tags/profiles/networks pulled directly from compose @ 273f220 (not a local checkout).
- The new lifecycle.md subsection heading exactly matches the existing pointer text `§ Mid-wave "Exploratory / E2E live-app pass"`.

## TechDebt: none — ontology/doc reconciliation; no new debt. Checksum resolution flows through the standard session-start `/ontology-rebuild`.

Closes #783
Closes #782

🤖 Generated with [Claude Code](https://claude.com/claude-code)
