### PR TITLE
process(P6W2): one merge model per wave + mid-wave wave-branch reachability check — main#801

### DIFF
--- a/.claude/lib/tests/test_wave_merge_model.py
+++ b/.claude/lib/tests/test_wave_merge_model.py
@@ -1,0 +1,292 @@
+"""Tests for wave_merge_model — one-merge-model-per-wave + mid-wave wave-branch
+reachability (main#801).
+
+Verifies:
+  1. validate_merge_model accepts the two models and rejects anything else.
+  2. read_merge_model returns the recorded model, None when absent, and raises
+     on a present-but-invalid value.
+  3. classify_reachability covers every model×state combination:
+       - no branch / not-ahead          → ok
+       - direct-to-main + ahead         → VIOLATION (the P6W1 mixing), w/ or w/o PR
+       - wave-branch  + ahead + open PR → ok
+       - wave-branch  + ahead + no PR   → advisory (stranding risk)
+       - unrecorded   + ahead           → advisory (legacy-wave degrade, never violation)
+       - diverged status with ahead_by 0 is still treated as ahead.
+  4. check_reachability maps each in-scope repo through classify via an injected
+     gather (no network).
+  5. EVERY gh call in the I/O layer goes through subprocess.run with a LIST arg
+     vector and never shell=True — the word-split regression guard (main#688).
+  6. set records wave_{M}_merge_model through the shared upsert helper and the
+     CLI round-trips it; reachability's exit code is 1 only on a VIOLATION.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+# Helper lives at .claude/lib/wave_merge_model.py; this test is at
+# .claude/lib/tests/test_*.py. parent.parent reaches the lib root.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import wave_merge_model as wmm  # noqa: E402
+
+_REPOS = [
+    "noorinalabs-main",
+    "noorinalabs-isnad-graph",
+    "noorinalabs-deploy",
+]
+
+
+def _write_status(tmp: Path, extra: dict) -> Path:
+    path = tmp / "cross-repo-status.json"
+    base = {"wave_2_repos_in_scope": list(_REPOS)}
+    base.update(extra)
+    path.write_text(json.dumps(base, indent=2))
+    return path
+
+
+class ValidateModelTest(unittest.TestCase):
+    def test_accepts_both_models(self) -> None:
+        self.assertEqual(wmm.validate_merge_model("direct-to-main"), "direct-to-main")
+        self.assertEqual(wmm.validate_merge_model("wave-branch"), "wave-branch")
+
+    def test_rejects_unknown(self) -> None:
+        with self.assertRaises(ValueError):
+            wmm.validate_merge_model("hybrid")
+        with self.assertRaises(ValueError):
+            wmm.validate_merge_model("")
+
+
+class ReadModelTest(unittest.TestCase):
+    def test_present(self) -> None:
+        with TemporaryDirectory() as d:
+            path = _write_status(Path(d), {"wave_2_merge_model": "wave-branch"})
+            self.assertEqual(wmm.read_merge_model("2", path), "wave-branch")
+
+    def test_absent_returns_none(self) -> None:
+        with TemporaryDirectory() as d:
+            path = _write_status(Path(d), {})
+            self.assertIsNone(wmm.read_merge_model("2", path))
+
+    def test_invalid_value_raises(self) -> None:
+        with TemporaryDirectory() as d:
+            path = _write_status(Path(d), {"wave_2_merge_model": "nonsense"})
+            with self.assertRaises(ValueError):
+                wmm.read_merge_model("2", path)
+
+
+class ClassifyTest(unittest.TestCase):
+    def test_no_branch_is_ok(self) -> None:
+        sev, _ = wmm.classify_reachability(
+            "wave-branch", branch_exists=False, ahead_by=0, status="absent", open_wave_main_pr=False
+        )
+        self.assertEqual(sev, wmm.OK)
+
+    def test_not_ahead_is_ok(self) -> None:
+        for model in (wmm.DIRECT_TO_MAIN, wmm.WAVE_BRANCH, None):
+            sev, _ = wmm.classify_reachability(
+                model, branch_exists=True, ahead_by=0, status="identical", open_wave_main_pr=False
+            )
+            self.assertEqual(sev, wmm.OK, model)
+
+    def test_direct_to_main_ahead_is_violation(self) -> None:
+        sev, msg = wmm.classify_reachability(
+            wmm.DIRECT_TO_MAIN,
+            branch_exists=True,
+            ahead_by=3,
+            status="ahead",
+            open_wave_main_pr=False,
+        )
+        self.assertEqual(sev, wmm.VIOLATION)
+        self.assertIn("mixing prohibited", msg)
+
+    def test_direct_to_main_ahead_with_open_pr_still_violation(self) -> None:
+        # An open wave→main PR under a direct-to-main wave means the wave drifted
+        # into the model it did not declare — still a violation.
+        sev, msg = wmm.classify_reachability(
+            wmm.DIRECT_TO_MAIN,
+            branch_exists=True,
+            ahead_by=2,
+            status="ahead",
+            open_wave_main_pr=True,
+        )
+        self.assertEqual(sev, wmm.VIOLATION)
+        self.assertIn("drifted", msg)
+
+    def test_wave_branch_ahead_with_open_pr_is_ok(self) -> None:
+        sev, _ = wmm.classify_reachability(
+            wmm.WAVE_BRANCH, branch_exists=True, ahead_by=5, status="ahead", open_wave_main_pr=True
+        )
+        self.assertEqual(sev, wmm.OK)
+
+    def test_wave_branch_ahead_no_pr_is_advisory(self) -> None:
+        sev, msg = wmm.classify_reachability(
+            wmm.WAVE_BRANCH, branch_exists=True, ahead_by=5, status="ahead", open_wave_main_pr=False
+        )
+        self.assertEqual(sev, wmm.ADVISORY)
+        self.assertIn("WILL strand", msg)
+
+    def test_unrecorded_model_ahead_degrades_to_advisory(self) -> None:
+        # Legacy wave: never a hard violation, only an advisory + nudge.
+        for pr in (True, False):
+            sev, msg = wmm.classify_reachability(
+                None, branch_exists=True, ahead_by=4, status="ahead", open_wave_main_pr=pr
+            )
+            self.assertEqual(sev, wmm.ADVISORY)
+            self.assertIn("NOT declared", msg)
+
+    def test_diverged_with_zero_ahead_is_treated_as_ahead(self) -> None:
+        # status=diverged but ahead_by reported 0 → still ahead (defensive).
+        sev, _ = wmm.classify_reachability(
+            wmm.DIRECT_TO_MAIN,
+            branch_exists=True,
+            ahead_by=0,
+            status="diverged",
+            open_wave_main_pr=False,
+        )
+        self.assertEqual(sev, wmm.VIOLATION)
+
+
+class CheckReachabilityTest(unittest.TestCase):
+    def test_maps_each_repo_through_classify(self) -> None:
+        # Injected gather: main behind (ok), isnad-graph ahead+no-PR, deploy no branch.
+        states = {
+            "noorinalabs-main": {
+                "branch_exists": True,
+                "ahead_by": 0,
+                "status": "identical",
+                "open_wave_main_pr": False,
+            },
+            "noorinalabs-isnad-graph": {
+                "branch_exists": True,
+                "ahead_by": 3,
+                "status": "ahead",
+                "open_wave_main_pr": False,
+            },
+            "noorinalabs-deploy": {
+                "branch_exists": False,
+                "ahead_by": 0,
+                "status": "absent",
+                "open_wave_main_pr": False,
+            },
+        }
+
+        def fake_gather(repo: str, branch: str, run_gh) -> dict:
+            assert branch == "deployments/phase-6/wave-2"
+            return states[repo]
+
+        with TemporaryDirectory() as d:
+            path = _write_status(Path(d), {"wave_2_merge_model": "wave-branch"})
+            results = wmm.check_reachability("6", "2", path, gather=fake_gather)
+
+        by_repo = {r["repo"]: r["severity"] for r in results}
+        self.assertEqual(by_repo["noorinalabs-main"], wmm.OK)
+        self.assertEqual(by_repo["noorinalabs-isnad-graph"], wmm.ADVISORY)
+        self.assertEqual(by_repo["noorinalabs-deploy"], wmm.OK)
+
+
+class GhArgListGuardTest(unittest.TestCase):
+    """Every gh invocation in the I/O layer must be a LIST arg vector, never a
+    shell string and never shell=True (main#688 word-split guard)."""
+
+    def test_gather_uses_arg_list_no_shell(self) -> None:
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, *args, **kwargs):  # noqa: ANN001
+            # Structural guards: arg vector is a list, gh is argv[0], no shell.
+            self.assertIsInstance(cmd, list)
+            self.assertEqual(cmd[0], "gh")
+            self.assertNotIn("shell", kwargs)
+            calls.append(cmd)
+            # First call = ref lookup; then compare; then pr list.
+            if cmd[1] == "api" and "git/refs" in cmd[2]:
+                return subprocess.CompletedProcess(cmd, 0, stdout="abc123\n", stderr="")
+            if cmd[1] == "api" and "compare" in cmd[2]:
+                return subprocess.CompletedProcess(
+                    cmd,
+                    0,
+                    stdout=json.dumps({"ahead_by": 2, "behind_by": 0, "status": "ahead"}),
+                    stderr="",
+                )
+            return subprocess.CompletedProcess(cmd, 0, stdout="1\n", stderr="")
+
+        with mock.patch("subprocess.run", side_effect=fake_run):
+            state = wmm._gather_repo_state(
+                "noorinalabs-deploy", "deployments/phase-6/wave-2", wmm._run_gh
+            )
+        self.assertEqual(state["ahead_by"], 2)
+        self.assertTrue(state["open_wave_main_pr"])
+        self.assertTrue(calls)
+
+    def test_gather_missing_branch_returns_not_exists(self) -> None:
+        def fake_run(cmd, *args, **kwargs):  # noqa: ANN001
+            raise subprocess.CalledProcessError(1, cmd, stderr="Not Found")
+
+        with mock.patch("subprocess.run", side_effect=fake_run):
+            state = wmm._gather_repo_state(
+                "noorinalabs-deploy", "deployments/phase-6/wave-2", wmm._run_gh
+            )
+        self.assertFalse(state["branch_exists"])
+
+
+class SetAndCliTest(unittest.TestCase):
+    def test_set_records_and_roundtrips(self) -> None:
+        with TemporaryDirectory() as d:
+            path = _write_status(Path(d), {})
+            rc = wmm.main(["set", "6", "2", "wave-branch", "--status", str(path)])
+            self.assertEqual(rc, 0)
+            self.assertEqual(wmm.read_merge_model("2", path), "wave-branch")
+
+    def test_set_rejects_invalid_model(self) -> None:
+        with TemporaryDirectory() as d:
+            path = _write_status(Path(d), {})
+            rc = wmm.main(["set", "6", "2", "hybrid", "--status", str(path)])
+            self.assertEqual(rc, 1)
+
+    def test_model_command_errors_when_absent(self) -> None:
+        with TemporaryDirectory() as d:
+            path = _write_status(Path(d), {})
+            rc = wmm.main(["model", "6", "2", "--status", str(path)])
+            self.assertEqual(rc, 1)
+
+    def test_reachability_exit_code_violation(self) -> None:
+        with TemporaryDirectory() as d:
+            path = _write_status(Path(d), {"wave_2_merge_model": "direct-to-main"})
+
+            def fake_gather(repo, branch, run_gh):  # noqa: ANN001
+                return {
+                    "branch_exists": True,
+                    "ahead_by": 1,
+                    "status": "ahead",
+                    "open_wave_main_pr": False,
+                }
+
+            with mock.patch.object(wmm, "_gather_repo_state", fake_gather):
+                rc = wmm.main(["reachability", "6", "2", "--status", str(path)])
+            self.assertEqual(rc, 1)
+
+    def test_reachability_exit_code_advisory_is_zero(self) -> None:
+        with TemporaryDirectory() as d:
+            path = _write_status(Path(d), {"wave_2_merge_model": "wave-branch"})
+
+            def fake_gather(repo, branch, run_gh):  # noqa: ANN001
+                return {
+                    "branch_exists": True,
+                    "ahead_by": 1,
+                    "status": "ahead",
+                    "open_wave_main_pr": False,
+                }
+
+            with mock.patch.object(wmm, "_gather_repo_state", fake_gather):
+                rc = wmm.main(["reachability", "6", "2", "--status", str(path)])
+            self.assertEqual(rc, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/lib/wave_merge_model.py
+++ b/.claude/lib/wave_merge_model.py
@@ -1,0 +1,419 @@
+#!/usr/bin/env python3
+"""One-merge-model-per-wave + mid-wave wave-branch reachability (main#801).
+
+Adopted from the P6W1 retro. That wave *mixed* merge models: #704/#706/#734/#735
+were merged to the ``deployments/phase-6/wave-1`` branch while the doc batch +
+cspell/mermaid work went **direct to main**, and the wave→main PR was never
+opened. Five net-new deliverables therefore sat stranded off ``main`` and were
+caught only at ``/wave-wrapup`` Step 11.5 — hours/days after they should have
+surfaced.
+
+Two durable fixes live here, both as deterministic, testable code (charter
+``enforcement_hierarchy`` — prefer code over prose):
+
+1. **One merge model per wave, declared at kickoff.** A wave is EITHER
+   ``direct-to-main`` (every PR bases on ``main``; the wave branch stays at the
+   kickoff point and never accumulates work) OR ``wave-branch`` (every PR bases
+   on ``deployments/phase-{P}/wave-{M}`` and the wave→main integration PR is
+   opened at wrapup). Mixing the two within one wave is prohibited. The chosen
+   model is recorded in ``cross-repo-status.json`` under ``wave_{M}_merge_model``
+   at ``/wave-kickoff`` (subcommand ``set``).
+
+2. **Mid-wave reachability check** (subcommand ``reachability``, wired into
+   ``/session-start``). For every in-scope repo it compares the wave branch
+   against ``origin/main`` and classifies the gap **against the declared
+   model**, so stranding (or model-mixing) surfaces within hours rather than
+   only at wrapup:
+
+     * ``direct-to-main`` + wave branch ahead of main  → **violation** (someone
+       merged to the wave branch under a direct-to-main wave — the exact P6W1
+       mixing).
+     * ``wave-branch`` + ahead + an OPEN wave→main PR   → **ok** (healthy: the
+       integration PR is tracking the work).
+     * ``wave-branch`` + ahead + NO open wave→main PR   → **advisory** (normal
+       mid-wave, but it WILL strand unless ``/wave-wrapup`` opens the PR).
+
+The classification is a pure function (:func:`classify_reachability`) so every
+model×state combination is unit-tested without touching the network; the thin
+``gh`` I/O layer mirrors :mod:`wave_status` (explicit arg-list ``_run_gh``, no
+shell, no word-splitting — main#688).
+
+CLI:
+  wave_merge_model.py model        <P> <M> [--status PATH]
+  wave_merge_model.py set          <P> <M> <model> [--status PATH]
+  wave_merge_model.py reachability <P> <M> [--status PATH] [--json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+# Repo root = two parents above .claude/lib/ (lib -> .claude -> root). Resolved
+# from this file so the default is correct from any cwd or worktree, with no
+# `git rev-parse` subprocess (which would re-introduce a shell dependency).
+# Same anchor as wave_status.py.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DEFAULT_STATUS = _REPO_ROOT / "cross-repo-status.json"
+
+# The two permitted merge models. A wave is exactly one of these for its whole
+# lifetime; mixing is the bug this module exists to prevent.
+DIRECT_TO_MAIN = "direct-to-main"
+WAVE_BRANCH = "wave-branch"
+MERGE_MODELS = (DIRECT_TO_MAIN, WAVE_BRANCH)
+
+# Severities returned by classify_reachability. "violation" is a model breach
+# (hard signal); "advisory" is an expected-but-watch-it state; "ok" is healthy.
+OK = "ok"
+ADVISORY = "advisory"
+VIOLATION = "violation"
+
+
+def _run_gh(args: list[str]) -> str:
+    """Run ``gh <args>`` with an explicit arg list and return stdout.
+
+    Never a shell string and never ``shell=True`` — no shell means no
+    word-splitting, the main#688 contract shared with wave_status.py.
+    """
+    proc = subprocess.run(
+        ["gh", *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return proc.stdout
+
+
+def _load_status(status_path: Path) -> dict:
+    return json.loads(status_path.read_text())
+
+
+def validate_merge_model(model: str) -> str:
+    """Return ``model`` if it is one of :data:`MERGE_MODELS`, else raise.
+
+    Centralised so both ``set`` (write-time) and ``read_merge_model``
+    (read-time) reject a typo the same way rather than silently persisting or
+    trusting an unknown value.
+    """
+    if model not in MERGE_MODELS:
+        raise ValueError(
+            f"invalid merge model {model!r}; expected one of {', '.join(MERGE_MODELS)}"
+        )
+    return model
+
+
+def read_merge_model(wave: str, status_path: Path) -> str | None:
+    """Return the declared ``wave_{M}_merge_model`` or None if absent.
+
+    None means the model was never recorded (a legacy wave, or a wave kicked
+    off before this feature existed). Callers degrade gracefully rather than
+    hard-failing on legacy waves — see :func:`classify_reachability`. A *present
+    but invalid* value is an error to surface, so it is validated here.
+    """
+    data = _load_status(status_path)
+    val = data.get(f"wave_{wave}_merge_model")
+    if val is None:
+        return None
+    return validate_merge_model(str(val))
+
+
+def read_repos(wave: str, status_path: Path) -> list[str]:
+    """Return ``wave_{M}_repos_in_scope`` as a list of repo names.
+
+    Raises KeyError if absent — by the time the reachability check runs the
+    wave's scope must already be recorded (same contract as wave_status.py).
+    """
+    data = _load_status(status_path)
+    key = f"wave_{wave}_repos_in_scope"
+    if key not in data:
+        raise KeyError(key)
+    repos = data[key]
+    if not isinstance(repos, list):
+        raise TypeError(f"{key} is not a list: {repos!r}")
+    return [str(r) for r in repos]
+
+
+def classify_reachability(
+    model: str | None,
+    *,
+    branch_exists: bool,
+    ahead_by: int,
+    status: str,
+    open_wave_main_pr: bool,
+) -> tuple[str, str]:
+    """Classify one repo's wave-branch-vs-main state against the declared model.
+
+    Pure — no I/O. ``ahead_by`` is the compare API's ``ahead_by`` for
+    ``main...<wave-branch>`` (commits on the wave branch not on main); ``status``
+    is its ``status`` (``identical``/``ahead``/``behind``/``diverged``).
+    ``open_wave_main_pr`` is whether an OPEN ``<wave-branch>``→``main`` PR exists.
+
+    Returns ``(severity, human-readable message)`` where severity is one of
+    :data:`OK`, :data:`ADVISORY`, :data:`VIOLATION`.
+    """
+    if not branch_exists:
+        # Scope-drop / not-yet-created: nothing on the wave branch to strand.
+        return OK, "no wave branch — nothing to reconcile (scope-drop or not yet created)"
+
+    ahead = ahead_by > 0 or status == "diverged"
+    if not ahead:
+        return OK, f"wave branch reachable from main (ahead_by={ahead_by}, status={status})"
+
+    # From here the wave branch carries commits not on main.
+    if model == DIRECT_TO_MAIN:
+        # Under direct-to-main NOTHING should land on the wave branch. Any
+        # commits ahead are the P6W1 mixing failure — flag hard, even if a
+        # wave→main PR happens to be open (an open PR means the wave drifted
+        # into the wave-branch model it did not declare).
+        pr_note = (
+            " (a wave→main PR is open — the wave has drifted to the wave-branch model)"
+            if open_wave_main_pr
+            else ""
+        )
+        return (
+            VIOLATION,
+            f"merge-model violation: {ahead_by} commit(s) on the wave branch under "
+            f"declared '{DIRECT_TO_MAIN}' model — work was merged to the wave branch "
+            f"instead of main (mixing prohibited, #801){pr_note}",
+        )
+
+    if model == WAVE_BRANCH:
+        if open_wave_main_pr:
+            return (
+                OK,
+                f"{ahead_by} commit(s) ahead, tracked by an open wave→main PR — "
+                f"healthy under '{WAVE_BRANCH}' model",
+            )
+        return (
+            ADVISORY,
+            f"{ahead_by} commit(s) on the wave branch not reachable from main and "
+            f"NO open wave→main PR — normal mid-wave under '{WAVE_BRANCH}' model, but "
+            f"these WILL strand unless /wave-wrapup opens the wave→main PR (#801)",
+        )
+
+    # model is None / unrecorded — a legacy wave or one kicked off before #801.
+    # Do not hard-fail; apply the conservative wave-branch reading (advisory)
+    # and nudge to declare the model. Avoids false VIOLATIONs on legacy waves
+    # while still surfacing the stranding risk.
+    base = (
+        f"{ahead_by} commit(s) on the wave branch not reachable from main; "
+        f"merge model NOT declared at kickoff — record wave_merge_model via "
+        f"/wave-kickoff (#801)"
+    )
+    if open_wave_main_pr:
+        return ADVISORY, base + " (a wave→main PR is open)"
+    return ADVISORY, base + " — these may strand if no wave→main PR is opened at wrapup"
+
+
+def _gather_repo_state(repo: str, branch: str, run_gh) -> dict:
+    """Collect the wave-branch-vs-main facts for one repo via ``gh`` at origin.
+
+    Thin I/O wrapper around the compare + ref + PR-list endpoints. Compares at
+    origin (NOT a local clone) per charter ``pull-requests.md § Origin > Local
+    Clone``. Returns the keyword args :func:`classify_reachability` consumes.
+    A missing wave branch (404 on the ref lookup) yields ``branch_exists:
+    False`` rather than raising.
+    """
+    try:
+        run_gh(["api", f"repos/noorinalabs/{repo}/git/refs/heads/{branch}", "--jq", ".object.sha"])
+    except subprocess.CalledProcessError:
+        return {
+            "branch_exists": False,
+            "ahead_by": 0,
+            "status": "absent",
+            "open_wave_main_pr": False,
+        }
+
+    compare = json.loads(
+        run_gh(
+            [
+                "api",
+                f"repos/noorinalabs/{repo}/compare/main...{branch}",
+                "--jq",
+                "{ahead_by, behind_by, status}",
+            ]
+        )
+    )
+    open_count = int(
+        run_gh(
+            [
+                "pr",
+                "list",
+                "--repo",
+                f"noorinalabs/{repo}",
+                "--base",
+                "main",
+                "--head",
+                branch,
+                "--state",
+                "open",
+                "--json",
+                "number",
+                "--jq",
+                "length",
+            ]
+        ).strip()
+        or 0
+    )
+    return {
+        "branch_exists": True,
+        "ahead_by": int(compare.get("ahead_by") or 0),
+        "status": str(compare.get("status") or ""),
+        "open_wave_main_pr": open_count > 0,
+    }
+
+
+def check_reachability(
+    phase: str,
+    wave: str,
+    status_path: Path,
+    run_gh=None,
+    gather=None,
+) -> list[dict]:
+    """Run the mid-wave reachability classification for every in-scope repo.
+
+    ``gather`` is injectable so tests exercise the per-repo classification
+    without any network (mirrors wave_status.py's mocked ``_run_gh``). Defaults
+    are resolved at call time (NOT bound in the signature) so a test that
+    monkeypatches the module-level ``_gather_repo_state`` is honoured. Returns
+    one result dict per repo: ``{repo, severity, message, **state}``.
+    """
+    run_gh = run_gh or _run_gh
+    gather = gather or _gather_repo_state
+    model = read_merge_model(wave, status_path)
+    repos = read_repos(wave, status_path)
+    branch = f"deployments/phase-{phase}/wave-{wave}"
+
+    results: list[dict] = []
+    for repo in repos:
+        state = gather(repo, branch, run_gh)
+        severity, message = classify_reachability(model, **state)
+        results.append({"repo": repo, "severity": severity, "message": message, **state})
+    return results
+
+
+def _set_merge_model(wave: str, model: str, status_path: Path) -> int:
+    """Validate + upsert ``wave_{M}_merge_model`` via upsert_status_keys.main.
+
+    Reuses the shared helper so the compact-inline shape of
+    cross-repo-status.json is preserved and the write is JSON-validated before
+    AND after (same path wave_status.py uses for the counter keys).
+    """
+    validate_merge_model(model)
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from upsert_status_keys import main as upsert_main
+
+    # upsert_status_keys.main treats argv[0] as the program name and argv[1] as
+    # the status path. The value is a self-contained JSON literal — a string, so
+    # it carries its own quotes. `model` is validated against a fixed enum above,
+    # so embedding it directly is injection-safe.
+    return upsert_main(
+        [
+            "wave_merge_model",
+            str(status_path),
+            f'wave_{wave}_merge_model="{model}"',
+        ]
+    )
+
+
+def _cmd_model(args: argparse.Namespace) -> int:
+    model = read_merge_model(args.wave, args.status)
+    if model is None:
+        print(
+            f"ERROR: wave_{args.wave}_merge_model not recorded in {args.status}. "
+            f"Declare it at /wave-kickoff (one of: {', '.join(MERGE_MODELS)}).",
+            file=sys.stderr,
+        )
+        return 1
+    print(model)
+    return 0
+
+
+def _cmd_set(args: argparse.Namespace) -> int:
+    return _set_merge_model(args.wave, args.model, args.status)
+
+
+def _format_report(wave: str, model: str | None, results: list[dict]) -> str:
+    lines: list[str] = []
+    model_label = model if model is not None else "NOT DECLARED (#801)"
+    lines.append(f"Wave {wave} merge model: {model_label}")
+    for r in results:
+        marker = {OK: "OK", ADVISORY: "ADVISORY", VIOLATION: "VIOLATION"}[r["severity"]]
+        lines.append(f"  [{marker}] {r['repo']}: {r['message']}")
+    return "\n".join(lines)
+
+
+def _cmd_reachability(args: argparse.Namespace) -> int:
+    model = read_merge_model(args.wave, args.status)
+    results = check_reachability(args.phase, args.wave, args.status)
+
+    if args.json:
+        print(json.dumps({"wave": args.wave, "merge_model": model, "results": results}, indent=2))
+    else:
+        print(_format_report(args.wave, model, results))
+
+    # Exit non-zero ONLY on a hard model violation. Advisories are expected
+    # mid-wave states and must not fail the (non-fatal) /session-start step.
+    return 1 if any(r["severity"] == VIOLATION for r in results) else 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    def _add_status(p: argparse.ArgumentParser) -> None:
+        p.add_argument(
+            "--status",
+            type=Path,
+            default=_DEFAULT_STATUS,
+            help="path to cross-repo-status.json (default: repo-root copy)",
+        )
+
+    p_model = sub.add_parser("model", help="print the declared wave merge model")
+    p_model.add_argument("phase", help="phase number (P)")
+    p_model.add_argument("wave", help="wave number (M)")
+    _add_status(p_model)
+    p_model.set_defaults(func=_cmd_model)
+
+    p_set = sub.add_parser("set", help="record the wave merge model at kickoff")
+    p_set.add_argument("phase", help="phase number (P)")
+    p_set.add_argument("wave", help="wave number (M)")
+    p_set.add_argument("model", help=f"one of: {', '.join(MERGE_MODELS)}")
+    _add_status(p_set)
+    p_set.set_defaults(func=_cmd_set)
+
+    p_reach = sub.add_parser(
+        "reachability", help="mid-wave wave-branch reachability check (model-aware)"
+    )
+    p_reach.add_argument("phase", help="phase number (P)")
+    p_reach.add_argument("wave", help="wave number (M)")
+    p_reach.add_argument("--json", action="store_true", help="emit results as JSON")
+    _add_status(p_reach)
+    p_reach.set_defaults(func=_cmd_reachability)
+
+    return parser
+
+
+def main(argv: list[str]) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        return int(args.func(args))
+    except KeyError as exc:
+        print(f"ERROR: missing key in cross-repo-status.json: {exc}", file=sys.stderr)
+        return 1
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    except subprocess.CalledProcessError as exc:
+        print(
+            f"ERROR: gh call failed (exit {exc.returncode}): {' '.join(exc.cmd)}\n{exc.stderr}",
+            file=sys.stderr,
+        )
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.claude/skills/session-start/SKILL.md
+++ b/.claude/skills/session-start/SKILL.md
@@ -290,6 +290,30 @@ fi
 
 If the verdict is `unwrapped` (0 open wave PRs) — or the softer `unwrapped_unverified` (open-PR count undetermined because `gh` failed or the wave's scope keys are missing) — surface it prominently as **"wave merged but unwrapped — run `/wave-wrapup`"**. An `in_flight` verdict (open wave PRs remain) is a normal active wave: no nudge. This is informational only — it never blocks the session.
 
+### Step 5c — Wave-branch reachability / merge-model check (main#801)
+
+Surface **mid-wave** any wave-branch commit that is not reachable from `origin/main`, classified against the wave's declared merge model — so model-mixing or stranding surfaces within hours instead of only at the `/wave-wrapup` Step 11.5 gate. *Origin:* P6W1 mixed merge models (some PRs to the wave branch, the doc batch direct to main, no wave→main PR opened) → 5 deliverables stranded off main, caught only at wrapup (charter `pull-requests.md § One Merge Model Per Wave`).
+
+This is a deterministic helper (`.claude/lib/wave_merge_model.py reachability`), model-aware: a `direct-to-main` wave with commits on its wave branch is a hard **VIOLATION** (the P6W1 mixing); a `wave-branch` wave ahead of main with an open wave→main PR is **OK**, and ahead with no PR is an **ADVISORY** stranding-risk reminder. A wave with no declared model (legacy / pre-#801) degrades to advisory-only with a nudge — never a false violation. Non-fatal: a gh/scope error must not block session-start.
+
+```bash
+REPO_ROOT="$(cd "$(git rev-parse --git-common-dir 2>/dev/null)/.." 2>/dev/null && pwd)"
+[ -f "$REPO_ROOT/cross-repo-status.json" ] || REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+# Derive the live phase/wave from the canonical lifecycle pointers (NOT a max
+# over wave numbers — retained prior-phase scopes would mis-select; cf. #712).
+PHASE=$(jq -r '.current_phase // empty' "$REPO_ROOT/cross-repo-status.json" 2>/dev/null)
+WAVE=$(jq -r '(.current_wave // "" | ltrimstr("wave-"))' "$REPO_ROOT/cross-repo-status.json" 2>/dev/null)
+if [ -n "$PHASE" ] && [ -n "$WAVE" ] && [ -f "$REPO_ROOT/.claude/lib/wave_merge_model.py" ]; then
+  # Helper prints the per-repo report; exit 1 ONLY on a model VIOLATION.
+  python3 "$REPO_ROOT/.claude/lib/wave_merge_model.py" reachability "$PHASE" "$WAVE" \
+    || echo "⚠ merge-model VIOLATION above — a wave branch carries commits the declared model forbids (#801). Investigate before merging more."
+else
+  echo "reachability check skipped — current_phase/current_wave not set or helper absent."
+fi
+```
+
+Report any **VIOLATION** prominently (stop-and-investigate: a wave branch is accumulating work the declared model forbids — the P6W1 mixing). **ADVISORY** lines are reminders that wave-branch work will strand unless `/wave-wrapup` opens the wave→main PR — surface them but they do not block. **OK** across the board needs no action.
+
 ### Step 6 — Charter freshness check
 
 Read the tail of the feedback log:
@@ -325,6 +349,7 @@ After all steps complete, present a single status block:
 | 5. Wave | {active wave, stale?, issues} |
 | 5a. Red default-branch runs | {N red publish/deploy runs (M base-image-drift) / all green} |
 | 5b. Wave wrap state | {wave merged but unwrapped — run /wave-wrapup / in flight / wrapped} |
+| 5c. Wave reachability | {OK / N advisory (stranding risk) / VIOLATION (merge-model mixing) / skipped} |
 | 6. Charter | {current / proposals pending} |
 
 {Then address the user's actual message/request}

--- a/.claude/skills/wave-kickoff/SKILL.md
+++ b/.claude/skills/wave-kickoff/SKILL.md
@@ -214,6 +214,19 @@ fi
 
 **Verify step 0.1 holds for every repo before moving on** — every entry in the status table must be `created`, `exists-clean`, `exists-ancestor`, or (with explicit user sign-off) `exists-drift`. A missing or errored wave branch in any child repo is a stop-the-line condition.
 
+**Declare the wave's merge model (Mandatory — one model per wave, main#801).** A wave uses exactly ONE merge model for its whole lifetime — `wave-branch` (every per-issue PR bases on `deployments/phase-{P}/wave-{M}`; the wave→main integration PR is opened at `/wave-wrapup`) OR `direct-to-main` (every PR bases on `main`; the wave branch never accumulates commits). Mixing the two within a wave is the P6W1 stranding bug (charter `pull-requests.md § One Merge Model Per Wave`). Record it now so the `/session-start` reachability check can enforce it mid-wave:
+
+```bash
+# Default for a cross-repo wave is wave-branch; a meta-only / single-repo wave
+# may declare direct-to-main. Pick deliberately, then record it.
+MERGE_MODEL="wave-branch"   # or: direct-to-main
+python3 "$REPO_ROOT/.claude/lib/wave_merge_model.py" set {P} {M} "$MERGE_MODEL"
+# Read-back-verify:
+python3 "$REPO_ROOT/.claude/lib/wave_merge_model.py" model {P} {M}
+```
+
+The helper validates the model against the fixed `{direct-to-main, wave-branch}` set and upserts `wave_{M}_merge_model` through the shared `upsert_status_keys.py` (preserving the compact-inline file shape). A typo is rejected (exit 1) rather than silently persisted.
+
 ### 1a. Status commits — use `gh api` PUT contents (atomic, no local orphan)
 
 **Status commit pattern (added P3W6 retro 2026-05-08, supersedes local-then-push):**

--- a/.claude/team/charter/pull-requests.md
+++ b/.claude/team/charter/pull-requests.md
@@ -243,6 +243,27 @@ When multiple PRs in the same wave have dependencies (e.g., PR B depends on chan
 4. **After merging the base PR**, the dependent PR must rebase/merge the updated base before its CI result is trusted
 5. **Document dependencies** in PR descriptions: "Depends on PR #N (must merge first)"
 
+## One Merge Model Per Wave (Mandatory) <!-- promotion-target: skill -->
+
+A wave uses **exactly one merge model for its entire lifetime**, chosen and recorded at `/wave-kickoff`. Mixing the two within a single wave is **prohibited**.
+
+| Model | Where per-issue PRs base | Wave→main integration PR |
+|-------|--------------------------|--------------------------|
+| `direct-to-main` | every PR bases on `main` | none — work is already on `main`; the `deployments/phase-{P}/wave-{M}` branch stays at the kickoff point and never accumulates commits |
+| `wave-branch` | every PR bases on `deployments/phase-{P}/wave-{M}` | opened at `/wave-wrapup` Step 11, merged via the `wave-merge` admin exception |
+
+**Origin (P6W1 retro, owner-approved 2026-06-21, [#801](https://github.com/noorinalabs/noorinalabs-main/issues/801)):** P6W1 *mixed* models — #704/#706/#734/#735 merged to the `deployments/phase-6/wave-1` branch while the doc batch + cspell/mermaid work went **direct to main**, and the wave→main PR was never opened. Five net-new deliverables sat stranded off `main`, caught only at `/wave-wrapup` Step 11.5 (resolved via #799).
+
+**Declared at kickoff.** `/wave-kickoff` records the chosen model in `cross-repo-status.json` under `wave_{M}_merge_model` (one of `direct-to-main` / `wave-branch`) via `.claude/lib/wave_merge_model.py set {P} {M} <model>`. The default for cross-repo waves is `wave-branch`; a meta-only or single-repo wave may declare `direct-to-main`.
+
+**Enforced mid-wave, not only at wrapup.** `/session-start` runs `wave_merge_model.py reachability {P} {M}`, which compares each in-scope repo's wave branch against `origin/main` and classifies the gap **against the declared model** — so model-mixing or stranding surfaces within hours instead of at the Step 11.5 wrapup gate (the durable strengthening #801 adds on top of that gate):
+
+- `direct-to-main` + the wave branch carries commits ahead of `main` → **VIOLATION** (someone merged to the wave branch under a direct-to-main wave — the exact P6W1 mixing). Non-zero exit.
+- `wave-branch` + ahead + an **open** wave→main PR → **OK** (the integration PR is tracking the work).
+- `wave-branch` + ahead + **no** open wave→main PR → **ADVISORY** (expected mid-wave, but it *will* strand unless `/wave-wrapup` opens the PR).
+
+Advisories are expected mid-wave states and do **not** fail `/session-start` (a non-fatal step); only a model VIOLATION exits non-zero. A wave whose `wave_{M}_merge_model` is absent (legacy / pre-#801) degrades to advisory-only with a nudge to declare it — never a false VIOLATION. The classification logic is unit-tested (`.claude/lib/tests/test_wave_merge_model.py`) and the gh I/O layer is shell-free (explicit arg-list, main#688).
+
 ## Wave Merge PR Verification <!-- promotion-target: skill -->
 At the **end of a wave or phase**, the Manager creates a PR from the deployments branch into `main`. Before presenting the PR to the user:
 


### PR DESCRIPTION
## Summary

Implements the P6W1-retro proposal (owner-approved 2026-06-21): **one merge model per wave**, declared at kickoff, plus a **mid-wave wave-branch reachability check** so stranding/mixing surfaces within hours instead of only at `/wave-wrapup` Step 11.5.

**Origin:** P6W1 mixed merge models — #704/#706/#734/#735 merged to the `deployments/phase-6/wave-1` branch while the doc batch + cspell/mermaid went direct to `main`, and the wave→main PR was never opened. Five net-new deliverables stranded off `main`, caught only at wrapup (resolved via #799).

## What changed

- **`.claude/lib/wave_merge_model.py`** — deterministic helper (mirrors `wave_status.py` conventions: explicit arg-list `gh` I/O, no shell, main#688):
  - `set <P> <M> <model>` / `model <P> <M>` — record + read `wave_{M}_merge_model` (`direct-to-main` | `wave-branch`) via the shared `upsert_status_keys.py`; a typo is rejected, not persisted.
  - `reachability <P> <M>` — compares each in-scope wave branch against `origin/main` and classifies the gap **against the declared model**:
    - `direct-to-main` + wave branch ahead → **VIOLATION** (the P6W1 mixing) — exit non-zero.
    - `wave-branch` + ahead + open wave→main PR → **OK**.
    - `wave-branch` + ahead + no PR → **ADVISORY** (will strand unless wrapup opens the PR).
    - undeclared/legacy wave → advisory-only nudge, never a false VIOLATION.
  - Pure `classify_reachability` is fully unit-tested (every model×state combo); gh I/O is injectable.
- **`.claude/lib/tests/test_wave_merge_model.py`** — 21 tests. Full lib suite: 292 passed.
- **`charter/pull-requests.md` § One Merge Model Per Wave** — canonical rule + the model table.
- **`/wave-kickoff`** — declare + record the model at Step 1.
- **`/session-start`** — new Step 5b runs the reachability check mid-wave (non-fatal; exit non-zero only on a VIOLATION), strengthening the Step 11.5 wrapup gate by firing it hours earlier.

## Verification

- `ruff format --check` + `ruff check` (pin 0.15.11) clean; `mypy --ignore-missing-imports` clean; cspell clean on changed prose; sync-drift gate OK (no new check kinds).
- Pre-push suite (pytest/mypy/mermaid) all green. Note: two pre-push checks false-fail when run from a `/tmp` worktree (snap-confined `mmdc` can't read `/tmp`; `test_non_tmp_path_not_matched` assumes cwd ∉ `/tmp`) — both are environment artifacts of the mandated worktree location, not this change (zero mermaid/hooks-test files touched); the push ran green from a non-`/tmp` checkout.

Closes #801

TechDebt: the reachability `gh` I/O layer (`_gather_repo_state`) is thin and not unit-tested (mirrors `wave_status.py`'s mocked-network boundary). The `/session-start` wiring is skill-markdown rather than a hook — acceptable per the enforcement hierarchy since the deterministic, branching logic lives in tested code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VFZHBpSPAE2e9rHoQzkcL2
