### PR TITLE
process(session-start): detect wave merged-but-unwrapped + nudge — #730

### DIFF
--- a/.claude/lib/tests/test_wave_unwrapped.py
+++ b/.claude/lib/tests/test_wave_unwrapped.py
@@ -1,0 +1,226 @@
+"""Tests for wave_unwrapped — the session-start "wave merged but unwrapped"
+detector (main#730).
+
+Verifies:
+  1. current_wave_number parses "wave-2" -> "2" and degrades on junk.
+  2. is_wrapped recognizes every historical marker spelling and ignores
+     completed_at (which marks an earlier point — must NOT count as wrapped).
+  3. The verdict matrix: ok / in_flight / unwrapped / unwrapped_unverified.
+  4. Detection is scoped to current_wave only — a stale cross-phase
+     wave_4_active=true ghost (main#683) does NOT false-fire.
+  5. base_branch prefers wave_{M}_branches.branch over a stale phase key.
+  6. A gh failure degrades to unwrapped_unverified, never a false 0/nudge-miss.
+  7. The `check` CLI always exits 0 (non-fatal) and prints a NUDGE only when
+     the verdict warrants one.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+# Helper lives at .claude/lib/wave_unwrapped.py; this test is at
+# .claude/lib/tests/test_*.py. parent.parent reaches the lib root.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import wave_unwrapped  # noqa: E402
+
+
+def _status(**overrides) -> dict:
+    """A baseline live-wave-2 status; overrides patch individual keys."""
+    data = {
+        "current_wave": "wave-2",
+        "wave_2_active": True,
+        "wave_2_repos_in_scope": ["noorinalabs-main", "noorinalabs-isnad-graph"],
+        "wave_2_branches": {"branch": "deployments/phase-6/wave-2"},
+    }
+    data.update(overrides)
+    return data
+
+
+class CurrentWaveNumberTest(unittest.TestCase):
+    def test_parses_prefixed_form(self) -> None:
+        self.assertEqual(wave_unwrapped.current_wave_number({"current_wave": "wave-2"}), "2")
+
+    def test_bare_digit(self) -> None:
+        self.assertEqual(wave_unwrapped.current_wave_number({"current_wave": "7"}), "7")
+
+    def test_missing_or_junk_is_none(self) -> None:
+        self.assertIsNone(wave_unwrapped.current_wave_number({}))
+        self.assertIsNone(wave_unwrapped.current_wave_number({"current_wave": "wave-x"}))
+        self.assertIsNone(wave_unwrapped.current_wave_number({"current_wave": 2}))
+
+
+class IsWrappedTest(unittest.TestCase):
+    def test_each_marker_variant_counts(self) -> None:
+        for marker in ("wrapped_up_at", "wrapup_completed_at", "wrapped_at"):
+            with self.subTest(marker=marker):
+                self.assertTrue(
+                    wave_unwrapped.is_wrapped({f"wave_2_{marker}": "2026-06-20T00:00:00Z"}, "2")
+                )
+
+    def test_null_marker_not_wrapped(self) -> None:
+        self.assertFalse(wave_unwrapped.is_wrapped({"wave_2_wrapped_up_at": None}, "2"))
+
+    def test_completed_at_does_not_count(self) -> None:
+        # completed_at marks an earlier lifecycle point; counting it would mask
+        # the merge->wrapup gap #730 exists to detect.
+        self.assertFalse(
+            wave_unwrapped.is_wrapped({"wave_2_completed_at": "2026-06-09T00:00:00Z"}, "2")
+        )
+
+
+class BaseBranchTest(unittest.TestCase):
+    def test_prefers_recorded_branch_over_stale_phase(self) -> None:
+        data = _status()
+        # Even with a misleading phase arg, the recorded branch wins.
+        self.assertEqual(wave_unwrapped.base_branch(data, "2", "4"), "deployments/phase-6/wave-2")
+
+    def test_constructs_from_phase_when_no_branch(self) -> None:
+        self.assertEqual(wave_unwrapped.base_branch({}, "2", "6"), "deployments/phase-6/wave-2")
+
+    def test_none_when_unresolvable(self) -> None:
+        self.assertIsNone(wave_unwrapped.base_branch({}, "2", None))
+
+
+class EvaluateVerdictTest(unittest.TestCase):
+    def test_unwrapped_fires_on_zero_open_prs(self) -> None:
+        with mock.patch.object(wave_unwrapped, "count_open_prs", return_value=0):
+            res = wave_unwrapped.evaluate(_status())
+        self.assertEqual(res["verdict"], "unwrapped")
+        self.assertEqual(res["open_pr_count"], 0)
+        self.assertIn("/wave-wrapup", res["message"])
+
+    def test_in_flight_when_open_prs_remain(self) -> None:
+        with mock.patch.object(wave_unwrapped, "count_open_prs", return_value=3):
+            res = wave_unwrapped.evaluate(_status())
+        self.assertEqual(res["verdict"], "in_flight")
+
+    def test_ok_when_wrapped(self) -> None:
+        res = wave_unwrapped.evaluate(
+            _status(wave_2_wrapped_up_at="2026-06-20T00:00:00Z"), check_prs=False
+        )
+        self.assertEqual(res["verdict"], "ok")
+        self.assertTrue(res["wrapped"])
+
+    def test_ok_when_inactive(self) -> None:
+        res = wave_unwrapped.evaluate(_status(wave_2_active=False), check_prs=False)
+        self.assertEqual(res["verdict"], "ok")
+
+    def test_ok_when_no_current_wave(self) -> None:
+        res = wave_unwrapped.evaluate({}, check_prs=False)
+        self.assertEqual(res["verdict"], "ok")
+        self.assertIsNone(res["wave"])
+
+    def test_gh_failure_degrades_to_unverified(self) -> None:
+        with mock.patch.object(wave_unwrapped, "count_open_prs", return_value=None):
+            res = wave_unwrapped.evaluate(_status())
+        self.assertEqual(res["verdict"], "unwrapped_unverified")
+
+    def test_no_gh_flag_degrades_to_unverified(self) -> None:
+        # check_prs=False must not invoke gh and must not claim 0 open PRs.
+        with mock.patch.object(wave_unwrapped, "_run_gh", side_effect=AssertionError("gh called")):
+            res = wave_unwrapped.evaluate(_status(), check_prs=False)
+        self.assertEqual(res["verdict"], "unwrapped_unverified")
+        self.assertIsNone(res["open_pr_count"])
+
+    def test_missing_scope_keys_degrade_unverified(self) -> None:
+        data = _status()
+        del data["wave_2_repos_in_scope"]
+        with mock.patch.object(wave_unwrapped, "_run_gh", side_effect=AssertionError("gh called")):
+            res = wave_unwrapped.evaluate(data)
+        self.assertEqual(res["verdict"], "unwrapped_unverified")
+
+
+class CrossPhaseGhostTest(unittest.TestCase):
+    """A stale wave_4_active=true from a prior phase (main#683) must not fire —
+    detection is scoped to current_wave (=2 here)."""
+
+    def test_stale_prior_phase_wave_ignored(self) -> None:
+        data = _status(
+            wave_4_active=True,  # leftover P5W4 ghost, unwrapped
+        )
+        with mock.patch.object(wave_unwrapped, "count_open_prs", return_value=3):
+            res = wave_unwrapped.evaluate(data)
+        # Verdict reflects wave 2 (in flight), never wave 4.
+        self.assertEqual(res["wave"], "2")
+        self.assertEqual(res["verdict"], "in_flight")
+
+
+class CountOpenPrsTest(unittest.TestCase):
+    def test_sums_across_repos_via_arg_list(self) -> None:
+        calls: list[list[str]] = []
+
+        def fake_gh(args: list[str]) -> str:
+            calls.append(args)
+            return json.dumps([{"number": 1}, {"number": 2}])
+
+        with mock.patch.object(wave_unwrapped, "_run_gh", side_effect=fake_gh):
+            total = wave_unwrapped.count_open_prs(["a", "b"], "deployments/phase-6/wave-2")
+        self.assertEqual(total, 4)  # 2 repos * 2 PRs
+        # Every gh call is a list arg vector with the correct base.
+        for c in calls:
+            self.assertIsInstance(c, list)
+            self.assertIn("deployments/phase-6/wave-2", c)
+
+    def test_gh_error_returns_none(self) -> None:
+        import subprocess
+
+        with mock.patch.object(
+            wave_unwrapped, "_run_gh", side_effect=subprocess.CalledProcessError(1, ["gh"])
+        ):
+            self.assertIsNone(wave_unwrapped.count_open_prs(["a"], "base"))
+
+
+class CliTest(unittest.TestCase):
+    def _write(self, data: dict) -> Path:
+        tmp = Path(self._tmp.name) / "cross-repo-status.json"
+        tmp.write_text(json.dumps(data))
+        return tmp
+
+    def setUp(self) -> None:
+        self._tmp = TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+
+    def test_check_prints_nudge_and_exits_zero(self) -> None:
+        status = self._write(_status())
+        buf = io.StringIO()
+        with mock.patch.object(wave_unwrapped, "count_open_prs", return_value=0):
+            with redirect_stdout(buf):
+                rc = wave_unwrapped.main(["check", "--status", str(status)])
+        self.assertEqual(rc, 0)
+        self.assertIn("NUDGE", buf.getvalue())
+        self.assertIn("/wave-wrapup", buf.getvalue())
+
+    def test_check_no_nudge_when_in_flight(self) -> None:
+        status = self._write(_status())
+        buf = io.StringIO()
+        with mock.patch.object(wave_unwrapped, "count_open_prs", return_value=2):
+            with redirect_stdout(buf):
+                rc = wave_unwrapped.main(["check", "--status", str(status)])
+        self.assertEqual(rc, 0)
+        self.assertNotIn("NUDGE", buf.getvalue())
+
+    def test_check_unreadable_status_exits_zero(self) -> None:
+        rc = wave_unwrapped.main(["check", "--status", "/no/such/path.json"])
+        self.assertEqual(rc, 0)
+
+    def test_json_output(self) -> None:
+        status = self._write(_status())
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = wave_unwrapped.main(["check", "--status", str(status), "--no-gh", "--json"])
+        self.assertEqual(rc, 0)
+        payload = json.loads(buf.getvalue())
+        self.assertEqual(payload["wave"], "2")
+        self.assertEqual(payload["verdict"], "unwrapped_unverified")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/lib/wave_unwrapped.py
+++ b/.claude/lib/wave_unwrapped.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""Detect a wave that merged to main but was never formally wrapped (main#730).
+
+P5W5 merged all 45 of its PRs to ``main`` days before the wave was formally
+wrapped — ``wave_5_wrapped_up_at`` stayed null, ``wave_5_active`` stayed true,
+and the post-wave audits (annunaki-attack, memory) never ran — because nothing
+at session-start surfaced the gap. This helper provides the deterministic,
+NON-FATAL detection /session-start (Step 5b) turns into a nudge toward
+``/wave-wrapup``.
+
+The signal (issue #730 acceptance criteria) is the conjunction:
+
+    wave_{M}_active == true
+      AND no wrapup marker present for wave M
+      AND 0 open wave PRs across the wave's in-scope repos
+
+scoped to the **current** wave only. Scoping to ``current_wave`` is load-bearing:
+wave keys in cross-repo-status.json are NOT phase-namespaced (memory
+``project_wave_key_cross_phase_collision`` / main#683), so the file legitimately
+retains stale ``wave_4_active: true`` rows from a *prior* phase's W4. A naive
+"any active+unwrapped wave" scan would false-fire on those cross-phase ghosts;
+deriving M from ``current_wave`` ("wave-2" -> "2") looks only at the live wave.
+
+Wrapup is recorded under one of several historical key spellings
+(``wrapped_up_at`` / ``wrapup_completed_at`` / ``wrapped_at``) — all three are
+treated as "wrapped". ``completed_at`` is deliberately NOT a wrapup marker: it
+is set at an earlier lifecycle point (e.g. wave_1 ``completed_at`` predates its
+``wrapup_completed_at`` by ~12 days), so counting it would mask the very
+merge-to-wrapup gap this detector exists to find.
+
+Everything degrades gracefully: a missing ``current_wave``, missing status keys,
+or a failed ``gh`` call yields a benign verdict (``ok`` or the softer
+``unwrapped_unverified``) and never raises — session-start must never break on
+this.
+
+CLI:
+  wave_unwrapped.py check [--status PATH] [--phase P] [--wave M]
+                          [--no-gh] [--json]
+
+Always exits 0 (the nudge is informational, not a gate).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+# Repo root = two parents above .claude/lib/ (lib -> .claude -> root). Resolved
+# from this file so the default is correct from any cwd or worktree.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DEFAULT_STATUS = _REPO_ROOT / "cross-repo-status.json"
+
+# Wrapup-marker key spellings, oldest-to-newest. ANY present-and-non-null value
+# means the wave was wrapped. ``completed_at`` is intentionally absent — see the
+# module docstring (it marks an earlier point and would mask the gap).
+_WRAPUP_MARKERS = ("wrapped_up_at", "wrapup_completed_at", "wrapped_at")
+
+
+def _run_gh(args: list[str]) -> str:
+    """Run ``gh <args>`` with an explicit arg list and return stdout.
+
+    Explicit arg list (never a shell string, never ``shell=True``) so a
+    multi-word value can never word-split under zsh — same contract as
+    ``wave_status._run_gh`` (main#688).
+    """
+    proc = subprocess.run(
+        ["gh", *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return proc.stdout
+
+
+def _load_status(status_path: Path) -> dict:
+    return json.loads(Path(status_path).read_text())
+
+
+def current_wave_number(data: dict) -> str | None:
+    """The live wave number from the ``current_wave`` pointer ("wave-2" -> "2").
+
+    Returns None when the pointer is absent or malformed — the caller treats
+    that as "nothing to check" rather than guessing a wave.
+    """
+    raw = data.get("current_wave")
+    if not isinstance(raw, str):
+        return None
+    num = raw[len("wave-") :] if raw.startswith("wave-") else raw
+    return num if num.isdigit() else None
+
+
+def is_active(data: dict, wave: str) -> bool:
+    """Truthy ``wave_{M}_active`` (absent -> not active)."""
+    return bool(data.get(f"wave_{wave}_active"))
+
+
+def is_wrapped(data: dict, wave: str) -> bool:
+    """True if any wrapup-marker variant for wave M is present and non-null."""
+    return any(data.get(f"wave_{wave}_{m}") for m in _WRAPUP_MARKERS)
+
+
+def base_branch(data: dict, wave: str, phase: str | None) -> str | None:
+    """The wave's deployment branch — the PR base used to count open wave PRs.
+
+    Prefers the exact branch recorded under ``wave_{M}_branches.branch`` (most
+    reliable: it carries the real phase even when the top-level ``phase`` key is
+    stale). Falls back to ``deployments/phase-{P}/wave-{M}`` only when an
+    explicit phase is supplied. Returns None when neither source is available.
+    """
+    branches = data.get(f"wave_{wave}_branches")
+    if isinstance(branches, dict):
+        branch = branches.get("branch")
+        if isinstance(branch, str) and branch:
+            return branch
+    if phase:
+        return f"deployments/phase-{phase}/wave-{wave}"
+    return None
+
+
+def _read_repos(data: dict, wave: str) -> list[str] | None:
+    """``wave_{M}_repos_in_scope`` as a list, or None if absent/malformed."""
+    repos = data.get(f"wave_{wave}_repos_in_scope")
+    if not isinstance(repos, list) or not repos:
+        return None
+    return [str(r) for r in repos]
+
+
+def count_open_prs(repos: list[str], base: str) -> int | None:
+    """Total open PRs targeting ``base`` across ``repos``.
+
+    Best-effort: any ``gh`` failure (auth, rate-limit, unknown repo) returns
+    None ("undetermined") rather than raising or reporting a false 0 — a false 0
+    would fire a spurious "merged but unwrapped" nudge mid-wave.
+    """
+    total = 0
+    for repo in repos:
+        try:
+            out = _run_gh(
+                [
+                    "pr",
+                    "list",
+                    "--repo",
+                    f"noorinalabs/{repo}",
+                    "--state",
+                    "open",
+                    "--base",
+                    base,
+                    "--json",
+                    "number",
+                ]
+            )
+            total += len(json.loads(out or "[]"))
+        except (subprocess.CalledProcessError, json.JSONDecodeError, OSError):
+            return None
+    return total
+
+
+def evaluate(
+    data: dict,
+    *,
+    wave: str | None = None,
+    phase: str | None = None,
+    check_prs: bool = True,
+) -> dict:
+    """Classify the current (or given) wave's wrap state.
+
+    Returns a dict with ``wave``, ``active``, ``wrapped``, ``open_pr_count``
+    (int or None), ``base_branch``, ``verdict`` and a human ``message``.
+
+    verdict:
+      * ``ok``                  — nothing to nudge (no current wave, or the wave
+                                  is inactive / already wrapped).
+      * ``in_flight``           — active, unwrapped, but open wave PRs remain:
+                                  a normal in-progress wave, no nudge.
+      * ``unwrapped``           — active, unwrapped, 0 open wave PRs: merged but
+                                  not wrapped — FIRE the /wave-wrapup nudge.
+      * ``unwrapped_unverified``— active, unwrapped, open-PR count undetermined
+                                  (gh failed / scope keys missing): softer nudge.
+    """
+    wave = wave or current_wave_number(data)
+    result: dict = {
+        "wave": wave,
+        "active": False,
+        "wrapped": False,
+        "open_pr_count": None,
+        "base_branch": None,
+        "verdict": "ok",
+        "message": "",
+    }
+    if wave is None:
+        result["message"] = "No current wave recorded — nothing to check."
+        return result
+
+    active = is_active(data, wave)
+    wrapped = is_wrapped(data, wave)
+    result["active"] = active
+    result["wrapped"] = wrapped
+
+    if not active:
+        result["message"] = f"Wave {wave} is not active."
+        return result
+    if wrapped:
+        result["message"] = f"Wave {wave} is already wrapped."
+        return result
+
+    # Active and unwrapped — the open-PR count discriminates "merged but
+    # unwrapped" from a still-in-flight wave.
+    base = base_branch(data, wave, phase)
+    result["base_branch"] = base
+    repos = _read_repos(data, wave)
+
+    open_count: int | None = None
+    if check_prs and base and repos:
+        open_count = count_open_prs(repos, base)
+    result["open_pr_count"] = open_count
+
+    if open_count == 0:
+        result["verdict"] = "unwrapped"
+        result["message"] = (
+            f"Wave {wave} is active and unwrapped with 0 open wave PRs — "
+            "merged but not wrapped. Run /wave-wrapup."
+        )
+    elif open_count is None:
+        result["verdict"] = "unwrapped_unverified"
+        why = "open-PR count undetermined (gh unavailable or wave scope not recorded)"
+        result["message"] = (
+            f"Wave {wave} is active and unwrapped; {why}. If its PRs are merged, run /wave-wrapup."
+        )
+    else:
+        result["verdict"] = "in_flight"
+        result["message"] = f"Wave {wave} is active with {open_count} open wave PR(s) — in flight."
+    return result
+
+
+def _cmd_check(args: argparse.Namespace) -> int:
+    try:
+        data = _load_status(args.status)
+    except (OSError, json.JSONDecodeError) as exc:
+        # Cannot read status -> degrade to a benign no-op so session-start lives.
+        print(f"wave-unwrapped: status unreadable ({exc}); skipping check.")
+        return 0
+
+    result = evaluate(
+        data,
+        wave=args.wave,
+        phase=args.phase,
+        check_prs=not args.no_gh,
+    )
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+        return 0
+
+    if result["verdict"] in ("unwrapped", "unwrapped_unverified"):
+        print(f"NUDGE: {result['message']}")
+    else:
+        print(result["message"])
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_check = sub.add_parser("check", help="classify the current wave's wrap state")
+    p_check.add_argument(
+        "--status",
+        type=Path,
+        default=_DEFAULT_STATUS,
+        help="path to cross-repo-status.json (default: repo-root copy)",
+    )
+    p_check.add_argument("--phase", default=None, help="phase number (fallback for base branch)")
+    p_check.add_argument("--wave", default=None, help="override the current-wave number")
+    p_check.add_argument(
+        "--no-gh",
+        action="store_true",
+        help="skip the open-PR gh probe (key-only verdict)",
+    )
+    p_check.add_argument("--json", action="store_true", help="emit the full result as JSON")
+    p_check.set_defaults(func=_cmd_check)
+    return parser
+
+
+def main(argv: list[str]) -> int:
+    args = _build_parser().parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.claude/skills/session-start/SKILL.md
+++ b/.claude/skills/session-start/SKILL.md
@@ -270,6 +270,26 @@ fi
 
 Report any red runs prominently — a red publish/deploy on a default branch is a stop-and-investigate signal, not background noise: it usually means the artifact consumers (staging, downstream pulls) are silently running stale or broken bits. A run tagged `base-image-drift` is a different remediation path than generic redness: the wave's code did not break it — an upstream base image grew a new advisory (e.g. the W4 openssl CVE-2026-45447) — so fix it forward by rebuilding/bumping the base image, not by reverting wave work. If `gh api` calls fail (auth/rate-limit), say so rather than reporting a false all-green; the classifier itself is best-effort and degrades to the unclassified `code/other` tag on any log-fetch failure.
 
+### Step 5b — Wave-merged-but-unwrapped nudge (P5W5 retro Proposed Change #1 / #730)
+
+Surface a wave whose PRs **merged to main but which was never formally wrapped**. *Rationale:* P5W5 merged all 45 of its PRs days before `/wave-wrapup` ran — `wave_5_wrapped_up_at` stayed null, `wave_5_active` stayed true, and the post-wave audits (annunaki-attack, memory) never ran — because nothing at session-start surfaced the gap, so wrap/retro deferred indefinitely.
+
+The signal is the conjunction `wave_{M}_active == true` AND no wrapup marker present (`wave_{M}_wrapped_up_at` / `wave_{M}_wrapup_completed_at` / `wave_{M}_wrapped_at`) AND **0 open wave PRs** across the wave's in-scope repos — scoped to the **current** wave (`current_wave`) only. Scoping to `current_wave` is load-bearing: wave keys are NOT phase-namespaced (memory `project_wave_key_cross_phase_collision` / #683), so the status file legitimately retains stale `wave_4_active: true` rows from a prior phase's W4 — an "any active+unwrapped wave" scan would false-fire on those ghosts. The detection is **non-fatal** and degrades gracefully: a missing `current_wave`, missing scope keys, or a failed `gh` probe yields a benign verdict (never a hard block, never a false nudge mid-wave).
+
+```bash
+REPO_ROOT="$(cd "$(git rev-parse --git-common-dir 2>/dev/null)/.." 2>/dev/null && pwd)"
+[ -f "$REPO_ROOT/cross-repo-status.json" ] || REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+# Always exits 0 (informational nudge, not a gate). Prints a line beginning
+# "NUDGE:" only when the wave is merged-but-unwrapped (or active+unwrapped with
+# an undetermined open-PR count); otherwise a one-line in-flight/ok status.
+if [ -f "$REPO_ROOT/.claude/lib/wave_unwrapped.py" ]; then
+  python3 "$REPO_ROOT/.claude/lib/wave_unwrapped.py" check \
+    --status "$REPO_ROOT/cross-repo-status.json" || true
+fi
+```
+
+If the verdict is `unwrapped` (0 open wave PRs) — or the softer `unwrapped_unverified` (open-PR count undetermined because `gh` failed or the wave's scope keys are missing) — surface it prominently as **"wave merged but unwrapped — run `/wave-wrapup`"**. An `in_flight` verdict (open wave PRs remain) is a normal active wave: no nudge. This is informational only — it never blocks the session.
+
 ### Step 6 — Charter freshness check
 
 Read the tail of the feedback log:
@@ -304,6 +324,7 @@ After all steps complete, present a single status block:
 | 4. Annunaki | {N errors, action needed? / clear} |
 | 5. Wave | {active wave, stale?, issues} |
 | 5a. Red default-branch runs | {N red publish/deploy runs (M base-image-drift) / all green} |
+| 5b. Wave wrap state | {wave merged but unwrapped — run /wave-wrapup / in flight / wrapped} |
 | 6. Charter | {current / proposals pending} |
 
 {Then address the user's actual message/request}


### PR DESCRIPTION
## Summary
Adds a deterministic, **non-fatal** session-start detector + nudge for a wave that **merged to main but was never formally wrapped** (the P5W5 gap: 45 PRs merged days before `/wave-wrapup` ran; `wave_5_wrapped_up_at` null, `wave_5_active` true, post-wave audits never ran).

## What changed
- **`.claude/lib/wave_unwrapped.py`** — classifies the **current** wave's wrap state. Signal = `wave_{M}_active == true` AND no wrapup marker AND **0 open wave PRs** across in-scope repos. Scoped to `current_wave` only, so stale cross-phase `wave_{M}_active` ghosts (#683 — wave keys are not phase-namespaced) cannot false-fire. Recognizes all three wrapup-marker spellings (`wrapped_up_at` / `wrapup_completed_at` / `wrapped_at`); deliberately excludes `completed_at` (earlier lifecycle point — counting it would mask the gap). Degrades gracefully (`unwrapped_unverified`, never a false `0`) on missing keys or a failed `gh` probe. `gh` runs via an explicit arg-list (no zsh word-split — same contract as `wave_status`).
- **`.claude/skills/session-start/SKILL.md`** — new **Step 5b** + output-table row: runs the helper and surfaces "wave merged but unwrapped — run `/wave-wrapup`". Informational only, never blocks the session.
- **`.claude/lib/tests/test_wave_unwrapped.py`** — 24 cases: verdict matrix (ok / in_flight / unwrapped / unwrapped_unverified), cross-phase-ghost guard, marker-spelling coverage, graceful degradation, CLI exit-0.

## Verification
- Full `.claude/lib/tests/` suite green (295 passed); mypy clean; ruff format+lint clean; `pre_commit_ci_sync` gate OK. Live run against real `cross-repo-status.json` correctly reports wave 2 `in_flight` (no false nudge).

Closes #730

TechDebt: none — net-new helper + skill step; no shortcuts taken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VFZHBpSPAE2e9rHoQzkcL2
