### PR TITLE
process(ci): widen mermaid render gate scope to README + charter + lifecycle (#795)

### DIFF
--- a/.claude/team/lifecycle.md
+++ b/.claude/team/lifecycle.md
@@ -60,9 +60,9 @@ flowchart TD
     subgraph "End of wave"
         WE1[/wave-wrapup P M/]
         WE2[/wave-retro P M/]
-        WE2_5[/promotion-audit/<br/>Step 7.5]
-        WE2_6[/annunaki-attack/<br/>Step 7.6]
-        WE3[/wave-scope P M+1/<br/>Step 9 auto-invoke]
+        WE2_5[/promotion-audit<br/>Step 7.5/]
+        WE2_6[/annunaki-attack<br/>Step 7.6/]
+        WE3[/wave-scope P M+1<br/>Step 9 auto-invoke/]
         WE1 --> WE2
         WE2 --> WE2_5
         WE2_5 --> WE2_6

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,7 +34,10 @@ on:
       # check (binaries are not matched by the **/*.md|json|yaml globs above).
       - "docs/office/**"
       - "scripts/gen-office.sh"
-      # Mermaid render gate (#787): a changed doc or the validator must re-run.
+      # Mermaid render gate (#787, scope widened #795): a changed doc or the
+      # validator must re-run. Every authored *.md is now in the gate's scan, so
+      # the `**/*.md` glob above already triggers it for README, charter, and
+      # lifecycle docs — no per-file path entry is needed here.
       - "scripts/check-mermaid.py"
       - ".github/workflows/docs.yml"
   pull_request:
@@ -57,7 +60,10 @@ on:
       # check (binaries are not matched by the **/*.md|json|yaml globs above).
       - "docs/office/**"
       - "scripts/gen-office.sh"
-      # Mermaid render gate (#787): a changed doc or the validator must re-run.
+      # Mermaid render gate (#787, scope widened #795): a changed doc or the
+      # validator must re-run. Every authored *.md is now in the gate's scan, so
+      # the `**/*.md` glob above already triggers it for README, charter, and
+      # lifecycle docs — no per-file path entry is needed here.
       - "scripts/check-mermaid.py"
       - ".github/workflows/docs.yml"
 
@@ -231,10 +237,12 @@ jobs:
         # pre-commit mirror's note (alongside the ruff/actionlint/cspell/pandoc pins).
         run: npm install -g @mermaid-js/mermaid-cli@11.12.0
       - name: Render every fenced mermaid block (fail on non-rendering)
-        # check-mermaid.py extracts each ```mermaid block from docs/*.md +
-        # ontology/*.md and renders it with mmdc; a syntactically-broken block
-        # (the #786 `<unset>` class) fails the build instead of shipping a blank
-        # box into the rendered docs and the #767 Office pipeline.
+        # check-mermaid.py extracts each ```mermaid block from every tracked
+        # *.md that contains one (the whole parent tree — README, charter, and
+        # lifecycle docs included as of #795 — minus .claude/memory/** and
+        # .claude/worktrees/**) and renders it with mmdc; a syntactically-broken
+        # block (the #786 `<unset>` class) fails the build instead of shipping a
+        # blank box into the rendered docs and the #767 Office pipeline.
         run: python3 scripts/check-mermaid.py
 
   office-drift:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -177,8 +177,10 @@ repos:
       # mermaid-render mirrors the `Mermaid render gate` CI job in
       # .github/workflows/docs.yml (the sync-drift gate classifies the `mermaid`
       # kind — #787/#684 — so the CI gate must be mirrored here or the gate goes
-      # red). Renders every fenced ```mermaid block in docs/*.md + ontology/*.md
-      # and HARD-BLOCKS the push on any block that fails to render (#786). Needs
+      # red). Renders every fenced ```mermaid block in every tracked *.md that
+      # contains one (the whole parent tree as of #795, minus .claude/memory/**
+      # and .claude/worktrees/**) and HARD-BLOCKS the push on any block that
+      # fails to render (#786). Needs
       # mmdc locally — check-mermaid.py resolves $MMDC, then `mmdc` on PATH, then
       # `npx -y @mermaid-js/mermaid-cli` (pin 11.12.0 to match CI). `always_run`
       # because it scans the whole doc set, not the staged file list; pre-push so

--- a/scripts/check-mermaid.py
+++ b/scripts/check-mermaid.py
@@ -8,7 +8,12 @@ closes that gap: it extracts each fenced mermaid block and renders it with
 mermaid-cli (`mmdc`, headless Chromium), failing the build on any block that
 does not render.
 
-Scope (default): docs/*.md + ontology/*.md. Pass explicit file paths to override.
+Scope (default): every tracked `*.md` in the parent tree that contains a fenced
+mermaid block — discovered from the git index, not a fixed docs/ + ontology/
+glob, so a diagram added to README.md, the charter, the lifecycle docs, or any
+future authored doc is gated automatically instead of shipping unguarded (#795).
+`.claude/memory/**` and `.claude/worktrees/**` are excluded (see _default_files).
+Pass explicit file paths to override.
 
 Detection: a block fails if `mmdc` exits non-zero (genuine syntax errors,
 unknown diagram types, malformed structure) OR if the produced SVG carries a
@@ -48,11 +53,51 @@ _ERROR_MARKERS = ("syntax error", "error in text", "aborted", "parse error")
 _RAW_ANGLE = re.compile(r"<(?!br\b|/|--|==|\.)|(?<![-=.])>")
 
 
+# Authored-doc scope exclusions. `.claude/memory/**` is excluded to match the
+# markdown/cspell/lychee linters (dense append-only notes, not rendered docs);
+# `.claude/worktrees/**` is excluded so a scratch worktree checkout isn't
+# double-scanned. The gitignored child repos never appear in this repo's index,
+# so they need no explicit exclusion under the git-ls-files path.
+_SCOPE_EXCLUDE_PREFIXES = (".claude/memory/", ".claude/worktrees/")
+
+
+def _has_mermaid_block(path: Path) -> bool:
+    try:
+        return "```mermaid" in path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return False
+
+
+def _tracked_markdown() -> list[Path] | None:
+    """Tracked `*.md` paths from the git index, or None if git is unavailable."""
+    try:
+        proc = subprocess.run(
+            ["git", "ls-files", "-z", "*.md"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    return [Path(p) for p in proc.stdout.split("\0") if p]
+
+
 def _default_files() -> list[Path]:
-    files: list[Path] = []
-    for d in ("docs", "ontology"):
-        files.extend(sorted(Path(d).glob("*.md")))
-    return files
+    tracked = _tracked_markdown()
+    if tracked is None:
+        # Not a git work tree (never the case for the CI / pre-push gate): fall
+        # back to the original docs/ + ontology/ glob so the gate still runs.
+        candidates: list[Path] = []
+        for d in ("docs", "ontology"):
+            candidates.extend(Path(d).glob("*.md"))
+    else:
+        candidates = tracked
+    files = [
+        p
+        for p in candidates
+        if not p.as_posix().startswith(_SCOPE_EXCLUDE_PREFIXES) and _has_mermaid_block(p)
+    ]
+    return sorted(files)
 
 
 def _resolve_mmdc() -> list[str] | None:


### PR DESCRIPTION
## Summary

Widens the #787 Mermaid render gate beyond its original `docs/*.md` + `ontology/*.md` floor so the **5 fenced ` ```mermaid ` blocks that live outside that scope are now guarded** (follow-up from #794 review by Nadia):

| File | Blocks newly covered |
|------|----------------------|
| `README.md` | 1 |
| `.claude/team/charter.md` | 1 |
| `.claude/team/lifecycle.md` | 3 |
| **Total** | **5** |

## What changed

- **`scripts/check-mermaid.py`** — the default scan set is now discovered from the **git index** (`git ls-files '*.md'`, filtered to files that contain a fenced mermaid block) instead of a fixed `docs/` + `ontology/` glob. `.claude/memory/**` and `.claude/worktrees/**` are excluded to match the markdown/cspell/lychee linter exclusions; the gitignored child repos never appear in the index. This makes the scope a deliberate rule ("every authored doc with a diagram"), so any *future* doc with a mermaid block is gated automatically — no whitelist to maintain. Falls back to the prior `docs/`+`ontology/` glob if git is unavailable (never the case for the CI/pre-push gate).
- **`.claude/team/lifecycle.md`** — fixed a **latent broken block** the widening surfaced: the wave-lifecycle flowchart used malformed parallelogram nodes `[/name/<br/>label]` (closing `/` misplaced) that mermaid could not parse. Corrected to `[/name<br/>label/]`. It had been shipping as an error box precisely because it was never in the gate's scope — exactly the gap #795 is about.
- **`.github/workflows/docs.yml`** + **`.pre-commit-config.yaml`** — updated the job/trigger/hook comments to describe the widened scope. The existing `**/*.md` path trigger already fires the job for the newly-covered files, so no per-file `paths:` entry was needed.

## Verification

- `python3 scripts/check-mermaid.py` → **30 blocks across 6 files render, exit 0** (mmdc via snap, local).
- `python3 .claude/lib/pre_commit_ci_sync.py .` → sync-drift gate passes (the `mermaid`/`check-mermaid` classification is unchanged).
- ruff (pinned 0.15.11) + actionlint clean; all pre-push hooks (incl. `mermaid-render`) passed on push.

Closes #795. Part of #765 follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T2U19RpdPtzAv8qfjQwacx
