### PR TITLE
fix(annunaki): rc=0 stdout-pattern precision + hook attribution (#835)

### DIFF
--- a/.claude/hooks/annunaki_monitor.py
+++ b/.claude/hooks/annunaki_monitor.py
@@ -32,6 +32,22 @@ Input Language:
                      genuine-error count by annunaki_parse, but retained for
                      forensics; a STRONG masked-failure signal (e.g. a `git
                      push | tail` REJECTED push) stays "high" and counted.
+  rc=0 precision (#835): every logged record also carries a `hook` field
+                     (always "annunaki_monitor" for command-failure captures,
+                     so the /annunaki breakdown stops bucketing them as
+                     "unknown") and a `category` triage label. The P6W16 retro
+                     found 85% of captures were exit-0 stdout-pattern matches
+                     (a pytest `FAILED` line surfacing through `… | tail`
+                     rc-masking, or benign demo output containing the literal)
+                     that #729's recall-preserving default tagged "high" and
+                     counted. #835 demotes that residual class — exit-0,
+                     stdout-only, NOT a STRONG masked-failure signal, NOT
+                     positively-recognized echoed content — to
+                     `confidence="low"` + `category="pipe-mask-suspect"`:
+                     retained for forensics and specifically triageable, but
+                     excluded from the count. The genuine exit-0-failure
+                     carve-out (STRONG masked-failure) stays "high"/counted as
+                     `category="masked-failure"`.
 
 Exit codes:
   0 — always (advisory hook, never blocks)
@@ -49,6 +65,26 @@ from annunaki_log import append_jsonl_record
 # Where we log errors — JSONL for easy dedup and processing
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 ERRORS_FILE = REPO_ROOT / ".claude" / "annunaki" / "errors.jsonl"
+
+# Hook attribution (#835): command-failure captures from this monitor carry a
+# `hook` field so /annunaki's `rec.get("hook", "unknown")` breakdown attributes
+# them to the monitor instead of bucketing them all as "unknown". The pretooluse
+# / posttooluse records written by annunaki_log set `hook` to the blocking hook
+# name; this is the analogous attribution for the auto-capture path.
+MONITOR_HOOK_NAME = "annunaki_monitor"
+
+# Triage categories (#835) — a coarse classification of WHY a record was logged,
+# orthogonal to `confidence`. Lets /annunaki-attack triage by class (e.g. batch-
+# dismiss `pipe-mask-suspect`, prioritize `masked-failure`) instead of re-deriving
+# it from the raw fields. `confidence` decides COUNTING; `category` describes KIND.
+CATEGORY_NONZERO_EXIT = "nonzero-exit"  # exit_code != 0 — hard failure (high)
+CATEGORY_STDERR_MATCH = "stderr-match"  # stderr pattern matched (high)
+CATEGORY_MASKED_FAILURE = "masked-failure"  # STRONG exit-0 masked failure (high)
+CATEGORY_ECHOED_CONTENT = "echoed-content"  # #729 displayed source/body (low)
+# The dominant P6W16 false-positive class: exit-0, stdout-only, no strong signal,
+# not positively-recognized echoed content — e.g. a pytest `FAILED` surfacing
+# through `… | tail` rc-masking, or benign demo output. Retained but NOT counted.
+CATEGORY_PIPE_MASK_SUSPECT = "pipe-mask-suspect"
 
 # Session-level dedup: skip errors we've already logged this session
 _seen_hashes: set = set()
@@ -411,27 +447,44 @@ def _is_echoed_content(command: str, error_lines: list[str]) -> bool:
 
 def _classify_confidence(
     command: str, exit_code: int, matched_patterns: list[str], error_lines: list[str]
-) -> str:
-    """Return "high" or "low" confidence for a logged error record (#729).
+) -> tuple[str, str]:
+    """Return (confidence, category) for a logged error record (#729, #835).
 
-    "high" — a non-zero exit, a stderr-pattern match, or an exit-0 stdout match
-             carrying a STRONG masked-failure signal (the genuine exit-0-failure
-             carve-out, e.g. `git push | tail` masking a REJECTED push).
-    "low"  — exit-0, stdout-only, no strong signal, and the matched line is
-             positively recognized as echoed content.
+    `confidence` ∈ {"high", "low"} decides whether annunaki_parse COUNTS the
+    record as a genuine error. `category` (#835) is a coarse triage label for
+    WHY it was logged. The branches, in precedence order:
 
-    An exit-0 stdout match not recognized as echoed stays "high": only display
-    we can positively recognize is demoted, never an unclassified failure.
+      nonzero-exit     — exit_code != 0                          → high
+      stderr-match     — a stderr-pattern match                  → high
+      masked-failure   — exit-0 stdout match with a STRONG       → high
+                         masked-failure signal (the genuine
+                         exit-0-failure carve-out, e.g. a
+                         `git push | tail` masking a REJECTED push)
+      echoed-content   — exit-0 stdout match positively          → low
+                         recognized as displayed source/body (#729)
+      pipe-mask-suspect — exit-0, stdout-only, no strong signal,  → low
+                         not recognized as echoed (#835). This is the
+                         dominant P6W16 false-positive class (a pytest
+                         `FAILED` surfacing through `… | tail` rc-masking,
+                         or benign demo output containing the literal).
+
+    #835 supersedes #729's recall-preserving "unrecognized exit-0 stdout match
+    defaults high" policy: the P6W16 retro measured that class at 85% false
+    positive, so it is now demoted to low/pipe-mask-suspect — retained in the
+    log for forensics (and specifically triageable by category) but excluded
+    from the genuine-error count. Recall is preserved for any RECOGNIZABLE
+    failure signal: a non-zero exit, a stderr pattern, or a STRONG masked-
+    failure phrase all still count.
     """
     if exit_code and exit_code != 0:
-        return "high"
+        return "high", CATEGORY_NONZERO_EXIT
     if any(p.startswith("stderr:") for p in matched_patterns):
-        return "high"
+        return "high", CATEGORY_STDERR_MATCH
     if STRONG_MASKED_FAILURE.search("\n".join(error_lines)):
-        return "high"
+        return "high", CATEGORY_MASKED_FAILURE
     if _is_echoed_content(command, error_lines):
-        return "low"
-    return "high"
+        return "low", CATEGORY_ECHOED_CONTENT
+    return "low", CATEGORY_PIPE_MASK_SUSPECT
 
 
 def check(input_data: dict) -> dict | None:
@@ -513,10 +566,12 @@ def check(input_data: dict) -> dict | None:
 
     error_lines = _extract_error_lines(combined_output)
 
-    # #729 confidence tag: exit-0 stdout-only matches that are echoed content
-    # (displayed source/body) are low-confidence; the reader excludes them from
-    # the genuine-error count but keeps every record for forensics.
-    confidence = _classify_confidence(command, exit_code, matched_patterns, error_lines)
+    # #729/#835 confidence + category tag: exit-0 stdout-only matches that are
+    # echoed content (displayed source/body, #729) OR an unrecognized rc=0
+    # stdout match (the P6W16 pipe-mask-suspect class, #835) are low-confidence;
+    # the reader excludes them from the genuine-error count but keeps every
+    # record for forensics. The category labels WHY each was logged.
+    confidence, category = _classify_confidence(command, exit_code, matched_patterns, error_lines)
 
     dedup_input = command[:200] + "|||" + "\n".join(error_lines)[:500]
     dedup_hash = hashlib.md5(dedup_input.encode("utf-8")).hexdigest()
@@ -526,10 +581,14 @@ def check(input_data: dict) -> dict | None:
 
     record = {
         "timestamp": datetime.now(timezone.utc).isoformat(),
+        # #835: attribute the capture to this monitor so /annunaki's by-hook
+        # breakdown stops bucketing command-failure records as "unknown".
+        "hook": MONITOR_HOOK_NAME,
         "command": command[:500],
         "exit_code": exit_code,
         "matched_patterns": matched_patterns[:5],
         "confidence": confidence,
+        "category": category,
         "error_lines": error_lines,
         "stderr_excerpt": stderr[:300] if stderr else "",
         "_dedup_hash": dedup_hash,
@@ -537,7 +596,12 @@ def check(input_data: dict) -> dict | None:
 
     append_jsonl_record(ERRORS_FILE, record)
 
-    return {"action": "logged", "dedup_hash": dedup_hash, "confidence": confidence}
+    return {
+        "action": "logged",
+        "dedup_hash": dedup_hash,
+        "confidence": confidence,
+        "category": category,
+    }
 
 
 def main() -> None:

--- a/.claude/hooks/tests/test_annunaki_monitor.py
+++ b/.claude/hooks/tests/test_annunaki_monitor.py
@@ -20,10 +20,13 @@ from pathlib import Path
 
 _HERE = Path(__file__).resolve().parent
 _HOOKS_DIR = _HERE.parent
+_LIB_DIR = _HOOKS_DIR.parent / "lib"
 sys.path.insert(0, str(_HOOKS_DIR))
+sys.path.insert(0, str(_LIB_DIR))
 
 import annunaki_log as alog  # noqa: E402
 import annunaki_monitor as am  # noqa: E402
+import annunaki_parse as ap  # noqa: E402
 
 
 def _bash_event(command: str, stdout: str = "", stderr: str = "", exit_code: int = 0) -> dict:
@@ -458,15 +461,20 @@ class ConfidenceTaggingTests(unittest.TestCase):
         )
         self.assertEqual(rec["confidence"], "high")
 
-    def test_unrecognized_exit_zero_match_defaults_high(self):
-        """An exit-0 stdout match we cannot positively recognize as echoed
-        stays high — the precision pass never silences an unclassified error."""
-        rec, _ = self._logged(
+    def test_unrecognized_exit_zero_match_demoted_pipe_mask_suspect(self):
+        """#835 supersedes the #729 default-high policy for this class: an
+        exit-0 stdout-only match with no STRONG masked-failure signal that the
+        monitor cannot positively recognize as echoed content is now demoted to
+        low/pipe-mask-suspect. The P6W16 retro measured this class at 85% false
+        positive; it is retained for forensics but excluded from the count."""
+        rec, result = self._logged(
             command="deploy.sh | tee /tmp/log",
             stdout="error while interpolating services.grafana.environment: required\n",
             exit_code=0,
         )
-        self.assertEqual(rec["confidence"], "high")
+        self.assertEqual(rec["confidence"], "low")
+        self.assertEqual(rec["category"], "pipe-mask-suspect")
+        self.assertEqual(result["category"], "pipe-mask-suspect")
 
 
 class AinoFollowupTests(unittest.TestCase):
@@ -1188,6 +1196,149 @@ class ContentDisplayTests(unittest.TestCase):
                 matched_patterns=["stdout:Traceback \\(most recent call last\\)"],
             )
         )
+
+
+class Rc0PrecisionTests(unittest.TestCase):
+    """#835: rc=0 stdout-pattern precision + hook attribution.
+
+    The P6W16 retro found 85% of captures were exit-0 stdout-pattern matches
+    (a pytest `FAILED` line surfacing through `… | tail` rc-masking, or benign
+    demo output) that #729's recall-preserving default tagged "high" and
+    counted, logged with no `hook` field so they bucketed as "unknown". This
+    suite covers the two headline cases the issue requires:
+      (a) the rc=0 false-positive class → low / pipe-mask-suspect (not counted);
+      (b) the genuine nonzero-rc capture → high / nonzero-exit (still counted);
+    plus the `hook` field population that fixes the /annunaki breakdown.
+    """
+
+    def setUp(self):
+        self._saved_env = {
+            "ENVIRONMENT": os.environ.pop("ENVIRONMENT", None),
+            "NOORIN_HOOK_TEST_MODE": os.environ.pop("NOORIN_HOOK_TEST_MODE", None),
+        }
+        am._seen_hashes.clear()
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self._errors_path = Path(self._tmpdir.name) / "errors.jsonl"
+        self._orig_monitor_file = am.ERRORS_FILE
+        self._orig_log_file = alog.ERRORS_FILE
+        am.ERRORS_FILE = self._errors_path
+        alog.ERRORS_FILE = self._errors_path
+
+    def tearDown(self):
+        am.ERRORS_FILE = self._orig_monitor_file
+        alog.ERRORS_FILE = self._orig_log_file
+        self._tmpdir.cleanup()
+        for k, v in self._saved_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def _logged(self, **kw):
+        result = am.check(_bash_event(**kw))
+        self.assertIsNotNone(result, "expected the command to be logged")
+        return _read_records(self._errors_path)[0], result
+
+    # --- (a) HEADLINE rc=0 false-positive: pytest FAILED via `| tail` ---
+
+    def test_pytest_failed_rc0_via_tail_is_pipe_mask_suspect(self):
+        """The dominant P6W16 false-positive: `pytest … | tail` exits 0 (tail's
+        rc) while a `FAILED` line surfaces on stdout. No STRONG masked-failure
+        signal, not echoed → demoted to low / pipe-mask-suspect. Still LOGGED
+        (retained for forensics), but excluded from the genuine-error count."""
+        rec, result = self._logged(
+            command="python3 -m pytest tests/ 2>&1 | tail -20",
+            stdout="FAILED tests/test_x.py::test_one\nFAILED tests/test_x.py::test_two\n",
+            exit_code=0,
+        )
+        self.assertEqual(rec["exit_code"], 0)
+        self.assertEqual(rec["confidence"], "low")
+        self.assertEqual(rec["category"], "pipe-mask-suspect")
+        self.assertEqual(result["category"], "pipe-mask-suspect")
+
+    def test_benign_demo_output_with_failed_literal_is_pipe_mask_suspect(self):
+        """Benign demo/probe output that merely contains the literal `FAILED`
+        at exit 0 → pipe-mask-suspect, not a counted error."""
+        rec, _ = self._logged(
+            command="./demo_runner.sh",
+            stdout="check 1 OK\nFAILED would be printed here on error\ncheck 2 OK\n",
+            exit_code=0,
+        )
+        self.assertEqual(rec["confidence"], "low")
+        self.assertEqual(rec["category"], "pipe-mask-suspect")
+
+    def test_pipe_mask_suspect_excluded_from_genuine_count(self):
+        """End-to-end: a pipe-mask-suspect record is excluded from the
+        annunaki_parse genuine-error count (it is confidence=low), while a
+        genuine nonzero-rc failure in the same log IS counted."""
+        am.check(
+            _bash_event(
+                "python3 -m pytest 2>&1 | tail -5",
+                stdout="FAILED tests/test_x.py::test_one\n",
+                exit_code=0,
+            )
+        )
+        am.check(_bash_event("false", exit_code=1))  # genuine nonzero-rc
+
+        all_records = _read_records(self._errors_path)
+        self.assertEqual(len(all_records), 2, "both records are logged/retained")
+        self.assertEqual(
+            ap.count_errors(self._errors_path),
+            1,
+            "only the genuine nonzero-rc failure counts; the suspect is excluded",
+        )
+        suspects = [r for r in all_records if ap.is_pipe_mask_suspect(r)]
+        self.assertEqual(len(suspects), 1)
+        self.assertEqual(suspects[0]["exit_code"], 0)
+
+    # --- (b) genuine nonzero-rc capture is unchanged (counted, high) ---
+
+    def test_genuine_nonzero_rc_capture_high_and_counted(self):
+        """A real nonzero-rc failure stays high / nonzero-exit → counted. The
+        rc=0 precision pass must not weaken genuine-failure capture."""
+        rec, _ = self._logged(
+            command="python3 -m pytest tests/",
+            stdout="FAILED tests/test_x.py::test_one\n",
+            exit_code=1,
+        )
+        self.assertEqual(rec["exit_code"], 1)
+        self.assertEqual(rec["confidence"], "high")
+        self.assertEqual(rec["category"], "nonzero-exit")
+
+    def test_strong_masked_failure_rc0_stays_high_masked_failure(self):
+        """The genuine exit-0-failure carve-out is preserved: a `git push |
+        tail` masking a REJECTED push (STRONG signal) stays high and is now
+        labeled category=masked-failure — flagged, not hidden (issue point 3)."""
+        rec, _ = self._logged(
+            command="git push origin N.Hakim/x 2>&1 | tail -3",
+            stdout=(
+                " ! [rejected]        N.Hakim/x -> N.Hakim/x (non-fast-forward)\n"
+                "error: failed to push some refs\n"
+            ),
+            exit_code=0,
+        )
+        self.assertEqual(rec["confidence"], "high")
+        self.assertEqual(rec["category"], "masked-failure")
+
+    # --- hook field population (fixes the /annunaki "unknown" bucket) ---
+
+    def test_hook_field_populated_on_command_failure_record(self):
+        """#835: every monitor capture carries hook=annunaki_monitor so the
+        /annunaki by-hook breakdown (rec.get("hook", "unknown")) stops
+        attributing them all to "unknown"."""
+        rec, _ = self._logged(command="false", exit_code=1)
+        self.assertEqual(rec["hook"], am.MONITOR_HOOK_NAME)
+        self.assertEqual(rec["hook"], "annunaki_monitor")
+
+    def test_hook_field_present_on_suspect_record_too(self):
+        """The hook field is set regardless of confidence/category — a suspect
+        record is still attributed to the monitor, not "unknown"."""
+        rec, _ = self._logged(
+            command="python3 -m pytest 2>&1 | tail",
+            stdout="FAILED tests/test_x.py::test_one\n",
+            exit_code=0,
+        )
+        self.assertEqual(rec["hook"], "annunaki_monitor")
 
 
 if __name__ == "__main__":

--- a/.claude/lib/annunaki_parse.py
+++ b/.claude/lib/annunaki_parse.py
@@ -27,6 +27,15 @@ retained in the log for forensics (pass `include_low_confidence=True`). The
 genuine exit-0-failure carve-out (a `git push | tail` masking a REJECTED push)
 is tagged `confidence: "high"` by the monitor and so is still counted.
 
+#835 widens the low-confidence class (same reader machinery, no change here) to
+include the `category: "pipe-mask-suspect"` records — exit-0 stdout-only matches
+with no STRONG masked-failure signal that are NOT positively recognized as
+echoed content (e.g. a pytest `FAILED` surfacing through `… | tail` rc-masking,
+or benign demo output). The P6W16 retro measured that class at 85% false
+positive, so the monitor now tags it `confidence: "low"`; it is excluded from
+the count by the existing low-confidence filter and retained for forensics. The
+`is_pipe_mask_suspect` helper lets callers triage that sub-class specifically.
+
 Exit codes (CLI):
     0 — always (this is a read-only summarizer; it never fails the caller)
 """
@@ -104,12 +113,27 @@ def is_trace(record: dict) -> bool:
 
 
 def is_low_confidence(record: dict) -> bool:
-    """True iff `record` is the #729 exit-0 echoed-output low-confidence class.
+    """True iff `record` is a low-confidence class (#729 echoed-output OR #835
+    pipe-mask-suspect).
 
     These are retained in the log for forensics but excluded from the
     genuine-error count by `iter_records`/`count_errors`.
     """
     return record.get("confidence") == "low"
+
+
+def is_pipe_mask_suspect(record: dict) -> bool:
+    """True iff `record` is the #835 exit-0 pipe-mask-suspect class.
+
+    A subset of the low-confidence records: an exit-0 stdout-only match with no
+    STRONG masked-failure signal that the monitor could not positively classify
+    as echoed content (e.g. a pytest `FAILED` surfacing through `… | tail`
+    rc-masking, or benign demo output). Excluded from the genuine-error count
+    like all low-confidence records; this helper lets `/annunaki-attack` triage
+    the suspect sub-class specifically (e.g. batch-dismiss, or promote a true
+    masked failure that slipped through).
+    """
+    return record.get("category") == "pipe-mask-suspect"
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/.claude/lib/tests/test_annunaki_parse.py
+++ b/.claude/lib/tests/test_annunaki_parse.py
@@ -26,6 +26,7 @@ from annunaki_parse import (  # noqa: E402
     TRACE_RECORD_TYPES,
     count_errors,
     is_low_confidence,
+    is_pipe_mask_suspect,
     is_trace,
     iter_records,
     main,
@@ -175,6 +176,60 @@ class LowConfidenceFilter(unittest.TestCase):
             p = Path(td) / "errors.jsonl"
             self._write(p)
             self.assertEqual(main([str(p), "--include-low-confidence"]), 0)
+
+
+# #835: the pipe-mask-suspect class — exit-0 stdout-only matches with no STRONG
+# masked-failure signal, not recognized as echoed (e.g. a pytest `FAILED`
+# surfacing through `… | tail` rc-masking). The monitor tags these
+# confidence="low" so the existing low-confidence filter excludes them from the
+# count; `category="pipe-mask-suspect"` lets callers triage the sub-class.
+_PIPE_MASK_SUSPECT = {
+    "timestamp": "t",
+    "hook": "annunaki_monitor",
+    "command": "python3 -m pytest 2>&1 | tail",
+    "exit_code": 0,
+    "matched_patterns": ["stdout:^FAILED"],
+    "confidence": "low",
+    "category": "pipe-mask-suspect",
+}
+
+
+class PipeMaskSuspectFilter(unittest.TestCase):
+    def _write(self, path: Path) -> None:
+        lines = [
+            json.dumps(_GENUINE_MONITOR),  # legacy, no confidence → counted
+            json.dumps(_PIPE_MASK_SUSPECT),  # #835 suspect → excluded from count
+            json.dumps(_HIGH_CONF_MASKED),  # genuine masked failure → counted
+        ]
+        path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    def test_count_excludes_pipe_mask_suspect(self) -> None:
+        with TemporaryDirectory() as td:
+            p = Path(td) / "errors.jsonl"
+            self._write(p)
+            # legacy + high masked failure = 2; pipe-mask-suspect excluded.
+            self.assertEqual(count_errors(p), 2)
+
+    def test_iter_default_skips_pipe_mask_suspect(self) -> None:
+        with TemporaryDirectory() as td:
+            p = Path(td) / "errors.jsonl"
+            self._write(p)
+            cmds = [r["command"] for r in iter_records(p)]
+            self.assertNotIn("python3 -m pytest 2>&1 | tail", cmds)
+
+    def test_include_low_confidence_retains_suspect(self) -> None:
+        with TemporaryDirectory() as td:
+            p = Path(td) / "errors.jsonl"
+            self._write(p)
+            recs = list(iter_records(p, include_low_confidence=True))
+            self.assertEqual(len(recs), 3)
+            self.assertIn("python3 -m pytest 2>&1 | tail", [r["command"] for r in recs])
+
+    def test_is_pipe_mask_suspect_helper(self) -> None:
+        self.assertTrue(is_pipe_mask_suspect(_PIPE_MASK_SUSPECT))
+        self.assertFalse(is_pipe_mask_suspect(_LOW_CONF_ECHO))  # low but echoed, not suspect
+        self.assertFalse(is_pipe_mask_suspect(_HIGH_CONF_MASKED))
+        self.assertFalse(is_pipe_mask_suspect(_GENUINE_MONITOR))
 
 
 class TraceTypeSourceOfTruth(unittest.TestCase):


### PR DESCRIPTION
## What

Tightens the Annunaki monitor's rc=0 handling and fixes hook attribution, per the P6W16 retro finding that **85% of captures (40/47) were `exit_code==0` records that pattern-matched `stdout:^FAILED`** — a pytest `FAILED` surfacing through `… | tail` rc-masking, or benign demo output containing the literal — logged with an empty `hook` field so they showed as `unknown` and crowded out the genuine signals.

## Changes

- **`_classify_confidence` now returns `(confidence, category)`** (`.claude/hooks/annunaki_monitor.py`). The residual exit-0 / stdout-only / no-STRONG-signal / not-echoed class is demoted to `confidence="low"` + `category="pipe-mask-suspect"`: **retained for forensics and specifically triageable, but excluded from the genuine-error count** (via the existing #729 low-confidence reader filter). This supersedes #729's recall-preserving "unrecognized exit-0 stdout match defaults high" policy for exactly the class the W16 data showed is 85% noise.
- **Genuine exit-0-failure carve-out preserved**: a STRONG masked-failure signal (`[rejected]`/`failed to push`, `exit status N`, `Traceback`, `(exit N)`) stays `high`/counted, now labeled `category="masked-failure"` — flagged, not hidden (issue point 3).
- **`hook` field populated** on every monitor capture (`hook="annunaki_monitor"`) so `/annunaki`'s `rec.get("hook", "unknown")` breakdown stops bucketing command-failure records as `unknown`.
- **`annunaki_parse`**: new `is_pipe_mask_suspect()` triage helper; the existing low-confidence filter already excludes the new class from `count_errors`.

## Tests

- rc=0 false-positive case: `pytest … | tail` exit-0 `FAILED` → `pipe-mask-suspect`, logged but not counted; benign demo output likewise.
- genuine nonzero-rc capture: stays `high`/`nonzero-exit`, counted (precision pass does not weaken genuine capture).
- STRONG masked-failure rc=0 (`git push | tail` rejected) → still `high`/`masked-failure`.
- `hook` field population on both genuine and suspect records.
- reader-side: pipe-mask-suspect excluded from `count_errors`, retained with `include_low_confidence=True`.

Full hooks + lib suites green (1882 passed); `pre-commit run --all-files` green on both commit and pre-push stages.

Re #835

Reviewers: Nino Kavtaradze (primary), Aino Virtanen (secondary)
