### PR TITLE
ci(docs): mermaid render gate — fail on non-rendering diagrams (#787)

### DIFF
--- a/.claude/lib/pre_commit_ci_sync.py
+++ b/.claude/lib/pre_commit_ci_sync.py
@@ -144,6 +144,13 @@ _KIND_PATTERNS: dict[str, tuple[str, ...]] = {
     # PR time. Patterns cover the hook `id`/`name` token (`office-drift`) and the
     # generator both sides invoke (`gen-office`).
     "office-drift": ("office-drift", "gen-office"),
+    # `mermaid` is the mermaid render gate (#787): the CI `Mermaid render gate`
+    # job installs mermaid-cli and runs `scripts/check-mermaid.py` to render every
+    # fenced mermaid block, failing on a non-rendering diagram. Classifying it
+    # makes the drift gate DEMAND the pre-commit mirror (#684). Patterns cover the
+    # tool/hook token (`mermaid`) and the validator both sides invoke
+    # (`check-mermaid`).
+    "mermaid": ("mermaid", "check-mermaid"),
 }
 
 

--- a/.claude/lib/tests/test_pre_commit_ci_sync.py
+++ b/.claude/lib/tests/test_pre_commit_ci_sync.py
@@ -248,6 +248,66 @@ repos:
         self.assertNotIn("office-drift", harmful)
 
 
+class MermaidKind(unittest.TestCase):
+    """#787: the mermaid render gate must be a classified kind so the sync-drift
+    gate DEMANDS a pre-commit mirror of the CI render job (an un-mirrored gate
+    lets a non-rendering diagram fail only at PR time)."""
+
+    def test_ci_mermaid_run_step_classified(self) -> None:
+        wf = """
+jobs:
+  mermaid-render:
+    steps:
+      - run: npm install -g @mermaid-js/mermaid-cli@11.12.0
+      - run: python3 scripts/check-mermaid.py
+"""
+        self.assertIn("mermaid", kinds_from_ci(wf))
+
+    def test_precommit_mermaid_hook_classified(self) -> None:
+        cfg = """
+repos:
+  - repo: local
+    hooks:
+      - id: mermaid-render
+        name: mermaid-render (pre-push)
+        entry: python3 scripts/check-mermaid.py
+"""
+        self.assertIn("mermaid", kinds_from_precommit(cfg))
+
+    def test_ci_mermaid_without_precommit_is_harmful_drift(self) -> None:
+        wf = """
+jobs:
+  mermaid-render:
+    steps:
+      - run: python3 scripts/check-mermaid.py
+"""
+        cfg = """
+repos:
+  - repo: local
+    hooks:
+      - id: ruff
+"""
+        harmful, _ = compute_drift(kinds_from_precommit(cfg), kinds_from_ci(wf))
+        self.assertIn("mermaid", harmful)
+
+    def test_ci_mermaid_with_precommit_mirror_no_drift(self) -> None:
+        wf = """
+jobs:
+  mermaid-render:
+    steps:
+      - run: python3 scripts/check-mermaid.py
+"""
+        cfg = """
+repos:
+  - repo: local
+    hooks:
+      - id: mermaid-render
+        entry: python3 scripts/check-mermaid.py
+"""
+        harmful, _ = compute_drift(kinds_from_precommit(cfg), kinds_from_ci(wf))
+        self.assertNotIn("mermaid", harmful)
+
+
 class BuildKindTightening(unittest.TestCase):
     """#576: runtime `docker build` / `docker buildx` steps are image-MOVING,
     not a build-QUALITY gate a local pre-commit hook can mirror — they must
@@ -492,6 +552,7 @@ _OLD_KIND_PATTERNS = {
     "memory-budget": ("memory-budget", "memory_budget"),
     "doc-freshness": ("doc-freshness", "doc_freshness"),
     "office-drift": ("office-drift", "gen-office"),
+    "mermaid": ("mermaid", "check-mermaid"),
 }
 _OLD_RUN_BLOCK_OPEN_RE = re.compile(r"^(?P<indent>\s*)-?\s*run:\s*[|>][+\-0-9]*\s*$")
 
@@ -571,6 +632,7 @@ _EXPECTED_KINDS = {
             "cspell",
             "doc-freshness",
             "memory-budget",
+            "mermaid",
             "mypy",
             "office-drift",
             "pytest",
@@ -582,6 +644,7 @@ _EXPECTED_KINDS = {
             "cspell",
             "doc-freshness",
             "memory-budget",
+            "mermaid",
             "mypy",
             "office-drift",
             "pytest",

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,6 +34,8 @@ on:
       # check (binaries are not matched by the **/*.md|json|yaml globs above).
       - "docs/office/**"
       - "scripts/gen-office.sh"
+      # Mermaid render gate (#787): a changed doc or the validator must re-run.
+      - "scripts/check-mermaid.py"
       - ".github/workflows/docs.yml"
   pull_request:
     branches: [main, "deployments/**"]
@@ -55,6 +57,8 @@ on:
       # check (binaries are not matched by the **/*.md|json|yaml globs above).
       - "docs/office/**"
       - "scripts/gen-office.sh"
+      # Mermaid render gate (#787): a changed doc or the validator must re-run.
+      - "scripts/check-mermaid.py"
       - ".github/workflows/docs.yml"
 
 permissions:
@@ -208,6 +212,30 @@ jobs:
         # shellcheck integration runs (per the actionlint-needs-shellcheck
         # discipline) rather than silently skipping.
         run: actionlint -color
+
+  mermaid-render:
+    name: Mermaid render gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install pinned mermaid-cli
+        # Pinned to @mermaid-js/mermaid-cli@11.12.0 (matches the version the gate
+        # was verified against). mermaid-cli bundles puppeteer, which downloads a
+        # headless Chromium on install. Keep this version in lock-step with the
+        # pre-commit mirror's note (alongside the ruff/actionlint/cspell/pandoc pins).
+        run: npm install -g @mermaid-js/mermaid-cli@11.12.0
+      - name: Render every fenced mermaid block (fail on non-rendering)
+        # check-mermaid.py extracts each ```mermaid block from docs/*.md +
+        # ontology/*.md and renders it with mmdc; a syntactically-broken block
+        # (the #786 `<unset>` class) fails the build instead of shipping a blank
+        # box into the rendered docs and the #767 Office pipeline.
+        run: python3 scripts/check-mermaid.py
 
   office-drift:
     name: Office docs drift gate

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -174,3 +174,19 @@ repos:
         pass_filenames: false
         always_run: true
         stages: [pre-push]
+      # mermaid-render mirrors the `Mermaid render gate` CI job in
+      # .github/workflows/docs.yml (the sync-drift gate classifies the `mermaid`
+      # kind — #787/#684 — so the CI gate must be mirrored here or the gate goes
+      # red). Renders every fenced ```mermaid block in docs/*.md + ontology/*.md
+      # and HARD-BLOCKS the push on any block that fails to render (#786). Needs
+      # mmdc locally — check-mermaid.py resolves $MMDC, then `mmdc` on PATH, then
+      # `npx -y @mermaid-js/mermaid-cli` (pin 11.12.0 to match CI). `always_run`
+      # because it scans the whole doc set, not the staged file list; pre-push so
+      # it doesn't fire (and spin up Chromium) on every incremental commit.
+      - id: mermaid-render
+        name: mermaid-render (pre-push)
+        entry: python3 scripts/check-mermaid.py
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-push]

--- a/scripts/check-mermaid.py
+++ b/scripts/check-mermaid.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Validate every fenced ```mermaid block in the given docs by RENDERING it.
+
+The #786 review surfaced that no CI job rendered mermaid diagrams, so a
+syntactically-broken block (the L3 alertmanager `<unset>` case) shipped green —
+markdown-lint, cspell, and lychee all pass a non-rendering diagram. This gate
+closes that gap: it extracts each fenced mermaid block and renders it with
+mermaid-cli (`mmdc`, headless Chromium), failing the build on any block that
+does not render.
+
+Scope (default): docs/*.md + ontology/*.md. Pass explicit file paths to override.
+
+Detection: a block fails if `mmdc` exits non-zero (genuine syntax errors,
+unknown diagram types, malformed structure) OR if the produced SVG carries a
+mermaid error marker (defends against versions that emit an error-SVG with a
+zero exit). KNOWN RESIDUAL (documented, not hidden): a literal `<` inside a
+`[label]` is treated by mermaid as an HTML tag and renders DEGRADED with a clean
+exit — render-gating cannot catch that via exit code. Authors must escape raw
+angle brackets in labels (`#lt;`/`#gt;`), which is exactly the #786 fix. The
+gate prints a warning when it sees a raw `<`/`>` inside a block so the footgun
+is at least surfaced.
+
+mmdc resolution order: $MMDC, then `mmdc` on PATH, then `npx -y
+@mermaid-js/mermaid-cli`. Chromium is run with `--no-sandbox` (required in CI
+containers) via a generated puppeteer config.
+
+Exit codes:
+    0 — every block rendered (gate green)
+    1 — at least one block failed to render
+    2 — no mmdc available / usage error
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+_MERMAID_BLOCK = re.compile(r"^([ \t]*)```mermaid[ \t]*\n(.*?)^[ \t]*```", re.DOTALL | re.MULTILINE)
+_ERROR_MARKERS = ("syntax error", "error in text", "aborted", "parse error")
+# A raw `<` or `>` that is not part of a mermaid edge token (`-->`, `<--`,
+# `<==`, `-.->`) and not a `<br>` line-break tag. Used only for an advisory
+# footgun warning, never to fail the gate (heuristic; full render is the gate).
+_RAW_ANGLE = re.compile(r"<(?!br\b|/|--|==|\.)|(?<![-=.])>")
+
+
+def _default_files() -> list[Path]:
+    files: list[Path] = []
+    for d in ("docs", "ontology"):
+        files.extend(sorted(Path(d).glob("*.md")))
+    return files
+
+
+def _resolve_mmdc() -> list[str] | None:
+    env = os.environ.get("MMDC")
+    if env:
+        return [env]
+    if shutil.which("mmdc"):
+        return ["mmdc"]
+    if shutil.which("npx"):
+        return ["npx", "-y", "@mermaid-js/mermaid-cli"]
+    return None
+
+
+def _iter_blocks(text: str) -> list[tuple[int, str]]:
+    """Return (1-based start line of the ```mermaid fence, block body)."""
+    blocks: list[tuple[int, str]] = []
+    for m in _MERMAID_BLOCK.finditer(text):
+        line_no = text.count("\n", 0, m.start()) + 1
+        blocks.append((line_no, m.group(2)))
+    return blocks
+
+
+def _render(mmdc: list[str], mmd: Path, out: Path, pp: Path) -> tuple[bool, str]:
+    """Render one block. Return (ok, detail)."""
+    try:
+        proc = subprocess.run(
+            [*mmdc, "-i", str(mmd), "-o", str(out), "-p", str(pp)],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+    except subprocess.TimeoutExpired:
+        return False, "mmdc timed out (>120s)"
+    if proc.returncode != 0:
+        tail = (proc.stderr or proc.stdout or "").strip().splitlines()
+        return False, tail[0] if tail else f"mmdc exit {proc.returncode}"
+    if out.is_file():
+        svg = out.read_text(encoding="utf-8", errors="replace").lower()
+        if any(mark in svg for mark in _ERROR_MARKERS):
+            return False, "rendered SVG contains a mermaid error marker"
+    return True, "ok"
+
+
+def main(argv: list[str]) -> int:
+    files = [Path(a) for a in argv[1:]] or _default_files()
+    files = [f for f in files if f.is_file()]
+    if not files:
+        print("check-mermaid: no input files.", file=sys.stderr)
+        return 0
+
+    mmdc = _resolve_mmdc()
+    if mmdc is None:
+        print(
+            "check-mermaid: mmdc not found. Install @mermaid-js/mermaid-cli "
+            "(npm i -g @mermaid-js/mermaid-cli) or set $MMDC.",
+            file=sys.stderr,
+        )
+        return 2
+
+    # Temp dir under cwd so a snap-confined local mmdc can read it (snap cannot
+    # access /tmp); CI's npm mmdc is unconfined and works either way.
+    workdir = Path(tempfile.mkdtemp(prefix=".mmcheck-", dir="."))
+    pp = workdir / "puppeteer.json"
+    pp.write_text('{"args":["--no-sandbox"]}', encoding="utf-8")
+
+    failures: list[str] = []
+    total = 0
+    try:
+        for f in files:
+            text = f.read_text(encoding="utf-8")
+            for idx, (line_no, body) in enumerate(_iter_blocks(text)):
+                total += 1
+                if _RAW_ANGLE.search(body):
+                    print(
+                        f"  warning {f}:{line_no} — raw '<'/'>' in a mermaid block; "
+                        "escape as #lt;/#gt; in labels (renders degraded otherwise, #786)."
+                    )
+                mmd = workdir / f"b{total}.mmd"
+                mmd.write_text(body, encoding="utf-8")
+                ok, detail = _render(mmdc, mmd, workdir / f"b{total}.svg", pp)
+                where = f"{f}:{line_no} (block #{idx + 1})"
+                if ok:
+                    print(f"  ok   {where}")
+                else:
+                    failures.append(f"{where} — {detail}")
+                    print(f"  FAIL {where} — {detail}")
+    finally:
+        shutil.rmtree(workdir, ignore_errors=True)
+
+    print(f"\nchecked {total} mermaid block(s) across {len(files)} file(s).")
+    if failures:
+        print(f"\n{len(failures)} mermaid block(s) failed to render:", file=sys.stderr)
+        for fail in failures:
+            print(f"  - {fail}", file=sys.stderr)
+        return 1
+    print("all mermaid blocks render cleanly.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
## Summary

Closes the structural gap #786 surfaced: **no CI job renders mermaid diagrams**, so a syntactically-broken block ships green (markdown-lint, cspell, and lychee all pass a non-rendering diagram). On #786, an L3 alertmanager block with a literal `<unset>` was caught *only* because a reviewer manually validated each block through the Mermaid Chart MCP — not a durable guarantee.

## What's in it (full render via mmdc, per owner choice)
- **`scripts/check-mermaid.py`** — extracts every ```mermaid block from `docs/*.md` + `ontology/*.md` and renders each with mermaid-cli (`mmdc`, headless Chromium, `--no-sandbox`). A block fails on non-zero exit OR a mermaid error marker in the rendered SVG.
- **`Mermaid render gate`** CI job in `docs.yml` (node + pinned `@mermaid-js/mermaid-cli@11.12.0`).
- **Pre-push mirror** (`mermaid-render` hook) for #684 local⇄CI parity.
- **`mermaid` kind** in `pre_commit_ci_sync.py` + **4 classifier tests**; parent parity expectations updated.

## Honest residual (no silent caps)
A literal `<` inside a `[label]` is treated by mermaid as an HTML tag and renders **degraded with a clean exit** — render-gating can't catch that via exit code. The script **warns** on raw `<`/`>` in a block, and authors must escape them (`#lt;`/`#gt;`) — exactly the #786 fix. mmdc *does* catch the broad class (syntax errors, unknown diagram types, malformed structure, bare `<unset>`).

## Verification (local)
- All **25** existing blocks render cleanly; a deliberately broken block **fails** the gate (rc=1).
- `pre_commit_ci_sync.py .` → `OK` (mermaid mirrored both sides); classifier suite **47 passed**; full lib suite **225 passed**; mypy + ruff clean.
- **The CI `Mermaid render gate` job is the dispositive proof** that npm mmdc + Chromium render the real diagrams in CI.

## TechDebt: none — completes a #765 follow-up; no new debt.

Closes #787

🤖 Generated with [Claude Code](https://claude.com/claude-code)
