### PR TITLE
feat(env): refresh + staleness guard for parent's child-repo checkouts (#832)

### DIFF
--- a/.claude/lib/check_child_checkouts.py
+++ b/.claude/lib/check_child_checkouts.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Refresh + staleness guard for the parent's embedded child-repo checkouts.
+
+The parent ``noorinalabs-main`` checkout ``.gitignore``s the child repos, which
+live as independent clones under ``$REPO_ROOT/noorinalabs-<name>``. They drift:
+during p6-wave-16 ``noorinalabs-user-service`` was parked on a *phase-3* commit
+and ``noorinalabs-isnad-graph`` sat ~207 commits behind ``origin/main`` (main#832).
+A stale child clone is the root cause of #816 (the parent pre-push test reads the
+stale on-disk child configs) and makes any agent that reads a child clone directly
+draw wrong conclusions.
+
+This is the sibling to :mod:`sync_main` (the parent ``main`` fast-forward, #713)
+for the *children*. It applies the **same safety stance**:
+
+  * It fast-forwards a child to ``origin/main`` ONLY when that child is currently
+    on ``main``, is strictly behind (``behind > 0`` and ``ahead == 0``), and has a
+    clean working tree (the ff is delegated to :func:`sync_main.sync_main`, which
+    stashes the machine-generated allowlist around the merge).
+  * It NEVER force-discards local work: a child parked on a feature branch, a
+    dirty tree, or a divergence is **FLAGGED for a manual decision** and left
+    exactly as it is. There is no force path.
+
+``behind``/``ahead`` are always measured against the child's own ``origin/main``
+from ``HEAD`` (not from ``main``), so a child parked on an old feature branch
+still reports how far behind the mainline it really is — that is the staleness
+signal the guard exists to surface.
+
+CLI: ``python3 .claude/lib/check_child_checkouts.py [REPO_ROOT] [--refresh]``
+
+  * default (guard/check): reports per-child status, mutates nothing.
+  * ``--refresh``: additionally fast-forwards the clean-on-main-behind children.
+
+Either way it prints a per-child report plus a FLAGGED block for the children
+needing a manual call, and exits 0 (a refusal/flag is a *safe* outcome — wiring
+this into session-start must never break on a "can't refresh right now" state).
+Exit is non-zero only on an internal plumbing error.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# Reuse the deterministic git primitives + safe fast-forward from sync_main so
+# the two guards share one implementation of "what is dirty" / "how to ff".
+from sync_main import (
+    GitRunner,
+    SyncResult,
+    _count,
+    _git,
+    _parse_dirty,
+)
+from sync_main import (
+    sync_main as _sync_branch,
+)
+
+# The 7 canonical child repos (CLAUDE.md Repository Map). Kept in sync with the
+# session-start Step 0 worktree iteration list.
+CHILD_REPOS: tuple[str, ...] = (
+    "noorinalabs-isnad-graph",
+    "noorinalabs-user-service",
+    "noorinalabs-deploy",
+    "noorinalabs-design-system",
+    "noorinalabs-data-acquisition",
+    "noorinalabs-isnad-ingest-platform",
+    "noorinalabs-landing-page",
+)
+
+# Statuses that need a human call (the FLAGGED block). Everything else
+# (current / fast-forwarded / absent) is a clean outcome.
+_ATTENTION = frozenset(
+    {"stale-on-main", "stale-feature-branch", "dirty", "diverged", "ahead", "error"}
+)
+
+
+@dataclass
+class ChildStatus:
+    """Outcome of inspecting (and optionally refreshing) one child checkout.
+
+    ``behind``/``ahead`` are HEAD-relative to the child's ``origin/main``.
+    ``status`` is machine-readable:
+
+      * ``absent``               — no clone on disk (not flagged; nothing to do)
+      * ``current``              — on main, clean, up-to-date with origin/main
+      * ``fast-forwarded``       — was stale-on-main-clean; refreshed this run
+      * ``stale-on-main``        — on main, clean, behind; refreshable (run --refresh)
+      * ``stale-feature-branch`` — parked off main and behind origin/main
+      * ``dirty``                — uncommitted tracked changes while behind
+      * ``diverged``             — local commits AND behind origin/main
+      * ``ahead``                — local commits ahead of origin/main, not behind
+      * ``error``                — git plumbing failed for this child
+    """
+
+    repo: str
+    status: str
+    branch: str = ""
+    behind: int = 0
+    ahead: int = 0
+    dirty: list[str] = field(default_factory=list)
+    detail: str = ""
+
+    @property
+    def needs_attention(self) -> bool:
+        return self.status in _ATTENTION
+
+
+def _branch_of(root: Path, runner: GitRunner) -> str:
+    res = runner(["rev-parse", "--abbrev-ref", "HEAD"], root)
+    return res.stdout.strip() if res.returncode == 0 else ""
+
+
+def check_child(
+    repo_root: str | Path,
+    child: str,
+    *,
+    refresh: bool = False,
+    remote: str = "origin",
+    fetch: bool = True,
+    runner: GitRunner = _git,
+) -> ChildStatus:
+    """Inspect (and, with ``refresh=True``, safely fast-forward) one child."""
+    child_root = Path(repo_root) / child
+    if not (child_root / ".git").exists():
+        return ChildStatus(child, "absent", detail="no clone on disk")
+
+    if fetch:
+        fres = runner(["fetch", remote, "main"], child_root)
+        if fres.returncode != 0:
+            return ChildStatus(
+                child, "error", detail=f"git fetch {remote} main failed: {fres.stderr.strip()}"
+            )
+
+    branch = _branch_of(child_root, runner)
+    if not branch:
+        return ChildStatus(child, "error", detail="could not resolve current branch")
+
+    ref = f"{remote}/main"
+    behind = _count(runner, child_root, f"HEAD..{ref}")
+    ahead = _count(runner, child_root, f"{ref}..HEAD")
+    if behind < 0 or ahead < 0:
+        return ChildStatus(
+            child, "error", branch=branch, detail=f"could not compare HEAD with {ref}"
+        )
+
+    dirty = _parse_dirty(runner(["status", "--porcelain"], child_root).stdout)
+    on_main = branch == "main"
+
+    # ---- divergence / ahead (local commits) — never touched ----------------
+    if ahead > 0:
+        status = "diverged" if behind > 0 else "ahead"
+        detail = (
+            f"on '{branch}', {ahead} local commit(s) ahead / {behind} behind {ref} "
+            f"— left as-is (no force)"
+        )
+        return ChildStatus(child, status, branch, behind, ahead, dirty, detail)
+
+    # ---- up to date with mainline -----------------------------------------
+    if behind == 0:
+        note = f" ({len(dirty)} uncommitted change(s))" if dirty else ""
+        return ChildStatus(
+            child, "current", branch, 0, 0, dirty, f"on '{branch}', current with {ref}{note}"
+        )
+
+    # behind > 0, ahead == 0 from here on.
+
+    # ---- dirty tree blocks a refresh — flag, never discard -----------------
+    if dirty:
+        return ChildStatus(
+            child,
+            "dirty",
+            branch,
+            behind,
+            0,
+            dirty,
+            f"on '{branch}', {behind} behind {ref} but {len(dirty)} uncommitted "
+            f"tracked change(s) block refresh: {', '.join(dirty)}. Reconcile manually.",
+        )
+
+    # ---- parked on an old feature branch — flag, never touch ---------------
+    if not on_main:
+        return ChildStatus(
+            child,
+            "stale-feature-branch",
+            branch,
+            behind,
+            0,
+            [],
+            f"parked on '{branch}', {behind} behind {ref} — genuine local branch, "
+            f"not refreshed (checkout main + pull manually if intended)",
+        )
+
+    # ---- clean, on main, strictly behind: refreshable ----------------------
+    if not refresh:
+        return ChildStatus(
+            child,
+            "stale-on-main",
+            branch,
+            behind,
+            0,
+            [],
+            f"on 'main', clean, {behind} behind {ref} — refreshable "
+            f"(run with --refresh to fast-forward)",
+        )
+
+    # refresh requested: delegate the actual ff to sync_main (handles the
+    # generated-file stash + --ff-only safety). fetch already done above.
+    res: SyncResult = _sync_branch(
+        child_root, branch="main", remote=remote, fetch=False, runner=runner
+    )
+    if res.status == "fast-forwarded":
+        return ChildStatus(child, "fast-forwarded", "main", behind, 0, [], f"main {res.detail}")
+    if res.status == "up-to-date":
+        # Raced to current between our count and the ff (benign).
+        return ChildStatus(child, "current", "main", 0, 0, [], f"main {res.detail}")
+    # Any sync_main refusal/error: surface it without forcing.
+    return ChildStatus(child, "error", "main", behind, 0, [], f"refresh failed: {res.detail}")
+
+
+def check_all(
+    repo_root: str | Path,
+    *,
+    refresh: bool = False,
+    children: Sequence[str] = CHILD_REPOS,
+    runner: GitRunner = _git,
+) -> list[ChildStatus]:
+    """Inspect every present child checkout under ``repo_root``."""
+    return [check_child(repo_root, c, refresh=refresh, runner=runner) for c in children]
+
+
+def render(results: Sequence[ChildStatus]) -> str:
+    """Render a per-child report + a FLAGGED block for the ones needing a call."""
+    present = [r for r in results if r.status != "absent"]
+    if not present:
+        return "child-checkouts: no child clones on disk."
+    lines: list[str] = ["--- child-repo checkouts (vs origin/main) ---"]
+    for r in present:
+        lines.append(f"  {r.status:<20} {r.repo} :: {r.detail}")
+    flagged = [r for r in present if r.needs_attention]
+    if flagged:
+        lines.append("--- FLAGGED child checkouts (manual decision; NOT refreshed) ---")
+        for r in flagged:
+            lines.append(f"  {r.status}  {r.repo} (behind {r.behind}, ahead {r.ahead})")
+    return "\n".join(lines)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    refresh = "--refresh" in args
+    positional = [a for a in args if not a.startswith("--")]
+    repo_root = positional[0] if positional else "."
+
+    results = check_all(repo_root, refresh=refresh)
+    print(render(results))
+
+    # Internal plumbing failure is the only non-zero exit. A flagged child
+    # (dirty/diverged/feature-branch/stale) is a SAFE outcome — exit 0 so a
+    # session-start caller never breaks on a "can't refresh right now" state.
+    return 1 if any(r.status == "error" for r in results) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/lib/tests/test_check_child_checkouts.py
+++ b/.claude/lib/tests/test_check_child_checkouts.py
@@ -1,0 +1,234 @@
+"""Tests for check_child_checkouts — the refresh + staleness guard for the
+parent's embedded child-repo clones (main#832).
+
+Each test drives REAL git against throwaway temp repos. A fake ``REPO_ROOT``
+holds one or more child clones, each backed by its own bare "remote", so the
+behind/ahead/dirty classification and the safe fast-forward are exercised
+end-to-end. Coverage mirrors the sync_main suite plus the child-specific cases:
+
+  * absent child                       -> absent (skipped, not flagged)
+  * on main, clean, current            -> current
+  * on main, clean, behind, no refresh -> stale-on-main (flagged, untouched)
+  * on main, clean, behind, --refresh  -> fast-forwarded (work pulled forward)
+  * parked on a feature branch, behind -> stale-feature-branch (never touched)
+  * dirty tree while behind            -> dirty (never discards local work)
+  * local commits + behind             -> diverged (never force)
+  * local commits only                 -> ahead (never force)
+  * render()                            -> FLAGGED block lists the attention set
+  * check_all + CLI exit code
+"""
+
+from __future__ import annotations
+
+import io
+import subprocess
+import sys
+import unittest
+from collections.abc import Sequence
+from contextlib import redirect_stdout
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+# Helper lives at .claude/lib/check_child_checkouts.py; this test is at .claude/lib/tests/.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from check_child_checkouts import (  # noqa: E402
+    ChildStatus,
+    check_all,
+    check_child,
+    render,
+)
+from check_child_checkouts import (  # noqa: E402
+    main as cli_main,
+)
+
+_IDENT = [
+    "-c",
+    "user.name=Test",
+    "-c",
+    "user.email=test@example.com",
+    "-c",
+    "commit.gpgsign=false",
+]
+
+
+def _git(args: Sequence[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *_IDENT, *args],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+def _commit(repo: Path, name: str, content: str, msg: str) -> None:
+    (repo / name).write_text(content)
+    _git(["add", name], repo)
+    _git(["commit", "-m", msg], repo)
+
+
+class CheckChildCheckoutsTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = TemporaryDirectory()
+        self.root = Path(self._tmp.name)  # acts as REPO_ROOT
+        self._remotes = self.root / "_remotes"
+        self._remotes.mkdir()
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def _make_child(self, name: str) -> Path:
+        """Create a child clone under REPO_ROOT, on main, in sync with its remote.
+
+        Returns the child working-clone path. A second helper clone ("_<name>")
+        is used to advance the remote independently (mirrors sync_main's tests).
+        """
+        remote = self._remotes / f"{name}.git"
+        _git(["init", "--bare", "-b", "main", str(remote)], self._remotes)
+        child = self.root / name
+        _git(["clone", str(remote), str(child)], self.root)
+        _git(["checkout", "-b", "main"], child)
+        _commit(child, "README.md", "v1\n", "init")
+        _git(["push", "-u", "origin", "main"], child)
+        return child
+
+    def _advance_remote(self, name: str) -> None:
+        """Push a new commit to a child's remote via a throwaway sibling clone."""
+        sib = self.root / f"_adv_{name}"
+        _git(["clone", str(self._remotes / f"{name}.git"), str(sib)], self.root)
+        _git(["checkout", "main"], sib)
+        _commit(sib, "README.md", "v2\n", "remote advance")
+        _git(["push", "origin", "main"], sib)
+
+    # ----- absent --------------------------------------------------------
+
+    def test_absent_child_not_flagged(self) -> None:
+        res = check_child(self.root, "noorinalabs-does-not-exist")
+        self.assertEqual(res.status, "absent")
+        self.assertFalse(res.needs_attention)
+
+    # ----- current -------------------------------------------------------
+
+    def test_current_when_on_main_clean_uptodate(self) -> None:
+        self._make_child("noorinalabs-deploy")
+        res = check_child(self.root, "noorinalabs-deploy")
+        self.assertEqual(res.status, "current")
+        self.assertEqual(res.behind, 0)
+        self.assertEqual(res.ahead, 0)
+        self.assertFalse(res.needs_attention)
+
+    # ----- stale-on-main (check) vs fast-forwarded (refresh) -------------
+
+    def test_stale_on_main_flagged_without_refresh(self) -> None:
+        child = self._make_child("noorinalabs-isnad-graph")
+        self._advance_remote("noorinalabs-isnad-graph")
+        res = check_child(self.root, "noorinalabs-isnad-graph", refresh=False)
+        self.assertEqual(res.status, "stale-on-main")
+        self.assertEqual(res.behind, 1)
+        self.assertTrue(res.needs_attention)
+        # Untouched: still on v1.
+        self.assertEqual((child / "README.md").read_text(), "v1\n")
+
+    def test_refresh_fast_forwards_clean_behind_main(self) -> None:
+        child = self._make_child("noorinalabs-isnad-graph")
+        self._advance_remote("noorinalabs-isnad-graph")
+        res = check_child(self.root, "noorinalabs-isnad-graph", refresh=True)
+        self.assertEqual(res.status, "fast-forwarded")
+        self.assertFalse(res.needs_attention)
+        # The remote commit was pulled forward.
+        self.assertEqual((child / "README.md").read_text(), "v2\n")
+
+    # ----- feature branch: flagged, never touched ------------------------
+
+    def test_stale_feature_branch_flagged_and_untouched(self) -> None:
+        child = self._make_child("noorinalabs-user-service")
+        # Park on an old feature branch, then let main advance on the remote.
+        _git(["checkout", "-b", "old/phase-3"], child)
+        self._advance_remote("noorinalabs-user-service")
+        res = check_child(self.root, "noorinalabs-user-service", refresh=True)
+        self.assertEqual(res.status, "stale-feature-branch")
+        self.assertEqual(res.branch, "old/phase-3")
+        self.assertGreaterEqual(res.behind, 1)
+        self.assertTrue(res.needs_attention)
+        # Refresh must NOT move a feature branch.
+        self.assertEqual((child / "README.md").read_text(), "v1\n")
+
+    # ----- dirty: flagged, never discards work ---------------------------
+
+    def test_dirty_while_behind_flagged_and_preserved(self) -> None:
+        child = self._make_child("noorinalabs-design-system")
+        self._advance_remote("noorinalabs-design-system")
+        (child / "README.md").write_text("uncommitted local edit\n")
+        res = check_child(self.root, "noorinalabs-design-system", refresh=True)
+        self.assertEqual(res.status, "dirty")
+        self.assertIn("README.md", res.dirty)
+        self.assertTrue(res.needs_attention)
+        # Local edit preserved — refresh refused, nothing discarded.
+        self.assertEqual((child / "README.md").read_text(), "uncommitted local edit\n")
+
+    # ----- diverged / ahead ----------------------------------------------
+
+    def test_diverged_when_local_commit_and_behind(self) -> None:
+        child = self._make_child("noorinalabs-landing-page")
+        self._advance_remote("noorinalabs-landing-page")
+        _commit(child, "local.txt", "local\n", "local-only commit")
+        res = check_child(self.root, "noorinalabs-landing-page", refresh=True)
+        self.assertEqual(res.status, "diverged")
+        self.assertGreaterEqual(res.ahead, 1)
+        self.assertGreaterEqual(res.behind, 1)
+        self.assertTrue(res.needs_attention)
+
+    def test_ahead_when_local_commit_only(self) -> None:
+        child = self._make_child("noorinalabs-data-acquisition")
+        _commit(child, "local.txt", "local\n", "local-only commit")
+        res = check_child(self.root, "noorinalabs-data-acquisition", refresh=True)
+        self.assertEqual(res.status, "ahead")
+        self.assertGreaterEqual(res.ahead, 1)
+        self.assertEqual(res.behind, 0)
+        self.assertTrue(res.needs_attention)
+
+    # ----- render + check_all + CLI --------------------------------------
+
+    def test_render_lists_flagged_block(self) -> None:
+        results = [
+            ChildStatus("noorinalabs-deploy", "current", "main", detail="ok"),
+            ChildStatus(
+                "noorinalabs-isnad-graph", "stale-on-main", "main", behind=207, detail="stale"
+            ),
+            ChildStatus("noorinalabs-absent", "absent", detail="no clone"),
+        ]
+        out = render(results)
+        self.assertIn("child-repo checkouts", out)
+        self.assertIn("FLAGGED", out)
+        self.assertIn("noorinalabs-isnad-graph", out)
+        # Absent children are not printed at all.
+        self.assertNotIn("noorinalabs-absent", out)
+        # A flagged-free render has no FLAGGED block.
+        clean = render([ChildStatus("noorinalabs-deploy", "current", "main", detail="ok")])
+        self.assertNotIn("FLAGGED", clean)
+
+    def test_render_empty_when_no_children(self) -> None:
+        self.assertIn("no child clones", render([ChildStatus("x", "absent")]))
+
+    def test_check_all_inspects_present_children(self) -> None:
+        self._make_child("noorinalabs-deploy")
+        results = check_all(self.root, children=("noorinalabs-deploy", "noorinalabs-missing"))
+        by_repo = {r.repo: r.status for r in results}
+        self.assertEqual(by_repo["noorinalabs-deploy"], "current")
+        self.assertEqual(by_repo["noorinalabs-missing"], "absent")
+
+    def test_cli_exit_zero_on_flagged_only(self) -> None:
+        # A stale-on-main child is a SAFE flagged outcome — CLI must exit 0 so a
+        # session-start caller never breaks on a "can't refresh right now" state.
+        self._make_child("noorinalabs-deploy")
+        self._advance_remote("noorinalabs-deploy")
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = cli_main([str(self.root)])
+        self.assertEqual(rc, 0)
+        self.assertIn("stale-on-main", buf.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/skills/session-start/SKILL.md
+++ b/.claude/skills/session-start/SKILL.md
@@ -67,6 +67,20 @@ if [ -f "$REPO_ROOT/.claude/lib/sync_main.py" ]; then
   python3 "$REPO_ROOT/.claude/lib/sync_main.py" "$REPO_ROOT" || true
 fi
 
+# Refresh + staleness-guard the embedded child-repo checkouts (#832) — the
+# sibling of the sync_main parent fast-forward above, for the children. The
+# parent .gitignore's its child clones and they drift badly (during p6-wave-16
+# user-service was parked on a phase-3 commit and isnad-graph sat ~207 commits
+# behind origin/main — the root cause of #816 and of any agent that reads a
+# stale child clone directly). Same safety stance as sync_main: a child that is
+# clean and on main is fast-forwarded to origin/main (--ff-only, never force);
+# a child that is dirty, diverged, or parked on an old feature branch is FLAGGED
+# for a manual decision and left untouched — there is no force-discard path.
+# Non-fatal: a flagged/refused child is a SAFE outcome and never blocks session-start.
+if [ -f "$REPO_ROOT/.claude/lib/check_child_checkouts.py" ]; then
+  python3 "$REPO_ROOT/.claude/lib/check_child_checkouts.py" "$REPO_ROOT" --refresh || true
+fi
+
 # Parent repo + the 7 canonical child repos (CLAUDE.md Repository Map).
 REPOS=("$REPO_ROOT")
 for child in \
@@ -139,6 +153,13 @@ fi
 Report how many merged worktrees were auto-removed and surface the FLAGGED
 list (locked + unmerged) to the user for a manual call. Do not force-remove a
 FLAGGED worktree without explicit confirmation.
+
+Also report the **child-repo checkout** result from `check_child_checkouts.py`
+(#832): how many child clones were fast-forwarded to `origin/main`, and surface
+its FLAGGED block (children that are dirty, diverged, or parked on an old feature
+branch — these are left untouched and need a manual call). A child sitting many
+commits behind `origin/main` is the root cause of stale on-disk child configs
+(#816) and of any agent that reads the clone directly drawing wrong conclusions.
 
 ### Step 1 — Team orientation
 
@@ -365,6 +386,7 @@ After all steps complete, present a single status block:
 | Step | Status |
 |------|--------|
 | 0. Worktree | {clean / N stale removed} |
+| 0b. Child checkouts | {N fast-forwarded / M flagged (dirty/diverged/feature-branch) / all current} |
 | 1. Team | {created fresh / error} |
 | 2. Handoff | {summary} |
 | 3. Ontology | {N dirty resolved / current} |


### PR DESCRIPTION
## What

Adds a **refresh + staleness guard** for the parent's embedded child-repo checkouts — the child-side sibling of `sync_main` (#713). Closes #832.

The parent `noorinalabs-main` checkout `.gitignore`s its child repos, which live as independent clones under `$REPO_ROOT/noorinalabs-<name>`. They drift badly: during p6-wave-16 `user-service` was parked on a phase-3 commit and `isnad-graph` sat ~207 commits behind `origin/main` — the root cause of #816 (the parent pre-push test reads the stale on-disk child configs) and of any agent that reads a child clone directly drawing wrong conclusions.

## How

New `.claude/lib/check_child_checkouts.py`, same safety stance as `sync_main`, **no force path**:

- A child that is **clean and on main** is fast-forwarded to `origin/main` under `--refresh` (the ff is delegated to `sync_main`: `--ff-only` + generated-file stash).
- A child that is **dirty, diverged, or parked on an old feature branch** is **FLAGGED** for a manual decision and left exactly as-is. Never force-discards local work.
- `behind`/`ahead` are measured `HEAD..origin/main`, so a child parked on an old feature branch still reports how far behind the mainline it really is — the staleness signal.

Wired into `/session-start` **Step 0** (`--refresh`) right after the `sync_main` parent fast-forward, with a reporting line + a new `0b. Child checkouts` row in the output table.

## Tests

`.claude/lib/tests/test_check_child_checkouts.py` — drives **real git** against throwaway temp repos. Covers every classification (`absent` / `current` / `stale-on-main` / `fast-forwarded` / `stale-feature-branch` / `dirty` / `diverged` / `ahead`), the no-force guarantees (feature branch + dirty + diverged are left untouched), `render()` FLAGGED block, and the CLI exit-0-on-flagged contract.

Local⇄CI parity green: ruff-format/lint, mypy, full lib pytest (418 passed), cspell, actionlint, and the pre-commit⇄CI sync-drift gate all pass.

## Reviewers
- Primary: **Lucas Ferreira**
- Secondary: **Aisha Idrissi**

Part of #832.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QnW8cWydBgAyT1TTrgQdis
