### PR TITLE
fix(lib)(P6W2): upsert_status_keys multi-line value replace — #736

### DIFF
--- a/.claude/lib/tests/test_upsert_status_keys.py
+++ b/.claude/lib/tests/test_upsert_status_keys.py
@@ -385,6 +385,120 @@ class UpsertUpdateExistingScalarTests(unittest.TestCase):
         self.assertEqual(out.count('"wave_1_branches"'), 1)
 
 
+class UpsertReplaceMultilineExistingValueTests(unittest.TestCase):
+    """main#736 — REPLACING an existing top-level key whose current value
+    spans multiple lines (pretty-printed object/array).
+
+    Pre-#736 the replace path spliced at the opener line's end (`m.end()`).
+    For a multi-line value the opener line ends with `{`/`[` and the value
+    body continues on following lines, so the old body was left dangling after
+    the new compact value — invalid JSON (`Expecting ',' delimiter`) that
+    aborted the whole upsert batch. This is the real `/wave-scope` failure
+    where a prior-phase `wave_{M}_scope` was stored as pretty JSON.
+    """
+
+    def test_replace_multiline_object_value(self):
+        """The /wave-scope reproducer: replace a multi-line wave_1_scope
+        object with a compact value. Surrounding keys (incl. a compact-inline
+        sibling) must be preserved byte-for-byte."""
+        text = (
+            "{\n"
+            '  "phase": "phase-4",\n'
+            '  "wave_1_scope": {\n'
+            '    "tier_1_data": ["#1", "#2"],\n'
+            '    "tier_2": {"a": 1}\n'
+            "  },\n"
+            '  "wave_1_meta_issue": 731\n'
+            "}\n"
+        )
+        out = upsert_top_level_key(text, "wave_1_scope", '"narrow"')
+        parsed = json.loads(out)
+        self.assertEqual(parsed["wave_1_scope"], "narrow")
+        # Surrounding keys intact, no duplicate, no truncation.
+        self.assertEqual(parsed["phase"], "phase-4")
+        self.assertEqual(parsed["wave_1_meta_issue"], 731)
+        self.assertEqual(out.count('"wave_1_scope"'), 1)
+        # Compact-inline siblings preserved byte-for-byte.
+        self.assertIn('  "phase": "phase-4",\n', out)
+        self.assertIn('  "wave_1_meta_issue": 731\n', out)
+
+    def test_replace_multiline_array_value(self):
+        text = (
+            "{\n"
+            '  "keep": 1,\n'
+            '  "wave_1_carry_forward": [\n'
+            '    "#341",\n'
+            '    "#342"\n'
+            "  ],\n"
+            '  "tail": 2\n'
+            "}\n"
+        )
+        out = upsert_top_level_key(text, "wave_1_carry_forward", '["#999"]')
+        parsed = json.loads(out)
+        self.assertEqual(parsed["wave_1_carry_forward"], ["#999"])
+        self.assertEqual(parsed["keep"], 1)
+        self.assertEqual(parsed["tail"], 2)
+        self.assertEqual(out.count('"wave_1_carry_forward"'), 1)
+
+    def test_replace_multiline_final_object_value(self):
+        """Multi-line value that is ALSO the JSON-final key (its `}` has no
+        trailing comma). The replacement must not introduce a stray comma."""
+        text = '{\n  "keep": 1,\n  "wave_1_scope": {\n    "a": 1,\n    "b": 2\n  }\n}\n'
+        out = upsert_top_level_key(text, "wave_1_scope", '"narrow"')
+        parsed = json.loads(out)
+        self.assertEqual(parsed["wave_1_scope"], "narrow")
+        self.assertEqual(parsed["keep"], 1)
+        self.assertEqual(out.count('"wave_1_scope"'), 1)
+
+    def test_replace_multiline_value_with_compact_object(self):
+        """Replacing a multi-line value with a NEW multi-line (pretty) value —
+        the helper produces this when json_value itself is pretty-printed."""
+        text = (
+            "{\n"
+            '  "wave_4_active": true,\n'
+            '  "wave_4_scope": {\n'
+            '    "old": 1\n'
+            "  },\n"
+            '  "wave_4_meta": 5\n'
+            "}\n"
+        )
+        new_val = '{\n    "new": 2\n  }'
+        out = upsert_top_level_key(text, "wave_4_scope", new_val)
+        parsed = json.loads(out)
+        self.assertEqual(parsed["wave_4_scope"], {"new": 2})
+        self.assertTrue(parsed["wave_4_active"])
+        self.assertEqual(parsed["wave_4_meta"], 5)
+
+    def test_replace_multiline_value_with_brackets_in_nested_strings(self):
+        """The old multi-line value contains string values with `{`/`[`/`}`/`]`
+        and escaped quotes — depth/string tracking must locate the true end."""
+        text = (
+            "{\n"
+            '  "wave_5_scope": {\n'
+            '    "note": "scope is {tight} and [bounded]",\n'
+            '    "quote": "He said \\"go\\" then }",\n'
+            '    "n": 3\n'
+            "  },\n"
+            '  "keep": 1\n'
+            "}\n"
+        )
+        out = upsert_top_level_key(text, "wave_5_scope", '"done"')
+        parsed = json.loads(out)
+        self.assertEqual(parsed["wave_5_scope"], "done")
+        self.assertEqual(parsed["keep"], 1)
+        self.assertEqual(out.count('"wave_5_scope"'), 1)
+
+    def test_replace_multiline_does_not_touch_nested_same_name(self):
+        """A nested key sharing the outer key's name must NOT be the replace
+        target — the _is_top_level_position guard still applies on the
+        multi-line replace path."""
+        text = '{\n  "wave_6_scope": {\n    "wave_6_scope": 99\n  },\n  "keep": 1\n}\n'
+        out = upsert_top_level_key(text, "wave_6_scope", '"narrow"')
+        parsed = json.loads(out)
+        self.assertEqual(parsed["wave_6_scope"], "narrow")
+        self.assertEqual(parsed["keep"], 1)
+
+
 class RemoveTopLevelKeyTests(unittest.TestCase):
     """main#611 — `remove_top_level_key` / `--remove-key` mode for phase-
     boundary cleanup of bare `wave_{M}_*` keys.

--- a/.claude/lib/upsert_status_keys.py
+++ b/.claude/lib/upsert_status_keys.py
@@ -168,6 +168,16 @@ def upsert_top_level_key(text: str, key: str, json_value: str) -> str:
     either invalid JSON or a logical/text divergence aborted by the
     post-write validation.
 
+    Multi-line existing value on replace (main#736): when the key already
+    exists and its current value spans multiple lines (a pretty-printed object
+    or array — the common shape in cross-repo-status.json), the replace path
+    excises the value through `_find_value_end`, not just the opener line. The
+    pre-#736 code spliced at the opener line's end, leaving the old multi-line
+    body dangling after the new compact value and producing invalid JSON that
+    aborted the whole upsert batch (the `/wave-scope` replace-`wave_{M}_scope`
+    failure). Single-line values are unaffected — `_find_value_end` returns the
+    opener-line end unchanged for them.
+
     Indent-tolerance (main#595/#611): the replace-in-place and sibling-finder
     regexes accept ANY leading whitespace, not just exactly 2 spaces. The
     file mixes 1-space legacy keys (P3W1-era, e.g. `current_wave` /
@@ -196,11 +206,20 @@ def upsert_top_level_key(text: str, key: str, json_value: str) -> str:
         if not _is_top_level_position(text, m.start()):
             continue
         indent = m.group(1)
-        existing = m.group(0).rstrip()
+        # `line_re` is line-anchored (`.*$` with no DOTALL), so `m.end()` is
+        # the end of the OPENER line only. For a multi-line existing value
+        # (the opener line ends with `{` or `[`), the value body continues on
+        # following lines — `_find_value_end` walks past it to the value's true
+        # terminator. The pre-#736 code spliced at `m.end()`, which for a
+        # multi-line value left the old body dangling after the new compact
+        # value and produced invalid JSON (`Expecting ',' delimiter`), aborting
+        # the whole batch. For a single-line value `_find_value_end` returns
+        # `m.end()` unchanged, so this is a no-op for the cases that worked.
+        value_end = _find_value_end(text, m.end())
         replacement = f'{indent}"{key}": {json_value}'
-        if existing.endswith(","):
+        if value_end > 0 and text[value_end - 1] == ",":
             replacement += ","
-        return text[: m.start()] + replacement + text[m.end() :]
+        return text[: m.start()] + replacement + text[value_end:]
 
     new_line = f'  "{key}": {json_value},'
     wave_num_match = re.match(r"wave_(\d+)_", key)


### PR DESCRIPTION
## Summary
Fixes `upsert_status_keys.upsert_top_level_key` replace-in-place path, which spliced at the opener line's end (`m.end()`). Because `line_re` is line-anchored (no DOTALL), a key whose existing value spans multiple lines (a pretty-printed object/array — the common shape in `cross-repo-status.json`) left the value body dangling after the new compact value, producing invalid JSON that aborted the whole upsert batch (the real `/wave-scope 6 1` failure).

Fix: locate the true end of the existing value via the same `_find_value_end` helper used by the insert (#332) and remove (#611) paths; preserve a trailing comma only if the excised value had one. Single-line values are unaffected.

Closes #736

TechDebt: none — this is itself a tech-debt fix; no new debt introduced. Regression test added under `.claude/lib/tests/`.

## Reviewers
- Requestor: Lucas Ferreira (implementer)
- Reviewer: Weronika Zielinska
- Reviewer: Nurul Hakim

🧵 Implementer went idle (API 529 overload) after committing+pushing but before opening the PR; PR opened by orchestrator (throttle-takeover) to preserve complete work. Authored commit is Lucas Ferreira's.
