### PR TITLE
fix(status): retire stale top-level phase field; derive phase from current_phase (#831)

### DIFF
--- a/.claude/hooks/tests/test_validate_wave_audit.py
+++ b/.claude/hooks/tests/test_validate_wave_audit.py
@@ -181,7 +181,40 @@ class WaveLabelDerivation(unittest.TestCase):
         return Path(tmp.name)
 
     def test_phase2_wave10_derives_both_forms(self) -> None:
-        """Returns BOTH the legacy p{N}-wave-{M} AND the new wave-{X} form (#810)."""
+        """Returns BOTH the legacy p{N}-wave-{M} AND the new wave-{X} form (#810).
+
+        Phase comes from the authoritative `current_phase` integer (#831).
+        """
+        path = self._write_status(
+            {"wave_active": True, "current_wave": "wave-10", "current_phase": 2}
+        )
+        try:
+            with mock.patch.object(hook, "_STATUS_PATH", path):
+                self.assertEqual(hook._read_current_wave_labels(), ["p2-wave-10", "wave-10"])
+        finally:
+            path.unlink()
+
+    def test_current_phase_wins_over_stale_phase_string(self) -> None:
+        """#831 regression: the live `current_phase` integer is authoritative;
+        a stale top-level `phase` string (the never-advanced phase-4 legacy
+        field) must be IGNORED for label derivation."""
+        path = self._write_status(
+            {
+                "wave_active": True,
+                "current_wave": "wave-17",
+                "current_phase": 6,
+                "phase": "phase-4",  # stale legacy field — must not win
+            }
+        )
+        try:
+            with mock.patch.object(hook, "_STATUS_PATH", path):
+                self.assertEqual(hook._read_current_wave_labels(), ["p6-wave-17", "wave-17"])
+        finally:
+            path.unlink()
+
+    def test_legacy_phase_string_fallback(self) -> None:
+        """Defensive fallback: when `current_phase` is absent, the legacy
+        `phase` ("phase-{N}") string still resolves (robustness)."""
         path = self._write_status(
             {"wave_active": True, "current_wave": "wave-10", "phase": "phase-2"}
         )
@@ -193,7 +226,7 @@ class WaveLabelDerivation(unittest.TestCase):
 
     def test_inactive_wave_returns_none(self) -> None:
         path = self._write_status(
-            {"wave_active": False, "current_wave": "wave-10", "phase": "phase-2"}
+            {"wave_active": False, "current_wave": "wave-10", "current_phase": 2}
         )
         try:
             with mock.patch.object(hook, "_STATUS_PATH", path):
@@ -207,8 +240,17 @@ class WaveLabelDerivation(unittest.TestCase):
 
     def test_malformed_current_wave_returns_none(self) -> None:
         path = self._write_status(
-            {"wave_active": True, "current_wave": "not-a-wave", "phase": "phase-2"}
+            {"wave_active": True, "current_wave": "not-a-wave", "current_phase": 2}
         )
+        try:
+            with mock.patch.object(hook, "_STATUS_PATH", path):
+                self.assertIsNone(hook._read_current_wave_labels())
+        finally:
+            path.unlink()
+
+    def test_missing_both_phase_fields_returns_none(self) -> None:
+        """No `current_phase` AND no `phase` → phase unresolvable → None."""
+        path = self._write_status({"wave_active": True, "current_wave": "wave-10"})
         try:
             with mock.patch.object(hook, "_STATUS_PATH", path):
                 self.assertIsNone(hook._read_current_wave_labels())
@@ -262,7 +304,7 @@ class WaveBranchDerivation(unittest.TestCase):
 
     def test_phase5_wave5_derives_branch(self) -> None:
         path = self._write_status(
-            {"wave_active": True, "current_wave": "wave-5", "phase": "phase-5"}
+            {"wave_active": True, "current_wave": "wave-5", "current_phase": 5}
         )
         try:
             with mock.patch.object(hook, "_STATUS_PATH", path):
@@ -270,9 +312,27 @@ class WaveBranchDerivation(unittest.TestCase):
         finally:
             path.unlink()
 
+    def test_branch_uses_current_phase_not_stale_phase_string(self) -> None:
+        """#831 core regression: branch derivation must read the authoritative
+        `current_phase` (6), NOT the stale top-level `phase` ("phase-4"). The
+        bug derived `deployments/phase-4/...`; the fix derives phase-6."""
+        path = self._write_status(
+            {
+                "wave_active": True,
+                "current_wave": "wave-17",
+                "current_phase": 6,
+                "phase": "phase-4",  # stale legacy field — must not win
+            }
+        )
+        try:
+            with mock.patch.object(hook, "_STATUS_PATH", path):
+                self.assertEqual(hook._read_current_wave_branch(), "deployments/phase-6/wave-17")
+        finally:
+            path.unlink()
+
     def test_inactive_wave_returns_none(self) -> None:
         path = self._write_status(
-            {"wave_active": False, "current_wave": "wave-5", "phase": "phase-5"}
+            {"wave_active": False, "current_wave": "wave-5", "current_phase": 5}
         )
         try:
             with mock.patch.object(hook, "_STATUS_PATH", path):
@@ -287,7 +347,7 @@ class WaveBranchDerivation(unittest.TestCase):
     def test_label_and_branch_share_phase_wave(self) -> None:
         """Label and branch must derive from the SAME phase/wave (no drift)."""
         path = self._write_status(
-            {"wave_active": True, "current_wave": "wave-12", "phase": "phase-3"}
+            {"wave_active": True, "current_wave": "wave-12", "current_phase": 3}
         )
         try:
             with mock.patch.object(hook, "_STATUS_PATH", path):
@@ -295,6 +355,29 @@ class WaveBranchDerivation(unittest.TestCase):
                 self.assertEqual(hook._read_current_wave_branch(), "deployments/phase-3/wave-12")
         finally:
             path.unlink()
+
+
+class PhaseNumDerivation(unittest.TestCase):
+    """Direct coverage on _read_phase_num — the authoritative phase reader (#831)."""
+
+    def test_current_phase_int_preferred(self) -> None:
+        self.assertEqual(hook._read_phase_num({"current_phase": 6, "phase": "phase-4"}), 6)
+
+    def test_current_phase_string_coerced(self) -> None:
+        """A stringified `current_phase` ("6") still coerces to int."""
+        self.assertEqual(hook._read_phase_num({"current_phase": "6"}), 6)
+
+    def test_falls_back_to_phase_string(self) -> None:
+        self.assertEqual(hook._read_phase_num({"phase": "phase-2"}), 2)
+
+    def test_unparseable_current_phase_falls_back_to_phase_string(self) -> None:
+        self.assertEqual(hook._read_phase_num({"current_phase": "n/a", "phase": "phase-7"}), 7)
+
+    def test_neither_field_returns_none(self) -> None:
+        self.assertIsNone(hook._read_phase_num({}))
+
+    def test_malformed_phase_string_returns_none(self) -> None:
+        self.assertIsNone(hook._read_phase_num({"phase": "phase-x"}))
 
 
 class ChecksGreen(unittest.TestCase):

--- a/.claude/hooks/validate_wave_audit.py
+++ b/.claude/hooks/validate_wave_audit.py
@@ -194,14 +194,38 @@ _STATUS_PATH = Path(__file__).resolve().parent.parent.parent / "cross-repo-statu
 _PER_REPO_TIMEOUT_SECONDS = 3
 
 
+def _read_phase_num(data: dict) -> int | None:
+    """Recover the active phase number from a loaded status dict, or None (#831).
+
+    `current_phase` (the live integer) is the AUTHORITATIVE phase pointer. The
+    legacy top-level `phase` ("phase-{N}") string was never advanced past
+    phase-4 — deriving the wave branch/label from it yielded a wrong
+    `deployments/phase-4/...` (#831), so it is retired from the status file. A
+    defensive `phase`-string fallback is retained for robustness and to mirror
+    the sibling readers `validate_wave_label_evidence._read_current_phase` and
+    `post_wave_kickoff_comment._phase_from_status` (#810).
+    """
+    cp = data.get("current_phase")
+    if cp is not None:
+        try:
+            return int(cp)
+        except (TypeError, ValueError):
+            pass
+    m = re.fullmatch(r"phase-(\d+)", str(data.get("phase", "")))
+    if m:
+        return int(m.group(1))
+    return None
+
+
 def _read_phase_wave_nums() -> tuple[int, int] | None:
     """Return the active (phase_num, wave_num) from cross-repo-status.json or None.
 
     Reads `cross-repo-status.json`, requires `wave_active` truthy, and parses
-    the `phase` ("phase-<P>") and `current_wave` ("wave-<M>") fields. Returns
-    None on any failure (missing file, malformed JSON, inactive wave, missing
-    or unparseable fields). Single source of truth for both the wave *label*
-    and the wave *branch* derivations below so they cannot drift apart.
+    the authoritative `current_phase` integer (via `_read_phase_num`) and the
+    `current_wave` ("wave-<M>") field. Returns None on any failure (missing
+    file, malformed JSON, inactive wave, missing or unparseable fields). Single
+    source of truth for both the wave *label* and the wave *branch* derivations
+    below so they cannot drift apart.
     """
     try:
         data = json.loads(_STATUS_PATH.read_text(encoding="utf-8"))
@@ -212,11 +236,11 @@ def _read_phase_wave_nums() -> tuple[int, int] | None:
         return None
 
     wave_match = re.fullmatch(r"wave-(\d+)", str(data.get("current_wave", "")))
-    phase_match = re.fullmatch(r"phase-(\d+)", str(data.get("phase", "")))
-    if not wave_match or not phase_match:
+    phase_num = _read_phase_num(data)
+    if not wave_match or phase_num is None:
         return None
 
-    return int(phase_match.group(1)), int(wave_match.group(1))
+    return phase_num, int(wave_match.group(1))
 
 
 def _read_current_wave_labels() -> list[str] | None:

--- a/cross-repo-status.json
+++ b/cross-repo-status.json
@@ -1137,7 +1137,6 @@
   "wave_started": "2026-06-23T00:21:35Z",
   "last_completed_wave": "wave-16",
   "last_completed_at": "2026-06-23T18:30:06Z",
-  "phase": "phase-4",
   "wave_3_meta_issue": 675,
   "wave_3_scope": {
     "theme": "Trustworthy data & search",


### PR DESCRIPTION
## Summary
Fixes the stale top-level `phase` field drift in `cross-repo-status.json` and the consumer that read it. Closes #831.

`cross-repo-status.json` carried a legacy `"phase": "phase-4"` that was never advanced and disagreed with the authoritative `current_phase: 6`. `validate_wave_audit._read_phase_wave_nums` derived the wave **branch/label** from that stale string, computing `deployments/phase-4/...` instead of the real `deployments/phase-6/...`. (#810's label code already preferred `current_phase`; only this branch-derivation reader was left behind.)

## Changes
- **`validate_wave_audit.py`** — new `_read_phase_num(data)` prefers the authoritative `current_phase` integer, with a defensive `phase`-string fallback that mirrors the sibling readers `validate_wave_label_evidence._read_current_phase` and `post_wave_kickoff_comment._phase_from_status`. `_read_phase_wave_nums` (feeding both `_read_current_wave_branch` and `_read_current_wave_labels`) now uses it.
- **`cross-repo-status.json`** — retired the stale top-level `phase` field via `upsert_status_keys.py --remove-key` (one-line deletion; compact-inline shape preserved; nested scope `phase` ints untouched). Nothing writes the field anymore — confirmed by grep across skills/lib.
- **Tests** — `#831` regression for BOTH branch and label derivation (`current_phase: 6` wins over a stale `"phase": "phase-4"` → `deployments/phase-6/wave-17`, `["p6-wave-17","wave-17"]`), legacy-string fallback, missing-both-fields → None, and a direct `_read_phase_num` unit class. `87 passed` + pre-push suite green.

## Validation
- `pre-commit run --all-files` and `--hook-stage pre-push --all-files`: all green (ruff, mypy, pytest, cspell, actionlint, sync-drift gate).
- `pre_commit_ci_sync.py .`: OK (parity intact).

## Reviewers
- Aino Virtanen (primary)
- Wanjiku Mwangi (secondary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QnW8cWydBgAyT1TTrgQdis
