### PR TITLE
feat(liveness): mechanize Agent Liveness Checkpoint + Throttle-Stall thresholds (#745)

### DIFF
--- a/.claude/lib/check_agent_liveness.py
+++ b/.claude/lib/check_agent_liveness.py
@@ -1,0 +1,422 @@
+#!/usr/bin/env python3
+"""Deterministic agent-liveness sweep over a spawn/task/artifact snapshot.
+
+Mechanizes the two Tier-1 liveness rules carried from noorinalabs-main#735 to
+the #745 follow-up (epic #726). The #735 charter→code pass converted the two
+clean *tool-boundary* rules (Dockerfile base-pin, fixture-realism); these two
+were flagged `deterministic-able` but `harder` (inventory caveat #4) because
+they are **orchestrator-side timers with no clean tool boundary** to hang a
+PreToolUse hook on:
+
+  * `agents.md § Agent Liveness Checkpoint`
+      (a) a `TaskCreate` must exist per spawned implementer, and
+      (b) a spawned implementer with **zero artifacts** (no branch pushed, no
+          PR opened, no commit landed) after **2** idle notifications is a stall
+          to auto-flag for takeover.
+  * `agents.md § Throttle-Stall Recovery — Trigger Thresholds`
+      a mid-task-with-pending-work idle that crosses the **30 / 45 / 60-min**
+      cadence is a throttle-stall: ping, ping, auto-takeover.
+
+Why a lib, not a hook
+=====================
+Neither rule has a tool call to intercept. Part (a) fires at spawn time, but the
+*violation* (a spawn with no matching task) is only observable by comparing the
+live `TaskList` ledger against the set of spawned implementers — a cross-tool
+reconciliation, not a single tool's arguments. Parts (b) and the throttle
+cadence are driven off **artifact counts and elapsed/notification time**, not
+off message activity, so there is no PreToolUse/PostToolUse event whose payload
+carries the signal. The closest deterministic enforcement surface is therefore a
+checker the orchestrator runs at a **status sweep** (e.g. each `/retro`,
+`/wave-wrapup` open-item pass, or any time it reviews in-flight agents), feeding
+it a snapshot it assembles from the tools it already calls:
+
+  * `tasks`        — the `TaskList` ledger (subject / owner / status).
+  * `implementers` — one entry per spawned agent, with the artifact counts the
+                     orchestrator reads via `gh`/`git` (branch pushed? PR open?
+                     commits?), the worktree-dirty signal, the count of
+                     consecutive zero-progress idle notifications, and minutes
+                     idle since the last observed progress.
+
+The check is a **pure function of that snapshot** (`evaluate`), so it is fully
+deterministic and unit-testable; the only non-determinism (which agents exist,
+how many commits, how long idle) lives in the snapshot the orchestrator hands
+in. This mirrors the reader-side oracle pattern of `pr_ci_state.py` /
+`pr_review_state.py`: a deterministic core the orchestrator invokes to turn a
+state it could *eyeball* into a verdict it *cannot silently skip*.
+
+The two failure shapes this surfaces both recurred two consecutive waves
+needing manual rescue: P5W2 #1024 (narrators-500 dispatch — zero branch/PR/
+commit across the whole wave) and P5W3 #1038 (silent idle, undetected until
+takeover); the throttle gap is W12 ig#931 (a 9h37m undetected stall). The point
+of mechanizing is that the next sweep names the stall instead of the orchestrator
+discovering it by accident hours later.
+
+Snapshot schema (JSON, from a file arg or stdin)
+================================================
+    {
+      "tasks": [
+        {"subject": "main#745 — mechanize liveness",
+         "owner": "Nadia Khoury", "status": "in_progress"}
+      ],
+      "implementers": [
+        {
+          "name": "Nadia Khoury",
+          "issue_ref": "main#745",
+          "role": "implementer",          # "reviewer" -> excluded (see below)
+          "idle_notifications": 2,         # consecutive zero-progress idles
+          "idle_minutes": 65,              # since last observed progress
+          "worktree_dirty": false,
+          "artifacts": {"branch_pushed": false,
+                        "pr_opened": false,
+                        "commits": 0}
+        }
+      ]
+    }
+
+`role` defaults to `"implementer"`. A `"reviewer"` entry is **excluded** from
+every check — reviewers don't carry uncommitted work, so the worktree-dirty
+signal doesn't apply (charter § Throttle-Stall § Out of scope), and the
+TaskCreate-per-implementer rule is implementer-scoped.
+
+CLI
+===
+    python3 .claude/lib/check_agent_liveness.py <snapshot.json>
+    cat snapshot.json | python3 .claude/lib/check_agent_liveness.py
+    python3 .claude/lib/check_agent_liveness.py <snapshot.json> --json
+
+Exit codes:
+    0 — every spawned implementer is live (has a task AND no stall signal)
+    1 — at least one liveness finding (missing task, zero-artifact stall, or a
+        throttle-cadence crossing) needs orchestrator attention
+    2 — usage / parse error (bad JSON, missing required field)
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import sys
+
+# --- Thresholds (charter agents.md § Agent Liveness Checkpoint / Throttle) ---
+
+# Part (b): a SECOND successive zero-artifact idle notification is a stall, not
+# "still working" — auto-flag for takeover at this count.
+IDLE_NOTIFICATION_FLAG_THRESHOLD = 2
+
+# Throttle-Stall cadence, in minutes idle since last observed progress.
+THROTTLE_FIRST_PING_MIN = 30
+THROTTLE_SECOND_PING_MIN = 45
+THROTTLE_TAKEOVER_MIN = 60
+
+
+class SnapshotError(Exception):
+    """The snapshot could not be parsed/validated (maps to CLI exit code 2)."""
+
+
+@dataclasses.dataclass(frozen=True)
+class Finding:
+    """One liveness signal for one implementer."""
+
+    implementer: str
+    issue_ref: str
+    rule: str  # "missing-task" | "zero-artifact" | "throttle-stall"
+    action: str  # what the orchestrator must do, e.g. "auto-takeover"
+    severity: str  # "low" | "moderate" | "high"
+    detail: str
+
+
+@dataclasses.dataclass
+class LivenessReport:
+    """Result of one sweep: findings plus who was checked / excluded."""
+
+    findings: list[Finding]
+    checked: list[str]
+    excluded: list[str]
+
+    def ok(self) -> bool:
+        """True iff no implementer surfaced a liveness finding."""
+        return not self.findings
+
+
+def _normalize(name: str) -> str:
+    """Case/space-insensitive key for owner-name matching."""
+    return " ".join(name.split()).casefold()
+
+
+def has_artifact(artifacts: dict) -> bool:
+    """True iff any forward-progress artifact exists.
+
+    Per charter: a branch pushed, a PR opened, or a commit landed. A dirty
+    worktree alone is NOT an artifact — modified-but-uncommitted files are the
+    throttle signal, not evidence of forward motion.
+    """
+    return bool(
+        artifacts.get("branch_pushed")
+        or artifacts.get("pr_opened")
+        or int(artifacts.get("commits", 0) or 0) > 0
+    )
+
+
+def has_pending_work(impl: dict) -> bool:
+    """True iff the implementer is mid-task with pending work (throttle scope).
+
+    Charter § Throttle-Stall § Trigger scope signals:
+      * worktree is dirty (modified files since session start), OR
+      * branch pushed but no PR opened, OR
+      * committed but branch not pushed.
+    """
+    artifacts = impl.get("artifacts", {})
+    if impl.get("worktree_dirty"):
+        return True
+    if artifacts.get("branch_pushed") and not artifacts.get("pr_opened"):
+        return True
+    if int(artifacts.get("commits", 0) or 0) > 0 and not artifacts.get("branch_pushed"):
+        return True
+    return False
+
+
+def task_exists_for(impl: dict, tasks: list[dict]) -> bool:
+    """True iff a task in the ledger belongs to this implementer.
+
+    Match = owner name matches (case/space-insensitive) AND the implementer's
+    `issue_ref` appears in the task subject. A `deleted` task does not count as
+    a live ledger entry; any other status (pending/in_progress/completed) does —
+    the rule asserts the TaskCreate *happened*, not that it is still open.
+    """
+    name_key = _normalize(impl.get("name", ""))
+    ref = (impl.get("issue_ref") or "").strip()
+    for task in tasks:
+        if task.get("status") == "deleted":
+            continue
+        if _normalize(task.get("owner", "")) != name_key:
+            continue
+        if ref and ref in (task.get("subject") or ""):
+            return True
+    return False
+
+
+def _evaluate_one(impl: dict, tasks: list[dict]) -> list[Finding]:
+    """All findings for a single implementer (empty list = live)."""
+    name = impl.get("name", "<unnamed>")
+    ref = impl.get("issue_ref", "")
+    artifacts = impl.get("artifacts", {})
+    findings: list[Finding] = []
+
+    # Part (a): a TaskCreate must exist per spawned implementer.
+    if not task_exists_for(impl, tasks):
+        findings.append(
+            Finding(
+                implementer=name,
+                issue_ref=ref,
+                rule="missing-task",
+                action="recreate-task",
+                severity="moderate",
+                detail=(
+                    "no TaskList entry matches this implementer "
+                    f"(owner={name!r}, ref={ref!r}); a zero-output stall would be "
+                    "invisible at the next sweep — recreate the task."
+                ),
+            )
+        )
+
+    # Part (b): zero artifact after N idle notifications.
+    idle_notifs = int(impl.get("idle_notifications", 0) or 0)
+    if not has_artifact(artifacts) and idle_notifs >= 1:
+        if idle_notifs >= IDLE_NOTIFICATION_FLAG_THRESHOLD:
+            findings.append(
+                Finding(
+                    implementer=name,
+                    issue_ref=ref,
+                    rule="zero-artifact",
+                    action="auto-flag-takeover",
+                    severity="moderate",
+                    detail=(
+                        f"{idle_notifs} idle notifications, still zero artifact "
+                        "(no branch/PR/commit); a 2nd zero-artifact idle is a "
+                        "stall, not progress — auto-flag for takeover/reassignment."
+                    ),
+                )
+            )
+        else:
+            findings.append(
+                Finding(
+                    implementer=name,
+                    issue_ref=ref,
+                    rule="zero-artifact",
+                    action="reprobe",
+                    severity="low",
+                    detail=(
+                        "1 idle notification with zero artifact; re-probe via "
+                        "SendMessage and verify the task exists in TaskList."
+                    ),
+                )
+            )
+
+    # Throttle-Stall cadence: mid-task-with-pending-work idle crossing 30/45/60.
+    idle_min = int(impl.get("idle_minutes", 0) or 0)
+    if has_pending_work(impl):
+        if idle_min >= THROTTLE_TAKEOVER_MIN:
+            findings.append(
+                Finding(
+                    implementer=name,
+                    issue_ref=ref,
+                    rule="throttle-stall",
+                    action="auto-takeover",
+                    severity="high",
+                    detail=(
+                        f"idle {idle_min}min with pending work "
+                        f"(>= {THROTTLE_TAKEOVER_MIN}min) — initiate "
+                        "feedback_throttle_takeover with the implementer's commit "
+                        "identity; record in the wave decisions log."
+                    ),
+                )
+            )
+        elif idle_min >= THROTTLE_SECOND_PING_MIN:
+            findings.append(
+                Finding(
+                    implementer=name,
+                    issue_ref=ref,
+                    rule="throttle-stall",
+                    action="second-ping",
+                    severity="moderate",
+                    detail=(
+                        f"idle {idle_min}min with pending work "
+                        f"(>= {THROTTLE_SECOND_PING_MIN}min) — second status ping; "
+                        f"auto-takeover at {THROTTLE_TAKEOVER_MIN}min."
+                    ),
+                )
+            )
+        elif idle_min >= THROTTLE_FIRST_PING_MIN:
+            findings.append(
+                Finding(
+                    implementer=name,
+                    issue_ref=ref,
+                    rule="throttle-stall",
+                    action="first-ping",
+                    severity="low",
+                    detail=(
+                        f"idle {idle_min}min with pending work "
+                        f"(>= {THROTTLE_FIRST_PING_MIN}min) — first status ping "
+                        "naming the observed state."
+                    ),
+                )
+            )
+
+    return findings
+
+
+def evaluate(snapshot: dict) -> LivenessReport:
+    """Run the liveness sweep over a snapshot. Pure; no I/O.
+
+    Raises SnapshotError if the snapshot is structurally invalid.
+    """
+    if not isinstance(snapshot, dict):
+        raise SnapshotError("snapshot must be a JSON object")
+    implementers = snapshot.get("implementers", [])
+    tasks = snapshot.get("tasks", [])
+    if not isinstance(implementers, list) or not isinstance(tasks, list):
+        raise SnapshotError("'implementers' and 'tasks' must be JSON arrays")
+
+    findings: list[Finding] = []
+    checked: list[str] = []
+    excluded: list[str] = []
+
+    for impl in implementers:
+        if not isinstance(impl, dict):
+            raise SnapshotError("each implementer must be a JSON object")
+        if "name" not in impl:
+            raise SnapshotError("each implementer requires a 'name'")
+        role = (impl.get("role") or "implementer").strip().casefold()
+        if role == "reviewer":
+            # Reviewers don't carry uncommitted work and are not
+            # TaskCreate-per-implementer scoped (charter § Out of scope).
+            excluded.append(impl["name"])
+            continue
+        checked.append(impl["name"])
+        findings.extend(_evaluate_one(impl, tasks))
+
+    return LivenessReport(findings=findings, checked=checked, excluded=excluded)
+
+
+def _render_text(report: LivenessReport) -> str:
+    lines: list[str] = []
+    if report.ok():
+        lines.append("OK: all spawned implementers are live (task present, no stall signal).")
+    else:
+        lines.append(
+            f"Agent-liveness findings ({len(report.findings)}) — "
+            "agents.md § Agent Liveness Checkpoint / § Throttle-Stall Recovery:"
+        )
+        for f in report.findings:
+            ref = f" [{f.issue_ref}]" if f.issue_ref else ""
+            lines.append(
+                f"  - {f.implementer}{ref}: {f.rule} ({f.severity}) -> {f.action}\n      {f.detail}"
+            )
+    if report.checked:
+        lines.append(f"  checked: {', '.join(report.checked)}")
+    if report.excluded:
+        lines.append(f"  excluded (reviewers): {', '.join(report.excluded)}")
+    return "\n".join(lines)
+
+
+def _render_json(report: LivenessReport) -> str:
+    payload = {
+        "ok": report.ok(),
+        "findings": [dataclasses.asdict(f) for f in report.findings],
+        "checked": report.checked,
+        "excluded": report.excluded,
+    }
+    return json.dumps(payload, indent=2, sort_keys=True)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="check_agent_liveness",
+        description=(
+            "Deterministic agent-liveness sweep. Reads a snapshot (TaskList "
+            "ledger + per-implementer artifact/idle state) and reports "
+            "spawned-but-zero-artifact stalls, missing TaskCreate entries, and "
+            "throttle-stall cadence crossings. Exit 0 if all live, 1 if any "
+            "finding, 2 on parse error."
+        ),
+    )
+    p.add_argument(
+        "snapshot",
+        nargs="?",
+        help="path to the JSON snapshot; omit to read from stdin",
+    )
+    p.add_argument(
+        "--json",
+        action="store_true",
+        help="emit machine-readable JSON instead of the text report",
+    )
+    return p
+
+
+def _load_snapshot(path: str | None) -> dict:
+    try:
+        raw = sys.stdin.read() if path is None else open(path, encoding="utf-8").read()
+    except OSError as exc:
+        raise SnapshotError(f"could not read snapshot: {exc}") from exc
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise SnapshotError(f"snapshot is not valid JSON: {exc}") from exc
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        snapshot = _load_snapshot(args.snapshot)
+        report = evaluate(snapshot)
+    except SnapshotError as exc:
+        print(f"check_agent_liveness: {exc}", file=sys.stderr)
+        return 2
+
+    print(_render_json(report) if args.json else _render_text(report))
+    return 0 if report.ok() else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/lib/tests/test_check_agent_liveness.py
+++ b/.claude/lib/tests/test_check_agent_liveness.py
@@ -1,0 +1,361 @@
+"""Tests for check_agent_liveness — the agent-liveness sweep (#745, from #735).
+
+Covers the two mechanized charter rules:
+  * agents.md § Agent Liveness Checkpoint — (a) TaskCreate-per-implementer and
+    (b) zero-artifact-after-N-idle-notifications.
+  * agents.md § Throttle-Stall Recovery — the 30/45/60-min cadence.
+
+The snapshots here are the failure shapes the rules exist to catch: the P5W2
+#1024 / P5W3 #1038 zero-artifact stalls and the W12 ig#931 throttle gap.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import io
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from check_agent_liveness import (  # noqa: E402
+    IDLE_NOTIFICATION_FLAG_THRESHOLD,
+    THROTTLE_FIRST_PING_MIN,
+    THROTTLE_SECOND_PING_MIN,
+    THROTTLE_TAKEOVER_MIN,
+    Finding,
+    SnapshotError,
+    evaluate,
+    has_artifact,
+    has_pending_work,
+    main,
+    task_exists_for,
+)
+
+NO_ARTIFACT = {"branch_pushed": False, "pr_opened": False, "commits": 0}
+
+
+def _impl(**over) -> dict:
+    """An otherwise-live implementer entry; override fields per test."""
+    base = {
+        "name": "Nadia Khoury",
+        "issue_ref": "main#745",
+        "role": "implementer",
+        "idle_notifications": 0,
+        "idle_minutes": 0,
+        "worktree_dirty": False,
+        "artifacts": {"branch_pushed": True, "pr_opened": True, "commits": 3},
+    }
+    base.update(over)
+    return base
+
+
+def _task(**over) -> dict:
+    base = {
+        "subject": "main#745 — mechanize liveness",
+        "owner": "Nadia Khoury",
+        "status": "in_progress",
+    }
+    base.update(over)
+    return base
+
+
+def _snap(impls, tasks=None) -> dict:
+    return {"implementers": impls, "tasks": tasks if tasks is not None else [_task()]}
+
+
+class HasArtifactTests(unittest.TestCase):
+    def test_none(self):
+        self.assertFalse(has_artifact(NO_ARTIFACT))
+
+    def test_branch_only(self):
+        self.assertTrue(has_artifact({"branch_pushed": True}))
+
+    def test_pr_only(self):
+        self.assertTrue(has_artifact({"pr_opened": True}))
+
+    def test_commits_only(self):
+        self.assertTrue(has_artifact({"commits": 1}))
+
+    def test_dirty_worktree_is_not_an_artifact(self):
+        # A dirty worktree is the throttle signal, not forward-progress evidence.
+        self.assertFalse(has_artifact(NO_ARTIFACT))
+
+
+class HasPendingWorkTests(unittest.TestCase):
+    def test_dirty_worktree(self):
+        self.assertTrue(has_pending_work({"worktree_dirty": True, "artifacts": {}}))
+
+    def test_branch_pushed_no_pr(self):
+        self.assertTrue(
+            has_pending_work({"artifacts": {"branch_pushed": True, "pr_opened": False}})
+        )
+
+    def test_committed_not_pushed(self):
+        self.assertTrue(has_pending_work({"artifacts": {"commits": 2, "branch_pushed": False}}))
+
+    def test_clean_pr_open_is_not_pending(self):
+        self.assertFalse(
+            has_pending_work(
+                {"artifacts": {"branch_pushed": True, "pr_opened": True, "commits": 3}}
+            )
+        )
+
+    def test_nothing_started_is_not_pending(self):
+        # Zero-artifact + clean worktree is Part (b)'s domain, not throttle's.
+        self.assertFalse(has_pending_work({"artifacts": NO_ARTIFACT}))
+
+
+class TaskExistsForTests(unittest.TestCase):
+    def test_match(self):
+        self.assertTrue(task_exists_for(_impl(), [_task()]))
+
+    def test_owner_mismatch(self):
+        self.assertFalse(task_exists_for(_impl(), [_task(owner="Aino Virtanen")]))
+
+    def test_ref_mismatch(self):
+        self.assertFalse(task_exists_for(_impl(), [_task(subject="main#999 — something else")]))
+
+    def test_case_and_space_insensitive_owner(self):
+        self.assertTrue(
+            task_exists_for(_impl(name="nadia   khoury"), [_task(owner="Nadia Khoury")])
+        )
+
+    def test_deleted_task_does_not_count(self):
+        self.assertFalse(task_exists_for(_impl(), [_task(status="deleted")]))
+
+    def test_completed_task_counts_as_created(self):
+        # The rule asserts the TaskCreate happened, not that it is still open.
+        self.assertTrue(task_exists_for(_impl(), [_task(status="completed")]))
+
+    def test_empty_ledger(self):
+        self.assertFalse(task_exists_for(_impl(), []))
+
+
+class EvaluateLiveTests(unittest.TestCase):
+    def test_fully_live_no_findings(self):
+        report = evaluate(_snap([_impl()]))
+        self.assertTrue(report.ok())
+        self.assertEqual(report.findings, [])
+        self.assertEqual(report.checked, ["Nadia Khoury"])
+
+    def test_idle_but_has_artifact_and_no_pending_work_is_live(self):
+        # Idle after a clean handoff (PR open) is not a stall.
+        report = evaluate(_snap([_impl(idle_minutes=120, idle_notifications=3)]))
+        self.assertTrue(report.ok())
+
+
+class MissingTaskTests(unittest.TestCase):
+    def test_missing_task_flagged(self):
+        report = evaluate(_snap([_impl()], tasks=[]))
+        rules = [f.rule for f in report.findings]
+        self.assertIn("missing-task", rules)
+        self.assertFalse(report.ok())
+
+    def test_missing_task_action_and_severity(self):
+        report = evaluate(_snap([_impl()], tasks=[]))
+        f = next(f for f in report.findings if f.rule == "missing-task")
+        self.assertEqual(f.action, "recreate-task")
+        self.assertEqual(f.severity, "moderate")
+
+
+class ZeroArtifactTests(unittest.TestCase):
+    def test_one_idle_notification_reprobe(self):
+        report = evaluate(_snap([_impl(artifacts=NO_ARTIFACT, idle_notifications=1)]))
+        f = next(f for f in report.findings if f.rule == "zero-artifact")
+        self.assertEqual(f.action, "reprobe")
+        self.assertEqual(f.severity, "low")
+
+    def test_two_idle_notifications_auto_flag(self):
+        # The P5W2 #1024 / P5W3 #1038 shape: 2nd zero-artifact idle = stall.
+        report = evaluate(_snap([_impl(artifacts=NO_ARTIFACT, idle_notifications=2)]))
+        f = next(f for f in report.findings if f.rule == "zero-artifact")
+        self.assertEqual(f.action, "auto-flag-takeover")
+        self.assertEqual(f.severity, "moderate")
+
+    def test_zero_notifications_no_zero_artifact_finding(self):
+        report = evaluate(_snap([_impl(artifacts=NO_ARTIFACT, idle_notifications=0)]))
+        self.assertNotIn("zero-artifact", [f.rule for f in report.findings])
+
+    def test_threshold_constant(self):
+        self.assertEqual(IDLE_NOTIFICATION_FLAG_THRESHOLD, 2)
+
+    def test_artifact_present_suppresses_finding(self):
+        report = evaluate(_snap([_impl(artifacts={"commits": 1}, idle_notifications=5)]))
+        self.assertNotIn("zero-artifact", [f.rule for f in report.findings])
+
+
+class ThrottleStallTests(unittest.TestCase):
+    def _throttle_finding(self, idle_minutes):
+        report = evaluate(
+            _snap(
+                [
+                    _impl(
+                        worktree_dirty=True,
+                        artifacts=NO_ARTIFACT,
+                        idle_minutes=idle_minutes,
+                        idle_notifications=0,
+                    )
+                ]
+            )
+        )
+        return [f for f in report.findings if f.rule == "throttle-stall"]
+
+    def test_below_first_threshold_no_finding(self):
+        self.assertEqual(self._throttle_finding(THROTTLE_FIRST_PING_MIN - 1), [])
+
+    def test_first_ping_at_30(self):
+        fs = self._throttle_finding(THROTTLE_FIRST_PING_MIN)
+        self.assertEqual(fs[0].action, "first-ping")
+        self.assertEqual(fs[0].severity, "low")
+
+    def test_second_ping_at_45(self):
+        fs = self._throttle_finding(THROTTLE_SECOND_PING_MIN)
+        self.assertEqual(fs[0].action, "second-ping")
+        self.assertEqual(fs[0].severity, "moderate")
+
+    def test_takeover_at_60(self):
+        fs = self._throttle_finding(THROTTLE_TAKEOVER_MIN)
+        self.assertEqual(fs[0].action, "auto-takeover")
+        self.assertEqual(fs[0].severity, "high")
+
+    def test_takeover_well_past_60(self):
+        # W12 ig#931: 9h37m undetected -> auto-takeover.
+        fs = self._throttle_finding(577)
+        self.assertEqual(fs[0].action, "auto-takeover")
+
+    def test_no_throttle_without_pending_work(self):
+        # Idle a long time but clean handoff (no pending work) — not a throttle.
+        report = evaluate(_snap([_impl(idle_minutes=300, worktree_dirty=False)]))
+        self.assertEqual([f for f in report.findings if f.rule == "throttle-stall"], [])
+
+
+class ComplementaryOverlapTests(unittest.TestCase):
+    def test_dirty_zero_artifact_fires_both_rules(self):
+        # A dirty worktree with no commit AND 2 idle notifications is both a
+        # zero-artifact stall (notification-driven) and a throttle-stall
+        # (time-driven). The charter calls these complementary.
+        report = evaluate(
+            _snap(
+                [
+                    _impl(
+                        artifacts=NO_ARTIFACT,
+                        worktree_dirty=True,
+                        idle_notifications=2,
+                        idle_minutes=70,
+                    )
+                ]
+            )
+        )
+        rules = {f.rule for f in report.findings}
+        self.assertIn("zero-artifact", rules)
+        self.assertIn("throttle-stall", rules)
+
+
+class ReviewerExclusionTests(unittest.TestCase):
+    def test_reviewer_excluded_from_all_checks(self):
+        report = evaluate(
+            _snap(
+                [
+                    _impl(
+                        name="Aino Virtanen",
+                        role="reviewer",
+                        artifacts=NO_ARTIFACT,
+                        worktree_dirty=True,
+                        idle_notifications=5,
+                        idle_minutes=300,
+                    )
+                ],
+                tasks=[],
+            )
+        )
+        self.assertTrue(report.ok())
+        self.assertEqual(report.excluded, ["Aino Virtanen"])
+        self.assertEqual(report.checked, [])
+
+    def test_role_defaults_to_implementer(self):
+        impl = _impl(artifacts=NO_ARTIFACT, idle_notifications=2)
+        del impl["role"]
+        report = evaluate(_snap([impl]))
+        self.assertFalse(report.ok())
+        self.assertEqual(report.checked, ["Nadia Khoury"])
+
+
+class SnapshotValidationTests(unittest.TestCase):
+    def test_non_object_snapshot(self):
+        with self.assertRaises(SnapshotError):
+            evaluate([])  # type: ignore[arg-type]
+
+    def test_implementers_not_a_list(self):
+        with self.assertRaises(SnapshotError):
+            evaluate({"implementers": {}, "tasks": []})
+
+    def test_implementer_missing_name(self):
+        with self.assertRaises(SnapshotError):
+            evaluate({"implementers": [{"issue_ref": "x"}], "tasks": []})
+
+    def test_missing_keys_default_empty(self):
+        # An empty snapshot is valid and trivially clean.
+        report = evaluate({})
+        self.assertTrue(report.ok())
+
+
+class CliTests(unittest.TestCase):
+    def _run(self, snapshot, extra=None):
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False, encoding="utf-8") as fh:
+            json.dump(snapshot, fh)
+            path = fh.name
+        try:
+            return main([path, *(extra or [])])
+        finally:
+            Path(path).unlink()
+
+    def test_exit_zero_when_live(self):
+        self.assertEqual(self._run(_snap([_impl()])), 0)
+
+    def test_exit_one_on_finding(self):
+        self.assertEqual(self._run(_snap([_impl(artifacts=NO_ARTIFACT, idle_notifications=2)])), 1)
+
+    def test_exit_two_on_bad_json(self):
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False, encoding="utf-8") as fh:
+            fh.write("{not json")
+            path = fh.name
+        try:
+            self.assertEqual(main([path]), 2)
+        finally:
+            Path(path).unlink()
+
+    def test_exit_two_on_missing_file(self):
+        self.assertEqual(main(["/nonexistent/snapshot.json"]), 2)
+
+    def test_json_output(self):
+        buf = io.StringIO()
+        with mock.patch("sys.stdout", buf):
+            rc = self._run(
+                _snap([_impl(artifacts=NO_ARTIFACT, idle_notifications=2)]),
+                extra=["--json"],
+            )
+        self.assertEqual(rc, 1)
+        payload = json.loads(buf.getvalue())
+        self.assertFalse(payload["ok"])
+        self.assertEqual(payload["findings"][0]["rule"], "zero-artifact")
+
+    def test_stdin_input(self):
+        snap = json.dumps(_snap([_impl()]))
+        with mock.patch("sys.stdin", io.StringIO(snap)):
+            self.assertEqual(main([]), 0)
+
+
+class FindingShapeTests(unittest.TestCase):
+    def test_finding_is_frozen_dataclass(self):
+        f = Finding("n", "r", "rule", "act", "low", "d")
+        with self.assertRaises(dataclasses.FrozenInstanceError):
+            f.severity = "high"  # type: ignore[misc]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/team/charter/agents.md
+++ b/.claude/team/charter/agents.md
@@ -637,6 +637,16 @@ This section covers the **zero-artifact stall**: the implementer has produced no
 - Orchestrator misses a zero-artifact stall because `TaskList` is empty (Part (a) violated): **moderate** — the stall the task list was designed to surface goes unreported.
 - Orchestrator infers "still working" from a second zero-artifact idle notification and takes no action (Part (b) violated): **moderate** — wave-level deadline risk; the P5W2 and P5W3 instances were both narrow misses on shipping the keystone deliverable.
 
