### PR TITLE
fix(mermaid-gate): stop _RAW_ANGLE false-warning on valid <br/> label tags (#797)

### DIFF
--- a/.claude/lib/tests/test_check_mermaid.py
+++ b/.claude/lib/tests/test_check_mermaid.py
@@ -1,0 +1,77 @@
+"""Tests for the check-mermaid raw-angle footgun heuristic (#797).
+
+The mermaid render gate (`scripts/check-mermaid.py`) prints an advisory warning
+when a fenced block carries a raw `<`/`>` in a label (which renders degraded —
+the #786 `<unset>` class). #797: the heuristic false-warned on valid HTML break
+tags (`<br/>`), which mermaid renders fine inside multi-line labels, because the
+closing `>` of the break tag matched. These tests pin both directions:
+
+  (a) a label with `<br>`/`<br/>`/`<br />` does NOT warn;
+  (b) a genuinely raw/unescaped angle bracket still warns; and
+  (c) mermaid edge tokens (`-->`, `<--`, `==>`) never warn.
+
+The script is loaded by file path because its name is hyphenated (not an
+importable module) and it lives under scripts/, not .claude/lib/.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parents[3] / "scripts" / "check-mermaid.py"
+_spec = importlib.util.spec_from_file_location("check_mermaid", _SCRIPT)
+assert _spec is not None and _spec.loader is not None
+check_mermaid = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(check_mermaid)
+
+_has_raw_angle = check_mermaid._has_raw_angle
+
+
+class BreakTagsDoNotWarn(unittest.TestCase):
+    def test_self_closing_br(self) -> None:
+        self.assertFalse(_has_raw_angle("flowchart TD\n  A[line one<br/>line two]"))
+
+    def test_bare_br(self) -> None:
+        self.assertFalse(_has_raw_angle("flowchart TD\n  A[line one<br>line two]"))
+
+    def test_spaced_br(self) -> None:
+        self.assertFalse(_has_raw_angle("flowchart TD\n  A[line one<br />line two]"))
+
+    def test_uppercase_br(self) -> None:
+        self.assertFalse(_has_raw_angle("flowchart TD\n  A[line one<BR/>line two]"))
+
+    def test_multiple_brs_in_one_label(self) -> None:
+        self.assertFalse(_has_raw_angle("flowchart TD\n  A[a<br/>b<br/>c]"))
+
+
+class GenuineRawAngleStillWarns(unittest.TestCase):
+    def test_unset_class_opening_angle(self) -> None:
+        # The #786 footgun: a literal `<` in a label renders as a degraded HTML tag.
+        self.assertTrue(_has_raw_angle("flowchart TD\n  A[state: <unset>]"))
+
+    def test_raw_angle_alongside_a_valid_br(self) -> None:
+        # A break tag must not mask a genuine raw bracket elsewhere in the block.
+        self.assertTrue(_has_raw_angle("flowchart TD\n  A[ok<br/>then <unset>]"))
+
+    def test_lone_greater_than(self) -> None:
+        self.assertTrue(_has_raw_angle("flowchart TD\n  A[count > 5]"))
+
+
+class EdgeTokensDoNotWarn(unittest.TestCase):
+    def test_forward_arrow(self) -> None:
+        self.assertFalse(_has_raw_angle("flowchart TD\n  A --> B"))
+
+    def test_reverse_arrow(self) -> None:
+        self.assertFalse(_has_raw_angle("flowchart TD\n  A <-- B"))
+
+    def test_thick_arrow(self) -> None:
+        self.assertFalse(_has_raw_angle("flowchart TD\n  A ==> B"))
+
+    def test_dotted_arrow(self) -> None:
+        self.assertFalse(_has_raw_angle("flowchart TD\n  A -.-> B"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/check-mermaid.py
+++ b/scripts/check-mermaid.py
@@ -47,10 +47,27 @@ from pathlib import Path
 
 _MERMAID_BLOCK = re.compile(r"^([ \t]*)```mermaid[ \t]*\n(.*?)^[ \t]*```", re.DOTALL | re.MULTILINE)
 _ERROR_MARKERS = ("syntax error", "error in text", "aborted", "parse error")
+# HTML line-break tags mermaid renders natively inside node labels (`<br>`,
+# `<br/>`, `<br />`, any case). Stripped before the raw-angle scan so a valid
+# multi-line label doesn't trip the advisory warning — the closing `>` of a
+# break tag would otherwise match `_RAW_ANGLE` (#797).
+_BR_TAG = re.compile(r"<br\s*/?>", re.IGNORECASE)
 # A raw `<` or `>` that is not part of a mermaid edge token (`-->`, `<--`,
-# `<==`, `-.->`) and not a `<br>` line-break tag. Used only for an advisory
-# footgun warning, never to fail the gate (heuristic; full render is the gate).
-_RAW_ANGLE = re.compile(r"<(?!br\b|/|--|==|\.)|(?<![-=.])>")
+# `<==`, `-.->`). Break tags are removed by `_BR_TAG` first; what remains and
+# matches here is a genuinely raw angle bracket (the #786 `<unset>` class).
+# Used only for an advisory footgun warning, never to fail the gate (heuristic;
+# full render is the gate).
+_RAW_ANGLE = re.compile(r"<(?!/|--|==|\.)|(?<![-=.])>")
+
+
+def _has_raw_angle(body: str) -> bool:
+    """True if a mermaid block carries a raw `<`/`>` that renders degraded.
+
+    Valid HTML break tags (`<br>`/`<br/>`/`<br />`) are stripped before the scan
+    so multi-line labels don't false-warn (#797); a genuinely unescaped angle
+    bracket in a label (the #786 `<unset>` class) still trips it.
+    """
+    return bool(_RAW_ANGLE.search(_BR_TAG.sub("", body)))
 
 
 # Authored-doc scope exclusions. `.claude/memory/**` is excluded to match the
@@ -170,7 +187,7 @@ def main(argv: list[str]) -> int:
             text = f.read_text(encoding="utf-8")
             for idx, (line_no, body) in enumerate(_iter_blocks(text)):
                 total += 1
-                if _RAW_ANGLE.search(body):
+                if _has_raw_angle(body):
                     print(
                         f"  warning {f}:{line_no} — raw '<'/'>' in a mermaid block; "
                         "escape as #lt;/#gt; in labels (renders degraded otherwise, #786)."


### PR DESCRIPTION
## Summary

Fixes the `_RAW_ANGLE` footgun heuristic in `scripts/check-mermaid.py` (the mermaid render gate, P6W1 #787/#794/#796) so it stops false-warning on valid HTML break tags inside mermaid node labels.

**Root cause:** the heuristic guarded the *opening* `<` of a break tag (`br\b` lookahead), but the *closing* `>` of `<br>`/`<br/>`/`<br />` still matched the `(?<![-=.])>` alternative — so a legit multi-line label (e.g. the lifecycle flowchart widened into scope by #795) fired a spurious advisory warning.

**Fix:** strip the break tags mermaid renders natively (`_BR_TAG`, any case/spacing) before the raw-angle scan, via a small `_has_raw_angle` helper. A genuinely unescaped angle bracket (the #786 `<unset>` class) still trips the warning — even when it sits next to a valid `<br/>` in the same block. The now-redundant `br\b` opening guard is dropped from `_RAW_ANGLE`. Advisory-only path; the render gate itself is unchanged.

**Test:** adds `.claude/lib/tests/test_check_mermaid.py` (collected by CI's pytest job + the pre-push mirror; loads the hyphenated script by path). Pins all three directions — break tags don't warn, genuine raw angles still warn (incl. alongside a valid `<br/>`), edge tokens (`-->`/`<--`/`==>`/`-.->`) never warn. This is the script's first regression test.

Verified locally: pytest green, ruff format/lint + mypy clean, and the full pre-push `mermaid-render` gate renders the whole doc set cleanly.

Reviewers: Nurul Hakim and Santiago Ferreira.

Closes #797

TechDebt: none — net-negative-risk (removes a false-positive in an advisory-only path; gate behavior unchanged) and adds the script's first regression test.
