### PR TITLE
tech-debt(reconcile): land stranded #734/#735 validators + wiring on main (#798)

### DIFF
--- a/.claude/lib/check_dockerfile_base_pin.py
+++ b/.claude/lib/check_dockerfile_base_pin.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Lint Dockerfile `FROM` statements for digest-pin + distro-upgrade compliance.
+
+Deterministic conversion of `.claude/team/charter/tech-decisions.md § Base Image
+Pinning` (noorinalabs-main#735, the charter-prose-inventory worklist item #4 /
+epic #726). The section requires every `FROM` to use a **digest-pinned tag**
+(`image:tag@sha256:<digest>`) **combined with an in-image package upgrade**, to
+close the two failure modes it names — floating-tag drift and within-tag package
+drift (the shape isnad-graph#853 hit).
+
+What this gate enforces (verbatim from the section's distro table)
+================================================================
+For every `FROM` that is not exempt:
+
+1. The image reference MUST carry an `@sha256:` digest pin.
+2. The stage MUST run the package-manager upgrade matching the base distro:
+
+   | Family      | Pin shape               | Upgrade command                                 |
+   |-------------|-------------------------|-------------------------------------------------|
+   | Alpine      | image:tag@sha256:digest | `RUN apk upgrade --no-cache`                    |
+   | Debian-slim | image:tag@sha256:digest | `apt-get update && apt-get -y upgrade && clean` |
+   | Distroless  | image:tag@sha256:digest | none — no package manager (pinned-only is fine) |
+
+   The distro family is inferred from the image name: `alpine` → Alpine,
+   `distroless` → Distroless (no upgrade required), otherwise the glibc/Debian
+   default (an apt upgrade is required). A genuinely-other base that has no
+   package manager should carry the `# RATIONALE:` exemption below.
+
+Exemptions honored (verbatim from the section)
+=============================================
+- **`scratch`** final/any layer — no package manager; the upstream stages that
+  produced its contents still follow the rule and are checked on their own
+  `FROM`.
+- **Distroless** — pinned-only is sufficient (no package manager); the digest
+  pin is still required.
+- **Multi-stage stage reference** — a `FROM <earlier-stage>` inherits the
+  upstream stage's pin, so it is not re-checked (the named stage was checked at
+  its defining `FROM`).
+- **Vendor images** documented with an inline `# RATIONALE:` comment on the
+  `FROM` line (or the comment line immediately above it).
+
+CLI
+===
+    python3 .claude/lib/check_dockerfile_base_pin.py <Dockerfile> [<Dockerfile> ...]
+
+Exit codes:
+    0 — every FROM in every file is compliant (or exempt)
+    1 — at least one violation (each printed as `path:line: FROM <image> — <why>`)
+    2 — usage / file-not-found error
+
+This is a reusable template (same CLI/exit-code shape as
+`.claude/lib/pre_commit_ci_sync.py`) so it wires identically into a repo's
+pre-commit config and its CI. The parent repo `noorinalabs-main` ships no
+Dockerfiles itself; the cross-repo rollout that points this at each child's
+Dockerfiles is a #735 follow-up.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# `FROM` is the only keyword we parse; Dockerfile keywords are case-insensitive.
+_FROM_RE = re.compile(r"^\s*FROM\s+(?P<rest>\S.*?)\s*$", re.IGNORECASE)
+# A leading `--platform=...` flag precedes the image and must be stripped.
+_PLATFORM_RE = re.compile(r"^--platform=\S+\s+", re.IGNORECASE)
+# A trailing `AS <stage>` names the build stage.
+_AS_RE = re.compile(r"\s+AS\s+(?P<stage>\S+)\s*$", re.IGNORECASE)
+
+# Upgrade-command signatures per distro family (searched over the stage body).
+_ALPINE_UPGRADE_RE = re.compile(r"\bapk\s+upgrade\b", re.IGNORECASE)
+# `apt-get update && apt-get -y upgrade` / `apt upgrade` — an apt invocation
+# followed (in the same command segment) by `upgrade`. `apt-get update` alone
+# does NOT match (that is "update", not "upgrade").
+_DEBIAN_UPGRADE_RE = re.compile(r"\bapt(?:-get)?\s+(?:-{1,2}\S+\s+)*upgrade\b", re.IGNORECASE)
+
+_RATIONALE_RE = re.compile(r"#\s*RATIONALE:", re.IGNORECASE)
+
+
+class FromStatement:
+    """One parsed `FROM` line: its image ref, optional stage name, exemptions."""
+
+    def __init__(self, lineno: int, image: str, stage: str | None, has_rationale: bool) -> None:
+        self.lineno = lineno
+        self.image = image
+        self.stage = stage
+        self.has_rationale = has_rationale
+
+
+def _preceding_comment_has_rationale(lines: list[str], from_idx: int) -> bool:
+    """True if the comment line(s) immediately above `from_idx` carry RATIONALE."""
+    j = from_idx - 1
+    while j >= 0:
+        stripped = lines[j].strip()
+        if stripped == "":
+            j -= 1
+            continue
+        if stripped.startswith("#"):
+            return bool(_RATIONALE_RE.search(stripped))
+        return False
+    return False
+
+
+def parse_froms(text: str) -> list[FromStatement]:
+    """Parse every `FROM` statement in a Dockerfile, in source order."""
+    lines = text.splitlines()
+    froms: list[FromStatement] = []
+    for idx, raw in enumerate(lines):
+        m = _FROM_RE.match(raw)
+        if not m:
+            continue
+        rest = m.group("rest")
+        has_rationale = bool(_RATIONALE_RE.search(raw)) or _preceding_comment_has_rationale(
+            lines, idx
+        )
+        # Drop any trailing inline comment, then a leading --platform flag.
+        code = rest.split("#", 1)[0].strip()
+        code = _PLATFORM_RE.sub("", code).strip()
+        stage: str | None = None
+        as_m = _AS_RE.search(code)
+        if as_m is not None:
+            stage = as_m.group("stage")
+            code = code[: as_m.start()].strip()
+        image = code.split()[0] if code.split() else ""
+        froms.append(FromStatement(idx + 1, image, stage, has_rationale))
+    return froms
+
+
+def _stage_body(text: str, from_lineno: int, next_from_lineno: int | None) -> str:
+    """Return the text between a `FROM` (exclusive) and the next `FROM`/EOF."""
+    lines = text.splitlines()
+    start = from_lineno  # from_lineno is 1-based; body starts on the next line
+    end = (next_from_lineno - 1) if next_from_lineno is not None else len(lines)
+    return "\n".join(lines[start:end])
+
+
+def check_dockerfile_text(path: str, text: str) -> list[str]:
+    """Return a list of human-readable violation strings for one Dockerfile."""
+    violations: list[str] = []
+    froms = parse_froms(text)
+    defined_stages: set[str] = set()
+    for i, stmt in enumerate(froms):
+        next_lineno = froms[i + 1].lineno if i + 1 < len(froms) else None
+        image_l = stmt.image.lower()
+
+        # Exemptions, in order. `scratch` and stage-references have no package
+        # manager / inherit the upstream pin; a documented vendor RATIONALE opts
+        # out explicitly. Record this stage's own name for later references.
+        is_exempt = image_l == "scratch" or image_l in defined_stages or stmt.has_rationale
+        if stmt.stage:
+            defined_stages.add(stmt.stage.lower())
+        if is_exempt:
+            continue
+
+        if "@sha256:" not in stmt.image:
+            violations.append(
+                f"{path}:{stmt.lineno}: FROM {stmt.image} — not digest-pinned "
+                f"(require image:tag@sha256:<digest>)"
+            )
+
+        body = _stage_body(text, stmt.lineno, next_lineno)
+        if "distroless" in image_l:
+            continue  # distroless has no package manager; pinned-only is sufficient
+        if "alpine" in image_l:
+            if not _ALPINE_UPGRADE_RE.search(body):
+                violations.append(
+                    f"{path}:{stmt.lineno}: FROM {stmt.image} — missing Alpine upgrade "
+                    f"step (RUN apk upgrade --no-cache)"
+                )
+        elif not _DEBIAN_UPGRADE_RE.search(body):
+            violations.append(
+                f"{path}:{stmt.lineno}: FROM {stmt.image} — missing Debian upgrade step "
+                f"(RUN apt-get update && apt-get -y upgrade && apt-get clean)"
+            )
+    return violations
+
+
+def check_file(path: Path) -> list[str]:
+    return check_dockerfile_text(str(path), path.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str]) -> int:
+    paths = argv[1:]
+    if not paths:
+        print(
+            "usage: check_dockerfile_base_pin.py <Dockerfile> [<Dockerfile> ...]",
+            file=sys.stderr,
+        )
+        return 2
+
+    all_violations: list[str] = []
+    for p in paths:
+        path = Path(p)
+        if not path.is_file():
+            print(f"ERROR: not a file: {p}", file=sys.stderr)
+            return 2
+        all_violations.extend(check_file(path))
+
+    if all_violations:
+        print("Base Image Pinning violations (tech-decisions.md § Base Image Pinning, #735):")
+        for v in all_violations:
+            print(f"  {v}")
+        print(
+            "\nEvery FROM must be digest-pinned (image:tag@sha256:<digest>) AND carry "
+            "the matching distro upgrade (apk/apt). Exemptions: scratch, distroless "
+            "(pin-only), a FROM that references an earlier stage, or a vendor image with "
+            "an inline `# RATIONALE:` comment on the FROM line."
+        )
+        return 1
+
+    print("OK: all Dockerfile FROM statements are digest-pinned with the required upgrade.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.claude/lib/check_fixture_realism.py
+++ b/.claude/lib/check_fixture_realism.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Lint Arabic-text fixtures for production-realism (vocalization + عن particle).
+
+Deterministic conversion of `.claude/team/charter/pull-requests.md § Text-
+Processing / NER / Graph Fixtures Must Use Production-Realistic Input`
+(noorinalabs-main#735, charter-prose-inventory worklist item #1 / epic #726).
+This is the "lint / review-lens" the section's *Enforcement opportunity*
+sub-section names as the optional half of #671: a cheap static signal that an
+Arabic fixture is a toy rather than a real upstream sample.
+
+The fixture-masks-bug class recurred 5+ times — most damningly *inside its own
+fix* (da#146 / PR #151 replaced an un-voweled toy blob with a Bukhari-h1 fixture
+that contained no عن, masking the over-segmentation later surfaced as da#155; the
+P5W5 thaqalayn parser shipped a schema-assumed fixture that hid 0% extracted
+Arabic, da#175). A fixture that is *greener than real data* is masking a bug.
+
+What this gate flags
+====================
+For every file it is given, the codepoints are scanned. A file with NO Arabic
+letters is **not** an Arabic-text fixture and is skipped (passes — this lens only
+judges Arabic fixtures). A file that DOES contain Arabic letters is flagged when:
+
+  (a) it contains NO Arabic vocalization diacritic — none in the harakat range
+      U+064B–U+0652 (ً tanwīn-fatḥ … ْ sukūn). Real corpus text is voweled;
+      a fixture stripped of diacritics exercises a code path the production
+      corpus never takes.
+  (b) it lacks the high-frequency transmission particle عن (ʿan, U+0639 U+0646)
+      anywhere — the substring a naive segmenter over-splits; omitting it lets an
+      over-segmentation bug pass. (The section scopes this to isnad strings; the
+      `files:`/discovery wiring chooses which paths are fixtures, and the check
+      applies the floor to any Arabic-bearing fixture it is handed.)
+
+The عن search runs over a diacritic-stripped copy of the text, NOT the raw bytes.
+In real voweled corpus text the particle is written عَنْ — a fatḥa sits *between*
+the ʿayn and the nūn — so a naive bare-`عن` substring search would FAIL on the
+exact voweled fixtures criterion (a) demands. Stripping the harakat first
+(عَنْ → عن) is what lets a production-realistic voweled chain satisfy both checks
+at once (without it the two criteria would be mutually unsatisfiable).
+
+Either condition alone flags the file; the diagnostic names which one(s) failed.
+
+CLI
+===
+    python3 .claude/lib/check_fixture_realism.py <fixture> [<fixture> ...]
+
+Exit codes:
+    0 — every Arabic-text fixture carries vocalization AND the عن particle
+        (non-Arabic files are skipped)
+    1 — at least one Arabic-text fixture is un-voweled or lacks عن
+    2 — usage / file-not-found error
+
+Reusable template (same CLI/exit-code shape as
+`.claude/lib/pre_commit_ci_sync.py`) so it wires identically into pre-commit and
+CI. The parent repo `noorinalabs-main` ships no Arabic fixtures itself; pointing
+this at each child's text-processing/NER/graph fixtures is a #735 follow-up.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# The transmission particle عن (ʿan): U+0639 (ʿayn) U+0646 (nūn). Substring-
+# searched verbatim, exactly as the charter rule specifies.
+_AN_PARTICLE = "عن"  # عن
+
+# Arabic vocalization diacritics — the harakat the rule names as `ً–ْ`:
+# U+064B (tanwīn fatḥ) … U+0652 (sukūn), inclusive.
+_DIACRITIC_START = 0x064B
+_DIACRITIC_END = 0x0652
+
+# Arabic consonantal letters (hamza U+0621 … yāʾ U+064A). Presence of any of
+# these is what makes a file an "Arabic-text fixture" worth judging — distinct
+# from the diacritics (which sit just above this range) and from digits/marks.
+_LETTER_START = 0x0621
+_LETTER_END = 0x064A
+
+# Tatweel / kashida (U+0640) is an elongation glyph, not a letter or a vowel; it
+# is stripped alongside the harakat so it cannot split the عن particle either.
+_TATWEEL = 0x0640
+
+
+def has_arabic_letters(text: str) -> bool:
+    """True if the text contains at least one Arabic consonantal letter."""
+    return any(_LETTER_START <= ord(ch) <= _LETTER_END for ch in text)
+
+
+def has_vocalization(text: str) -> bool:
+    """True if the text contains at least one harakat diacritic (U+064B–U+0652)."""
+    return any(_DIACRITIC_START <= ord(ch) <= _DIACRITIC_END for ch in text)
+
+
+def strip_diacritics(text: str) -> str:
+    """Remove harakat (U+064B–U+0652) and tatweel so عَنْ collapses to عن."""
+    return "".join(
+        ch
+        for ch in text
+        if not (_DIACRITIC_START <= ord(ch) <= _DIACRITIC_END) and ord(ch) != _TATWEEL
+    )
+
+
+def has_an_particle(text: str) -> bool:
+    """True if عن appears once diacritics/tatweel are stripped (عَنْ → عن)."""
+    return _AN_PARTICLE in strip_diacritics(text)
+
+
+def check_fixture_text(path: str, text: str) -> list[str]:
+    """Return violation strings for one fixture (empty list = clean or skipped)."""
+    if not has_arabic_letters(text):
+        return []  # not an Arabic-text fixture — this lens does not judge it
+    reasons: list[str] = []
+    if not has_vocalization(text):
+        reasons.append("no vocalization diacritics (none in U+064B–U+0652 ً–ْ)")
+    if not has_an_particle(text):
+        reasons.append("missing transmission particle عن")
+    if not reasons:
+        return []
+    return [f"{path}: Arabic-text fixture is not production-realistic — {'; '.join(reasons)}"]
+
+
+def check_file(path: Path) -> list[str]:
+    return check_fixture_text(str(path), path.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str]) -> int:
+    paths = argv[1:]
+    if not paths:
+        print(
+            "usage: check_fixture_realism.py <fixture> [<fixture> ...]",
+            file=sys.stderr,
+        )
+        return 2
+
+    all_violations: list[str] = []
+    for p in paths:
+        path = Path(p)
+        if not path.is_file():
+            print(f"ERROR: not a file: {p}", file=sys.stderr)
+            return 2
+        all_violations.extend(check_file(path))
+
+    if all_violations:
+        print("Fixture-realism violations (pull-requests.md § Production-Realistic Input, #735):")
+        for v in all_violations:
+            print(f"  {v}")
+        print(
+            "\nArabic-text fixtures must be lifted from a real upstream sample: voweled "
+            "(diacritics in U+064B–U+0652) and carrying the عن transmission particle. "
+            "A fixture greener than real data masks the next bug in that path."
+        )
+        return 1
+
+    print("OK: all Arabic-text fixtures carry vocalization and the عن particle.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.claude/lib/pre_commit_ci_sync.py
+++ b/.claude/lib/pre_commit_ci_sync.py
@@ -47,7 +47,7 @@ kind tokens so they compare:
 
     ruff-lint, ruff-format, mypy, pytest, eslint, typescript, prettier,
     terraform-fmt, gitleaks, actionlint, astro-check, pip-audit, build,
-    cspell
+    cspell, dockerfile-base-pin, fixture-realism
 
 Unknown tools are ignored (neither side gates on a kind we can't classify),
 which keeps the gate conservative — it never fails on something it doesn't
@@ -151,6 +151,15 @@ _KIND_PATTERNS: dict[str, tuple[str, ...]] = {
     # tool/hook token (`mermaid`) and the validator both sides invoke
     # (`check-mermaid`).
     "mermaid": ("mermaid", "check-mermaid"),
+    # `dockerfile-base-pin` and `fixture-realism` are the two charter-prose→code
+    # gates built in #735 (worklist #4 + #1 of the #734 inventory). Each is a
+    # `.claude/lib/check_*.py` invoked identically by a CI job and a pre-commit
+    # hook; classifying them here is what makes the sync-drift gate DEMAND the
+    # mirror (the #684 contract: an un-classified CI check is a silent blind
+    # spot). Patterns match the script basename (present on both sides' invoke
+    # line) and the hook id / job name.
+    "dockerfile-base-pin": ("check_dockerfile_base_pin", "dockerfile-base-pin"),
+    "fixture-realism": ("check_fixture_realism", "fixture-realism"),
 }
 
 

--- a/.claude/lib/tests/test_check_dockerfile_base_pin.py
+++ b/.claude/lib/tests/test_check_dockerfile_base_pin.py
@@ -1,0 +1,195 @@
+"""Tests for check_dockerfile_base_pin — the Base Image Pinning gate (#735).
+
+Verifies the deterministic conversion of `tech-decisions.md § Base Image
+Pinning`: every FROM must be digest-pinned AND carry the matching distro
+upgrade, with the section's exact exemptions (scratch, distroless, stage
+references, vendor `# RATIONALE:`). Positive cases use the real required pattern
+the section documents; negative cases use the exact prohibited shapes it names
+(floating tag, pin-only, apk-only).
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from check_dockerfile_base_pin import (  # noqa: E402
+    check_dockerfile_text,
+    main,
+    parse_froms,
+)
+
+# A real digest (truncated only for readability is NOT allowed by the checker —
+# it needs the literal `@sha256:` marker, which these carry in full shape).
+_DIGEST = "@sha256:0272e4609f1b5f3a2d8c9e1a4b6c8d0e2f4a6b8c0d2e4f6a8b0c2d4e6f8a0b2c4"
+
+
+class CompliantFromsPass(unittest.TestCase):
+    def test_alpine_pinned_with_apk_upgrade(self) -> None:
+        df = f"""# Digest-pinned tag + apk upgrade for defense-in-depth
+FROM nginx:stable-alpine3.23{_DIGEST}
+RUN apk upgrade --no-cache
+"""
+        self.assertEqual(check_dockerfile_text("Dockerfile", df), [])
+
+    def test_debian_slim_pinned_with_apt_upgrade(self) -> None:
+        df = f"""FROM python:3.12-slim{_DIGEST}
+RUN apt-get update && apt-get -y upgrade && apt-get clean && rm -rf /var/lib/apt/lists/*
+"""
+        self.assertEqual(check_dockerfile_text("Dockerfile", df), [])
+
+    def test_distroless_pin_only_is_sufficient(self) -> None:
+        # Distroless has no package manager — pinned-only passes, no upgrade.
+        df = f"FROM gcr.io/distroless/static-debian12{_DIGEST}\n"
+        self.assertEqual(check_dockerfile_text("Dockerfile", df), [])
+
+    def test_multistage_scratch_final_layer_exempt(self) -> None:
+        df = f"""FROM golang:1.22-alpine{_DIGEST} AS builder
+RUN apk upgrade --no-cache
+RUN go build -o /app
+
+FROM scratch
+COPY --from=builder /app /app
+"""
+        self.assertEqual(check_dockerfile_text("Dockerfile", df), [])
+
+    def test_multistage_stage_reference_inherits_pin(self) -> None:
+        # `FROM builder` references an earlier stage; it inherits the pin and is
+        # not re-checked for a digest or an upgrade.
+        df = f"""FROM python:3.12-slim{_DIGEST} AS builder
+RUN apt-get update && apt-get -y upgrade && apt-get clean
+
+FROM builder
+RUN pip install .
+"""
+        self.assertEqual(check_dockerfile_text("Dockerfile", df), [])
+
+    def test_vendor_rationale_inline_comment_exempts(self) -> None:
+        df = "FROM vendor/proprietary:1.4  # RATIONALE: not redistributable digest-pinned\n"
+        self.assertEqual(check_dockerfile_text("Dockerfile", df), [])
+
+    def test_vendor_rationale_preceding_comment_exempts(self) -> None:
+        df = """# RATIONALE: vendor image, not available as a digest-pinned ref
+FROM vendor/proprietary:1.4
+"""
+        self.assertEqual(check_dockerfile_text("Dockerfile", df), [])
+
+    def test_platform_flag_is_stripped(self) -> None:
+        df = f"""FROM --platform=linux/amd64 node:20-alpine{_DIGEST}
+RUN apk upgrade --no-cache
+"""
+        self.assertEqual(check_dockerfile_text("Dockerfile", df), [])
+
+
+class ProhibitedShapesFlagged(unittest.TestCase):
+    def test_floating_tag_flagged(self) -> None:
+        # WRONG (floating tag): no digest, no upgrade — both defenses missing.
+        violations = check_dockerfile_text("Dockerfile", "FROM nginx:alpine\n")
+        self.assertEqual(len(violations), 2)
+        self.assertTrue(any("not digest-pinned" in v for v in violations))
+        self.assertTrue(any("Alpine upgrade" in v for v in violations))
+
+    def test_pin_only_alpine_missing_upgrade(self) -> None:
+        # INSUFFICIENT (pin-only): tag frozen but Alpine packages drift — the
+        # exact shape isnad-graph#853 hit.
+        df = f"FROM nginx:stable-alpine3.23{_DIGEST}\n"
+        violations = check_dockerfile_text("Dockerfile", df)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("missing Alpine upgrade", violations[0])
+
+    def test_apk_only_missing_digest(self) -> None:
+        # INSUFFICIENT (apk-only): upgrade present but base layer is unpinned.
+        df = "FROM nginx:alpine\nRUN apk upgrade --no-cache\n"
+        violations = check_dockerfile_text("Dockerfile", df)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("not digest-pinned", violations[0])
+
+    def test_debian_pinned_missing_apt_upgrade(self) -> None:
+        df = f"FROM python:3.12-slim{_DIGEST}\nRUN pip install .\n"
+        violations = check_dockerfile_text("Dockerfile", df)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("missing Debian upgrade", violations[0])
+
+    def test_apt_update_only_is_not_an_upgrade(self) -> None:
+        # `apt-get update` is not `apt-get upgrade`; pin present, upgrade absent.
+        df = f"FROM debian:bookworm-slim{_DIGEST}\nRUN apt-get update\n"
+        violations = check_dockerfile_text("Dockerfile", df)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("missing Debian upgrade", violations[0])
+
+    def test_line_number_reported(self) -> None:
+        df = """# header comment
+FROM nginx:alpine
+RUN apk upgrade --no-cache
+"""
+        violations = check_dockerfile_text("Dockerfile", df)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("Dockerfile:2:", violations[0])
+
+
+class MultiStageMixed(unittest.TestCase):
+    def test_compliant_builder_but_bad_runtime_flags_only_runtime(self) -> None:
+        df = f"""FROM golang:1.22-alpine{_DIGEST} AS builder
+RUN apk upgrade --no-cache
+RUN go build -o /app
+
+FROM nginx:alpine
+COPY --from=builder /app /app
+"""
+        violations = check_dockerfile_text("Dockerfile", df)
+        # builder is clean; only the floating runtime FROM is flagged (pin+upgrade).
+        self.assertEqual(len(violations), 2)
+        self.assertTrue(all("FROM nginx:alpine" in v for v in violations))
+
+
+class ParserBehavior(unittest.TestCase):
+    def test_parse_collects_stage_names_and_images(self) -> None:
+        df = f"""FROM python:3.12-slim{_DIGEST} AS builder
+FROM scratch
+"""
+        froms = parse_froms(df)
+        self.assertEqual(len(froms), 2)
+        self.assertEqual(froms[0].stage, "builder")
+        self.assertTrue(froms[0].image.startswith("python:3.12-slim@sha256:"))
+        self.assertEqual(froms[1].image, "scratch")
+
+    def test_from_keyword_case_insensitive(self) -> None:
+        df = f"from nginx:alpine{_DIGEST} as web\nRUN apk upgrade --no-cache\n"
+        self.assertEqual(check_dockerfile_text("Dockerfile", df), [])
+
+
+class CliBehavior(unittest.TestCase):
+    def test_clean_file_exits_zero(self) -> None:
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w", suffix=".dockerfile", delete=False) as fh:
+            fh.write(f"FROM nginx:stable-alpine3.23{_DIGEST}\nRUN apk upgrade --no-cache\n")
+            name = fh.name
+        try:
+            self.assertEqual(main(["check_dockerfile_base_pin.py", name]), 0)
+        finally:
+            Path(name).unlink()
+
+    def test_violating_file_exits_one(self) -> None:
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w", suffix=".dockerfile", delete=False) as fh:
+            fh.write("FROM nginx:alpine\n")
+            name = fh.name
+        try:
+            self.assertEqual(main(["check_dockerfile_base_pin.py", name]), 1)
+        finally:
+            Path(name).unlink()
+
+    def test_no_args_is_usage_error(self) -> None:
+        self.assertEqual(main(["check_dockerfile_base_pin.py"]), 2)
+
+    def test_missing_file_is_error(self) -> None:
+        self.assertEqual(main(["check_dockerfile_base_pin.py", "/no/such/Dockerfile"]), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/lib/tests/test_check_fixture_realism.py
+++ b/.claude/lib/tests/test_check_fixture_realism.py
@@ -1,0 +1,146 @@
+"""Tests for check_fixture_realism — the Production-Realistic fixture lint (#735).
+
+Per the rule it enforces, this test's OWN fixtures are production-realistic:
+
+  - POSITIVE cases are real-shape voweled Arabic isnad chains carrying عَنْ (the
+    عن particle, voweled) — e.g. the Bukhari mu`allaq chain shape
+    `حَدَّثَنَا … عَنْ … عَنْ …`.
+  - NEGATIVE cases are the exact toy shapes the rule flags: an un-voweled blob,
+    and the da#146/da#155 worked example — a voweled Bukhari-h1-shape chain that
+    is missing عن (the gap that masked the over-segmentation bug).
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from check_fixture_realism import (  # noqa: E402
+    check_fixture_text,
+    has_an_particle,
+    has_arabic_letters,
+    has_vocalization,
+    main,
+    strip_diacritics,
+)
+
+# Real-shape voweled isnad with the عَنْ particle (Bukhari-style mu`an`an chain).
+# Production-realistic: full harakat + repeated عَنْ, exactly what a naive
+# segmenter over-splits.
+REAL_VOWELED_WITH_AN = (
+    "حَدَّثَنَا مُسَدَّدٌ قَالَ حَدَّثَنَا يَحْيَى عَنْ شُعْبَةَ عَنْ قَتَادَةَ عَنْ أَنَسٍ عَنِ النَّبِيِّ صَلَّى اللَّهُ عَلَيْهِ وَسَلَّمَ"
+)
+
+# da#146/da#155 worked example: a voweled Bukhari-h1-shape chain that uses only
+# قَالَ / سَمِعَ and carries NO عن — the fixture that masked the over-segmentation.
+VOWELED_MISSING_AN = "حَدَّثَنَا الْحُمَيْدِيُّ قَالَ حَدَّثَنَا سُفْيَانُ قَالَ سَمِعْتُ يَحْيَى بْنَ سَعِيدٍ الْأَنْصَارِيَّ"
+
+# Un-voweled toy blob: no diacritics at all (and no عن).
+UNVOWELED_TOY = "حدثنا محمد قال حدثنا يحيى بن سعيد"
+
+# Un-voweled but DOES contain عن — isolates the "no vocalization" reason.
+UNVOWELED_WITH_AN = "حدثنا محمد عن يحيى عن انس عن النبي"
+
+
+class HelperPrimitives(unittest.TestCase):
+    def test_has_arabic_letters_true_on_arabic(self) -> None:
+        self.assertTrue(has_arabic_letters(REAL_VOWELED_WITH_AN))
+
+    def test_has_arabic_letters_false_on_ascii(self) -> None:
+        self.assertFalse(has_arabic_letters("hadithReference: 1\nnarrator: Anas"))
+
+    def test_has_vocalization_distinguishes_voweled(self) -> None:
+        self.assertTrue(has_vocalization(REAL_VOWELED_WITH_AN))
+        self.assertFalse(has_vocalization(UNVOWELED_TOY))
+
+    def test_strip_diacritics_collapses_voweled_an(self) -> None:
+        # عَنْ must collapse to bare عن so the particle search can see it.
+        self.assertIn("عن", strip_diacritics("عَنْ"))
+
+    def test_has_an_particle_sees_through_vowels(self) -> None:
+        # The load-bearing case: voweled عَنْ is detected as the particle.
+        self.assertTrue(has_an_particle(REAL_VOWELED_WITH_AN))
+        self.assertTrue(has_an_particle(UNVOWELED_WITH_AN))
+        self.assertFalse(has_an_particle(VOWELED_MISSING_AN))
+        self.assertFalse(has_an_particle(UNVOWELED_TOY))
+
+
+class CleanFixturesPass(unittest.TestCase):
+    def test_real_voweled_chain_with_an_passes(self) -> None:
+        self.assertEqual(check_fixture_text("fix.json", REAL_VOWELED_WITH_AN), [])
+
+    def test_non_arabic_file_is_skipped(self) -> None:
+        # English / schema-only files are not Arabic-text fixtures — not judged.
+        self.assertEqual(check_fixture_text("schema.json", '{"narrator": "Anas", "n": 1}'), [])
+
+    def test_real_chain_embedded_in_json_passes(self) -> None:
+        payload = f'{{"matn_ar": "...", "isnad_ar": "{REAL_VOWELED_WITH_AN}"}}'
+        self.assertEqual(check_fixture_text("hadith.json", payload), [])
+
+
+class ToyFixturesFlagged(unittest.TestCase):
+    def test_unvoweled_toy_flags_both_reasons(self) -> None:
+        violations = check_fixture_text("toy.json", UNVOWELED_TOY)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("no vocalization diacritics", violations[0])
+        self.assertIn("missing transmission particle", violations[0])
+
+    def test_voweled_missing_an_flags_only_particle(self) -> None:
+        # The da#146/da#155 shape: voweled (passes a) but no عن (fails b).
+        violations = check_fixture_text("bukhari_h1.json", VOWELED_MISSING_AN)
+        self.assertEqual(len(violations), 1)
+        self.assertNotIn("no vocalization diacritics", violations[0])
+        self.assertIn("missing transmission particle", violations[0])
+
+    def test_unvoweled_with_an_flags_only_vocalization(self) -> None:
+        violations = check_fixture_text("toy2.json", UNVOWELED_WITH_AN)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("no vocalization diacritics", violations[0])
+        self.assertNotIn("missing transmission particle", violations[0])
+
+    def test_path_reported_in_violation(self) -> None:
+        violations = check_fixture_text("fixtures/toy.json", UNVOWELED_TOY)
+        self.assertTrue(violations[0].startswith("fixtures/toy.json:"))
+
+
+class CliBehavior(unittest.TestCase):
+    def _write(self, text: str) -> str:
+        fh = tempfile.NamedTemporaryFile("w", suffix=".json", delete=False, encoding="utf-8")
+        fh.write(text)
+        fh.close()
+        return fh.name
+
+    def test_clean_fixture_exits_zero(self) -> None:
+        name = self._write(REAL_VOWELED_WITH_AN)
+        try:
+            self.assertEqual(main(["check_fixture_realism.py", name]), 0)
+        finally:
+            Path(name).unlink()
+
+    def test_toy_fixture_exits_one(self) -> None:
+        name = self._write(UNVOWELED_TOY)
+        try:
+            self.assertEqual(main(["check_fixture_realism.py", name]), 1)
+        finally:
+            Path(name).unlink()
+
+    def test_non_arabic_fixture_exits_zero(self) -> None:
+        name = self._write('{"narrator": "Anas"}')
+        try:
+            self.assertEqual(main(["check_fixture_realism.py", name]), 0)
+        finally:
+            Path(name).unlink()
+
+    def test_no_args_is_usage_error(self) -> None:
+        self.assertEqual(main(["check_fixture_realism.py"]), 2)
+
+    def test_missing_file_is_error(self) -> None:
+        self.assertEqual(main(["check_fixture_realism.py", "/no/such/fixture.json"]), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/lib/tests/test_pre_commit_ci_sync.py
+++ b/.claude/lib/tests/test_pre_commit_ci_sync.py
@@ -308,6 +308,124 @@ repos:
         self.assertNotIn("mermaid", harmful)
 
 
+class DockerfileBasePinKind(unittest.TestCase):
+    """#735: the dockerfile-base-pin charter-prose→code gate must be a classified
+    kind so the sync-drift gate DEMANDS a pre-commit mirror of the CI lint job (an
+    un-mirrored gate lets an unpinned base image fail only at PR time)."""
+
+    def test_ci_dockerfile_base_pin_run_step_classified(self) -> None:
+        wf = """
+jobs:
+  dockerfile-base-pin:
+    steps:
+      - run: python3 .claude/lib/check_dockerfile_base_pin.py $files
+"""
+        self.assertIn("dockerfile-base-pin", kinds_from_ci(wf))
+
+    def test_precommit_dockerfile_base_pin_hook_classified(self) -> None:
+        cfg = """
+repos:
+  - repo: local
+    hooks:
+      - id: dockerfile-base-pin
+        name: dockerfile-base-pin
+        entry: python3 .claude/lib/check_dockerfile_base_pin.py
+"""
+        self.assertIn("dockerfile-base-pin", kinds_from_precommit(cfg))
+
+    def test_ci_dockerfile_base_pin_without_precommit_is_harmful_drift(self) -> None:
+        wf = """
+jobs:
+  dockerfile-base-pin:
+    steps:
+      - run: python3 .claude/lib/check_dockerfile_base_pin.py $files
+"""
+        cfg = """
+repos:
+  - repo: local
+    hooks:
+      - id: ruff
+"""
+        harmful, _ = compute_drift(kinds_from_precommit(cfg), kinds_from_ci(wf))
+        self.assertIn("dockerfile-base-pin", harmful)
+
+    def test_ci_dockerfile_base_pin_with_precommit_mirror_no_drift(self) -> None:
+        wf = """
+jobs:
+  dockerfile-base-pin:
+    steps:
+      - run: python3 .claude/lib/check_dockerfile_base_pin.py $files
+"""
+        cfg = """
+repos:
+  - repo: local
+    hooks:
+      - id: dockerfile-base-pin
+        entry: python3 .claude/lib/check_dockerfile_base_pin.py
+"""
+        harmful, _ = compute_drift(kinds_from_precommit(cfg), kinds_from_ci(wf))
+        self.assertNotIn("dockerfile-base-pin", harmful)
+
+
+class FixtureRealismKind(unittest.TestCase):
+    """#735: the fixture-realism charter-prose→code gate must be a classified kind
+    so the sync-drift gate DEMANDS a pre-commit mirror of the CI lint job (an
+    un-mirrored gate lets an un-voweled Arabic fixture fail only at PR time)."""
+
+    def test_ci_fixture_realism_run_step_classified(self) -> None:
+        wf = """
+jobs:
+  fixture-realism:
+    steps:
+      - run: python3 .claude/lib/check_fixture_realism.py $files
+"""
+        self.assertIn("fixture-realism", kinds_from_ci(wf))
+
+    def test_precommit_fixture_realism_hook_classified(self) -> None:
+        cfg = """
+repos:
+  - repo: local
+    hooks:
+      - id: fixture-realism
+        name: fixture-realism
+        entry: python3 .claude/lib/check_fixture_realism.py
+"""
+        self.assertIn("fixture-realism", kinds_from_precommit(cfg))
+
+    def test_ci_fixture_realism_without_precommit_is_harmful_drift(self) -> None:
+        wf = """
+jobs:
+  fixture-realism:
+    steps:
+      - run: python3 .claude/lib/check_fixture_realism.py $files
+"""
+        cfg = """
+repos:
+  - repo: local
+    hooks:
+      - id: ruff
+"""
+        harmful, _ = compute_drift(kinds_from_precommit(cfg), kinds_from_ci(wf))
+        self.assertIn("fixture-realism", harmful)
+
+    def test_ci_fixture_realism_with_precommit_mirror_no_drift(self) -> None:
+        wf = """
+jobs:
+  fixture-realism:
+    steps:
+      - run: python3 .claude/lib/check_fixture_realism.py $files
+"""
+        cfg = """
+repos:
+  - repo: local
+    hooks:
+      - id: fixture-realism
+        entry: python3 .claude/lib/check_fixture_realism.py
+"""
+        harmful, _ = compute_drift(kinds_from_precommit(cfg), kinds_from_ci(wf))
+        self.assertNotIn("fixture-realism", harmful)
+
+
 class BuildKindTightening(unittest.TestCase):
     """#576: runtime `docker build` / `docker buildx` steps are image-MOVING,
     not a build-QUALITY gate a local pre-commit hook can mirror — they must
@@ -553,6 +671,8 @@ _OLD_KIND_PATTERNS = {
     "doc-freshness": ("doc-freshness", "doc_freshness"),
     "office-drift": ("office-drift", "gen-office"),
     "mermaid": ("mermaid", "check-mermaid"),
+    "dockerfile-base-pin": ("check_dockerfile_base_pin", "dockerfile-base-pin"),
+    "fixture-realism": ("check_fixture_realism", "fixture-realism"),
 }
 _OLD_RUN_BLOCK_OPEN_RE = re.compile(r"^(?P<indent>\s*)-?\s*run:\s*[|>][+\-0-9]*\s*$")
 
@@ -630,7 +750,9 @@ _EXPECTED_KINDS = {
         "precommit": {
             "actionlint",
             "cspell",
+            "dockerfile-base-pin",
             "doc-freshness",
+            "fixture-realism",
             "memory-budget",
             "mermaid",
             "mypy",
@@ -642,7 +764,9 @@ _EXPECTED_KINDS = {
         "ci": {
             "actionlint",
             "cspell",
+            "dockerfile-base-pin",
             "doc-freshness",
+            "fixture-realism",
             "memory-budget",
             "mermaid",
             "mypy",

--- a/.claude/team/charter_prose_inventory.md
+++ b/.claude/team/charter_prose_inventory.md
@@ -1,0 +1,275 @@
+# Charter Prose Inventory — deterministic-able vs intentionally-prose
+
+> **Deliverable of [#734](https://github.com/noorinalabs/noorinalabs-main/issues/734)** (P6 W1, criterion #2 / epic [#726](https://github.com/noorinalabs/noorinalabs-main/issues/726)).
+> This is the **analysis/scoping pass**. The sibling issue [#735](https://github.com/noorinalabs/noorinalabs-main/issues/735) does the actual conversion of the `deterministic-able` set; this doc is its ordered worklist.
+> Authored by Nadia Khoury, 2026-06-20, against charter HEAD on `deployments/phase-6/wave-1`.
+
+## Method
+
+Every rule in `.claude/team/charter/*.md` (13 sub-docs, ~3,100 lines) was walked and classified into the three buckets the issue specifies:
+
+- **`already-enforced`** — a hook or `.claude/lib/` check already makes this binding. Cite the artifact. (Not a conversion target.)
+- **`deterministic-able`** — could be mechanized as a hook/lib gate but currently is **not** (or only partially). These are the worklist for #735, ranked by leverage below.
+- **`intentionally-prose`** — judgment, context, rationale, or a structural fact that cannot or should not be mechanized. One-line rationale each.
+
+**Stable identifier** = `<file> § <Section Heading>` (the H2/H3 as it appears at HEAD).
+
+### Leverage of the pre-existing `promotion-target` marker
+
+The charter already annotates most sections with an HTML comment `<!-- promotion-target: hook | skill | none -->`. Census at HEAD: **`hook` ×7, `skill` ×24, `none` ×72**. This is a *partial* classification that long predates #734, and the inventory uses it as a strong prior — but it is **not** the same axis as this issue's taxonomy, for three reasons, so each section was re-judged rather than copied:
+
+1. `promotion-target` records the *aspirational* tier ("this could become a hook"); it does **not** distinguish "target hook not yet built" from "hook already built." Several `promotion-target: hook` sections are in fact **already-enforced** (e.g. `skills.md § Wave Lifecycle — Open-Item Audit` → Hook 17). The marker never gets flipped once the hook lands.
+2. `promotion-target: skill` means "mechanize as a *skill*," which under the enforcement hierarchy (hook > skill > charter > memory) is still **code-over-prose** — so for this issue's purpose a `skill` target counts as `deterministic-able` (mechanization form = skill), not as prose.
+3. A handful of `promotion-target: none` sections are in fact trivially mechanizable (e.g. `hooks.md § Dispatcher Consolidation Policy` — a count check). Where the marker and the honest classification diverge, the divergence is flagged in the row (**[marker-divergence]**).
+
+### Alignment with `feedback_enforcement_hierarchy.md` (acceptance criterion #5)
+
+The recalled memory states: **hook > skill > charter > memory; a rule with no enforcement decays.** This inventory operationalizes that thesis: the `deterministic-able` ranking is *exactly* "which still-prose rules decay hardest," and the established **promote-on-first-(or-Nth)-violation** trigger is honored — sections the charter has already *decided to DEFER* (zero observed violations, e.g. `skills.md § Cross-repo-status.json upsert`) are ranked low, not high, because per the hierarchy memo charter-only-without-violations does not warrant a hook yet. Leverage = observed recurrence, not theoretical mechanizability.
+
+---
+
+## Summary counts
+
+| Bucket | Count (sections) |
+|---|---|
+| already-enforced (hook/lib binding exists) | 24 |
+| deterministic-able (conversion candidates for #735) | 23 |
+| intentionally-prose | 38 |
+| **mixed** (partially already-enforced; a deterministic-able remainder is split out into the worklist) | 9 of the above counted in both their enforced part and their remainder |
+
+The 23 `deterministic-able` sections are ranked below; the per-file tables that follow give the full walk with rationale for every section.
+
+---
+
+## RANKED deterministic-able worklist for #735
+
+Ranked by **leverage** = how often the gap has actually bitten (retro recurrence + memory-corpus footprint + severity-if-violated), highest first. The tier boundaries are the natural break points for #735 to size its scope ("do Tier 1, then re-measure").
+
+### Tier 1 — highest leverage (recurred across multiple waves; explicit hook-target; high severity)
+
+| # | Rule (`file § section`) | marker | Mechanization | Leverage evidence |
+|---|---|---|---|---|
+| 1 | `pull-requests.md § Text-Processing / NER / Graph Fixtures Must Use Production-Realistic Input` | hook | Lint Arabic-text fixtures for absence of vocalization codepoints (`ً–ْ`) and absence of the عن particle in isnad strings → flag toy/schema-assumed fixtures. (The section already names this as the "optional half of #671".) | **Recurred 5+ times** and once *inside its own fix*: da#146/PR#151, da#155, da#175 (thaqalayn 0% matn), MockNeo4j APPEARS_IN-null, double-prefix hadith-id. The single most-recurrent fixture class; directly upstream of the P7 data-quality breakage (`project_prod_loaded_quality_broken`). |
+| 2 | `agents.md § Agent Liveness Checkpoint` | hook | (a) Assert a `TaskCreate` exists per spawned implementer; (b) zero-artifact-after-2-idle-notifications auto-flag (count branch/PR/commit artifacts, not messages). | **Recurred two consecutive waves** — P5W2 #1024 (no branch/PR/commit all wave) + P5W3 Nneka #1038 silent-idle. Both needed manual rescue; both near-missed the keystone deliverable. |
+| 3 | `agents.md § Throttle-Stall Recovery — Trigger Thresholds` | hook | 30/45/60-min idle cadence for mid-task-with-pending-work stalls → auto-takeover trigger. (Mechanic already in memory `feedback_throttle_takeover`; this is the *trigger*.) | W12 ig#931 stall went **9h37m** undetected. Sibling of #2 (same liveness family). Harder (orchestrator-side timer, no tool-boundary) → ranked just under #2. |
+| 4 | `tech-decisions.md § Base Image Pinning` | none **[marker-divergence: trivially mechanizable]** | `validate_dockerfile_base_pin` PreToolUse/CI lint: every `FROM` digest-pinned **and** carries the matching `apk/apt upgrade` (distro table in-section). The section already names this future hook as "step 3." | Surfaced by ig#853 Trivy CVE; cross-repo (all 8 repos build images); recurring reviewer-reminder load. Mechanical/unambiguous. |
+
+### Tier 2 — clear mechanization path; some recurrence or high severity; several are charter-"decided-deferred"
+
+| # | Rule (`file § section`) | marker | Mechanization | Leverage evidence |
+|---|---|---|---|---|
+| 5 | `pull-requests.md § Retro PR Body-vs-Diff Discipline` | skill | Wire the body-vs-diff check the section already spells out into `/wave-retro` Step 6/8 + `/wave-wrapup` (compare PR-body "Files changed" vs `gh pr view --json files`). | **Severe**-rated; #124/#126 (5 charter/skill edits landed direct-to-main, bypassed 2-reviewer + CI). Skill-tier, low-risk to wire. |
+| 6 | `pull-requests.md § CI Workflow pull_request Triggers Must Cover Wave Branches` | none **[divergence]** | `validate_ci_trigger_branches` (the section names it): block a workflow PR whose `pull_request.branches` is a single-branch list omitting `deployments/**`. Sibling of live Hook 19. | P2W10 ×2 independent (user-service#81, deploy#152/#154); silent-CI-skip class. |
+| 7 | `pull-requests.md § Additive Commits on ChangesRequested (Mandatory)` | none **[divergence]** | Detect `git push --force`/`--force-with-lease` on a branch with an open ChangesRequested verdict → block (extends `block_no_verify` family). | Moderate severity; HEAD-SHA anchor is load-bearing for reviewer re-verify chain. Needs ChangesRequested-state lookup (medium effort). |
+| 8 | `agents.md § Spawn Isolation Default` | none **[divergence]** | PreToolUse `Agent` hook: implementer-class spawn must set `isolation: "worktree"` (coordinator/fork carve-outs per section). | P3W6: 18 implementer spawns mis-rendered as background tasks (#290). Tool-boundary check (clean). |
+| 9 | `artifact-ownership.md § Create-time ownership gate` | none | The section's own "step 2" deferred hook: block Edit/Write that creates a parent-canonical artifact class (shared hook, org skill, org charter) under a *child* repo tree, or a child-shadowing org-skill name. | #328 family; reviewer-enforced today (drift filed as #560). Clear class boundary. |
+| 10 | `hooks.md § Dispatcher Consolidation Policy` | none **[divergence]** | Count hooks per matcher in the dispatcher/settings; fail PR that adds a 4th without a dispatcher. | Cheap/unambiguous; low recurrence (consolidation discipline mostly held). |
+| 11 | `skills.md § Zsh-safe repo iteration in wave skills` | hook (**DEFER decided**) | `validate_skill_bash_no_param_for_loop` grep-gate over skill `*.md` bash fences for `for \w+ in \$[A-Z_]`. Lib (`wave_status.py`) already removed the live instances. | Bit 3× in one P5W4 wrapup (#688) — but charter has **already decided DEFER** (0 current violations post-lib). Promote on first recurrence. |
+| 12 | `pull-requests.md § All Deliberately-Assigned Reviewers Must Approve (Blast-Radius PRs)` | none | Merge gate keyed on the *assigned* reviewer slate count (3+), not just the 2-distinct-Approved minimum. Section itself: "a future enhancement could key the merge gate on assigned-reviewer count." | P4W4 ig#1002 merged 2/3 (lucky). Needs durable slate tracking (harder) → mid-tier. |
+| 13 | `hooks.md § Hook Authorship Requirements §5a` (segment-parser 6-class test matrix) | none | The "out-of-scope follow-up" grep CI gate asserting all six `# segment-class:` convention names present. | #537/#538 newline-gap shipped because coverage was partial. §7's analogue **is already a gate** (see already-enforced) — precedent exists. |
+
+### Tier 3 — mechanizable but low value / low recurrence (do only if Tiers 1–2 leave budget)
+
+| # | Rule (`file § section`) | marker | Mechanization / note |
+|---|---|---|---|
+| 14 | `skills.md § Cross-repo-status.json upsert pattern` | hook (**DEFER decided**) | Lib (`upsert_status_keys.py`) already exists + consumers use it; section explicitly DEFERs the format-guard hook (0 violations W6–W9). Lowest-priority hook. |
+| 15 | `pull-requests.md § Pre-Push Checklist` (branch-name sub-item) | none | Lint/test parity already enforced by pre-commit/pre-push; only the `git branch --show-current` format-match is unmechanized. Minor. |
+| 16 | `agents.md § Agent Naming with Repo Prefix` + `§ Agent Naming Convention` (pattern only) | none | PreToolUse `Agent` name-format check (`{repo}-{firstname}`). Role-fit half stays prose. Low. |
+| 17 | `brand.md` (whole) | (none) | cspell/grep lint: flag `NoorinALabs`/`noorina-labs` in user-facing text (allow code identifier `noorinalabs`). Low recurrence; fits the #684 cspell rollout. |
+| 18 | `pull-requests.md § PR Template` + `§ Review Prompt Template` (structure) | none | Validate PR body carries Summary/Related Issues/Review Checklist. Output format already gated by `validate_pr_review`; template-presence is low value. |
+| 19 | `issues.md § Manual Issues` (`[MANUAL]` prefix) | none | Trivial prefix lint. Very low. |
+| 20 | `pull-requests.md § gh pr edit projects-classic deprecation` | none | Warn-on `gh pr edit --body` (silent-no-op family); read-back already advised. Low. |
+| 21 | `agents.md § Worktree Lock Management` (20-min stale-lock timeout) | (none) | Skill-side cleanup mechanization (`/wave-wrapup`). Low. |
+| 22 | `agents.md § Auto-Trigger` (`/wave-wrapup` on all-PRs-merged) | (none) | Event-driven trigger; partially covered by `validate_wave_audit`/wrap discipline. Low. |
+| 23 | `pull-requests.md § Load-Bearing Followups for Disabled CI Jobs` | skill | Reviewer/skill check that a CI-disabling PR carries the `## Disabled CI jobs` breadcrumb + load-bearing followup issue. Judgment-adjacent; low. |
+
+> **Partially-enforced remainders also feeding #735 (tracked elsewhere, listed for completeness, not re-ranked):**
+> - `pull-requests.md § Full Local⇄CI Tooling Parity` — the sync-drift gate exists but is blind to unclassified kinds (cspell); closing that is **already in flight as #684 / task** (do not double-scope).
+> - `agents.md § Child-Repo Implementer Rule` — commit-time roster is already Hook-5-enforced; only the *pre-spawn-brief* gate (marker:hook) is the remainder (lower value — Hook 5 already catches it downstream).
+> - `issues.md § Issue-Filing Premise Verification at Origin HEAD` — partially covered by Hook 20 at wave-label-time; a general issue-create premise gate is hard (judgment) and stays mostly prose.
+
+---
+
+## Full per-file walk
+
+Legend: **AE** = already-enforced · **DA** = deterministic-able (→ worklist # above) · **IP** = intentionally-prose.
+
+### `hooks.md`
+
+| Section | Class | Rationale / citation |
+|---|---|---|
+| Hooks 1–21 (each `## Hook N: …`) | **AE** | These *are* the enforcement layer — each entry documents its live `.py` (validate_commit_identity, block_no_verify, block_git_config, auto_set_env_test, validate_labels, validate_lockfile_paths, validate_pr_review, block_gh_pr_review, validate_branch_freshness, validate_vps_host, warn_ghcr_image, validate_wave_context, auto_add_issue_to_board, validate_pr_ci_status, enforce_librarian_consulted, no_worktree_self_delete, validate_wave_audit, validate_edit_completion, validate_workflow_paths_coverage, validate_wave_label_evidence, post_label_change_wave_field_sync). |
+| § Bash Hook Dispatcher Architecture | **IP** | Architecture reference; the dispatcher *is* the implementation, the prose just documents it. |
+| § Dispatcher Consolidation Policy | **DA #10** | >3-per-matcher count is trivially mechanizable; marker says `none` but it is a count check. |
+| § Hook 13/14 inline notes, NEUTRAL allowlist, etc. | **AE** | Behavior of live hooks. |
+| § Shared Helpers (`_shell_parse`, `_wave_label_parse`, `_consultation_sentinel`) | **IP** | Reference docs for existing lib primitives; not a rule to gate. |
+| § Hook Sync Across Child Repos | **IP** (remainder → see artifact-ownership #9) | Mostly reviewer-verified config convention; the mechanizable part is the create-time gate, owned by `artifact-ownership.md § Create-time gate`. |
+| § Hook Authorship Requirements §1 Input-language / §2 charter entry / §3 negative-match tests / §4 dispatcher reg / §6 provenance phrasing | **IP** | Authoring discipline checked at PR review by Standards lead; §6's phrasing is *consumed* by `/promotion-audit` parser (that side is AE) but authoring it is prose. |
+| § Hook Authorship Requirements §5 fixture-with-fix | **IP** (deferred CI gate is low-value) | Discipline; the "CI flags PRs that change parser logic without a fixture" is a deferred follow-up, lower leverage than §5a. |
+| § Hook Authorship Requirements §5a six-class segment-parser matrix | **DA #13** | Explicit out-of-scope grep gate on the six `# segment-class:` names. |
+| § Hook Authorship Requirements §7 gh-command parser invariant | **AE** | Machine-enforced by `.claude/hooks/tests/test_gh_command_parser_invariant.py` (in the pytest suite CI mirrors). |
+| § Hook Audit Protocol | **IP** | Method discipline (committed-tree vs filesystem); a procedure, not a gate. |
+
+### `agents.md`
+
+| Section | Class | Rationale |
+|---|---|---|
+| § Agent Naming Convention | **IP** (pattern sub-part → #16) | Role-fit mapping is judgment; only the name *pattern* is mechanizable. |
+| § How to Instantiate the Team | **IP** | Session-bootstrap procedure (partially `/session-start`); prose. |
+| § Agent Lifecycle Management + § Wave Retrospective (Required) | **IP** | Procedure realized by wave-lifecycle skills; the *discipline* (don't skip retro) is judgment. |
+| § Per-Repo Worktree Isolation (Child Repos) | **IP** | Spawn-brief procedural guidance; child-repo cross-contamination is mitigated by brief content, not a gate. |
+| § Scaffold Migration Chain Strategy | **IP** | Context-specific judgment (alembic chain base). |
+| § Worktree Lock Management | **DA #21** (stale-lock timeout) | The 20-min timeout cleanup is mechanizable (skill-side); rest is procedure. |
+| § Auto-Trigger | **DA #22** | Event-driven `/wave-wrapup` trigger; low. |
+| § Team Teardown Procedure | **IP** | Shutdown procedure; harness-dependent. |
+| § Orchestrator Spawn Discipline — Reuse Idle Teammates | **IP** | Reuse-vs-clone is judgment. |
+| § Hub-and-Spoke Orchestration Model | **AE** (by harness) / **IP** | Enforced structurally — spawned agents lack the Agent tool; not a hook but not convertible either. |
+| § Spawn Request Delegation / § No Direct-to-Engineer Spawns | **IP** | Orchestrator judgment/hierarchy discipline. |
+| § Spawn Isolation Default | **DA #8** | PreToolUse `Agent` `isolation` check. |
+| § Agent Naming with Repo Prefix | **DA #16** | Name-format check on Agent tool. |
+| § Team Names | **IP** | Reference table. |
+| § Single-Leader Constraint | **AE** (by harness) / **IP** | One implicit team is a harness fact, not a charter-enforceable gate. |
+| § Reviewer slate discipline (FIRST-LINE) | **IP** (sub-parts mechanizable) | Manager-of-repo and PR-author exclusions are partly mechanizable, but "valid reviewer source" is judgment; spawn briefs aren't tool-gated. |
+| § Reviewer spawn brief — throughline-watch | **IP** | Template-inclusion in a non-gated surface (spawn brief). |
+| § Orchestrator checklist when spawning an implementer | **AE** (items 2,3,10) / **IP** | Item 2 → `enforce_ontology_context`, item 3 → Hook 15, item 10 → green-before-push (#684); rest is composition discipline. |
+| § Orchestrator checklist when spawning a reviewer | **AE** (verdict format) / **IP** | Verdict literal-form is gated by `validate_pr_review` + `validate_review_comment_format`; brief-composition is prose. |
+| § Pre-Spawn State Check + Crossed-Message Race | **IP** | Message-bus race protocol; accept-as-cost-of-throughput is judgment. |
+| § Surface enumeration (+ where/how/caveats sub-secs) | **IP** | Pre-spawn counting discipline; judgment. |
+| § Orchestrator State-Correction Discipline | **IP** | Anti-serial-toggle judgment. |
+| § Child-Repo Implementer Rule + Spawn-Brief Verification | **AE** (Hook 5, commit-time) / remainder IP | `validate_commit_identity` blocks wrong-roster at first commit; the pre-spawn-brief gate (marker:hook) is a low-value remainder since Hook 5 catches it downstream. |
+| § Parent-Orchestrator Implementer Declarations Are Advisory | **IP** | Authority-source judgment. |
+| § Agent Liveness Checkpoint | **DA #2** | marker:hook; recurred P5W2/W3. |
+| § Throttle-Stall Recovery — Trigger Thresholds | **DA #3** | marker:hook; W12 9h stall. |
+
+### `pull-requests.md`
+
+| Section | Class | Rationale |
+|---|---|---|
+| § Comment-Based Reviews (Mandatory) | **AE** | `validate_pr_review` + `validate_review_comment_format` + `block_gh_pr_review`. |
+| § Review Prompt Template (Mandatory) | **IP** (output AE) | Template is guidance; the *resulting* format is hook-gated. |
+| § Two-Reviewer Assignment at Wave Kickoff | **AE** (count) / **IP** (planning) | 2-distinct-Approved gated by `validate_pr_review`; "assign at kickoff" is planning prose. |
+| § All Deliberately-Assigned Reviewers Must Approve (Blast-Radius) | **DA #12** | assigned-slate merge gate (section invites the enhancement). |
+| § Single-Reviewer Exception (Wave-Bootstrap Only) | **AE** | `validate_pr_review` honors the `wave-bootstrap` waiver (main#228). |
+| § Load-Bearing Followups for Disabled CI Jobs | **DA #23** | breadcrumb/followup check; judgment-adjacent. |
+| § PR Review Workflow for Deployments Branch PRs | **AE** (2-review) / **IP** | gate via `validate_pr_review`; rest procedural. |
+| § Additive Commits on ChangesRequested (Mandatory) | **DA #7** | force-push-during-CR detection. |
+| § Review Finding Disposition | **AE** (TechDebt line) / **IP** | `validate_pr_review` requires `TechDebt:`; the must-fix/tech-debt triage is judgment. |
+| § Post-Merge Integration Verification | **IP** (CI-on-push AE) | manager manual check is judgment; the `deployments/**` push-CI part is config-enforced. |
+| § CI Workflow pull_request Triggers Must Cover Wave Branches | **DA #6** | `validate_ci_trigger_branches`; sibling of live Hook 19. |
+| § Cross-Contract PRs | **IP** | "is this a cross-contract PR" is judgment. |
+| § Cross-PR Dependency Sequencing | **IP** | dependency-order judgment. |
+| § Wave Merge PR Verification | **AE/IP** | `/wave-wrapup` skill + `validate_pr_ci_status` + admin-merge gate realize most of it. |
+| § Wave-Wrapup Staging-Promotion Gate (Mandatory) | **AE** | `/wave-wrapup` Step 11.6 (skill-tier gate). |
+| § End-State Criterion Verification Requires Live-Environment Evidence | **IP** | live-env evidence judgment. |
+| § PR Template | **DA #18** | body-section presence check (low). |
+| § Closes-vs-Refs Disposition — Decided at Brief Time | **IP** | disposition judgment. |
+| § Pre-Push Checklist | **AE** (lint/type/test) / **DA #15** (branch-name) | pre-commit/pre-push hooks run the checks; branch-name match unmechanized. |
+| § CI Must Be Green Before Merge | **AE** | `validate_pr_ci_status` (Hook 14). |
+| § Full Local⇄CI Tooling Parity + No Force-Merging | **AE** (sync-drift gate + block_no_verify) / remainder = **#684** | gate exists but blind to cspell; closing it is the in-flight #684, not new #735 scope. |
+| § Org-Wide Branch Protection + Admin-Merge Exceptions | **AE** | `validate_pr_ci_status` admin-merge gate + GH rulesets (rollout tracked by #322). |
+| § CI Enforcement After PR Creation | **AE/IP** | Hook 14 + procedure. |
+| § Design-Rationale Block for Critical-Path PRs | **IP** | "is this critical-path" + block quality is judgment. |
+| § Trust the Artifact, Not the Framing | **IP** (head-SHA confirm = minor mechanizable) | core discipline (read artifact not framing) is behavioral. |
+| § Trivial Cross-Repo Doc Sweep | **AE** (exception class) / **IP** | `doc-sweep` is a recognized admin-merge exception class in the hook; "is it byte-identical" is judgment. |
+| § Security Guards Belong Inline, Not in a Followup | **IP** | threat-model judgment. |
+| § Live-Trace Evidence > Synthetic-Test Acceptance | **IP** | evidence-quality judgment. |
+| § Text-Processing / NER / Graph Fixtures Production-Realistic Input | **DA #1** | marker:hook; the highest-recurrence class. |
+| § PR-Time Acceptance vs Runtime Acceptance | **IP** | lifecycle-separation judgment. |
+| § Sandbox Test-Verification Pattern | **IP** | environmental judgment. |
+| § Close Runtime-Gated Issues on Verified-Live | **IP** | Refs-vs-Closes judgment for runtime gates. |
+| § Origin > Local Clone for "Still-Has-X" Claims | **AE** (Hook 20, label-time) / **IP** | `validate_wave_label_evidence` covers the wave-label surface; reviewer-claim discipline otherwise is behavioral. |
+| § Retro PR Body-vs-Diff Discipline | **DA #5** | skill-enforcement snippet already written; wire into `/wave-retro`. |
+| § gh pr edit projects-classic deprecation | **DA #20** | warn-on-`gh pr edit --body`; low. |
+
+### `issues.md`
+
+| Section | Class | Rationale |
+|---|---|---|
+| § Delegation Flow | **IP** | decomposition/delegation procedure. |
+| § Issue Review Process | **IP** | "speak up only if meaningful" is judgment. |
+| § Work Gate: Issues Before Implementation | **IP** | planning judgment. |
+| § Issue-Filing Premise Verification at Origin HEAD | **IP** (partial AE via Hook 20) | general premise verification is judgment; wave-label path-existence is Hook-20-gated. |
+| § Wave Planning — Project Board Is Authoritative | **AE** | `/board-audit` skill (+ Hook 13 / Hook 21 board sync). |
+| § Multi-Step Meta-Issue Freshness Re-Audit | **IP** | 48h re-audit is procedural judgment (skill could host but the trigger is judgment). |
+| § Pre-Wave Checklist | **AE/IP** | `/wave-kickoff` realizes most; roster validation overlaps Hook 1. |
+| § Implementation Kickoff & Issue Assignment (Assignment / Reassignment / Manual / Hygiene) | **IP** (Manual prefix → #19) | assignment/hygiene judgment; only `[MANUAL]` prefix is a trivial lint. |
+| § End-State Criterion: Delivered vs Applied-and-Verified-at-Origin | **IP** | applied-vs-delivered judgment. |
+| § Comment Format | **IP** | issue-comment format is not a gated surface (unlike PR verdicts); low value to mechanize. |
+| § Reply Protocol | **IP** | swap/notify procedure. |
+| § Ticket Update Rules Based on Ownership | **IP** | ownership-driven judgment. |
+| § Escalation & Cross-Team Clarification | **IP** | escalation procedure. |
+
+### `skills.md`
+
+| Section | Class | Rationale |
+|---|---|---|
+| § Wave Lifecycle — Open-Item Audit | **AE** | marker:hook but **already done** — Hook 17 `validate_wave_audit` (line-5 marker confirms). Marker stale. |
+| § Cross-repo-status.json upsert pattern | **AE** (lib) / **DA #14** | `.claude/lib/upsert_status_keys.py` exists + consumers use it; the format-guard hook is charter-**DEFERed** (0 violations). |
+| § Codify Determinism on Tooling Fragility | **IP** | this is the meta-thesis itself (the principle behind #726). |
+| § Zsh-safe repo iteration in wave skills | **AE** (lib) / **DA #11** | `wave_status.py` removed live instances; grep gate DEFERed pending recurrence. |
+| § Promotion Pipeline Marker Convention | **AE** (parser) / **IP** | `/promotion-audit` parsers recognize the two shapes; "forbidden shapes" is reviewer-rejected (a lint is possible but low value). |
+| § Process-Doc Authorship: Derived-From-SKILL.md-At-HEAD | **IP** | author-from-artifact discipline; behavioral. |
+| § Acceptance-Criteria-Bucketing-In-Reports | **IP** | summary-bucketing is authoring judgment. |
+
+### `state-claims.md`
+
+| Section | Class | Rationale |
+|---|---|---|
+| § Refresh State Before Claim (+ all sub-rules: pre-write checklist, Manager-not-exempt, PR-state/Issue-state field sets, merge_commit_sha reachability, Ledger reconciliation) | **IP** | The section's own "Aspiration" note says the structural SendMessage-boundary hook "remains proposed"; verify-before-claim is fundamentally behavioral. The field-set sub-rules are *recipes*, not gates. |
+| § Refresh State Before Acting | **IP** | action-class refresh discipline; behavioral. |
+| § Canonical Source via `git show <sha>:<path>` | **IP** | "use the canonical sha not the worktree" is behavioral judgment. |
+
+### Small files
+
+| Section | Class | Rationale |
+|---|---|---|
+| `branching.md` § Deployments / Feature Branches / Worktree Cleanup | **IP** (branch-name format → overlaps #15) | branch naming partly mechanizable (overlaps Pre-Push branch-name); freshness already Hook-9-gated; cleanup is procedure. |
+| `commits.md` (whole) | **AE** | Hook 1 `validate_commit_identity` + Hook 3 `block_git_config`. |
+| `communication.md` (whole) | **IP** | cross-repo messaging protocol / shared-state conventions; reference. |
+| `brand.md` (whole) | **DA #17** | "Noorina Labs" vs `noorinalabs` is a grep/cspell lint. |
+| `artifact-ownership.md` (matrix + collision rules + audit) | **IP** | reference matrix + audit; the one rule is the create-time gate ↓. |
+| `artifact-ownership.md § Create-time ownership gate` | **DA #9** | section's own "step 2" deferred PreToolUse gate. |
+| `emergency-mode.md` (whole) | **IP** (emergency admin-merge class AE) | trigger conditions are judgment; `emergency` is a recognized admin-merge exception class in `validate_pr_ci_status`; `[EMERGENCY]` prefix is a trivial-but-low lint. |
+| `tech-decisions.md § Individual Preferences / Debate / Tie-Breaking (LCA) | **IP** | decision-making process; judgment. |
+| `tech-decisions.md § Base Image Pinning` | **DA #4** | `validate_dockerfile_base_pin` (named in-section). |
+| `tech-decisions.md § Per-Env OAuth Provisioning` | **IP** | provisioning convention; config/judgment. |
+
+---
+
+## Already-enforced index (citation map — NOT conversion targets)
+
+| Charter rule | Enforced by |
+|---|---|
+| Commit identity / no git-config | Hook 1 `validate_commit_identity`, Hook 3 `block_git_config` |
+| No `--no-verify` | Hook 2 `block_no_verify` |
+| `ENVIRONMENT=test` before pytest | Hook 4 `auto_set_env_test` |
+| Label hygiene on `gh issue create` | Hook 5 `validate_labels` |
+| Lockfile `/tmp/` paths | Hook 6 `validate_lockfile_paths` |
+| 2-reviewer / verdict format / no self-approve | Hook 7 `validate_pr_review`, Hook 8 `block_gh_pr_review`, `validate_review_comment_format` |
+| Branch freshness before PR | Hook 9 `validate_branch_freshness` |
+| Deploy safety (VPS_HOST / GHCR) | Hook 10 `validate_vps_host`, Hook 11 `warn_ghcr_image` |
+| Wave context before spawn | Hook 12 `validate_wave_context` |
+| Issue → board (create + label-edit) | Hook 13 `auto_add_issue_to_board`, Hook 21 `post_label_change_wave_field_sync` |
+| CI green / admin-merge exceptions before merge | Hook 14 `validate_pr_ci_status` |
+| Librarian consulted before Edit/Write | Hook 15 `enforce_librarian_consulted` |
+| Worktree self-delete | Hook 16 `no_worktree_self_delete` |
+| Wave open-item audit before "concluded" | Hook 17 `validate_wave_audit` (= `skills.md § Wave Lifecycle`) |
+| Edit-error soft-accept | Hook 18 `validate_edit_completion` |
+| Workflow-file orphan coverage | Hook 19 `validate_workflow_paths_coverage` |
+| Stale-path wave labeling | Hook 20 `validate_wave_label_evidence` |
+| Ontology context baked into spawn | `enforce_ontology_context` |
+| gh-command parser invariant | `test_gh_command_parser_invariant.py` |
+| Wave-counter / status-file writes | `.claude/lib/wave_status.py`, `.claude/lib/upsert_status_keys.py` |
+| Local⇄CI parity (partial) | `.claude/lib/pre_commit_ci_sync.py` sync-drift gate (cspell blind-spot → #684) |
+| Board orphan/Wave-field sync | `/board-audit` skill |
+| Staging-promotion wave gate | `/wave-wrapup` Step 11.6 |
+| Branch protection (server-side) | GH rulesets (rollout tracked by #322) |
+
+---
+
+## Caveats for #735
+
+1. **Re-verify every "DA" at conversion time.** Several rows are charter-**DEFERed** by an explicit hierarchy decision (zero violations) — #11, #14. Per `feedback_enforcement_hierarchy`, do **not** build those on spec; build them on the first/next recorded violation. They are listed so #735 knows they exist, not so it builds all 23.
+2. **Flip stale markers as you go.** `skills.md § Wave Lifecycle` is `promotion-target: hook` but Hook 17 already exists; any conversion PR touching these should correct the marker (or the conversion work should add a "marker reflects built-state" pass).
+3. **Don't double-scope #684.** The Full-Local⇄CI-parity cspell-classification remainder is already an in-flight wave issue; #735 should reference, not re-open it.
+4. **Tool-boundary > orchestrator-timer.** Tiers were set partly by mechanizability: tool-boundary checks (#1 fixture lint, #8 Agent-isolation) are clean PreToolUse hooks; orchestrator-side timers (#3 throttle cadence) have no clean tool boundary and are harder — reflected in their rank.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,58 @@ jobs:
           done
           exit $status
 
+  dockerfile-base-pin:
+    name: Dockerfile base-image pinning lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      # Charter-prose→code gate (#735, tech-decisions.md § Base Image Pinning).
+      # Discovers every Dockerfile and asserts each FROM is digest-pinned with the
+      # matching distro upgrade. Mirrors the `dockerfile-base-pin` pre-commit hook
+      # (sync-drift gate classifies the kind). The parent ships no Dockerfiles, so
+      # this is a no-op template here; child repos inherit it to scan their real
+      # Dockerfiles (#735 follow-up rollout).
+      - name: Lint Dockerfile FROM digest-pin + distro upgrade
+        run: |
+          files=$(find . -path ./.claude/worktrees -prune -o \
+            \( -name 'Dockerfile' -o -name 'Dockerfile.*' -o -name '*.dockerfile' \) -print)
+          if [ -z "$files" ]; then
+            echo "No Dockerfiles in this repo — base-pin lint is a no-op template here (#735)."
+            exit 0
+          fi
+          # shellcheck disable=SC2086  # word-splitting is intended (one path per arg)
+          python3 .claude/lib/check_dockerfile_base_pin.py $files
+
+  fixture-realism:
+    name: Arabic fixture production-realism lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      # Charter-prose→code gate (#735, pull-requests.md § Production-Realistic
+      # Input). Discovers fixture files and flags Arabic-text fixtures that are
+      # un-voweled or lack the عن particle. Mirrors the `fixture-realism`
+      # pre-commit hook. The parent ships no Arabic fixtures, so this is a no-op
+      # template here; child repos inherit it for their real fixtures (#735
+      # follow-up rollout).
+      - name: Lint Arabic-text fixtures for vocalization + عن particle
+        run: |
+          files=$(find . -path ./.claude/worktrees -prune -o \
+            \( -path '*/fixtures/*' -o -path '*/test_data/*' -o -path '*/testdata/*' \) \
+            -type f \( -name '*.json' -o -name '*.jsonl' -o -name '*.ndjson' \
+            -o -name '*.txt' -o -name '*.csv' -o -name '*.tsv' -o -name '*.py' \) -print)
+          if [ -z "$files" ]; then
+            echo "No fixture files in this repo — realism lint is a no-op template here (#735)."
+            exit 0
+          fi
+          # shellcheck disable=SC2086  # word-splitting is intended (one path per arg)
+          python3 .claude/lib/check_fixture_realism.py $files
+
   precommit-ci-sync:
     name: Pre-commit ⇄ CI sync-drift gate
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -90,6 +90,33 @@ repos:
         args: ["--no-must-find-files", "--no-progress", "--no-summary", "--config", ".cspell.json"]
         files: ^(\.claude/team/charter/.*\.md|\.claude/skills/.*\.md|ontology/.*\.md|CLAUDE\.md|CONTRIBUTING\.md|ONBOARDING\.md|README\.md|docs/.*\.md)$
 
+  # Charter-prose→code gates (#735). Each runs a `.claude/lib/check_*.py` over
+  # the matching file class, mirroring a CI job of the same name (the sync-drift
+  # gate classifies both kinds — `dockerfile-base-pin`, `fixture-realism` — so
+  # this mirror is mandatory, not optional). Both are commit-stage (cheap
+  # static scans). `files:` scopes which paths are candidates; the check itself
+  # self-filters (a non-Arabic file is skipped, a scratch/exempt FROM passes).
+  # The parent repo ships no Dockerfiles or Arabic fixtures, so these match
+  # nothing here today — they are the reusable template the #735 follow-up rolls
+  # out to each child repo's real files.
+  - repo: local
+    hooks:
+      - id: dockerfile-base-pin
+        name: dockerfile-base-pin
+        entry: python3 .claude/lib/check_dockerfile_base_pin.py
+        language: system
+        files: ((^|/)Dockerfile(\.[^/]+)?$|\.dockerfile$)
+        exclude: ^\.claude/worktrees/
+        pass_filenames: true
+      - id: fixture-realism
+        name: fixture-realism
+        entry: python3 .claude/lib/check_fixture_realism.py
+        language: system
+        # Test-data / fixture conventions; the check skips any non-Arabic file.
+        files: (^|/)(fixtures|test_data|testdata)/.*\.(json|jsonl|txt|csv|tsv|ndjson|py)$
+        exclude: ^\.claude/worktrees/
+        pass_filenames: true
+
   # Heavier checks run at pre-push (mirror CI's mypy + pytest jobs). Running as
   # `local`/`system` hooks so we use the system tools and don't drift from
   # whatever CI pins.


### PR DESCRIPTION
Closes #798. Unblocks #744. Part of P6W1 wrap (#731).

## Why

The code-over-prose / TD work (#734/#735) was merged into the
`deployments/phase-6/wave-1` branch (PRs #737/#738/#739/#743), but the
**wave→main PR was never opened**. The wave branch diverged (4 ahead / 55
behind) and five net-new #734/#735 validator deliverables never reached
`main` — so `main` references the validators nowhere (CI not broken, just
absent/inert) and #744 (roll the validators out to child-repo CI)
presupposes they are live on main. This reconciles them **surgically off
current `main`** (not a 55-behind wave→main merge).

## What landed

**Files restored verbatim from the wave branch:**
- `.claude/lib/check_dockerfile_base_pin.py` + `.claude/lib/tests/test_check_dockerfile_base_pin.py`
- `.claude/lib/check_fixture_realism.py` + `.claude/lib/tests/test_check_fixture_realism.py`
- `.claude/team/charter_prose_inventory.md`

**Wiring reconciled onto main's current (diverged) config — added, not clobbering newer content:**
- `.github/workflows/ci.yml` — `dockerfile-base-pin` + `fixture-realism` jobs (before the sync-drift gate)
- `.pre-commit-config.yaml` — the two commit-stage hooks
- `.claude/lib/pre_commit_ci_sync.py` — both kinds added to `_KIND_PATTERNS` + the docstring kind list, so the sync-drift gate DEMANDS the ci<->pre-commit mirror for each (the #684 contract). Main's existing cspell / memory-budget / doc-freshness / office-drift / mermaid kinds were preserved.
- `.claude/lib/tests/test_pre_commit_ci_sync.py` — lock-step `_OLD_KIND_PATTERNS`, extended the parent `_EXPECTED_KINDS` parity table (`test_new_matches_documented_expectations`), and added `DockerfileBasePinKind` / `FixtureRealismKind` classification + drift test classes.

## Verification (validators RUN against main's current content)

- **dockerfile-base-pin**: parent ships **no Dockerfiles** -> CI job is a no-op template here (exit 0).
- **fixture-realism**: green over all **44** fixture files on main (`OK: all Arabic-text fixtures carry vocalization and the عن particle`).
- `python3 .claude/lib/pre_commit_ci_sync.py .` -> `OK: pre-commit config mirrors all CI-enforced checks` (no unclassified drift).
- `pytest .claude/lib/tests/` -> **271 passed**.
- `pre-commit run --all-files` (commit + pre-push stages) -> all green.

No validator was weakened to force green.
