### PR TITLE
feat(trust): mechanical bidirectional trust scoring (#842 / §4b of #819)

### DIFF
--- a/.claude/lib/tests/test_trust_signals.py
+++ b/.claude/lib/tests/test_trust_signals.py
@@ -1,0 +1,321 @@
+"""Tests for trust_signals — per-engineer mechanical trust signals + the
+evidence-anchored scoring model (main#842, persona Option B §4b / Finding D).
+
+Covers:
+  * Extraction maps author identity (commit author) → prs_merged / ci_red /
+    rework, and reviewer identity (Requestor field) → must_fix_caught, reusing
+    wave_status.merged_prs with its no-shell list-arg-vector contract.
+  * Verdict parsing accepts bare AND bold Requestor/RequestOrReplied forms and
+    detects self-marked false-positives.
+  * score_delta is bidirectional and clamped to [-2, +2].
+  * decay drifts unsignalled scores one step toward NEUTRAL after N waves.
+  * distribution discipline reserves 5 for the top relative performer.
+  * the forced negative-signal pass bans bare "None".
+  * the performance-triggered retirement trigger fires on sustained bottom-tier
+    or repeated CI-red merges, and not before K waves of evidence.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+from unittest import mock
+
+# Helper lives at .claude/lib/trust_signals.py; this test is at
+# .claude/lib/tests/test_*.py. parent.parent reaches the lib root.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import trust_signals as ts  # noqa: E402
+import wave_status  # noqa: E402
+
+_REPOS = ["noorinalabs-isnad-graph", "noorinalabs-user-service"]
+
+
+def _verdict(requestor: str, requestee: str, verdict: str, *, bold: bool = False) -> str:
+    if bold:
+        return (
+            f"**Requestor:** {requestor}\n"
+            f"**Requestee:** {requestee}\n"
+            f"**RequestOrReplied:** {verdict}\n"
+        )
+    return f"Requestor: {requestor}\nRequestee: {requestee}\nRequestOrReplied: {verdict}\n"
+
+
+class _FakeGh:
+    """subprocess.run side_effect emulating the gh calls trust_signals makes,
+    driven by a flat PR fixture. Each PR dict carries: repo, number, sha,
+    mergedAt, commit_author, comments (list of bodies), ci_red (bool)."""
+
+    def __init__(self, prs: list[dict]) -> None:
+        self.prs = prs
+        self.calls: list[list[str]] = []
+
+    def __call__(self, cmd, *args, **kwargs):  # noqa: ANN001
+        assert isinstance(cmd, list), f"gh called with non-list cmd: {cmd!r}"
+        assert cmd[0] == "gh"
+        assert kwargs.get("shell") is not True
+        self.calls.append(cmd)
+
+        if cmd[1:3] == ["pr", "list"]:
+            repo = cmd[cmd.index("--repo") + 1].removeprefix("noorinalabs/")
+            listed = [
+                {
+                    "number": p["number"],
+                    "headRefOid": p["sha"],
+                    "mergedAt": p["mergedAt"],
+                    "author": {"login": "octocat"},
+                }
+                for p in self.prs
+                if p["repo"] == repo
+            ]
+            return SimpleNamespace(stdout=json.dumps(listed), returncode=0, stderr="")
+
+        if cmd[1:3] == ["pr", "view"]:
+            number = int(cmd[3])
+            p = next(x for x in self.prs if x["number"] == number)
+            rollup = [{"conclusion": "FAILURE"}] if p.get("ci_red") else [{"conclusion": "SUCCESS"}]
+            return SimpleNamespace(stdout=json.dumps(rollup), returncode=0, stderr="")
+
+        if cmd[1] == "api":
+            path = cmd[2]
+            parts = path.split("/")
+            if "/commits/" in path:
+                sha = parts[4]
+                name = next(p["commit_author"] for p in self.prs if p["sha"] == sha)
+                return SimpleNamespace(stdout=name + "\n", returncode=0, stderr="")
+            if path.endswith("/comments"):
+                number = int(parts[4])
+                bodies = next(p.get("comments", []) for p in self.prs if p["number"] == number)
+                return SimpleNamespace(stdout=json.dumps(bodies), returncode=0, stderr="")
+
+        raise AssertionError(f"unexpected gh call: {cmd!r}")
+
+
+def _write_status(path: Path, *, repos: list[str], wave: str) -> None:
+    path.write_text(
+        json.dumps({"current_wave": int(wave), f"wave_{wave}_repos_in_scope": repos}) + "\n",
+        encoding="utf-8",
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Verdict parsing (pure)
+# --------------------------------------------------------------------------- #
+class ParseVerdicts(unittest.TestCase):
+    def test_bare_and_bold_forms(self) -> None:
+        bodies = [
+            _verdict("Aino Virtanen", "Nadia Khoury", "ChangesRequested"),
+            _verdict("Santiago Ferreira", "Nadia Khoury", "Approved", bold=True),
+            "just a normal comment, no verdict here",
+        ]
+        verdicts = ts.parse_verdicts(bodies)
+        self.assertEqual(len(verdicts), 2)
+        self.assertEqual(verdicts[0].requestor, "Aino Virtanen")
+        self.assertEqual(verdicts[0].requestee, "Nadia Khoury")
+        self.assertEqual(verdicts[0].verdict, "ChangesRequested")
+        self.assertEqual(verdicts[1].requestor, "Santiago Ferreira")
+        self.assertEqual(verdicts[1].verdict, "Approved")
+
+    def test_false_positive_detected(self) -> None:
+        body = (
+            _verdict("Aino Virtanen", "Nadia Khoury", "ChangesRequested")
+            + "\nUpdate: this was a false-positive, withdrawing."
+        )
+        v = ts.parse_verdicts([body])[0]
+        self.assertTrue(v.false_positive)
+
+
+# --------------------------------------------------------------------------- #
+# Extraction (gh-mocked)
+# --------------------------------------------------------------------------- #
+class Extract(unittest.TestCase):
+    def _run(self, prs: list[dict]) -> dict[str, ts.Signals]:
+        fake = _FakeGh(prs)
+        with TemporaryDirectory() as td:
+            status = Path(td) / "cross-repo-status.json"
+            _write_status(status, repos=_REPOS, wave="17")
+            with mock.patch.object(wave_status.subprocess, "run", fake):
+                sigs = ts.extract_signals("6", "17", status)
+        self.fake = fake
+        return sigs
+
+    def test_author_and_reviewer_attribution(self) -> None:
+        prs = [
+            {
+                "repo": _REPOS[0],
+                "number": 901,
+                "sha": "s901",
+                "mergedAt": "2026-06-24T02:00:00Z",
+                "commit_author": "Nadia Khoury",
+                "comments": [_verdict("Aino Virtanen", "Nadia Khoury", "ChangesRequested")],
+                "ci_red": False,
+            },
+            {
+                "repo": _REPOS[1],
+                "number": 902,
+                "sha": "s902",
+                "mergedAt": "2026-06-24T03:00:00Z",
+                "commit_author": "Nadia Khoury",
+                "comments": [_verdict("Aino Virtanen", "Nadia Khoury", "Approved")],
+                "ci_red": True,
+            },
+        ]
+        sigs = self._run(prs)
+        nadia = sigs["Nadia Khoury"]
+        self.assertEqual(nadia.prs_merged, 2)
+        self.assertEqual(nadia.authored_prs, [901, 902])
+        self.assertEqual(nadia.must_fix_received, 1)
+        self.assertEqual(nadia.rework_cycles, 1)  # one PR needed a rework round
+        self.assertEqual(nadia.ci_red_merges, 1)  # PR 902 merged red
+        # Reviewer credit lands on the Requestor, not the gh principal.
+        self.assertEqual(sigs["Aino Virtanen"].must_fix_caught, 1)
+
+    def test_false_positive_dings_reviewer(self) -> None:
+        prs = [
+            {
+                "repo": _REPOS[0],
+                "number": 903,
+                "sha": "s903",
+                "mergedAt": "2026-06-24T02:00:00Z",
+                "commit_author": "Mateo Salazar",
+                "comments": [
+                    _verdict("Idris Yusuf", "Mateo Salazar", "ChangesRequested")
+                    + "\nOn reflection this finding was invalid finding — withdrawn."
+                ],
+                "ci_red": False,
+            },
+        ]
+        sigs = self._run(prs)
+        self.assertEqual(sigs["Idris Yusuf"].review_false_positives, 1)
+        self.assertEqual(sigs["Idris Yusuf"].must_fix_caught, 1)
+
+    def test_gh_calls_are_list_vectors_no_shell(self) -> None:
+        prs = [
+            {
+                "repo": _REPOS[0],
+                "number": 904,
+                "sha": "s904",
+                "mergedAt": "2026-06-24T02:00:00Z",
+                "commit_author": "Nadia Khoury",
+                "comments": [],
+                "ci_red": False,
+            }
+        ]
+        self._run(prs)
+        self.assertTrue(self.fake.calls)
+        self.assertTrue(all(isinstance(c, list) and c[0] == "gh" for c in self.fake.calls))
+
+
+# --------------------------------------------------------------------------- #
+# Scoring (pure)
+# --------------------------------------------------------------------------- #
+class ScoreDelta(unittest.TestCase):
+    def test_clean_multi_pr_plus_one(self) -> None:
+        s = ts.Signals(prs_merged=3)
+        self.assertEqual(ts.score_delta(s), 1)
+
+    def test_strong_reviewer_and_author_capped_at_two(self) -> None:
+        s = ts.Signals(prs_merged=3, must_fix_caught=4)
+        self.assertEqual(ts.score_delta(s), 2)
+
+    def test_ci_red_is_negative(self) -> None:
+        s = ts.Signals(prs_merged=2, ci_red_merges=1)
+        self.assertEqual(ts.score_delta(s), -1)
+
+    def test_false_positive_is_negative(self) -> None:
+        s = ts.Signals(prs_merged=1, must_fix_caught=3, review_false_positives=1)
+        self.assertEqual(ts.score_delta(s), -1)
+
+    def test_clamped_to_minus_two(self) -> None:
+        s = ts.Signals(prs_merged=1, ci_red_merges=5)
+        self.assertEqual(ts.score_delta(s), -2)
+
+    def test_no_signal_zero_delta(self) -> None:
+        self.assertEqual(ts.score_delta(ts.Signals()), 0)
+
+    def test_one_clean_pr_no_increase(self) -> None:
+        # A single clean PR is not "exceptional" — no bump.
+        self.assertEqual(ts.score_delta(ts.Signals(prs_merged=1)), 0)
+
+
+class Decay(unittest.TestCase):
+    def test_no_decay_before_threshold(self) -> None:
+        self.assertEqual(ts.decay(5, 2), 5)
+        self.assertEqual(ts.decay(1, 2), 1)
+
+    def test_decays_high_down(self) -> None:
+        self.assertEqual(ts.decay(5, 3), 4)
+
+    def test_decays_low_up(self) -> None:
+        self.assertEqual(ts.decay(2, 3), 3)
+
+    def test_neutral_stays(self) -> None:
+        self.assertEqual(ts.decay(3, 9), 3)
+
+
+class DistributionDiscipline(unittest.TestCase):
+    def test_five_reserved_for_top_performer(self) -> None:
+        proposals = {
+            "Top": (5, ts.Signals(prs_merged=5, must_fix_caught=3)),
+            "AlsoFive": (5, ts.Signals(prs_merged=2)),
+        }
+        out = ts.apply_distribution_discipline(proposals)
+        self.assertEqual(out["Top"], 5)
+        self.assertEqual(out["AlsoFive"], 4)  # capped — not the top performer
+
+    def test_four_passes_through(self) -> None:
+        proposals = {"X": (4, ts.Signals(prs_merged=2))}
+        self.assertEqual(ts.apply_distribution_discipline(proposals)["X"], 4)
+
+    def test_no_five_when_top_is_not_positive(self) -> None:
+        proposals = {"X": (5, ts.Signals())}
+        self.assertEqual(ts.apply_distribution_discipline(proposals)["X"], 4)
+
+
+class NegativeSignalPass(unittest.TestCase):
+    def test_clean_line_shows_numbers_not_none(self) -> None:
+        line = ts.negative_signal_line("Nadia Khoury", ts.Signals(prs_merged=2, must_fix_caught=3))
+        self.assertIn("metrics clean", line)
+        self.assertNotEqual(line.strip().lower(), "none")
+        self.assertIn("prs_merged=2", line)
+
+    def test_negative_line_cites_gap(self) -> None:
+        line = ts.negative_signal_line("X", ts.Signals(prs_merged=1, ci_red_merges=2))
+        self.assertIn("2 CI-red merge", line)
+
+    def test_validate_flags_bare_none(self) -> None:
+        lines = ["None", "- none", "N/A", "Aino: metrics clean: prs_merged=1"]
+        offenders = ts.validate_negative_signal_pass(lines)
+        self.assertEqual(len(offenders), 3)
+
+    def test_validate_clean_pass_returns_empty(self) -> None:
+        lines = ["Aino: metrics clean: prs_merged=1", "X: 1 CI-red merge(s)"]
+        self.assertEqual(ts.validate_negative_signal_pass(lines), [])
+
+
+class RetirementTrigger(unittest.TestCase):
+    def test_sustained_bottom_tier_fires(self) -> None:
+        fired, reason = ts.retirement_trigger([3, 2, 2, 1], [0, 0, 0, 0])
+        self.assertTrue(fired)
+        self.assertIn("bottom-tier", reason)
+
+    def test_repeated_ci_red_fires(self) -> None:
+        fired, reason = ts.retirement_trigger([3, 3, 3], [1, 2, 1])
+        self.assertTrue(fired)
+        self.assertIn("CI-red", reason)
+
+    def test_not_enough_history_never_fires(self) -> None:
+        fired, _ = ts.retirement_trigger([1, 1], [1, 1])
+        self.assertFalse(fired)
+
+    def test_healthy_does_not_fire(self) -> None:
+        fired, _ = ts.retirement_trigger([4, 4, 5], [0, 0, 0])
+        self.assertFalse(fired)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/lib/trust_signals.py
+++ b/.claude/lib/trust_signals.py
@@ -1,0 +1,467 @@
+#!/usr/bin/env python3
+"""Per-engineer mechanical trust signals + evidence-anchored scoring (main#842).
+
+Replaces narrative self-grading in the trust matrix with **countable** signals
+derived from the wave's merged-PR set (§4b of the persona-model Option-B work,
+parent #819 / Finding D). The trust-matrix scoring rules in
+``.claude/team/trust_matrix.md`` § Mechanical Scoring describe the same model in
+prose; this module is the executable counterpart that ``/wave-wrapup`` and
+``/wave-retro`` call so a trust delta always cites a number.
+
+Two cleanly separated layers:
+
+  * **Extraction** (gh-dependent) — :func:`extract_signals` builds a
+    ``{engineer_name: Signals}`` map from the merged-PR set. It reuses
+    :func:`wave_status.merged_prs` (so the #423 cross-window filter and the
+    no-shell / list-arg-vector contract of main#688 are inherited unchanged) and
+    parses each PR's verdict comments for the org's ``Requestor:`` /
+    ``RequestOrReplied:`` shape (the same shape Hook 4 and ``wave_status``'s
+    ChangesRequested counter read).
+
+  * **Scoring** (pure, no I/O) — :func:`score_delta`, :func:`decay`,
+    :func:`apply_distribution_discipline`, :func:`negative_signal_line`,
+    :func:`validate_negative_signal_pass`, :func:`retirement_trigger`. Every one
+    is a pure function so the model is unit-testable without touching gh.
+
+Signals per engineer (all integers, all countable from the merged-PR set):
+
+  ===========================  ============================================
+  prs_merged                   PRs merged this wave with them as commit
+                               author.
+  must_fix_received            ChangesRequested verdicts on PRs they
+                               authored (negative — author signal).
+  must_fix_caught              ChangesRequested verdicts they issued as the
+                               Requestor/reviewer (positive — review
+                               signal).
+  ci_red_merges                PRs they authored that merged with a failing
+                               required check (negative — hard ding).
+  rework_cycles                PRs they authored that needed >=1 rework
+                               round (received >=1 ChangesRequested).
+  review_false_positives       must-fix items they raised that were later
+                               marked withdrawn/false-positive (negative —
+                               review-quality signal).
+  ===========================  ============================================
+
+CLI:
+  trust_signals.py extract <P> <M> [--status PATH]    # signals as JSON
+  trust_signals.py score   <P> <M> [--status PATH]    # signals + proposed
+                                                      # deltas + forced
+                                                      # negative-signal line
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+# wave_status lives alongside this file in .claude/lib/. Running as a script puts
+# this dir on sys.path[0]; the tests add it explicitly.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import wave_status  # noqa: E402
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DEFAULT_STATUS = _REPO_ROOT / "cross-repo-status.json"
+
+# Neutral / default trust score. Decay drifts unsignalled scores back to it.
+NEUTRAL = 3
+MIN_SCORE = 1
+MAX_SCORE = 5
+
+# Decay: no trust-relevant signal for this many waves → drift one step toward
+# NEUTRAL (a 4 with nothing to say for 3 waves is no longer evidence of a 4).
+DECAY_AFTER_WAVES = 3
+
+# Retirement: sustained bottom-tier or repeated CI-red merges over K waves.
+RETIRE_AFTER_WAVES = 3
+BOTTOM_TIER = 2
+
+# A verdict comment field, e.g. ``Requestor: Aino Virtanen`` or the bold form
+# ``**Requestor:** Aino Virtanen`` (feedback_verdict_count_hook_regex). Optional
+# surrounding ``**`` on the label AND the value; value trimmed of trailing bold.
+_FIELD_RE = {
+    "requestor": re.compile(r"^\**Requestor\**:\**\s*(.+?)\**\s*$", re.MULTILINE),
+    "requestee": re.compile(r"^\**Requestee\**:\**\s*(.+?)\**\s*$", re.MULTILINE),
+    "verdict": re.compile(r"^\**RequestOrReplied\**:\**\s*(\w+)", re.MULTILINE),
+}
+
+# A verdict comment is a "false positive" when its author explicitly retracts it
+# (withdrawn / false-positive / retracted). Heuristic, deliberately conservative
+# — only a self-marked retraction counts, never an inferred one.
+_FALSE_POSITIVE_RE = re.compile(
+    r"\b(false[\s-]?positive|withdrawn|withdraw|retracted|retract|invalid finding)\b",
+    re.IGNORECASE,
+)
+
+
+@dataclass
+class Signals:
+    """Countable per-engineer signals for one wave. All fields are evidence."""
+
+    prs_merged: int = 0
+    must_fix_received: int = 0
+    must_fix_caught: int = 0
+    ci_red_merges: int = 0
+    rework_cycles: int = 0
+    review_false_positives: int = 0
+    # PR numbers the engineer authored (for the evidence citation in the line).
+    authored_prs: list[int] = field(default_factory=list)
+
+    def has_signal(self) -> bool:
+        """True if anything trust-relevant happened — drives the decay path."""
+        return any(
+            (
+                self.prs_merged,
+                self.must_fix_received,
+                self.must_fix_caught,
+                self.ci_red_merges,
+                self.rework_cycles,
+                self.review_false_positives,
+            )
+        )
+
+    def has_negative(self) -> bool:
+        return bool(self.must_fix_received or self.ci_red_merges or self.review_false_positives)
+
+
+@dataclass
+class Verdict:
+    """A parsed verdict comment: who reviewed whom, the call, and retraction."""
+
+    requestor: str | None
+    requestee: str | None
+    verdict: str | None
+    false_positive: bool
+
+
+def parse_verdicts(comment_bodies: list[str]) -> list[Verdict]:
+    """Parse the org's verdict-comment shape out of a PR's comment bodies.
+
+    Pure function — no I/O. Accepts both the bare (``Requestor: Name``) and bold
+    (``**Requestor:** Name``) forms so it matches everything Hook 4 accepts. A
+    comment with no ``RequestOrReplied`` line is not a verdict and is skipped.
+    """
+    out: list[Verdict] = []
+    for body in comment_bodies:
+        verdict_m = _FIELD_RE["verdict"].search(body)
+        if not verdict_m:
+            continue
+        req_m = _FIELD_RE["requestor"].search(body)
+        ree_m = _FIELD_RE["requestee"].search(body)
+        out.append(
+            Verdict(
+                requestor=req_m.group(1).strip() if req_m else None,
+                requestee=ree_m.group(1).strip() if ree_m else None,
+                verdict=verdict_m.group(1).strip(),
+                false_positive=bool(_FALSE_POSITIVE_RE.search(body)),
+            )
+        )
+    return out
+
+
+def _is_changes_requested(verdict: str | None) -> bool:
+    return verdict is not None and verdict.lower() == "changesrequested"
+
+
+def _pr_comment_bodies(repo: str, number: int) -> list[str]:
+    """Every issue-comment body on a PR (verdict comments live here)."""
+    raw = wave_status._run_gh(
+        [
+            "api",
+            f"repos/noorinalabs/{repo}/issues/{number}/comments",
+            "--jq",
+            "[.[].body]",
+        ]
+    )
+    parsed = json.loads(raw or "[]")
+    return [str(b) for b in parsed]
+
+
+def _pr_ci_is_red(repo: str, number: int) -> bool:
+    """True if the PR's latest status rollup carries a failing required check.
+
+    Reads ``statusCheckRollup`` at the PR head. Post-merge this reflects the
+    final state of the merged head, which is the closest mechanical proxy for
+    "merged with red CI" available after the fact (memory
+    feedback_statuscheckrollup_ci_clean — local pass != CI pass; the rollup is
+    the oracle). Treats both the checks-API ``conclusion`` and the legacy
+    commit-status ``state`` failure vocabularies as red.
+    """
+    raw = wave_status._run_gh(
+        [
+            "pr",
+            "view",
+            str(number),
+            "--repo",
+            f"noorinalabs/{repo}",
+            "--json",
+            "statusCheckRollup",
+            "--jq",
+            ".statusCheckRollup",
+        ]
+    )
+    rollup = json.loads(raw or "[]") or []
+    red = {"FAILURE", "ERROR", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED"}
+    for check in rollup:
+        status = (check.get("conclusion") or check.get("state") or "").upper()
+        if status in red:
+            return True
+    return False
+
+
+def extract_signals(phase: str, wave: str, status_path: Path) -> dict[str, Signals]:
+    """Build the ``{engineer_name: Signals}`` map for one wave.
+
+    Author identity is the head commit's author name (``commit_author_name`` from
+    :func:`wave_status.merged_prs` — the same identity the top-concentration
+    metric uses). Reviewer identity is the ``Requestor:`` field of the verdict
+    comment, because the gh principal that posts comments is the orchestrator,
+    not the reviewer (memory feedback_gh_review_self_approve_422).
+    """
+    prs = wave_status.merged_prs(phase, wave, status_path)
+    signals: dict[str, Signals] = {}
+
+    def _bucket(name: str) -> Signals:
+        return signals.setdefault(name, Signals())
+
+    for pr in prs:
+        author = pr.get("commit_author_name") or "(unknown)"
+        repo = pr["repo"]
+        number = pr["number"]
+
+        author_sig = _bucket(author)
+        author_sig.prs_merged += 1
+        author_sig.authored_prs.append(number)
+
+        if _pr_ci_is_red(repo, number):
+            author_sig.ci_red_merges += 1
+
+        verdicts = parse_verdicts(_pr_comment_bodies(repo, number))
+        pr_had_changes_requested = False
+        for v in verdicts:
+            if _is_changes_requested(v.verdict):
+                pr_had_changes_requested = True
+                author_sig.must_fix_received += 1
+                if v.requestor:
+                    _bucket(v.requestor).must_fix_caught += 1
+            if v.false_positive and v.requestor:
+                _bucket(v.requestor).review_false_positives += 1
+        if pr_had_changes_requested:
+            author_sig.rework_cycles += 1
+
+    return signals
+
+
+def score_delta(sig: Signals) -> int:
+    """Evidence-anchored, **bidirectional** trust delta for one wave.
+
+    Pure function of the countable signals — never a narrative judgement. The
+    mapping is intentionally simple and symmetric, clamped to [-2, +2] so a
+    single wave cannot swing trust across the whole scale:
+
+      negative
+        - each CI-red merge:                      -1  (hard ding)
+        - each review false-positive:             -1
+        - 3+ must-fix items received as author:   -1
+      positive (only when the wave is clean of the negatives above)
+        - 2+ PRs merged clean:                    +1
+        - 2+ must-fix items caught as reviewer:   +1
+    """
+    delta = 0
+    delta -= sig.ci_red_merges
+    delta -= sig.review_false_positives
+    if sig.must_fix_received >= 3:
+        delta -= 1
+
+    clean = not sig.has_negative()
+    if clean:
+        if sig.prs_merged >= 2:
+            delta += 1
+        if sig.must_fix_caught >= 2:
+            delta += 1
+
+    return max(-2, min(2, delta))
+
+
+def decay(old_score: int, waves_since_signal: int, *, after: int = DECAY_AFTER_WAVES) -> int:
+    """Drift an unsignalled score one step toward NEUTRAL after ``after`` waves.
+
+    No signal for N waves is itself a (weak) signal: a stale 4 or 2 is no longer
+    earned. Drifts a single step per call so decay is gradual, never a reset.
+    """
+    if waves_since_signal < after:
+        return old_score
+    if old_score > NEUTRAL:
+        return old_score - 1
+    if old_score < NEUTRAL:
+        return old_score + 1
+    return NEUTRAL
+
+
+def apply_distribution_discipline(
+    proposals: dict[str, tuple[int, Signals]],
+) -> dict[str, int]:
+    """Cap 5 to the wave's exceptional **relative** performers (distribution
+    discipline). 5 is reserved — it is not handed out for merely-clean work.
+
+    ``proposals`` maps name → (proposed_new_score, signals). A proposed 5 is
+    allowed only for the engineer(s) whose composite signal score is the wave
+    maximum AND strictly positive; every other proposed 5 is capped to 4. Scores
+    of 4 and below pass through untouched.
+    """
+
+    def composite(s: Signals) -> int:
+        # Reward output + good reviewing; penalise the negatives. Pure ranking
+        # key, not a trust score.
+        return (
+            s.prs_merged
+            + s.must_fix_caught
+            - s.must_fix_received
+            - 2 * s.ci_red_merges
+            - 2 * s.review_false_positives
+        )
+
+    if not proposals:
+        return {}
+    top = max(composite(s) for _, (_, s) in proposals.items())
+    out: dict[str, int] = {}
+    for name, (proposed, sig) in proposals.items():
+        if proposed >= MAX_SCORE and not (composite(sig) == top and top > 0):
+            out[name] = MAX_SCORE - 1
+        else:
+            out[name] = proposed
+    return out
+
+
+def negative_signal_line(name: str, sig: Signals) -> str:
+    """The forced negative-signal pass line for one engineer.
+
+    Bans the bare ``None``: every active engineer gets either a specific,
+    evidence-backed gap OR an explicit ``metrics clean: {numbers}`` statement
+    that still shows the receipts. Never returns an empty / "None" string.
+    """
+    if sig.has_negative():
+        gaps = []
+        if sig.ci_red_merges:
+            gaps.append(f"{sig.ci_red_merges} CI-red merge(s)")
+        if sig.must_fix_received:
+            gaps.append(f"{sig.must_fix_received} must-fix received")
+        if sig.review_false_positives:
+            gaps.append(f"{sig.review_false_positives} review false-positive(s)")
+        return f"{name}: " + ", ".join(gaps)
+    return (
+        f"{name}: metrics clean: prs_merged={sig.prs_merged}, "
+        f"must_fix_received=0, ci_red_merges=0, false_positives=0, "
+        f"must_fix_caught={sig.must_fix_caught}"
+    )
+
+
+# Bare-"None" detector for the forced negative-signal pass. A negative-signal
+# entry of exactly "None" / "n/a" / "-" (case-insensitive, optional bullet /
+# trailing punctuation) is the banned shape.
+_BARE_NONE_RE = re.compile(r"^\s*[-*]?\s*(none|n/?a|-+)\s*[.;]?\s*$", re.IGNORECASE)
+
+
+def validate_negative_signal_pass(lines: list[str]) -> list[str]:
+    """Return the offending lines that are a bare "None" (forced-pass violation).
+
+    Empty return == the pass is clean. Used by ``/wave-retro`` to mechanically
+    reject a retro that left a bare "None" in the negative-signal column.
+    """
+    return [ln for ln in lines if _BARE_NONE_RE.match(ln)]
+
+
+def retirement_trigger(
+    score_history: list[int],
+    ci_red_history: list[int],
+    *,
+    k: int = RETIRE_AFTER_WAVES,
+) -> tuple[bool, str]:
+    """Performance-triggered exit. Returns (should_retire, reason).
+
+    Two independent triggers over the most recent ``k`` waves (oldest→newest):
+      * sustained bottom-tier: score <= BOTTOM_TIER in each of the last k waves.
+      * repeated CI-red merges: >=1 CI-red merge in each of the last k waves.
+
+    Fewer than k waves of history never triggers — there isn't enough evidence.
+    """
+    recent_scores = score_history[-k:]
+    if len(recent_scores) >= k and all(s <= BOTTOM_TIER for s in recent_scores):
+        return True, (
+            f"sustained bottom-tier: score <= {BOTTOM_TIER} for {k} consecutive "
+            f"waves ({recent_scores})"
+        )
+    recent_ci = ci_red_history[-k:]
+    if len(recent_ci) >= k and all(c >= 1 for c in recent_ci):
+        return True, (f"repeated CI-red merges: >=1 in each of {k} consecutive waves ({recent_ci})")
+    return False, ""
+
+
+def _cmd_extract(args: argparse.Namespace) -> int:
+    sigs = extract_signals(args.phase, args.wave, args.status)
+    print(json.dumps({n: asdict(s) for n, s in sigs.items()}, indent=2, sort_keys=True))
+    return 0
+
+
+def _cmd_score(args: argparse.Namespace) -> int:
+    sigs = extract_signals(args.phase, args.wave, args.status)
+    proposals = {n: (NEUTRAL + score_delta(s), s) for n, s in sigs.items()}
+    disciplined = apply_distribution_discipline(proposals)
+    report = {
+        n: {
+            "signals": asdict(s),
+            "delta": score_delta(s),
+            "proposed_from_neutral": disciplined[n],
+            "negative_signal_line": negative_signal_line(n, s),
+        }
+        for n, s in sigs.items()
+    }
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    def _add_pm(p: argparse.ArgumentParser) -> None:
+        p.add_argument("phase", help="phase number (P)")
+        p.add_argument("wave", help="wave number (M)")
+        p.add_argument(
+            "--status",
+            type=Path,
+            default=_DEFAULT_STATUS,
+            help="path to cross-repo-status.json (default: repo-root copy)",
+        )
+
+    p_extract = sub.add_parser("extract", help="emit per-engineer signals as JSON")
+    _add_pm(p_extract)
+    p_extract.set_defaults(func=_cmd_extract)
+
+    p_score = sub.add_parser("score", help="emit signals + proposed deltas as JSON")
+    _add_pm(p_score)
+    p_score.set_defaults(func=_cmd_score)
+    return parser
+
+
+def main(argv: list[str]) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        return int(args.func(args))
+    except KeyError as exc:
+        print(f"ERROR: missing key in cross-repo-status.json: {exc}", file=sys.stderr)
+        return 1
+    except subprocess.CalledProcessError as exc:
+        print(
+            f"ERROR: gh call failed (exit {exc.returncode}): {' '.join(exc.cmd)}\n{exc.stderr}",
+            file=sys.stderr,
+        )
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.claude/skills/wave-retro/SKILL.md
+++ b/.claude/skills/wave-retro/SKILL.md
@@ -77,36 +77,62 @@ Collect:
 
 ### 4. Per-engineer assessment
 
-For each engineer who had PRs in this wave, assess:
+Per-engineer trust scoring is **mechanical and evidence-anchored** as of P6W17 (#842 / Option B §4b) — narrative self-grading is retired. Read the per-engineer signals `/wave-wrapup` Step 10.6 wrote, or re-extract them (the helper is idempotent over the same merged-PR set):
 
-- **Positive findings:** clean PRs, fast turnaround, good reviews given, helpful collaboration
-- **Negative findings:** CI failures, must-fix items from reviews, late delivery, missing tests
-- **Severity:** minor / moderate / severe (per charter § Feedback System)
+```bash
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+# Prefer the wrapup-written block; fall back to a live re-extract if absent.
+jq -e --arg m "{M}" '.["wave_" + $m + "_trust_signals"]' "$REPO_ROOT/cross-repo-status.json" \
+  || python3 "$REPO_ROOT/.claude/lib/trust_signals.py" extract {N} {M}
 
-Structure as:
+# `score` emits, per engineer: signals, the bidirectional delta, the
+# distribution-disciplined proposed score, and the forced negative-signal line.
+python3 "$REPO_ROOT/.claude/lib/trust_signals.py" score {N} {M}
+```
+
+For each engineer who had PRs in this wave, assess from the **countable signals** (`prs_merged`, `must_fix_caught`, `must_fix_received`, `ci_red_merges`, `rework_cycles`, `review_false_positives`) — not from narrative impressions:
 
 ```
 ### {Engineer Name}
 - PRs: #{N1}, #{N2}
-- CI failures: {count}
-- Must-fix items received: {count}
-- Tech-debt items created: {count}
-- Assessment: {positive/negative findings}
+- Signals: prs_merged={x}, must_fix_caught={x}, must_fix_received={x}, ci_red_merges={x}, rework_cycles={x}, review_false_positives={x}
+- Delta: {trust_signals.score_delta} (cite the signal(s) behind it)
+- Negative-signal line: {trust_signals.negative_signal_line — a specific gap OR "metrics clean: {numbers}", NEVER bare "None"}
 - Severity: {minor|moderate|severe|none}
+```
+
+**Forced negative-signal pass (banned: bare "None").** Every active engineer MUST get a `negative_signal_line` — a specific evidence-backed gap or an explicit `metrics clean: {numbers}`. Mechanically reject a bare `None` / `N/A` / `-` before continuing:
+
+```bash
+# Collect the negative-signal lines you wrote (one per engineer) into a file,
+# then validate. A non-empty result is a forced-pass violation — fix it.
+python3 - <<'PY'
+import sys
+sys.path.insert(0, ".claude/lib")
+import trust_signals
+lines = [ln.rstrip("\n") for ln in open("/tmp/negative_signal_lines.txt")]
+bad = trust_signals.validate_negative_signal_pass(lines)
+if bad:
+    print("FORCED-PASS VIOLATION (bare None banned):", bad)
+    sys.exit(1)
+print("negative-signal pass clean")
+PY
 ```
 
 ### 5. Update trust matrix
 
 **Trust matrix lives on `main`**, not a side branch. Edit `.claude/team/trust_matrix.md` directly on the retro branch so the update lands in the same retro PR as the feedback log. Do NOT use a separate worktree or push to `CEO/0000-Trust_Matrix` — that pattern (retired 2026-04-17) orphaned trust updates off-main for months.
 
-Apply directional trust changes based on wave performance:
-- Reliable delivery, clean reviews → increase trust (+1, max 5)
-- CI failures, must-fix items, broken commitments → decrease trust (-1, min 1)
-- No significant signal → no change
+Trust deltas are **mechanical** (`.claude/team/trust_matrix.md` § Mechanical Scoring, implemented in `.claude/lib/trust_signals.py`) — every row cites the countable signal behind it:
+
+- **Delta:** `new = clamp(old + score_delta(signals), 1, 5)` — bidirectional, clamped to ±2/wave. Each CI-red merge / false-positive is −1; clean multi-PR delivery or strong reviewing (`must_fix_caught ≥ 2`) is +1. A single clean PR is **not** a bump.
+- **Decay:** an engineer with no signal for 3 consecutive waves drifts one step toward 3 (`trust_signals.decay`).
+- **Distribution discipline:** 5 is reserved for the wave's top relative performer (`trust_signals.apply_distribution_discipline`) — never handed out for merely-clean work.
+- **Retirement trigger:** run `trust_signals.retirement_trigger(score_history, ci_red_history)` per engineer; if it fires (bottom-tier ≤2 or ≥1 CI-red merge in each of the last 3 waves), surface a **persona-archive recommendation** for owner confirmation — do not auto-delete.
 
 Append a new `## Phase {N} Wave {M} Trust Updates ({DATE}) — {theme}` section with:
-- A `| Rated | Old | New | Reason |` table for each relevant team grouping (e.g., `### Org-Level Team`)
-- A `### Done Well / Needs Improvement (Phase {N} Wave {M})` matrix
+- A `| Rated | Old | New | Reason |` table for each relevant team grouping (e.g., `### Org-Level Team`) — the `Reason` MUST cite the signal numbers, not prose impressions.
+- A `### Done Well / Needs Improvement (Phase {N} Wave {M})` matrix whose "Needs Improvement" column is the forced negative-signal line (no bare "None").
 
 The edit will be committed as part of the retro PR (see Step 6). Do NOT create a separate commit or PR for the trust matrix update.
 

--- a/.claude/skills/wave-wrapup/SKILL.md
+++ b/.claude/skills/wave-wrapup/SKILL.md
@@ -324,6 +324,25 @@ Optionally also write a richer `wave_{M}_summary` block with wave-shape detail (
 
 If a key cannot be computed (e.g., no PRs merged this wave), write the literal `0` — `/wave-retro` Step 2.5 distinguishes "0 cycles" from "key missing" and only the latter is treated as drift.
 
+### 10.6. Per-engineer trust signals (added P6W17 #842 — Option B §4b)
+
+The wave-level counters above describe the *wave*; the trust matrix needs the same evidence broken down **per engineer**. Extract the countable per-engineer signals from the merged-PR set so `/wave-retro` applies mechanical, evidence-anchored trust deltas instead of narrative self-grading. The signals are: `prs_merged`, `must_fix_received` (author), `must_fix_caught` (reviewer), `ci_red_merges`, `rework_cycles`, `review_false_positives`. The helper reuses `wave_status.merged_prs` (so the #423 cross-window filter and the no-shell list-arg-vector contract of main#688 carry over) and parses each PR's verdict comments for the `Requestor:` / `RequestOrReplied:` shape.
+
+```bash
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+# Per-engineer signal JSON, persisted as a single top-level key so /wave-retro
+# Step 4 reads deterministic numbers rather than re-deriving them by hand.
+SIGNALS=$(python3 "$REPO_ROOT/.claude/lib/trust_signals.py" extract {P} {M})
+python3 "$REPO_ROOT/.claude/lib/upsert_status_keys.py" "$REPO_ROOT/cross-repo-status.json" \
+    "wave_{M}_trust_signals=$SIGNALS"
+
+# Read-back verify (gh silent-no-op family) — the block must be present and parse.
+jq -e --arg m "{M}" '.["wave_" + $m + "_trust_signals"]' "$REPO_ROOT/cross-repo-status.json" >/dev/null \
+    && echo "trust signals written" || echo "ERROR: trust signals not written"
+```
+
+**Acceptance:** `wave_{M}_trust_signals` exists at top-level after wrapup, mapping each active engineer to their integer signal counts. `/wave-retro` Step 4 consumes it; if absent, retro re-extracts it directly (the helper is idempotent and reads from the same merged-PR set).
+
 ### 11. Merge to main per repo (every wave)
 
 **Every wave's wrapup merges its wave branch to main** (changed 2026-06-09 — owner directive; previously gated to the final wave only). Each repo in `wave_{M}_repos_in_scope` has its OWN `deployments/phase-{P}/wave-{M}` branch (created by `/wave-kickoff` step 1) that needs its own PR to main. This is the symmetric counterpart of the multi-repo branch creation gap (main#238). Merging each wave keeps `main` continuously current: the next wave bases off main (`/wave-start` § 3 base determination; ref cut by `/wave-kickoff` Step 1), so an unmerged wave would strand its work the moment the following wave starts.

--- a/.claude/team/trust_matrix.md
+++ b/.claude/team/trust_matrix.md
@@ -20,6 +20,49 @@ All team members maintain a trust score for every other team member they interac
 - **Updates:** This file is updated on `main` whenever a trust-relevant interaction occurs (typically during wave retros). Changes should include a brief log entry explaining the adjustment.
 - **Scope:** Trust is directional — A's trust in B may differ from B's trust in A.
 
+## Mechanical Scoring (evidence-anchored) — authoritative as of P6W17 (#842 / Option B §4b)
+
+Narrative self-grading is **retired** for the orchestrator → team direction. A trust delta is no longer "felt"; it is **derived from countable wave signals** and must cite them. The executable model lives in [`.claude/lib/trust_signals.py`](../lib/trust_signals.py) (`/wave-wrapup` extracts the signals, `/wave-retro` applies the deltas); the rules below are the human-readable contract that file implements. The five legacy scale points (1–5) and the directional semantics above are unchanged — only *how a change is justified* changes.
+
+### Per-engineer signals (countable, from the merged-PR set)
+
+Each is an integer extracted by `trust_signals.extract_signals(phase, wave)` over the wave's merged PRs (author = head-commit author name; reviewer = the verdict comment's `Requestor:` field):
+
+| Signal | Direction | Definition |
+|--------|-----------|------------|
+| `prs_merged` | + | PRs merged this wave authored by the engineer |
+| `must_fix_caught` | + | ChangesRequested verdicts the engineer issued as reviewer |
+| `must_fix_received` | − | ChangesRequested verdicts on PRs the engineer authored |
+| `ci_red_merges` | − | authored PRs that merged with a failing required check |
+| `rework_cycles` | − | authored PRs that needed ≥1 rework round |
+| `review_false_positives` | − | must-fix items the engineer raised that were later self-marked withdrawn / false-positive |
+
+### Evidence-anchored, bidirectional delta
+
+`trust_signals.score_delta(signals)` — pure, symmetric, clamped to **[−2, +2]** (one wave cannot swing trust across the whole scale):
+
+- **−1** per CI-red merge; **−1** per review false-positive; **−1** if `must_fix_received ≥ 3`.
+- **+1** if `prs_merged ≥ 2` *and* the wave is clean of the negatives above; **+1** if `must_fix_caught ≥ 2` and no false-positives.
+- A single clean PR is **not** an increase (it is baseline expected delivery, not exceptional).
+
+`new = clamp(old + delta, 1, 5)`. Every retro trust-table row MUST cite the numbers behind its delta — a row with no signal citation is rejected at review.
+
+### Decay toward neutral
+
+`trust_signals.decay(old, waves_since_signal)` — if an engineer produced **no** trust-relevant signal for **3** consecutive waves, drift the score **one step toward 3** (a stale 4 or 2 is no longer earned). Decay is gradual (one step per qualifying wave), never a reset.
+
+### Distribution discipline
+
+`trust_signals.apply_distribution_discipline(...)` — **5 is reserved** for exceptional *relative* wave performance, not handed out for merely-clean work. A proposed 5 is allowed only for the engineer(s) with the wave's top composite signal score (and that score must be strictly positive); every other proposed 5 is capped to 4.
+
+### Forced negative-signal pass (bare "None" is banned)
+
+Each retro records, **per active engineer**, either a specific evidence-backed gap **or** an explicit `metrics clean: {numbers}` line — produced by `trust_signals.negative_signal_line(name, signals)`. A bare `None` / `N/A` / `-` is a forced-pass violation; `/wave-retro` rejects it via `trust_signals.validate_negative_signal_pass(...)`.
+
+### Performance-triggered retirement
+
+`trust_signals.retirement_trigger(score_history, ci_red_history)` — a persona is flagged for archive / not-spawned when, over the most recent **3** waves, **either** the score stayed bottom-tier (≤2) every wave **or** there was ≥1 CI-red merge every wave. Fewer than 3 waves of history never triggers (insufficient evidence). The trigger is a *recommendation surfaced at retro* for owner confirmation, not an automatic deletion.
+
 ## Matrix
 
 Rows = the team member rating. Columns = the team member being rated.


### PR DESCRIPTION
## Summary

Implements **#842** (child of **#819**, persona Option B §4b / Finding D): replaces narrative trust self-grading with mechanical, bidirectional, evidence-anchored trust scoring.

Part of #842. Part of #819.

## What changed

- **`.claude/lib/trust_signals.py`** (new) — per-engineer mechanical signal extraction from the wave's merged-PR set, plus the pure scoring model:
  - Signals: `prs_merged`, `must_fix_received` (author), `must_fix_caught` (reviewer), `ci_red_merges`, `rework_cycles`, `review_false_positives`. Author identity = head-commit author; reviewer identity = the verdict comment's requestor field (gh principal is the orchestrator, not the reviewer).
  - Reuses `wave_status.merged_prs` so the #423 cross-window filter and the no-shell / list-arg-vector contract of main#688 carry over unchanged.
  - `score_delta` — bidirectional, clamped to ±2/wave; `decay` toward neutral after 3 signal-less waves; `apply_distribution_discipline` reserving 5 for the top relative performer; `negative_signal_line` + `validate_negative_signal_pass` enforcing the forced negative-signal pass (bans bare "None"); `retirement_trigger` for performance-triggered persona archive.
- **`.claude/lib/tests/test_trust_signals.py`** (new) — 27 tests: verdict parsing (bare + bold forms), author/reviewer attribution, false-positive dinging, the no-shell list-arg-vector contract, and every scoring rule + edge case.
- **`.claude/team/trust_matrix.md`** — new § Mechanical Scoring (evidence-anchored): the human-readable contract `trust_signals.py` implements.
- **`.claude/skills/wave-wrapup/SKILL.md`** — Step 10.6 extends the per-wave counters to per-engineer signals (persisted as `wave_{M}_trust_signals`).
- **`.claude/skills/wave-retro/SKILL.md`** — Steps 4/5 consume the signals: mechanical deltas, decay, distribution discipline, retirement trigger, and the forced negative-signal pass gate.

## Scope boundary

Stays within the #842 stream (scoring rules + wrapup/retro extraction). Does **not** touch the roster cards / `Learned Adjustments` section — that is the parallel #841 stream.

## Verification

- `pre-commit run --all-files` equivalent on changed files: ruff-format, ruff-lint, cspell all pass.
- Pre-push: mypy + full pytest (433 lib tests, incl. the 27 new) + sync-drift gate all green.

## Reviewers

- Primary: **Aino Virtanen**
- Secondary: **Santiago Ferreira**

## Files changed

- `.claude/lib/trust_signals.py`
- `.claude/lib/tests/test_trust_signals.py`
- `.claude/team/trust_matrix.md`
- `.claude/skills/wave-wrapup/SKILL.md`
- `.claude/skills/wave-retro/SKILL.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QnW8cWydBgAyT1TTrgQdis
