### PR TITLE
fix(annunaki): exit-0 echoed-output low-confidence sub-class; keep masked-failure carve-out (#729)

### DIFF
--- a/.claude/hooks/annunaki_monitor.py
+++ b/.claude/hooks/annunaki_monitor.py
@@ -25,6 +25,13 @@ Input Language:
                   session-dedup hits
   Flag pass-through: stdin JSON is forwarded verbatim to `check()` by the
                      PostToolUse dispatcher (`post_dispatcher.py`)
+  Confidence tag (#729): every logged record carries `confidence` in
+                     {"high", "low"}. An exit-0 stdout-only match that is
+                     echoed content (displayed source `except ImportError:`,
+                     a `gh pr view --json` body) is "low" and excluded from the
+                     genuine-error count by annunaki_parse, but retained for
+                     forensics; a STRONG masked-failure signal (e.g. a `git
+                     push | tail` REJECTED push) stays "high" and counted.
 
 Exit codes:
   0 — always (advisory hook, never blocks)
@@ -211,6 +218,69 @@ CONTENT_DISPLAY_STDOUT_MERGE = re.compile(r"2>&1")
 # that nonetheless emitted a No-such-file failure must still log (#517 outlier).
 CONTENT_DISPLAY_EXCLUDED_PATTERN = "stdout:No such file or directory"
 
+# Confidence classification (#729) -------------------------------------------
+# A record matched purely by a stdout pattern at exit 0 is ambiguous. The
+# trigger word may be a REAL failure masked by a pipe — `git push ... | tail`
+# swallows a REJECTED push because the pipeline rc is the pager's 0, not git's
+# (feedback_push_pipe_masks_rejection) — OR it may be a trigger word sitting in
+# ECHOED OUTPUT the command merely displayed: source code (`except ImportError:`,
+# a `re.compile(...)` from this monitor's own body), a `gh pr view --json` PR
+# body, an issue body quoting "ERROR: ...". The second class is not a failure;
+# it drowned the real signal (85% / 40-of-47 of the P5W5 window — #729).
+#
+# Rather than DROP these (the #517/#596 ignore families do that for the cases
+# they can prove benign), we TAG every surviving record with a `confidence`
+# field and let the reader (annunaki_parse) exclude the low-confidence sub-class
+# from the genuine-error COUNT while keeping every record for forensics:
+#   high — a hard failure signal (non-zero exit, a stderr-pattern match) OR an
+#          exit-0 stdout match carrying a STRONG masked-failure signal.
+#   low  — exit-0, stdout-only, no strong signal, and the matched line is
+#          positively recognized as echoed content (displayed source / body).
+# An exit-0 stdout match we CANNOT positively recognize as echoed stays `high`:
+# we only ever demote display we are confident about, never an unclassified
+# failure (recall-preserving — the precision pass must not silence real errors).
+
+# Strong masked-failure signals: phrases marking a REAL failure even when the
+# pipeline exited 0. Kept counted — this is the acceptance-criterion carve-out
+# preserving the genuine exit-0-failure class (the `git push | tail` REJECTED
+# case and script self-reports like "... failed (exit 1)"). A real Python
+# `Traceback` is included so its source frames (a `  raise ValueError(...)`
+# line) cannot mis-trip the echoed-source signal below; pure cat/gh-api
+# displays of error-shaped content were already dropped upstream by #596.
+STRONG_MASKED_FAILURE = re.compile(
+    r"failed to push"  # git push rejection masked by a pager pipe
+    r"|\[rejected\]|\[remote rejected\]|non-fast-forward"
+    r"|exit status [1-9]"
+    r"|failed with exit code"
+    r"|\(exit [1-9][0-9]*\)"  # self-report: "ERROR: gh call failed (exit 1)"
+    r"|Traceback \(most recent call last\)",
+    re.IGNORECASE,
+)
+
+# Echoed-content signal 1: the matched line is a Python source clause being
+# DISPLAYED (a `cat`/`echo`/diff/`gh api .../contents` dump), not a raised
+# error. `except ImportError:` / a displayed `re.compile(...)` are the dominant
+# #729 false class. A genuinely-raised error reads `ImportError: <msg>` (or
+# pytest `E   ImportError:`) — start-of-line error name then a message — which
+# this deliberately does NOT match. `raise`/`except` lines inside a genuine
+# traceback are guarded by the STRONG `Traceback` keeper, which wins first.
+SOURCE_CLAUSE_LINE = re.compile(
+    r"^\s*[+-]?\s*(?:except|raise)\s+[\w.(]"  # except/raise <Error>[(]
+    r"|^\s*[+-]?\s*re\.compile\(",  # displayed monitor/source regex
+)
+
+# Echoed-content signal 2: the matched line opens a JSON object/array body —
+# `{"` or `[{` / `["` at line start (after an optional diff +/-). A
+# `gh ... --json` / `gh api` body dump that quotes an error string inside the
+# emitted JSON lands here. The trailing quote is required so a bare `[]` array,
+# a `[WARNING] ...` log prefix, or a markdown `[link]` line does NOT match
+# (recall guard — those appear in genuine failure output). A genuinely-raised
+# error never starts its extracted line with a quoted-key JSON brace (it leads
+# with an error name, `error:`/`fatal:`, or pytest `E `). Keyed on the LINE
+# shape, not the command, so a compound command that buries a `gh pr view`
+# alongside a real failing build/test step is NOT demoted on that substring.
+JSON_BODY_LINE = re.compile(r'^\s*[+-]?\s*[{\[]\s*["{]')
+
 
 def _is_content_display(command: str, exit_code: int, matched_patterns: list[str]) -> bool:
     """Return True if this matches the #596 content-display idiom.
@@ -323,6 +393,47 @@ def _should_ignore(command: str, output: str) -> bool:
     return False
 
 
+def _is_echoed_content(command: str, error_lines: list[str]) -> bool:
+    """Return True if the trigger match looks like displayed content (#729).
+
+    Two positive signals on the matched line(s): a displayed Python source
+    clause (`except`/`raise`/`re.compile(` — signal 1), or a JSON-data-shaped
+    line (`{`/`[` at line start — signal 2, a `gh --json`/body dump). Either
+    marks the trigger as echoed output rather than a failure. `command` is
+    accepted for signature symmetry with the other classifiers but the
+    decision is line-shape-based (see JSON_BODY_LINE for why).
+    """
+    for line in error_lines:
+        if SOURCE_CLAUSE_LINE.search(line) or JSON_BODY_LINE.search(line):
+            return True
+    return False
+
+
+def _classify_confidence(
+    command: str, exit_code: int, matched_patterns: list[str], error_lines: list[str]
+) -> str:
+    """Return "high" or "low" confidence for a logged error record (#729).
+
+    "high" — a non-zero exit, a stderr-pattern match, or an exit-0 stdout match
+             carrying a STRONG masked-failure signal (the genuine exit-0-failure
+             carve-out, e.g. `git push | tail` masking a REJECTED push).
+    "low"  — exit-0, stdout-only, no strong signal, and the matched line is
+             positively recognized as echoed content.
+
+    An exit-0 stdout match not recognized as echoed stays "high": only display
+    we can positively recognize is demoted, never an unclassified failure.
+    """
+    if exit_code and exit_code != 0:
+        return "high"
+    if any(p.startswith("stderr:") for p in matched_patterns):
+        return "high"
+    if STRONG_MASKED_FAILURE.search("\n".join(error_lines)):
+        return "high"
+    if _is_echoed_content(command, error_lines):
+        return "low"
+    return "high"
+
+
 def check(input_data: dict) -> dict | None:
     """Dispatcher-compatible entry point for PostToolUse Bash.
 
@@ -402,6 +513,11 @@ def check(input_data: dict) -> dict | None:
 
     error_lines = _extract_error_lines(combined_output)
 
+    # #729 confidence tag: exit-0 stdout-only matches that are echoed content
+    # (displayed source/body) are low-confidence; the reader excludes them from
+    # the genuine-error count but keeps every record for forensics.
+    confidence = _classify_confidence(command, exit_code, matched_patterns, error_lines)
+
     dedup_input = command[:200] + "|||" + "\n".join(error_lines)[:500]
     dedup_hash = hashlib.md5(dedup_input.encode("utf-8")).hexdigest()
     if dedup_hash in _seen_hashes:
@@ -413,6 +529,7 @@ def check(input_data: dict) -> dict | None:
         "command": command[:500],
         "exit_code": exit_code,
         "matched_patterns": matched_patterns[:5],
+        "confidence": confidence,
         "error_lines": error_lines,
         "stderr_excerpt": stderr[:300] if stderr else "",
         "_dedup_hash": dedup_hash,
@@ -420,7 +537,7 @@ def check(input_data: dict) -> dict | None:
 
     append_jsonl_record(ERRORS_FILE, record)
 
-    return {"action": "logged", "dedup_hash": dedup_hash}
+    return {"action": "logged", "dedup_hash": dedup_hash, "confidence": confidence}
 
 
 def main() -> None:

--- a/.claude/hooks/tests/test_annunaki_monitor.py
+++ b/.claude/hooks/tests/test_annunaki_monitor.py
@@ -325,6 +325,150 @@ class SilentBooleanTestIdiomTests(unittest.TestCase):
         self.assertIsNone(result)
 
 
+class ConfidenceTaggingTests(unittest.TestCase):
+    """#729: exit-0 stdout-only matches are tagged with a `confidence` field so
+    the reader can exclude echoed-output false positives from the genuine-error
+    count while RETAINING the genuine exit-0-failure carve-out (a `git push |
+    tail` masking a REJECTED push). Every record is still LOGGED — confidence
+    refines the count, it never drops a record."""
+
+    def setUp(self):
+        self._saved_env = {
+            "ENVIRONMENT": os.environ.pop("ENVIRONMENT", None),
+            "NOORIN_HOOK_TEST_MODE": os.environ.pop("NOORIN_HOOK_TEST_MODE", None),
+        }
+        am._seen_hashes.clear()
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self._errors_path = Path(self._tmpdir.name) / "errors.jsonl"
+        self._orig_monitor_file = am.ERRORS_FILE
+        self._orig_log_file = alog.ERRORS_FILE
+        am.ERRORS_FILE = self._errors_path
+        alog.ERRORS_FILE = self._errors_path
+
+    def tearDown(self):
+        am.ERRORS_FILE = self._orig_monitor_file
+        alog.ERRORS_FILE = self._orig_log_file
+        self._tmpdir.cleanup()
+        for k, v in self._saved_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def _logged(self, **kw):
+        result = am.check(_bash_event(**kw))
+        self.assertIsNotNone(result, "expected the command to be logged")
+        return _read_records(self._errors_path)[0], result
+
+    # --- (a) benign exit-0-with-trigger-word is LOGGED but LOW confidence ---
+
+    def test_echoed_source_clause_tagged_low(self):
+        """Displaying source with `except ImportError:` (the dominant #729
+        false class) at exit 0 → logged, but confidence=low. The `cd … &&`
+        prefix breaks the anchored #596 content-display IGNORE, so the record
+        survives to be tagged (this is exactly the residual class #729 fixes)."""
+        rec, result = self._logged(
+            command="cd /repo && cat .claude/lib/foo.py",
+            stdout="        except ImportError:\n            continue\n",
+            exit_code=0,
+        )
+        self.assertEqual(rec["exit_code"], 0)
+        self.assertEqual(rec["confidence"], "low")
+        self.assertEqual(result["confidence"], "low")
+
+    def test_echoed_source_clause_low_even_with_setup_prefix(self):
+        """The compound `cd … && echo …` shape that slips past the anchored
+        #596 content-display IGNORE is still demoted to low by line shape."""
+        rec, _ = self._logged(
+            command='cd /repo/child && echo "=== src ===" && sed -n 1,20p mod.py',
+            stdout="    except ImportError:  # pragma: no cover\n        import x\n",
+            exit_code=0,
+        )
+        self.assertEqual(rec["confidence"], "low")
+
+    def test_echoed_json_body_tagged_low(self):
+        """A `gh pr view --json` body that quotes 'ModuleNotFoundError' → the
+        JSON-body line shape demotes it to low. The `cd … &&` prefix again
+        slips past the anchored #596 IGNORE so the record reaches the tagger."""
+        rec, _ = self._logged(
+            command="cd /repo && gh pr view 1094 --repo o/r --json title,body",
+            stdout='{"body":"## Summary\\nfix ModuleNotFoundError: no module x"}\n',
+            exit_code=0,
+        )
+        self.assertEqual(rec["confidence"], "low")
+
+    # --- (b) genuine exit-0 FAILURE is LOGGED and HIGH confidence (kept) ---
+
+    def test_git_push_pipe_masking_rejection_tagged_high(self):
+        """The feedback_push_pipe_masks_rejection case: `git push … | tail`
+        exits 0 (pager rc) while the push was REJECTED. The 'failed to push'
+        strong signal keeps it confidence=high → still counted."""
+        rec, result = self._logged(
+            command="git push origin N.Hakim/x --force-with-lease 2>&1 | tail -3",
+            stdout=(
+                "To github.com:o/r.git\n"
+                " ! [rejected]        N.Hakim/x -> N.Hakim/x (non-fast-forward)\n"
+                "error: failed to push some refs to 'github.com:o/r.git'\n"
+            ),
+            exit_code=0,
+        )
+        self.assertEqual(rec["exit_code"], 0, "pipe masked the non-zero rc")
+        self.assertEqual(rec["confidence"], "high")
+        self.assertEqual(result["confidence"], "high")
+
+    def test_script_self_reported_exit_code_tagged_high(self):
+        """A wrapper that echoes 'ERROR: … failed (exit 1)' at pipeline exit 0
+        is a genuine masked failure → high."""
+        rec, _ = self._logged(
+            command="run_checks.sh | tee /tmp/log",
+            stdout="ERROR: gh call failed (exit 1): gh api repos/o/r\n",
+            exit_code=0,
+        )
+        self.assertEqual(rec["confidence"], "high")
+
+    def test_real_traceback_with_raise_frame_tagged_high(self):
+        """A genuine exit-0 traceback contains a `raise ValueError(...)` source
+        frame; the STRONG Traceback keeper must win so the `raise` line does
+        NOT mis-demote it via the echoed-source signal."""
+        rec, _ = self._logged(
+            command="cd /repo && python3 parse.py | tail",
+            stdout=(
+                "Traceback (most recent call last):\n"
+                '  File "parse.py", line 3, in <module>\n'
+                '    raise ValueError("bad yaml")\n'
+                "ValueError: bad yaml\n"
+            ),
+            exit_code=0,
+        )
+        self.assertEqual(rec["confidence"], "high")
+
+    # --- hard failure signals always win ---
+
+    def test_nonzero_exit_tagged_high(self):
+        """A non-zero exit is a hard failure signal → high regardless of text."""
+        rec, _ = self._logged(command="pytest", stdout="FAILED test_x\n", exit_code=1)
+        self.assertEqual(rec["confidence"], "high")
+
+    def test_stderr_pattern_tagged_high(self):
+        """A stderr-pattern match is a hard failure signal → high."""
+        rec, _ = self._logged(
+            command="some_tool",
+            stderr="fatal: unexpected internal state\n",
+            exit_code=0,
+        )
+        self.assertEqual(rec["confidence"], "high")
+
+    def test_unrecognized_exit_zero_match_defaults_high(self):
+        """An exit-0 stdout match we cannot positively recognize as echoed
+        stays high — the precision pass never silences an unclassified error."""
+        rec, _ = self._logged(
+            command="deploy.sh | tee /tmp/log",
+            stdout="error while interpolating services.grafana.environment: required\n",
+            exit_code=0,
+        )
+        self.assertEqual(rec["confidence"], "high")
+
+
 class AinoFollowupTests(unittest.TestCase):
     """Aino's two non-blocking follow-up cases from PR #473 review."""
 

--- a/.claude/lib/annunaki_parse.py
+++ b/.claude/lib/annunaki_parse.py
@@ -19,6 +19,14 @@ module imports it so the writer and reader never drift. If that import fails
 (e.g. the lib is vendored without the hook), a local fallback copy keeps the
 reader working.
 
+#729 adds a second reader-side exclusion: records the monitor tagged
+`confidence: "low"` — exit-0 stdout-only matches where the trigger word is in
+echoed output (displayed source `except ImportError:`, a `gh pr view --json`
+body), not a real failure. These are excluded from the genuine-error count but
+retained in the log for forensics (pass `include_low_confidence=True`). The
+genuine exit-0-failure carve-out (a `git push | tail` masking a REJECTED push)
+is tagged `confidence: "high"` by the monitor and so is still counted.
+
 Exit codes (CLI):
     0 — always (this is a read-only summarizer; it never fails the caller)
 """
@@ -42,12 +50,21 @@ except Exception:  # noqa: BLE001 — vendored-without-hooks fallback
     TRACE_RECORD_TYPES = frozenset({"posttooluse_dispatch", "pretooluse_diagnostic"})
 
 
-def iter_records(path: Path, *, include_traces: bool = False) -> Iterator[dict]:
+def iter_records(
+    path: Path, *, include_traces: bool = False, include_low_confidence: bool = False
+) -> Iterator[dict]:
     """Yield parsed JSONL records from `path`, skipping blank/corrupt lines.
 
-    By default, records whose `type` is in `TRACE_RECORD_TYPES` are skipped
-    (the #625 genuine-error filter). Pass `include_traces=True` to yield every
-    parseable record (used by a trace-specific viewer or by tests).
+    By default two sub-classes are skipped so the caller sees only genuine
+    errors:
+      - records whose `type` is in `TRACE_RECORD_TYPES` (the #625 benign-trace
+        filter) — pass `include_traces=True` to keep them;
+      - records whose `confidence` is "low" (the #729 exit-0 echoed-output
+        false-positive class — a trigger word matched in displayed source/body
+        at exit 0) — pass `include_low_confidence=True` to keep them for
+        forensics. Records with no `confidence` field (legacy logs written
+        before #729) are treated as genuine and kept, so historical errors are
+        never silently dropped.
 
     A missing file yields nothing. Each line is `.strip()`-ed before parsing,
     because the log has historically contained blank lines from manual edits;
@@ -70,17 +87,29 @@ def iter_records(path: Path, *, include_traces: bool = False) -> Iterator[dict]:
                 continue
             if not include_traces and rec.get("type") in TRACE_RECORD_TYPES:
                 continue
+            if not include_low_confidence and rec.get("confidence") == "low":
+                continue
             yield rec
 
 
 def count_errors(path: Path) -> int:
-    """Return the number of genuine error records (benign traces excluded)."""
+    """Return the genuine-error count (benign traces AND #729 low-confidence
+    echoed-output records excluded)."""
     return sum(1 for _ in iter_records(path))
 
 
 def is_trace(record: dict) -> bool:
     """True iff `record` is a benign forensic trace, not a genuine error."""
     return record.get("type") in TRACE_RECORD_TYPES
+
+
+def is_low_confidence(record: dict) -> bool:
+    """True iff `record` is the #729 exit-0 echoed-output low-confidence class.
+
+    These are retained in the log for forensics but excluded from the
+    genuine-error count by `iter_records`/`count_errors`.
+    """
+    return record.get("confidence") == "low"
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -97,6 +126,11 @@ def main(argv: list[str] | None = None) -> int:
         help="include benign-trace records in the output/count",
     )
     parser.add_argument(
+        "--include-low-confidence",
+        action="store_true",
+        help="include #729 low-confidence echoed-output records in the output",
+    )
+    parser.add_argument(
         "--count",
         action="store_true",
         help="print only the genuine-error count and exit",
@@ -108,7 +142,11 @@ def main(argv: list[str] | None = None) -> int:
         print(count_errors(path))
         return 0
 
-    for rec in iter_records(path, include_traces=args.include_traces):
+    for rec in iter_records(
+        path,
+        include_traces=args.include_traces,
+        include_low_confidence=args.include_low_confidence,
+    ):
         print(json.dumps(rec, ensure_ascii=False))
     return 0
 

--- a/.claude/lib/tests/test_annunaki_parse.py
+++ b/.claude/lib/tests/test_annunaki_parse.py
@@ -25,6 +25,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from annunaki_parse import (  # noqa: E402
     TRACE_RECORD_TYPES,
     count_errors,
+    is_low_confidence,
     is_trace,
     iter_records,
     main,
@@ -111,6 +112,69 @@ class IsTrace(unittest.TestCase):
         self.assertFalse(is_trace(_GENUINE_MONITOR))
         self.assertFalse(is_trace(_GENUINE_BLOCK))
         self.assertFalse(is_trace(_GENUINE_EVENT))
+
+
+# #729: exit-0 echoed-output records are tagged confidence="low" by the monitor.
+# The reader excludes them from the genuine-error count but retains them in the
+# log (include_low_confidence=True) for forensics. A genuine masked failure is
+# tagged "high" and counted; a legacy record with no `confidence` field counts.
+_LOW_CONF_ECHO = {
+    "timestamp": "t",
+    "command": "cat mod.py",
+    "exit_code": 0,
+    "matched_patterns": ["stdout:ImportError:"],
+    "confidence": "low",
+}
+_HIGH_CONF_MASKED = {
+    "timestamp": "t",
+    "command": "git push ... | tail",
+    "exit_code": 0,
+    "matched_patterns": ["stdout:^error\\b"],
+    "confidence": "high",
+}
+
+
+class LowConfidenceFilter(unittest.TestCase):
+    def _write(self, path: Path) -> None:
+        lines = [
+            json.dumps(_GENUINE_MONITOR),  # legacy, no confidence → counted
+            json.dumps(_LOW_CONF_ECHO),  # excluded from count
+            json.dumps(_HIGH_CONF_MASKED),  # genuine masked failure → counted
+        ]
+        path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    def test_count_excludes_low_confidence(self) -> None:
+        with TemporaryDirectory() as td:
+            p = Path(td) / "errors.jsonl"
+            self._write(p)
+            # legacy + high-confidence masked failure = 2; low excluded.
+            self.assertEqual(count_errors(p), 2)
+
+    def test_iter_default_skips_low_confidence(self) -> None:
+        with TemporaryDirectory() as td:
+            p = Path(td) / "errors.jsonl"
+            self._write(p)
+            cmds = [r["command"] for r in iter_records(p)]
+            self.assertEqual(cmds, ["pytest", "git push ... | tail"])
+
+    def test_include_low_confidence_retains_for_forensics(self) -> None:
+        with TemporaryDirectory() as td:
+            p = Path(td) / "errors.jsonl"
+            self._write(p)
+            recs = list(iter_records(p, include_low_confidence=True))
+            self.assertEqual(len(recs), 3)
+            self.assertIn("cat mod.py", [r["command"] for r in recs])
+
+    def test_is_low_confidence_helper(self) -> None:
+        self.assertTrue(is_low_confidence(_LOW_CONF_ECHO))
+        self.assertFalse(is_low_confidence(_HIGH_CONF_MASKED))
+        self.assertFalse(is_low_confidence(_GENUINE_MONITOR))  # legacy → not low
+
+    def test_cli_include_low_confidence_flag(self) -> None:
+        with TemporaryDirectory() as td:
+            p = Path(td) / "errors.jsonl"
+            self._write(p)
+            self.assertEqual(main([str(p), "--include-low-confidence"]), 0)
 
 
 class TraceTypeSourceOfTruth(unittest.TestCase):


### PR DESCRIPTION
## Summary

Precision pass on Annunaki exit-0 false positives (#729). 85% of the P5W5 window's "errors" (40/47) were exit-0 records flagged purely because a trigger word (`error`/`fail`/`ImportError`) appeared in **echoed output** — displayed source code, a `gh pr view --json` body — while the command actually succeeded. This drowned the real signal.

The fix tags every logged record with a `confidence` field instead of dropping records (forensics retained):

- **`low`** — exit-0, stdout-only match positively recognized as echoed content: a displayed Python source clause (`except ImportError:`, a `re.compile(...)` dump) or a JSON-object body line (`{"…`).
- **`high`** — a hard failure signal (non-zero exit, a stderr-pattern match) OR an exit-0 stdout match carrying a STRONG masked-failure signal: a `git push | tail` REJECTED push (`feedback_push_pipe_masks_rejection`), `… failed (exit 1)`, a real `Traceback`.
- An exit-0 stdout match **not** positively recognized as echoed stays `high` — the pass never silences an unclassified failure (recall-preserving).

`annunaki_parse` (the shared reader) excludes `confidence: "low"` from the genuine-error **count** (`count_errors` / default `iter_records`) but retains the records for forensics via `include_low_confidence=True` (+ a `--include-low-confidence` CLI flag and an `is_low_confidence` helper). Legacy records with no `confidence` field are counted, so historical errors are never silently dropped.

## Acceptance criteria

- [x] Tag exit-0 echoed-output matches as a distinct low-confidence sub-class
- [x] Exclude the sub-class from the genuine-error count; retain for forensics
- [x] PRESERVE genuine exit-0 failures (the `git push | tail` REJECTED case stays `high`/counted) — no blanket exit-0 ignore
- [x] Tests cover a benign exit-0-with-trigger-word AND a genuine exit-0 failure

## Validation

Classifier run over the live 61-record log: **17 echoed-output false positives demoted to low**, **every genuine masked failure preserved** (git push / rebase / `fatal:` / pytest `FAILED` / command-not-found / traceback / `ERROR: …(exit N)` self-reports). 93 targeted tests + full 1681-test suite green; ruff + mypy clean.

## Tests

- `.claude/hooks/tests/test_annunaki_monitor.py::ConfidenceTaggingTests` — writer tagging (echoed source/JSON → low; git-push-masking / self-report / traceback / non-zero-exit / stderr / unrecognized → high)
- `.claude/lib/tests/test_annunaki_parse.py::LowConfidenceFilter` — reader excludes low from count, retains via `include_low_confidence`, legacy counted, `is_low_confidence` helper, CLI flag

Closes #729

TechDebt: residual exit-0 false positives stay HIGH when the trigger sits in displayed markdown / issue-body PROSE (e.g. `gh issue view` quoting an error string) rather than source or JSON; a prose-vs-failure classifier is deferred, recall prioritized over demoting those few.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VFZHBpSPAE2e9rHoQzkcL2