+### Enforcement (mechanized) <!-- promoted-to: lib/check_agent_liveness.py -->
+
+Both parts are mechanized by `.claude/lib/check_agent_liveness.py` (main#745, follow-up to #735). There is **no clean tool boundary** to hang a PreToolUse hook on — Part (a)'s violation (a spawn with no matching task) is a cross-tool reconciliation of the `TaskList` ledger against the set of spawned implementers, and Part (b) is driven off artifact counts + idle-notification count, not off any single tool's arguments. The deterministic enforcement surface is therefore a checker the orchestrator runs at each **status sweep** (`/retro`, the `/wave-wrapup` open-item pass, or any in-flight-agent review), fed a snapshot it assembles from tools it already calls (`TaskList` + the `gh`/`git` artifact reads):
+
+```bash
+python3 .claude/lib/check_agent_liveness.py <snapshot.json>   # exit 1 = a liveness finding
+```
+
+The checker emits a `missing-task` finding (Part (a)) when no `TaskList` entry matches an implementer (owner + issue_ref), and a `zero-artifact` finding (Part (b)) — `reprobe` at 1 idle notification, `auto-flag-takeover` at the 2nd — when a spawned implementer has no branch/PR/commit. Reviewers are excluded. See the module docstring for the snapshot schema and the why-a-lib-not-a-hook rationale.
+
 ### Provenance
 
 P5W3 retro (2026-06-14) § Proposed Process Change #1 — recurred two consecutive waves. Part (a) (TaskCreate at spawn) was codified via P5W2 retro in `/wave-kickoff` § 9b. Part (b) (zero-artifact threshold) is the P5W3 addition. Both promoted here to charter level so the liveness rule applies across all spawn contexts, not just those initiated via `/wave-kickoff`.
@@ -678,6 +688,10 @@ Normal **idle-after-turn-completion** does NOT trigger this — an implementer w
 ### Severity if violated
 
 Reactive-only detection (no cadence, stall discovered at the next state review): **minor-to-moderate** depending on deadline proximity — the work is recoverable via takeover, but the idle gap is dead time that compounds against wave deadlines (especially hard cutovers like the node24 June-2 class).
+
+### Enforcement (mechanized) <!-- promoted-to: lib/check_agent_liveness.py -->
+
+The 30/45/60-min cadence is mechanized by `.claude/lib/check_agent_liveness.py` (main#745, follow-up to #735) — the same status-sweep checker that enforces § Agent Liveness Checkpoint. Per § Out of scope above this is **not** a hook (the trigger is orchestrator-side elapsed-time off artifact state, with no tool event to intercept); the lib is the deterministic surface the orchestrator runs at each sweep. For an implementer that is mid-task **with pending work** (`worktree_dirty`, or branch-pushed-no-PR, or committed-not-pushed), the checker emits a `throttle-stall` finding keyed to `idle_minutes`: `first-ping` (≥30), `second-ping` (≥45), `auto-takeover` (≥60). Idle after a clean handoff (no pending work) and reviewer agents do not trigger. The `auto-takeover` finding directs the orchestrator into `feedback_throttle_takeover` (the mechanic); this section + the lib are the trigger.
 
 ### Provenance
 


### PR DESCRIPTION
## What & why

Mechanizes the two Tier-1 liveness rules the #735 charter→code pass deferred (inventory worklist **#2/#3**, caveat #4 — *orchestrator-side timers with no clean tool boundary*). Both failure shapes recurred two consecutive waves needing manual rescue (P5W2 #1024, P5W3 #1038) and a 9h37m undetected throttle stall (W12 ig#931). This turns "the orchestrator should notice" into "the next status sweep names the stall".

## The mechanism

`.claude/lib/check_agent_liveness.py` — a deterministic, pure-function checker (`evaluate()`) over a spawn/task/artifact **snapshot** the orchestrator assembles from tools it already calls (`TaskList` ledger + `gh`/`git` artifact reads). Emits structured findings:

| Rule | Trigger | Action |
|------|---------|--------|
| `missing-task` (§ Checkpoint Part a) | no `TaskList` entry matches a spawned implementer (owner + issue_ref) | recreate-task |
| `zero-artifact` (§ Checkpoint Part b) | no branch/PR/commit after idle notifications | `reprobe` @1, `auto-flag-takeover` @2 |
| `throttle-stall` (§ Throttle-Stall) | mid-task-with-pending-work idle | `first-ping` ≥30m, `second-ping` ≥45m, `auto-takeover` ≥60m |

Reviewers are excluded (no uncommitted work; not TaskCreate-scoped). CLI reads a file or stdin, supports `--json`, exits `0` (all live) / `1` (finding) / `2` (parse error).

## Why a lib, not a hook (the deferred-rule question)

Neither rule has a tool event whose payload carries the signal:
- **Part (a)** is a cross-tool reconciliation of the `TaskList` ledger against the spawned-implementer set — not a single tool's arguments.
- **Part (b)** and the **throttle cadence** are driven off **artifact counts + elapsed/notification time**, not message activity — no PreToolUse/PostToolUse event observes them.

The closest deterministic enforcement surface is therefore a checker the orchestrator runs at each **status sweep** (`/retro`, the `/wave-wrapup` open-item pass, any in-flight-agent review). The non-determinism lives in the snapshot; the verdict is pure and unit-tested. This mirrors the reader-side oracle pattern of `pr_ci_state.py` / `pr_review_state.py`. Rationale is documented in the module docstring and both charter sections.

## Charter prose updated to point at the mechanism

Added **"Enforcement (mechanized)"** subsections to `agents.md § Agent Liveness Checkpoint` and `§ Throttle-Stall Recovery — Trigger Thresholds`, each carrying a `<!-- promoted-to: lib/check_agent_liveness.py -->` back-reference. `promotion-audit` now classifies **both** sections `ALREADY-PROMOTED` (markers flipped to built-state).

## Test evidence

- `.claude/lib/tests/test_check_agent_liveness.py` — **46 cases**, all pass: every threshold boundary (29/30/45/60/577 min, 0/1/2 notifications), task-match edges (owner/ref mismatch, case+space-insensitive, deleted vs completed status), reviewer exclusion, complementary zero-artifact+throttle overlap, snapshot validation, and CLI exit codes / stdin / `--json`.
- `pre-commit run --all-files` (commit + pre-push stages) green: ruff-format, ruff-lint, actionlint, **cspell**, mypy, pytest, pytest-skills, memory-budget, doc-freshness, office-drift, mermaid-render.
- `pre_commit_ci_sync.py .` green (no new check kind — lib + tests are picked up by the existing `.claude/lib/**` ruff + `.claude/lib/tests/` pytest globs).

Closes #745. Follow-up to #735, epic #726.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W7PudS35xmg2FW6tJekTGP
