### PR TITLE
fix(sync_main): allowlist checksums.json + loud stale-base refusal (#822)

### DIFF
--- a/.claude/lib/sync_main.py
+++ b/.claude/lib/sync_main.py
@@ -17,10 +17,10 @@ local ``branch`` to ``remote/branch`` ONLY when:
     outside :data:`GENERATED_ALLOWLIST` abort the sync.
 
 It NEVER force-updates, NEVER creates a merge commit (``--ff-only``), and NEVER
-discards real local work. Generated, append-only files (the annunaki error log)
-are stashed around the fast-forward and restored, so a perpetually-dirty log
-does not block the sync. Anything it cannot do safely it reports and refuses
-(``ok=False``) rather than guessing.
+discards real local work. Machine-generated files (the annunaki error log, the
+ontology checksums) are stashed around the fast-forward and restored, so a
+perpetually-dirty generated file does not block the sync. Anything it cannot do
+safely it reports and refuses (``ok=False``) rather than guessing.
 
 CLI: ``python3 .claude/lib/sync_main.py [REPO_ROOT]`` — prints a one-line status
 and exits non-zero on a hard failure (``status == "error"``). A refusal
@@ -37,10 +37,21 @@ from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 
-# Tracked, machine-generated, append-only files that are safe to stash around a
-# fast-forward. They are perpetually dirty in an active session and would
-# otherwise block every sync. Repo-root-relative POSIX paths.
-GENERATED_ALLOWLIST: frozenset[str] = frozenset({".claude/annunaki/errors.jsonl"})
+# Tracked, machine-generated files that are safe to stash around a fast-forward.
+# They are perpetually dirty in an active session and would otherwise block
+# every sync. Repo-root-relative POSIX paths.
+#
+#  * ``.claude/annunaki/errors.jsonl`` — append-only error log.
+#  * ``ontology/checksums.json`` — rewritten by the ontology change-tracker
+#    PostToolUse hook on every Edit/Write, so it is dirty in any session that
+#    has touched a file (i.e. all of them). Unlike the append-only log it can
+#    carry genuine pending resolutions, but the stash/pop restores its content;
+#    if an incoming origin rewrite conflicts the pop, the ff still lands and the
+#    stash is left for manual recovery (see the pop path below) — graceful, not
+#    lossy.
+GENERATED_ALLOWLIST: frozenset[str] = frozenset(
+    {".claude/annunaki/errors.jsonl", "ontology/checksums.json"}
+)
 
 
 @dataclass
@@ -171,10 +182,19 @@ def sync_main(
     dirty = _parse_dirty(runner(["status", "--porcelain"], root).stdout)
     blocking = [p for p in dirty if p not in GENERATED_ALLOWLIST]
     if blocking:
+        # behind > 0 is guaranteed here (we are past the behind == 0 return), so
+        # every refused-dirty is a STALE BASE: local main cannot pick up origin's
+        # commits. Make the detail loud — behind-count + the blocking paths — so
+        # the operator does not silently start main-targeting work off a stale
+        # tree (main#822: a quiet single line was missed and a superseded
+        # ontology rebuild was nearly pushed).
         return SyncResult(
             True,
             "refused-dirty",
-            f"local tracked changes block ff: {', '.join(blocking)} — commit/stash first",
+            f"STALE BASE: '{branch}' is {behind} commit(s) behind {remote}/{branch} "
+            f"and cannot fast-forward — local tracked changes block it: "
+            f"{', '.join(blocking)}. Reconcile (commit/stash) before doing "
+            f"{branch}-targeting work.",
             behind,
             ahead,
             from_sha,
@@ -230,7 +250,16 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = list(sys.argv[1:] if argv is None else argv)
     repo_root = args[0] if args else "."
     result = sync_main(repo_root)
-    print(f"sync_main: {result.status} — {result.detail}")
+    if result.status == "refused-dirty" and result.behind > 0:
+        # A refused ff while behind is a stale-base hazard — render it as a
+        # multi-line banner so it stands out in session-start Step 0 output
+        # rather than scrolling past as one quiet line (main#822).
+        bar = "!" * 72
+        print(bar)
+        print(f"⚠  sync_main: {result.detail}")
+        print(bar)
+    else:
+        print(f"sync_main: {result.status} — {result.detail}")
     return 1 if result.status == "error" else 0
 
 

--- a/.claude/lib/tests/test_sync_main.py
+++ b/.claude/lib/tests/test_sync_main.py
@@ -9,24 +9,37 @@ working clones) so the plumbing is exercised end-to-end. Coverage:
   * not on the target branch    -> skipped-not-on-branch
   * local ahead only            -> refused-ahead (never force-pushes/rewrites)
   * local + remote diverged     -> refused-diverged
-  * real tracked local change   -> refused-dirty (never discards work)
-  * only generated-allowlist     -> stashed around ff and restored
+  * real tracked local change   -> refused-dirty (never discards work) + the
+                                   loud STALE-BASE detail (behind-count + paths)
+  * only generated-allowlist     -> stashed around ff and restored (every entry,
+                                   incl. ontology/checksums.json per main#822)
+  * conflicting generated pop    -> ff still lands, stash left for recovery
+  * CLI refused-dirty banner    -> multi-line, not a single quiet line
   * _parse_dirty                -> excludes untracked/ignored, follows renames
 """
 
 from __future__ import annotations
 
+import io
 import subprocess
 import sys
 import unittest
 from collections.abc import Sequence
+from contextlib import redirect_stdout
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
 # Helper lives at .claude/lib/sync_main.py; this test is at .claude/lib/tests/.
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from sync_main import GENERATED_ALLOWLIST, _parse_dirty, sync_main  # noqa: E402
+from sync_main import (  # noqa: E402
+    GENERATED_ALLOWLIST,
+    _parse_dirty,
+    sync_main,
+)
+from sync_main import (
+    main as cli_main,
+)
 
 _IDENT = [
     "-c",
@@ -136,27 +149,98 @@ class SyncMainTest(unittest.TestCase):
         # Fast-forward did NOT happen — local content preserved.
         self.assertEqual((self.local / "README.md").read_text(), "uncommitted edit\n")
 
-    def test_generated_allowlist_stashed_and_restored(self) -> None:
-        # Track an allowlisted generated file, then dirty it while behind.
-        gen = next(iter(GENERATED_ALLOWLIST))
+    def test_refused_dirty_detail_is_loud_stale_base_warning(self) -> None:
+        # main#822 (b): a refused ff while behind > 0 must surface a prominent
+        # stale-base warning carrying the behind-count and the blocking paths,
+        # not a single quiet line.
+        self._advance_remote()
+        (self.local / "README.md").write_text("uncommitted edit\n")
+        res = sync_main(self.local)
+        self.assertEqual(res.status, "refused-dirty")
+        self.assertGreater(res.behind, 0)
+        self.assertIn("STALE BASE", res.detail)
+        self.assertIn(str(res.behind), res.detail)  # behind-count is surfaced
+        self.assertIn("README.md", res.detail)  # blocking path is surfaced
+
+    def _track_generated(self, gen: str) -> Path:
+        """Track an allowlisted generated file on both clones, leaving a clean,
+        in-sync state ready for a later ``_advance_remote`` clean ff."""
         gpath = self.local / gen
         gpath.parent.mkdir(parents=True, exist_ok=True)
         gpath.write_text("line1\n")
         _git(["add", gen], self.local)
-        _git(["commit", "-m", "track generated log"], self.local)
+        _git(["commit", "-m", f"track {gen}"], self.local)
         _git(["push", "origin", "main"], self.local)
         # other must catch up so a later remote advance is a clean ff for local.
         _git(["pull", "origin", "main"], self.other)
+        return gpath
 
-        self._advance_remote()
-        gpath.write_text("line1\nlocal-append\n")  # dirty the generated file
+    def test_generated_allowlist_stashed_and_restored(self) -> None:
+        # Every allowlisted generated file, dirtied alone, is stashed around the
+        # ff and restored — it must NOT block the fast-forward. Covers main#822's
+        # ontology/checksums.json alongside the annunaki log.
+        self.tearDown()  # discard the auto-setUp repos; build fresh per entry
+        for gen in sorted(GENERATED_ALLOWLIST):
+            with self.subTest(generated=gen):
+                self.setUp()  # fresh temp repos per allowlist entry
+                try:
+                    gpath = self._track_generated(gen)
+                    self._advance_remote()
+                    gpath.write_text("line1\nlocal-append\n")  # dirty it while behind
+
+                    res = sync_main(self.local)
+                    self.assertTrue(res.ok)
+                    self.assertEqual(res.status, "fast-forwarded")
+                    # Remote change landed AND the local generated append survived.
+                    self.assertEqual((self.local / "README.md").read_text(), "v2\n")
+                    self.assertEqual(gpath.read_text(), "line1\nlocal-append\n")
+                finally:
+                    self.tearDown()
+
+    def test_checksums_json_is_allowlisted(self) -> None:
+        # main#822 (1): the perpetually-dirty ontology checksums file must be in
+        # the ff-stash allowlist so it never blocks a session-start fast-forward.
+        self.assertIn("ontology/checksums.json", GENERATED_ALLOWLIST)
+
+    def test_conflicting_generated_pop_degrades_gracefully(self) -> None:
+        # main#822 caveat: if an incoming origin rewrite of a generated file
+        # conflicts the stash pop, the ff still lands and the stash is left for
+        # manual recovery — graceful, never a hard error and never lost work.
+        gen = "ontology/checksums.json"
+        gpath = self._track_generated(gen)
+
+        # Remote rewrites BOTH the generated file and README, so the ff brings a
+        # new generated-file blob that the stashed local edit conflicts with.
+        (self.other / gen).write_text("line1\nremote-rewrite\n")
+        (self.other / "README.md").write_text("v2\n")
+        _git(["add", gen, "README.md"], self.other)
+        _git(["commit", "-m", "remote rewrites generated file"], self.other)
+        _git(["push", "origin", "main"], self.other)
+
+        gpath.write_text("line1\nlocal-append\n")  # diverging local edit
 
         res = sync_main(self.local)
-        self.assertTrue(res.ok)
+        self.assertTrue(res.ok)  # NOT a hard error
         self.assertEqual(res.status, "fast-forwarded")
-        # Remote change landed AND the local generated append was restored.
+        self.assertIn("stash", res.detail.lower())  # signals manual recovery
+        # The fast-forward (the load-bearing part) landed.
         self.assertEqual((self.local / "README.md").read_text(), "v2\n")
-        self.assertEqual(gpath.read_text(), "line1\nlocal-append\n")
+        # Local work is preserved in the stash, not discarded.
+        stash_list = _git(["stash", "list"], self.local).stdout
+        self.assertTrue(stash_list.strip(), "local generated edit must remain stashed")
+
+    def test_cli_refused_dirty_prints_loud_banner(self) -> None:
+        # main#822 (b): the CLI surface (session-start Step 0) renders a refused
+        # ff while behind as a multi-line banner, not one quiet line.
+        self._advance_remote()
+        (self.local / "README.md").write_text("uncommitted edit\n")
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = cli_main([str(self.local)])
+        out = buf.getvalue()
+        self.assertEqual(rc, 0)  # refusal is a safe outcome, exit 0
+        self.assertGreaterEqual(len(out.strip().splitlines()), 3)  # banner, not 1 line
+        self.assertIn("STALE BASE", out)
 
     # ----- _parse_dirty unit -------------------------------------------
 


### PR DESCRIPTION
## Summary

Fixes the two `sync_main` defects from #822 that left a session-start fast-forward refused on a stale base.

### 1. `ontology/checksums.json` not in the ff-stash allowlist
`GENERATED_ALLOWLIST` held only `.claude/annunaki/errors.jsonl`. But `ontology/checksums.json` is rewritten by the ontology change-tracker `PostToolUse` hook on every Edit/Write, so it is dirty in any active session — landing in `blocking` and refusing the ff. Added it to the allowlist so it is stashed/popped around the ff like the annunaki log.

**Graceful-pop confirmed:** the existing best-effort `stash pop` already degrades gracefully when an incoming origin rewrite conflicts the pop — the ff still lands and the stash is retained for manual recovery (`status == fast-forwarded`, detail notes the left-in-stash file). A new test exercises exactly this conflict path.

### 2. Refused ff while N-behind was too quiet
A refused-dirty refusal is — by construction — always `behind > 0` (it is past the `behind == 0` return). The `refused-dirty` detail now carries a loud `STALE BASE` warning with the behind-count and the blocking paths, and the CLI (`session-start` Step 0) renders it as a multi-line banner instead of one quiet line.

## Tests (acceptance)
- `test_checksums_json_is_allowlisted` — membership.
- `test_generated_allowlist_stashed_and_restored` — looped over **every** allowlist entry (incl. `checksums.json`): a dirty generated file alone does NOT block the ff.
- `test_refused_dirty_detail_is_loud_stale_base_warning` — refused ff while behind emits the loud warning (behind-count + paths).
- `test_conflicting_generated_pop_degrades_gracefully` — conflicting origin rewrite → ff lands, stash retained, no hard error, no lost work.
- `test_cli_refused_dirty_prints_loud_banner` — CLI banner is multi-line.

Evidence: full `.claude/lib` + `.claude/hooks` suite **1769 passed**; ruff format/lint, mypy, and the pre-commit⇄CI sync-drift gate all clean; all pre-push gates passed.

Closes #822

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W7PudS35xmg2FW6tJekTGP
