### PR TITLE
security(P6W2): bleach GHSA-g75f-g53v-794x revisit — no upstream fix, bleach now EOL (Re #703)

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -96,3 +96,4 @@
 - [Cross-spawn cwd collision](feedback_cwd_collision_cross_spawn.md) — two agents sharing one cwd on different branches: 2nd checkout moves the 1st → commits on wrong branch.
 - [Prod loaded but quality-broken](project_prod_loaded_quality_broken.md) — prod NO LONGER empty; 768k nodes/8.98% linked, narrators polluted, chains empty, search 500s → P7 data-quality. meta main#723.
 - [Brand is "Noorina Labs" (two words)](feedback_brand_noorina_labs.md) — camel-case "NoorinALabs" WRONG in prose; lowercase slug stays; cspell now enforces (dict entry removed). main#792.
+- [bleach ReDoS standing item](project_bleach_redos_standing_item.md) — GHSA-g75f-g53v-794x no fix + bleach EOL 2026-06-05; per-repo --ignore-vuln stays; revisit each wave; close only when kaggle dropped. main#703.

--- a/.claude/memory/project_bleach_redos_standing_item.md
+++ b/.claude/memory/project_bleach_redos_standing_item.md
@@ -1,0 +1,20 @@
+---
+name: project_bleach_redos_standing_item
+description: "bleach GHSA-g75f-g53v-794x (linkify parse_email ReDoS) — no upstream fix and never will be (bleach EOL 2026-06-05); pip-audit --ignore-vuln stays in place per-repo; revisit each wave (main#703); close only when kaggle is dropped."
+metadata:
+  node_type: memory
+  type: project
+---
+
+`bleach` is a transitive dep (via `kaggle`) carrying **GHSA-g75f-g53v-794x** — a ReDoS in `linkify()` when `parse_email=True` (~30 KB crafted input → multi-second CPU per call). Tracked by the standing revisit issue **main#703** (`security` + `tech-debt`, scheduled in `phase-6.md` for W3 but verified early each wave). The advisory is **non-applicable to our code** — we never call `bleach.linkify(parse_email=True)` — but `pip-audit --strict` flags it on any gated repo, so a narrowly-scoped `--ignore-vuln GHSA-g75f-g53v-794x` keeps the gate honest.
+
+**Where the ignore / floor lives (child repos — edits belong to those repos' own personas, [[feedback_child_repo_implementer_rule]]):**
+- `noorinalabs-isnad-ingest-platform` — `ci.yml` `security-audit`: `pip-audit --strict --desc --ignore-vuln GHSA-g75f-g53v-794x`. bleach pinned 6.4.0. The ignore is what unblocks the gate.
+- `noorinalabs-data-acquisition` — `pyproject.toml` floors `bleach>=6.4.0` (clears the two FIXED advisories GHSA-gj48-438w-jh9v + GHSA-8rfp-98v4-mmr6). Runs **no** pip-audit gate, so **no** `--ignore-vuln` needed there.
+
+**The two non-ReDoS bleach advisories ARE fixed** by `bleach>=6.4.0` and are NOT ignored — only the ReDoS one is.
+
+## Revisit log
+- **P6W2 (2026-06-21, Nino Kavtaradze, main#703):** Re-verified. (1) **No upstream fix** — GHSA-g75f-g53v-794x still lists `Patched versions: none`; latest bleach is **6.4.0** (2026-06-05) and the project is now **formally deprecated/EOL** ("Bleach is no longer maintained. There will be no future releases including for security issues"). So an upstream fix will **never** arrive — this is now a permanent ignore, not a wait-for-patch. (2) **Still needed** — bleach is pulled transitively by `kaggle`; not directly used. (3) **Ignore confirmed correct** — narrowly scoped to the single advisory, on the latest available bleach. No child-repo config change required this wave. **Remediation path is now singular: drop/replace `kaggle`** (the only way to remove bleach) — no kaggle-drop issue exists yet; candidate to file. Issue stays **OPEN** (close criteria — fix lands OR kaggle dropped — unmet; advisory-DB-drift caveat: [[feedback_pip_audit_strict_advisory_db_drift]]).
+
+**Close main#703 ONLY when:** bleach ships a fix for GHSA-g75f-g53v-794x (impossible now — EOL) **OR** `kaggle` is dropped/replaced so bleach is no longer pulled (the only real remediation). Until then, surface via `/wave-scope` every wave.


### PR DESCRIPTION
## P6W2 security revisit — bleach GHSA-g75f-g53v-794x (linkify ReDoS)

Per-wave re-verification of the standing security item **main#703**. The pip-audit `--ignore-vuln` for this advisory was last confirmed P5W5; this wave re-checks upstream + per-repo state.

### Revisit outcome
1. **Upstream fix?** No. Advisory still lists `Patched versions: none`. Latest bleach is **6.4.0 (2026-06-05)** and the project is now **formally deprecated/EOL** — *"Bleach is no longer maintained. There will be no future releases including for security issues."* An upstream fix will **never** arrive → this is a permanent ignore, not a wait-for-patch.
2. **Still needed?** Yes — bleach is transitive via `kaggle`; not used directly. We never call `linkify(parse_email=True)`, so the advisory is non-applicable to our code.
3. **Ignore still correct?** Yes, and narrowly scoped to the single advisory, on the latest available bleach:
   - `noorinalabs-isnad-ingest-platform` `ci.yml` → `pip-audit --strict --desc --ignore-vuln GHSA-g75f-g53v-794x` (bleach 6.4.0). Verified at `origin/main`.
   - `noorinalabs-data-acquisition` floors `bleach>=6.4.0` (clears the two FIXED advisories) and runs no pip-audit gate → no `--ignore-vuln` needed.

**No child-repo config change is required this wave** — the ignore + floor are already correct. Per [[feedback_child_repo_implementer_rule]], child CI/pyproject edits (if ever needed) belong to those repos' own personas, not this parent-org PR.

### What this PR lands
A durable, transferable project-memory record of the standing item + this wave's revisit log (`.claude/memory/project_bleach_redos_standing_item.md` + index line). Documentation-only; no code/CI change.

### Why not `Closes #703`
The issue's own close criteria — *fix lands OR kaggle dropped* — are unmet (and the fix path is now permanently closed by EOL). `phase-6.md` schedules it for W3. So it stays **open** and is surfaced again via `/wave-scope`. Using `Re #703`, not a close keyword.

TechDebt: bleach's only remediation is now singular — **drop/replace `kaggle`** (the sole importer of bleach), since no upstream fix can ever come. No kaggle-drop issue exists yet; recommend filing one in `noorinalabs-data-acquisition` as the real-remediation tracker that would let #703 finally close.

Re #703

Reviewers: Aino Virtanen, Aisha Idrissi
