### PR TITLE
feat(wave-scope): scope-time premise-rot gate (#837)

### DIFF
--- a/.claude/lib/premise_check.py
+++ b/.claude/lib/premise_check.py
@@ -1,0 +1,487 @@
+#!/usr/bin/env python3
+"""Scope-time premise-rot gate for /wave-scope (main#837).
+
+The P6W16 retro found that two scoped issues reached *execution* on premises
+that no longer held at origin HEAD: **#705** targeted ``wave_key_reset.py`` —
+a file #804 had already deleted — and **#816**'s named root cause had been
+inverted. ``/wave-scope`` reconciled labels-vs-meta-issue but never checked that
+a scoped issue's named *file / path / symbol* still exists at the repo's origin
+HEAD. This module is the deterministic check that closes that gap: it extends
+``feedback_verify_diagnosis_before_delegating`` +
+``feedback_pre_spawn_verify_file_exists`` from *spawn* time back to *scope* time.
+
+Two-layer design (the pure core is the testable part; git I/O is injectable):
+
+  * ``extract_path_candidates(text)`` — pure. Pulls path-like tokens out of an
+    issue body (backtick code spans + a strict path regex over the full text),
+    filtered by :func:`looks_like_path` so prose never produces a false STOP.
+  * ``check_issue(issue, ref, path_checker, symbol_checker)`` — wires extraction
+    to existence checks. The two checkers are injected (default: real git) so
+    unit tests run with zero git, and the verdict logic is exercised in
+    isolation.
+  * ``git_path_status`` / ``git_symbol_status`` — the real checks:
+    ``git -C <dir> cat-file -e <ref>:<path>`` for a path,
+    ``git -C <dir> grep -q -e <symbol> <ref>`` for a symbol.
+
+Verdict policy (deterministic):
+
+  * a named path/symbol that the ref can read but does NOT contain -> ``MISSING``
+    -> issue verdict ``STOP`` (premise rot — the headline #837 signal).
+  * a ref or repo dir that cannot be read at all (child repo not cloned,
+    origin not fetched, bad ref) -> ``UNVERIFIABLE`` -> verdict ``WARN``. This is
+    deliberately NOT a STOP: a missing local checkout is an environment gap, not
+    evidence the premise rotted — a false STOP there would block scope on
+    tooling state, the opposite of the gate's purpose.
+  * everything present, or no concrete refs to check -> ``OK``.
+
+An issue may also declare explicit ``paths`` / ``symbols`` arrays (deliberate
+named premises the orchestrator wants asserted even if the body phrasing is too
+loose for auto-extraction); a symbol may be scoped to a pathspec.
+
+CLI:
+  premise_check.py check --issues ISSUES.json [--ref origin/main]
+                         [--repos-root DIR] [--warn-only] [--json]
+
+  ISSUES.json is a JSON array; each element:
+    {
+      "ref": "main#705",            # human label for reporting (required)
+      "repo": "noorinalabs-main",   # used to resolve repo_dir under repos-root
+      "body": "... `wave_key_reset.py` ...",   # auto-extracted (optional)
+      "paths": ["explicit/path.py"],           # optional explicit paths
+      "symbols": [                              # optional explicit symbols
+        {"name": "wave_key_reset", "pathspec": ".claude/lib/"}
+      ],
+      "repo_dir": "/abs/path",      # optional; overrides repos-root resolution
+      "git_ref": "origin/main"      # optional per-issue ref override
+    }
+
+Exit code: 1 if any issue verdict is STOP (unless ``--warn-only``), else 0.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# Repo root = two parents above .claude/lib/ (lib -> .claude -> root). Resolved
+# from this file so the default repos-root is correct from any cwd or worktree.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Candidate existence states.
+EXISTS = "exists"
+MISSING = "missing"
+UNVERIFIABLE = "unverifiable"
+
+# Per-issue verdicts.
+OK = "ok"
+WARN = "warn"
+STOP = "stop"
+
+# File extensions that mark a bare (slash-less) token as a path rather than
+# prose. Lower-cased; the token's suffix is compared case-insensitively.
+_CODE_EXTENSIONS = frozenset(
+    {
+        "py",
+        "pyi",
+        "md",
+        "json",
+        "jsonl",
+        "ndjson",
+        "yaml",
+        "yml",
+        "toml",
+        "ts",
+        "tsx",
+        "js",
+        "jsx",
+        "mjs",
+        "cjs",
+        "sh",
+        "bash",
+        "zsh",
+        "cfg",
+        "ini",
+        "txt",
+        "lock",
+        "sql",
+        "tf",
+        "tfvars",
+        "astro",
+        "css",
+        "scss",
+        "html",
+        "env",
+        "mk",
+        "rs",
+        "go",
+        "csv",
+        "tsv",
+    }
+)
+
+# A token that could be a path: only path-safe characters, no whitespace. The
+# stricter looks_like_path() decides whether it actually is one.
+_PATH_TOKEN_RE = re.compile(r"[\w./\-]+")
+
+# Backtick code span: ``foo`` -> foo. Non-greedy, single line.
+_BACKTICK_RE = re.compile(r"`([^`\n]+)`")
+
+
+def looks_like_path(token: str) -> bool:
+    """True when ``token`` is plausibly a repo-relative file/dir path.
+
+    Precision over recall: a false negative just means one fewer thing checked;
+    a false positive turns prose into a spurious STOP. Accepts a token only when
+    it is whitespace-free, path-character-only, and EITHER contains a ``/``
+    (directory structure) OR ends in a known code extension.
+    """
+    tok = token.strip()
+    if not tok or " " in tok or "\t" in tok:
+        return False
+    if "://" in tok:  # URL, not a path
+        return False
+    if not re.fullmatch(r"[\w./\-]+", tok):
+        return False
+    # A bare issue/anchor ref or a number is never a path.
+    if tok.lstrip("#").isdigit():
+        return False
+    if "/" in tok:
+        return True
+    ext = tok.rsplit(".", 1)[-1].lower() if "." in tok else ""
+    return ext in _CODE_EXTENSIONS
+
+
+def normalize_path(token: str) -> str:
+    """Strip decoration so a raw token becomes a git-addressable repo path.
+
+    Removes a leading ``./``, surrounding quotes/backticks, trailing sentence
+    punctuation, and a ``:line`` / ``#Lnn`` location suffix (``foo.py:42`` and
+    ``foo.py#L42`` both address ``foo.py``).
+    """
+    tok = token.strip().lstrip("`'\"")
+    # Drop a file:line / file#Lnn location suffix before trimming punctuation
+    # (so the digits aren't mistaken for a path char and the colon is removed).
+    tok = re.sub(r":\d+(-\d+)?$", "", tok)
+    tok = re.sub(r"#L\d+$", "", tok)
+    # Trailing decoration: backticks, quotes, sentence punctuation. NOT stripped
+    # from the left, where a leading `.` is meaningful (`.claude/...`, `./a`).
+    tok = tok.rstrip("`'\").,;:")
+    if tok.startswith("./"):
+        tok = tok[2:]
+    return tok
+
+
+def extract_path_candidates(text: str) -> list[str]:
+    """Path-like tokens in ``text``, de-duplicated, order-preserving.
+
+    Union of backtick code spans and a path-token regex over the full text,
+    each normalized and filtered through :func:`looks_like_path`.
+    """
+    if not text:
+        return []
+    raw: list[str] = list(_BACKTICK_RE.findall(text))
+    raw.extend(_PATH_TOKEN_RE.findall(text))
+
+    seen: set[str] = set()
+    out: list[str] = []
+    for token in raw:
+        norm = normalize_path(token)
+        if not looks_like_path(norm):
+            continue
+        if norm in seen:
+            continue
+        seen.add(norm)
+        out.append(norm)
+    return out
+
+
+# --- git I/O (the injectable, side-effecting layer) -------------------------
+
+
+def _run_git(repo_dir: str, args: list[str]) -> subprocess.CompletedProcess[str]:
+    """Run ``git -C <repo_dir> <args>`` with an explicit arg list.
+
+    Never a shell string and never ``shell=True`` — no shell means no
+    word-splitting under zsh (main#688), the contract shared across the lib.
+    """
+    return subprocess.run(  # noqa: S603 - fixed argv, no shell
+        ["git", "-C", repo_dir, *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def git_ref_exists(repo_dir: str, ref: str) -> bool:
+    """True when ``ref`` resolves in the repo at ``repo_dir``."""
+    if not Path(repo_dir).is_dir():
+        return False
+    proc = _run_git(repo_dir, ["rev-parse", "--verify", "--quiet", f"{ref}^{{commit}}"])
+    return proc.returncode == 0
+
+
+def git_path_status(repo_dir: str, ref: str, path: str) -> str:
+    """Existence of ``path`` at ``ref`` via ``git cat-file -e``.
+
+    Returns :data:`UNVERIFIABLE` when the repo dir or ref cannot be read (an
+    environment gap, never treated as premise rot), otherwise :data:`EXISTS` /
+    :data:`MISSING`.
+    """
+    if not git_ref_exists(repo_dir, ref):
+        return UNVERIFIABLE
+    proc = _run_git(repo_dir, ["cat-file", "-e", f"{ref}:{path}"])
+    return EXISTS if proc.returncode == 0 else MISSING
+
+
+def git_symbol_status(repo_dir: str, ref: str, symbol: str, pathspec: str | None = None) -> str:
+    """Presence of ``symbol`` at ``ref`` via ``git grep`` (optionally scoped).
+
+    ``git grep`` exits 0 on a match, 1 on no match, and >1 on error. The error
+    case (and an unreadable ref) degrades to :data:`UNVERIFIABLE`.
+    """
+    if not git_ref_exists(repo_dir, ref):
+        return UNVERIFIABLE
+    args = ["grep", "-I", "-q", "-F", "-e", symbol, ref]
+    if pathspec:
+        args += ["--", pathspec]
+    proc = _run_git(repo_dir, args)
+    if proc.returncode == 0:
+        return EXISTS
+    if proc.returncode == 1:
+        return MISSING
+    return UNVERIFIABLE
+
+
+# --- verdict layer (pure given the injected checkers) -----------------------
+
+# (repo_dir, ref, value) -> status
+PathChecker = Callable[[str, str, str], str]
+# (repo_dir, ref, symbol, pathspec) -> status
+SymbolChecker = Callable[[str, str, str, "str | None"], str]
+
+
+@dataclass
+class CandidateResult:
+    kind: str  # "path" | "symbol"
+    value: str
+    status: str  # EXISTS | MISSING | UNVERIFIABLE
+    pathspec: str | None = None
+
+
+@dataclass
+class IssueResult:
+    ref: str
+    repo: str
+    repo_dir: str
+    git_ref: str
+    verdict: str  # OK | WARN | STOP
+    candidates: list[CandidateResult] = field(default_factory=list)
+
+    @property
+    def missing(self) -> list[CandidateResult]:
+        return [c for c in self.candidates if c.status == MISSING]
+
+    @property
+    def unverifiable(self) -> list[CandidateResult]:
+        return [c for c in self.candidates if c.status == UNVERIFIABLE]
+
+
+def _verdict_for(candidates: list[CandidateResult]) -> str:
+    if any(c.status == MISSING for c in candidates):
+        return STOP
+    if any(c.status == UNVERIFIABLE for c in candidates):
+        return WARN
+    return OK
+
+
+def resolve_repo_dir(issue: dict, repos_root: Path) -> str:
+    """Filesystem dir for an issue's repo.
+
+    Explicit ``repo_dir`` wins. Otherwise the parent org root *is*
+    ``noorinalabs-main``; every child repo lives at ``<repos_root>/<repo>``.
+    """
+    explicit = issue.get("repo_dir")
+    if explicit:
+        return str(explicit)
+    repo = issue.get("repo") or "noorinalabs-main"
+    if repo == "noorinalabs-main":
+        return str(repos_root)
+    return str(repos_root / repo)
+
+
+def collect_candidates(issue: dict) -> list[tuple[str, str, str | None]]:
+    """Flatten an issue's premises to ``(kind, value, pathspec)`` triples.
+
+    Auto-extracted body paths + explicit ``paths`` (kind ``path``) and explicit
+    ``symbols`` (kind ``symbol``). De-duplicated on ``(kind, value, pathspec)``.
+    """
+    triples: list[tuple[str, str, str | None]] = []
+    seen: set[tuple[str, str, str | None]] = set()
+
+    def _add(kind: str, value: str, pathspec: str | None) -> None:
+        key = (kind, value, pathspec)
+        if value and key not in seen:
+            seen.add(key)
+            triples.append(key)
+
+    for p in extract_path_candidates(issue.get("body", "") or ""):
+        _add("path", p, None)
+    for p in issue.get("paths", []) or []:
+        _add("path", normalize_path(str(p)), None)
+    for sym in issue.get("symbols", []) or []:
+        if isinstance(sym, dict):
+            _add("symbol", str(sym.get("name", "")), sym.get("pathspec"))
+        else:
+            _add("symbol", str(sym), None)
+    return triples
+
+
+def check_issue(
+    issue: dict,
+    repos_root: Path,
+    default_ref: str,
+    path_checker: PathChecker = git_path_status,
+    symbol_checker: SymbolChecker = git_symbol_status,
+) -> IssueResult:
+    """Verify every named premise of one scoped issue against its repo HEAD."""
+    repo_dir = resolve_repo_dir(issue, repos_root)
+    git_ref = issue.get("git_ref") or default_ref
+    candidates: list[CandidateResult] = []
+    for kind, value, pathspec in collect_candidates(issue):
+        if kind == "path":
+            status = path_checker(repo_dir, git_ref, value)
+        else:
+            status = symbol_checker(repo_dir, git_ref, value, pathspec)
+        candidates.append(CandidateResult(kind, value, status, pathspec))
+    return IssueResult(
+        ref=str(issue.get("ref", "?")),
+        repo=str(issue.get("repo", "noorinalabs-main")),
+        repo_dir=repo_dir,
+        git_ref=git_ref,
+        verdict=_verdict_for(candidates),
+        candidates=candidates,
+    )
+
+
+def check_issues(
+    issues: list[dict],
+    repos_root: Path,
+    default_ref: str,
+    path_checker: PathChecker = git_path_status,
+    symbol_checker: SymbolChecker = git_symbol_status,
+) -> list[IssueResult]:
+    return [check_issue(i, repos_root, default_ref, path_checker, symbol_checker) for i in issues]
+
+
+# --- reporting + CLI --------------------------------------------------------
+
+_STATUS_GLYPH = {EXISTS: "ok", MISSING: "MISSING", UNVERIFIABLE: "unverifiable"}
+
+
+def render_report(results: list[IssueResult]) -> str:
+    lines: list[str] = []
+    stops = [r for r in results if r.verdict == STOP]
+    warns = [r for r in results if r.verdict == WARN]
+
+    for r in results:
+        if r.verdict == OK and not r.candidates:
+            lines.append(f"[ok]   {r.ref}: no concrete file/symbol refs to verify")
+            continue
+        tag = {OK: "ok", WARN: "WARN", STOP: "STOP"}[r.verdict]
+        lines.append(f"[{tag}] {r.ref}  ({r.repo} @ {r.git_ref})")
+        for c in r.candidates:
+            scope = f" in {c.pathspec}" if c.pathspec else ""
+            lines.append(f"    - {c.kind} `{c.value}`{scope}: {_STATUS_GLYPH[c.status]}")
+
+    lines.append("")
+    if stops:
+        lines.append(
+            f"STOP: {len(stops)} issue(s) name a file/symbol absent at origin HEAD "
+            "(premise rot). Re-scope, re-point, or close before /wave-kickoff:"
+        )
+        for r in stops:
+            refs = ", ".join(f"{c.kind} {c.value}" for c in r.missing)
+            lines.append(f"  - {r.ref}: {refs}")
+    if warns:
+        lines.append(
+            f"WARN: {len(warns)} issue(s) could not be verified "
+            "(repo not cloned / ref not fetched / unreadable). Verify manually:"
+        )
+        for r in warns:
+            refs = ", ".join(f"{c.kind} {c.value}" for c in r.unverifiable)
+            lines.append(f"  - {r.ref} ({r.repo_dir} @ {r.git_ref}): {refs}")
+    if not stops and not warns:
+        lines.append("All named files/symbols verified present at origin HEAD.")
+    return "\n".join(lines)
+
+
+def _result_to_dict(r: IssueResult) -> dict:
+    return {
+        "ref": r.ref,
+        "repo": r.repo,
+        "repo_dir": r.repo_dir,
+        "git_ref": r.git_ref,
+        "verdict": r.verdict,
+        "candidates": [
+            {"kind": c.kind, "value": c.value, "status": c.status, "pathspec": c.pathspec}
+            for c in r.candidates
+        ],
+    }
+
+
+def _cmd_check(args: argparse.Namespace) -> int:
+    issues = json.loads(Path(args.issues).read_text())
+    if not isinstance(issues, list):
+        print("ERROR: --issues must be a JSON array of issue objects", file=sys.stderr)
+        return 2
+    results = check_issues(issues, args.repos_root, args.ref)
+
+    if args.json:
+        print(json.dumps([_result_to_dict(r) for r in results], indent=2))
+    else:
+        print(render_report(results))
+
+    has_stop = any(r.verdict == STOP for r in results)
+    if has_stop and not args.warn_only:
+        return 1
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_check = sub.add_parser("check", help="verify scoped issues' named files/symbols")
+    p_check.add_argument("--issues", required=True, help="path to the issues JSON array")
+    p_check.add_argument(
+        "--ref", default="origin/main", help="git ref to check against (default origin/main)"
+    )
+    p_check.add_argument(
+        "--repos-root",
+        type=Path,
+        default=_REPO_ROOT,
+        help="root dir holding the org repos (default: this repo's root)",
+    )
+    p_check.add_argument(
+        "--warn-only",
+        action="store_true",
+        help="report STOPs but exit 0 (advisory mode)",
+    )
+    p_check.add_argument("--json", action="store_true", help="machine-readable output")
+    p_check.set_defaults(func=_cmd_check)
+    return parser
+
+
+def main(argv: list[str]) -> int:
+    args = _build_parser().parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.claude/lib/tests/test_premise_check.py
+++ b/.claude/lib/tests/test_premise_check.py
@@ -1,0 +1,314 @@
+"""Tests for premise_check — the /wave-scope premise-rot gate (main#837).
+
+Covers the three layers the module is split into:
+
+  1. Pure extraction/classification — ``looks_like_path``, ``normalize_path``,
+     ``extract_path_candidates``: prose must NOT yield candidates (no false
+     STOP), real paths and symbol-in-file refs must.
+  2. Verdict logic with INJECTED checkers (zero git): MISSING -> STOP,
+     UNVERIFIABLE -> WARN (env gap, never a STOP), all-present -> OK, and the
+     #705/#816 regression cases.
+  3. A real ``git`` integration test over a throwaway repo — proves
+     ``git cat-file -e`` / ``git grep`` are invoked correctly against a ref,
+     distinguishing a present path, a deleted path, and an unknown ref.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import subprocess
+import sys
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+# Helper lives at .claude/lib/premise_check.py; this test is at
+# .claude/lib/tests/test_*.py. parent.parent reaches the lib root.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import premise_check as pc  # noqa: E402
+
+
+class LooksLikePathTest(unittest.TestCase):
+    def test_accepts_slash_paths(self) -> None:
+        self.assertTrue(pc.looks_like_path(".claude/lib/wave_seq.py"))
+        self.assertTrue(pc.looks_like_path("ontology/repos/deploy.yaml"))
+        self.assertTrue(pc.looks_like_path(".claude/lib/"))  # directory tree
+
+    def test_accepts_bare_filename_with_known_ext(self) -> None:
+        self.assertTrue(pc.looks_like_path("wave_key_reset.py"))
+        self.assertTrue(pc.looks_like_path("CLAUDE.md"))
+
+    def test_rejects_prose_and_non_paths(self) -> None:
+        for tok in ("origin", "the", "wave-scope", "HEAD", "premise"):
+            self.assertFalse(pc.looks_like_path(tok), tok)
+
+    def test_rejects_bare_filename_unknown_ext(self) -> None:
+        # No slash and an unknown extension -> not confidently a path.
+        self.assertFalse(pc.looks_like_path("v1.2"))
+        self.assertFalse(pc.looks_like_path("e.g"))
+
+    def test_rejects_url_issue_ref_number(self) -> None:
+        self.assertFalse(pc.looks_like_path("https://example.com/a/b.py"))
+        self.assertFalse(pc.looks_like_path("#705"))
+        self.assertFalse(pc.looks_like_path("42"))
+
+    def test_rejects_whitespace(self) -> None:
+        self.assertFalse(pc.looks_like_path("a b.py"))
+
+
+class NormalizePathTest(unittest.TestCase):
+    def test_strips_backticks_and_trailing_punct(self) -> None:
+        self.assertEqual(pc.normalize_path("`foo.py`,"), "foo.py")
+        self.assertEqual(pc.normalize_path("foo.py."), "foo.py")
+
+    def test_strips_leading_dot_slash(self) -> None:
+        self.assertEqual(pc.normalize_path("./a/b.py"), "a/b.py")
+
+    def test_strips_line_and_anchor_suffix(self) -> None:
+        self.assertEqual(pc.normalize_path("a/b.py:42"), "a/b.py")
+        self.assertEqual(pc.normalize_path("a/b.py:10-20"), "a/b.py")
+        self.assertEqual(pc.normalize_path("a/b.py#L42"), "a/b.py")
+
+
+class ExtractPathCandidatesTest(unittest.TestCase):
+    def test_pulls_from_backticks_and_text(self) -> None:
+        body = (
+            "Two issues slipped: **#705** targeted the already-deleted "
+            "`wave_key_reset.py` (removed by #804), and #816 referenced "
+            "ontology/repos/deploy.yaml in passing."
+        )
+        got = pc.extract_path_candidates(body)
+        self.assertIn("wave_key_reset.py", got)
+        self.assertIn("ontology/repos/deploy.yaml", got)
+
+    def test_prose_yields_nothing(self) -> None:
+        body = "The premise no longer holds at origin HEAD; re-scope before kickoff."
+        self.assertEqual(pc.extract_path_candidates(body), [])
+
+    def test_dedup_and_order(self) -> None:
+        body = "`a/b.py` then `a/b.py` again then `c/d.md`"
+        self.assertEqual(pc.extract_path_candidates(body), ["a/b.py", "c/d.md"])
+
+    def test_empty(self) -> None:
+        self.assertEqual(pc.extract_path_candidates(""), [])
+
+
+# --- verdict layer with injected (fake) checkers ----------------------------
+
+
+def _checker(table: dict[str, str], default: str = pc.EXISTS):
+    """A path/symbol checker that looks the value up in ``table``."""
+
+    def _path(_repo_dir: str, _ref: str, value: str) -> str:
+        return table.get(value, default)
+
+    def _symbol(_repo_dir: str, _ref: str, value: str, _pathspec: str | None = None) -> str:
+        return table.get(value, default)
+
+    return _path, _symbol
+
+
+class CheckIssueVerdictTest(unittest.TestCase):
+    def _check(self, issue: dict, table: dict[str, str], default: str = pc.EXISTS):
+        path_fn, sym_fn = _checker(table, default)
+        return pc.check_issue(issue, Path("/repos"), "origin/main", path_fn, sym_fn)
+
+    def test_705_deleted_file_is_stop(self) -> None:
+        # The #705 regression: names a file that was deleted at HEAD.
+        issue = {"ref": "main#705", "body": "targets `wave_key_reset.py`"}
+        res = self._check(issue, {"wave_key_reset.py": pc.MISSING})
+        self.assertEqual(res.verdict, pc.STOP)
+        self.assertEqual([c.value for c in res.missing], ["wave_key_reset.py"])
+
+    def test_present_file_is_ok(self) -> None:
+        issue = {"ref": "main#999", "body": "touches `.claude/lib/wave_seq.py`"}
+        res = self._check(issue, {".claude/lib/wave_seq.py": pc.EXISTS})
+        self.assertEqual(res.verdict, pc.OK)
+
+    def test_unverifiable_is_warn_not_stop(self) -> None:
+        # Env gap (repo not cloned / ref not fetched) must never read as rot.
+        issue = {"ref": "deploy#1", "repo": "noorinalabs-deploy", "body": "`infra/main.tf`"}
+        res = self._check(issue, {"infra/main.tf": pc.UNVERIFIABLE})
+        self.assertEqual(res.verdict, pc.WARN)
+        self.assertEqual(len(res.unverifiable), 1)
+
+    def test_missing_dominates_unverifiable(self) -> None:
+        issue = {"ref": "main#42", "body": "`gone.py` and `maybe.py`"}
+        res = self._check(issue, {"gone.py": pc.MISSING, "maybe.py": pc.UNVERIFIABLE})
+        self.assertEqual(res.verdict, pc.STOP)
+
+    def test_no_candidates_is_ok(self) -> None:
+        issue = {"ref": "main#7", "body": "purely process; nothing concrete named"}
+        res = self._check(issue, {})
+        self.assertEqual(res.verdict, pc.OK)
+        self.assertEqual(res.candidates, [])
+
+    def test_explicit_symbol_missing_is_stop(self) -> None:
+        # The #816-shaped case: a named symbol no longer present at HEAD.
+        issue = {
+            "ref": "main#816",
+            "body": "root cause in the cspell map",
+            "symbols": [{"name": "build_cspell_map", "pathspec": ".claude/lib/"}],
+        }
+        res = self._check(issue, {"build_cspell_map": pc.MISSING})
+        self.assertEqual(res.verdict, pc.STOP)
+        self.assertEqual(res.candidates[0].kind, "symbol")
+        self.assertEqual(res.candidates[0].pathspec, ".claude/lib/")
+
+    def test_explicit_paths_merged_with_body(self) -> None:
+        issue = {
+            "ref": "main#5",
+            "body": "see `a.py`",
+            "paths": ["b/c.py"],
+        }
+        res = self._check(issue, {"a.py": pc.EXISTS, "b/c.py": pc.EXISTS})
+        self.assertEqual({c.value for c in res.candidates}, {"a.py", "b/c.py"})
+
+
+class ResolveRepoDirTest(unittest.TestCase):
+    def test_main_maps_to_root(self) -> None:
+        self.assertEqual(pc.resolve_repo_dir({"repo": "noorinalabs-main"}, Path("/r")), "/r")
+
+    def test_child_maps_under_root(self) -> None:
+        self.assertEqual(
+            pc.resolve_repo_dir({"repo": "noorinalabs-deploy"}, Path("/r")),
+            "/r/noorinalabs-deploy",
+        )
+
+    def test_explicit_repo_dir_wins(self) -> None:
+        self.assertEqual(
+            pc.resolve_repo_dir({"repo": "x", "repo_dir": "/custom"}, Path("/r")),
+            "/custom",
+        )
+
+
+class CliTest(unittest.TestCase):
+    def _run(self, issues: list[dict], extra: list[str] | None = None) -> tuple[int, str]:
+        with TemporaryDirectory() as d:
+            p = Path(d) / "issues.json"
+            p.write_text(json.dumps(issues))
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                # No real repo at /repos -> all candidates UNVERIFIABLE -> WARN,
+                # so exit 0 (a STOP requires a readable ref that lacks the path).
+                rc = pc.main(
+                    ["check", "--issues", str(p), "--repos-root", "/nonexistent", *(extra or [])]
+                )
+            return rc, buf.getvalue()
+
+    def test_warn_only_exits_zero_even_with_stop(self) -> None:
+        # Force a STOP via a real temp repo would be heavier; instead assert the
+        # --warn-only flag downgrades. Use a repo dir that resolves so the path
+        # check returns MISSING is not possible without git, so we rely on the
+        # integration test for STOP exit. Here just confirm WARN -> rc 0.
+        rc, out = self._run([{"ref": "main#1", "body": "`x/y.py`"}])
+        self.assertEqual(rc, 0)
+        self.assertIn("WARN", out)
+
+    def test_json_output_is_parseable(self) -> None:
+        rc, out = self._run([{"ref": "main#1", "body": "`x/y.py`"}], extra=["--json"])
+        self.assertEqual(rc, 0)
+        parsed = json.loads(out)
+        self.assertEqual(parsed[0]["ref"], "main#1")
+        self.assertEqual(parsed[0]["verdict"], pc.WARN)
+
+
+class GitIntegrationTest(unittest.TestCase):
+    """Real git over a throwaway repo — the only test that shells out."""
+
+    def _git(self, repo: Path, *args: str) -> None:
+        subprocess.run(
+            ["git", "-C", str(repo), *args],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    def _make_repo(self, root: Path) -> Path:
+        # The org root *is* noorinalabs-main, so resolve_repo_dir maps that repo
+        # name to repos_root itself — init the repo directly at root.
+        repo = root
+        self._git(repo, "init", "-q")
+        self._git(repo, "config", "user.email", "t@t")
+        self._git(repo, "config", "user.name", "t")
+        (repo / "kept.py").write_text("def kept_symbol():\n    return 1\n")
+        (repo / "doomed.py").write_text("x = 1\n")
+        self._git(repo, "add", "-A")
+        self._git(repo, "commit", "-q", "-m", "base")
+        # Delete doomed.py in a second commit -> absent at HEAD.
+        (repo / "doomed.py").unlink()
+        self._git(repo, "add", "-A")
+        self._git(repo, "commit", "-q", "-m", "remove doomed")
+        return repo
+
+    def test_present_deleted_and_symbol(self) -> None:
+        with TemporaryDirectory() as d:
+            root = Path(d)
+            self._make_repo(root)
+            ref = "HEAD"
+
+            issue = {
+                "ref": "main#705",
+                "repo": "noorinalabs-main",
+                "body": "needs `kept.py` and `doomed.py`",
+                "symbols": [
+                    {"name": "kept_symbol"},
+                    {"name": "vanished_symbol"},
+                ],
+            }
+            res = pc.check_issue(issue, root, ref)
+
+            statuses = {(c.kind, c.value): c.status for c in res.candidates}
+            self.assertEqual(statuses[("path", "kept.py")], pc.EXISTS)
+            self.assertEqual(statuses[("path", "doomed.py")], pc.MISSING)
+            self.assertEqual(statuses[("symbol", "kept_symbol")], pc.EXISTS)
+            self.assertEqual(statuses[("symbol", "vanished_symbol")], pc.MISSING)
+            self.assertEqual(res.verdict, pc.STOP)
+
+    def test_unknown_ref_is_unverifiable(self) -> None:
+        with TemporaryDirectory() as d:
+            root = Path(d)
+            self._make_repo(root)
+            issue = {"ref": "main#1", "repo": "noorinalabs-main", "body": "`kept.py`"}
+            res = pc.check_issue(issue, root, "origin/does-not-exist")
+            self.assertEqual(res.verdict, pc.WARN)
+            self.assertEqual(res.candidates[0].status, pc.UNVERIFIABLE)
+
+    def test_cli_stop_exit_code_over_real_repo(self) -> None:
+        with TemporaryDirectory() as d:
+            root = Path(d)
+            self._make_repo(root)
+            issues = [{"ref": "main#705", "repo": "noorinalabs-main", "body": "`doomed.py`"}]
+            p = root / "issues.json"
+            p.write_text(json.dumps(issues))
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = pc.main(
+                    ["check", "--issues", str(p), "--repos-root", str(root), "--ref", "HEAD"]
+                )
+            self.assertEqual(rc, 1)
+            self.assertIn("STOP", buf.getvalue())
+
+            # --warn-only downgrades the same input to exit 0.
+            buf2 = io.StringIO()
+            with redirect_stdout(buf2):
+                rc2 = pc.main(
+                    [
+                        "check",
+                        "--issues",
+                        str(p),
+                        "--repos-root",
+                        str(root),
+                        "--ref",
+                        "HEAD",
+                        "--warn-only",
+                    ]
+                )
+            self.assertEqual(rc2, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/skills/wave-scope/SKILL.md
+++ b/.claude/skills/wave-scope/SKILL.md
@@ -251,6 +251,69 @@ Per-item body excerpt:
 gh issue view {N} --repo "noorinalabs/{repo}" --json body --jq '.body | .[0:80]'
 ```
 
+### 6.5. Premise-rot gate — verify named files/symbols exist at origin HEAD (#837)
+
+P6W16 shipped two issues to execution on **rotted premises**: #705 targeted
+`wave_key_reset.py`, a file #804 had already deleted, and #816's named root cause
+was inverted. `/wave-scope` reconciled labels-vs-meta but never asserted that a
+scoped issue's named *file / path / symbol* still exists at origin HEAD. This
+gate closes that — it is the scope-time twin of [[feedback_pre_spawn_verify_file_exists]]
+(spawn-time) and [[feedback_verify_diagnosis_before_delegating]].
+
+The deterministic check is `.claude/lib/premise_check.py`. It auto-extracts
+path-like tokens from each in-scope issue's body (backtick spans + a strict path
+regex, so prose never produces a false STOP), then runs `git cat-file -e
+<ref>:<path>` per path (and `git grep` per explicitly-declared symbol) against
+the repo's origin HEAD. Verdicts: a path/symbol the ref can read but does not
+contain → **STOP** (premise rot); a repo/ref that cannot be read at all (child
+not cloned, origin not fetched) → **WARN** (an environment gap, deliberately not
+a STOP); everything present → **OK**.
+
+Run it over the actual labeled scope (Step 4 output). Fetch each in-scope repo's
+`origin` first so the check resolves against real HEADs (an unfetched repo only
+downgrades to WARN, never a false STOP):
+
+```bash
+PREMISE_CHECK="$REPO_ROOT/.claude/lib/premise_check.py"
+PREMISE_ROWS="/tmp/wavescope-{M}-premise-rows.jsonl"
+PREMISE_INPUT="/tmp/wavescope-{M}-premise-issues.json"
+
+# Best-effort fetch of every in-scope repo so origin/main resolves locally.
+for repo in "${REPOS[@]}"; do
+    dir="$REPO_ROOT"
+    [ "$repo" != "noorinalabs-main" ] && dir="$REPO_ROOT/$repo"
+    [ -d "$dir/.git" ] && git -C "$dir" fetch -q origin 2>/dev/null || true
+done
+
+# Build the issues JSON from the actual labeled set (repo#N\ttitle\tcreatedAt).
+: > "$PREMISE_ROWS"
+while IFS="$(printf '\t')" read -r ref title created; do
+    [ -z "$ref" ] && continue
+    repo="${ref%%#*}"
+    num="${ref##*#}"
+    body=$(gh issue view "$num" --repo "noorinalabs/$repo" --json body --jq '.body' 2>/dev/null || true)
+    jq -nc --arg ref "$ref" --arg repo "$repo" --arg body "$body" \
+        '{ref:$ref, repo:$repo, body:$body}' >> "$PREMISE_ROWS"
+done < /tmp/wavescope-{M}-actual-issues.txt
+jq -s '.' "$PREMISE_ROWS" > "$PREMISE_INPUT"
+
+python3 "$PREMISE_CHECK" check --issues "$PREMISE_INPUT" --ref origin/main
+PREMISE_RC=$?
+if [ "$PREMISE_RC" -ne 0 ]; then
+    echo "STOP: premise-rot detected (see above). For each flagged issue, either"
+    echo "  re-point it to the current file/symbol, re-scope it, or close it,"
+    echo "  BEFORE collecting dispositions (Step 7). Re-run /wave-scope after."
+    exit 1
+fi
+```
+
+WARN-level rows (unverifiable) are surfaced but do not block; verify those
+manually when the named repo could not be read. To declare a concrete symbol (or
+a path the body phrasing is too loose to auto-extract) add explicit `paths` /
+`symbols` arrays to that issue's row before the `jq -s` merge — see the module
+docstring for the per-issue shape. `--warn-only` downgrades a STOP to advisory
+for a dry run, but the gate is a hard STOP by default.
+
 ### 7. Collect dispositions per item (manual — owner judgment)
 
 For each unscoped item, the owner picks one of:


### PR DESCRIPTION
## Summary

Adds a **scope-time premise-rot gate** to `/wave-scope`, closing the gap the
P6W16 retro found: #705 reached execution targeting `wave_key_reset.py` (a file
#804 had already deleted) and #816's named root cause was inverted. `/wave-scope`
reconciled labels-vs-meta-issue but never asserted that a scoped issue's named
file/path/symbol still exists at origin HEAD.

Closes #837.

## What changed

- **`.claude/lib/premise_check.py`** — deterministic, dependency-injected helper.
  - Pure layer: `extract_path_candidates` pulls path-like tokens from an issue
    body (backtick spans + strict path regex), filtered so prose never yields a
    false STOP.
  - git layer: `git cat-file -e <ref>:<path>` per path, `git grep` per
    explicitly-declared symbol, against origin HEAD.
  - Verdicts: named-but-absent -> **STOP** (premise rot); unreadable repo/ref
    (child not cloned / origin not fetched) -> **WARN** (environment gap,
    deliberately never a STOP); present/none -> **OK**.
  - CLI: `premise_check.py check --issues ISSUES.json [--ref origin/main]
    [--repos-root DIR] [--warn-only] [--json]`. Exit 1 on any STOP.
- **`.claude/skills/wave-scope/SKILL.md`** — new **Step 6.5** between drift
  (Step 6) and dispositions (Step 7): builds the issues JSON from the actual
  labeled set, best-effort fetches each in-scope repo, hard-STOPs before
  dispositions if a named premise rotted. zsh-safe, statically-analyzable bash
  (temp-file redirects, no process substitution — per #839).
- **`.claude/lib/tests/test_premise_check.py`** — 28 tests: pure
  extraction/normalization, injected-checker verdict matrix (incl. #705/#816
  regression shapes), and a real-git integration test over a throwaway repo
  (present path, deleted path, missing symbol, unknown ref).

Extends `feedback_pre_spawn_verify_file_exists` (spawn-time) and
`feedback_verify_diagnosis_before_delegating` to *scope* time.

## Verification

- `pre-commit run --all-files` and `--hook-stage pre-push` both green
  (ruff-format, ruff-lint, actionlint, cspell, mypy, pytest, sync-drift gate).
- End-to-end smoke against this repo's `origin/main` correctly flagged the #705
  deleted file as MISSING -> STOP, and prose-only issues as OK.

## Reviewers

- Santiago Ferreira (primary)
- Aino Virtanen (secondary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QnW8cWydBgAyT1TTrgQdis
