### PR TITLE
feat(lib): deterministic post-merge verification for deployable merges (#864)

### DIFF
--- a/.claude/lib/tests/test_verify_deployable_merge.py
+++ b/.claude/lib/tests/test_verify_deployable_merge.py
@@ -1,0 +1,338 @@
+"""Tests for verify_deployable_merge — post-merge deployable verification (main#864).
+
+Network is never touched: the gh-shelling functions (fetch_workflow_files,
+fetch_runs_for_sha) are monkeypatched, and the poll loop's sleep/clock are
+injected so the time-based logic runs instantly. Coverage maps to the gap the
+tool closes:
+
+  1. the GHA-YAML ``on: True`` boolean gotcha is handled
+  2. push-to-main / tag / pull_request triggers classify correctly
+  3. post-merge-only = deployable AND not pull_request
+  4. a FAILED post-merge run -> NOT verified (exit 1)
+  5. a MISSING expected workflow (silent drop) -> NOT verified, never a pass
+  6. pending resolves to verified once runs complete across polls
+  7. no expected workflows resolved -> GhError (exit 2)
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import verify_deployable_merge as vdm  # noqa: E402
+
+# A publish workflow: push-to-main + tags, NO pull_request → post-merge-only.
+PUBLISH_YAML = """
+name: Publish to GHCR
+on:
+  push:
+    branches: [main]
+    tags:
+      - "v*"
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps: [{run: "echo hi"}]
+"""
+
+# A standard CI workflow: push AND pull_request → deployable but NOT post-merge-only.
+CI_YAML = """
+name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps: [{run: "pytest"}]
+"""
+
+# A PR-only workflow: never deployable.
+PR_ONLY_YAML = """
+name: Lint
+on: pull_request
+jobs:
+  lint: {runs-on: ubuntu-latest, steps: [{run: "ruff"}]}
+"""
+
+# A tag-only workflow (like isnad-graph's "Pipeline"): runs on a data-v* tag
+# push, NOT on a branch merge to main. Must NOT be merge-triggered.
+TAG_ONLY_YAML = """
+name: Pipeline
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'data-v*'
+jobs:
+  run: {runs-on: ubuntu-latest, steps: [{run: "make"}]}
+"""
+
+# A push-to-main workflow with a paths filter: conditional, so NOT required
+# (it may legitimately skip a merge that doesn't touch those paths).
+PATH_FILTERED_YAML = """
+name: Docs
+on:
+  push:
+    branches: [main]
+    paths: ["docs/**"]
+jobs:
+  build: {runs-on: ubuntu-latest, steps: [{run: "mkdocs"}]}
+"""
+
+
+class ClassifyTriggerTests(unittest.TestCase):
+    def test_on_boolean_gotcha_is_handled(self) -> None:
+        # PyYAML parses the bare `on` key as the boolean True; the publish YAML
+        # must still classify as push-triggered despite that.
+        trig = vdm.classify_trigger("Publish to GHCR", ".github/workflows/p.yml", PUBLISH_YAML)
+        self.assertIsNotNone(trig)
+        assert trig is not None
+        self.assertTrue(trig.on_push_main)
+        self.assertTrue(trig.on_tag)
+        self.assertFalse(trig.on_pull_request)
+
+    def test_publish_is_post_merge_only(self) -> None:
+        trig = vdm.classify_trigger("Publish to GHCR", "p.yml", PUBLISH_YAML)
+        assert trig is not None
+        self.assertTrue(trig.is_merge_triggered)
+        self.assertTrue(trig.is_post_merge_only)
+
+    def test_ci_is_merge_triggered_but_not_post_merge_only(self) -> None:
+        trig = vdm.classify_trigger("CI", "ci.yml", CI_YAML)
+        assert trig is not None
+        self.assertTrue(trig.is_merge_triggered)
+        self.assertFalse(trig.is_post_merge_only)  # also runs on PRs
+
+    def test_pr_only_is_not_merge_triggered(self) -> None:
+        trig = vdm.classify_trigger("Lint", "lint.yml", PR_ONLY_YAML)
+        assert trig is not None
+        self.assertFalse(trig.is_merge_triggered)
+
+    def test_tag_only_is_not_merge_triggered(self) -> None:
+        # The "Pipeline" false-positive: tag push ≠ branch merge to main.
+        trig = vdm.classify_trigger("Pipeline", "pipeline.yml", TAG_ONLY_YAML)
+        assert trig is not None
+        self.assertFalse(trig.on_push_main)
+        self.assertTrue(trig.on_tag)
+        self.assertFalse(trig.is_merge_triggered)
+
+    def test_path_filtered_push_is_not_required(self) -> None:
+        trig = vdm.classify_trigger("Docs", "docs.yml", PATH_FILTERED_YAML)
+        assert trig is not None
+        self.assertTrue(trig.on_push_main)
+        self.assertTrue(trig.push_path_filtered)
+        self.assertFalse(trig.is_merge_triggered)  # conditional → not required
+
+    def test_list_form_on(self) -> None:
+        trig = vdm.classify_trigger("L", "l.yml", "on: [push, pull_request]\njobs: {}\n")
+        assert trig is not None
+        self.assertTrue(trig.on_push_main)  # no branch filter → all branches incl main
+        self.assertTrue(trig.on_pull_request)
+
+    def test_string_form_on(self) -> None:
+        trig = vdm.classify_trigger("S", "s.yml", "on: push\njobs: {}\n")
+        assert trig is not None
+        self.assertTrue(trig.on_push_main)
+        self.assertFalse(trig.on_pull_request)
+
+    def test_push_to_non_main_branch_only(self) -> None:
+        text = "on:\n  push:\n    branches: [develop]\njobs: {}\n"
+        trig = vdm.classify_trigger("D", "d.yml", text)
+        assert trig is not None
+        self.assertFalse(trig.on_push_main)  # only develop, not main
+
+    def test_unparseable_returns_none(self) -> None:
+        self.assertIsNone(vdm.classify_trigger("X", "x.yml", "::: not yaml :::\n\t- bad"))
+
+
+class DisplayNameTests(unittest.TestCase):
+    def test_uses_name_field(self) -> None:
+        self.assertEqual(vdm.workflow_display_name("p.yml", PUBLISH_YAML), "Publish to GHCR")
+
+    def test_falls_back_to_filename(self) -> None:
+        text = "on: push\njobs: {}\n"
+        self.assertEqual(vdm.workflow_display_name(".github/workflows/anon.yml", text), "anon.yml")
+
+
+class ClassifyRunTests(unittest.TestCase):
+    def test_pending_when_not_completed(self) -> None:
+        self.assertEqual(vdm.classify_run("in_progress", "").bucket, "pending")
+        self.assertEqual(vdm.classify_run("queued", "").bucket, "pending")
+
+    def test_pass_buckets(self) -> None:
+        self.assertEqual(vdm.classify_run("completed", "success").bucket, "pass")
+        self.assertEqual(vdm.classify_run("completed", "skipped").bucket, "pass")
+
+    def test_fail_buckets(self) -> None:
+        self.assertEqual(vdm.classify_run("completed", "failure").bucket, "fail")
+        self.assertEqual(vdm.classify_run("completed", "cancelled").bucket, "fail")
+        # Completed with a null conclusion must NOT pass.
+        self.assertEqual(vdm.classify_run("completed", "").bucket, "fail")
+
+
+class AggregateTests(unittest.TestCase):
+    def test_all_pass_verified(self) -> None:
+        runs = [
+            {
+                "name": "Publish to GHCR",
+                "status": "completed",
+                "conclusion": "success",
+                "html_url": "u",
+            },
+            {"name": "CI", "status": "completed", "conclusion": "success", "html_url": "u"},
+        ]
+        agg = vdm.aggregate(["CI", "Publish to GHCR"], runs)
+        self.assertTrue(agg.verified)
+        self.assertFalse(agg.pending)
+
+    def test_one_failure_not_verified(self) -> None:
+        runs = [
+            {
+                "name": "Publish to GHCR",
+                "status": "completed",
+                "conclusion": "failure",
+                "html_url": "u",
+            },
+        ]
+        agg = vdm.aggregate(["Publish to GHCR"], runs)
+        self.assertFalse(agg.verified)
+        self.assertFalse(agg.pending)
+
+    def test_missing_expected_is_not_verified(self) -> None:
+        # Expected a workflow that produced no run for the SHA → silent drop.
+        agg = vdm.aggregate(["Publish to GHCR"], [])
+        self.assertFalse(agg.verified)
+        self.assertTrue(agg.pending)
+        self.assertEqual(agg.missing, ["Publish to GHCR"])
+
+    def test_rerun_keeps_newest(self) -> None:
+        # API order is newest-first; the first record per name wins.
+        runs = [
+            {"name": "CI", "status": "completed", "conclusion": "success", "html_url": "new"},
+            {"name": "CI", "status": "completed", "conclusion": "failure", "html_url": "old"},
+        ]
+        agg = vdm.aggregate(["CI"], runs)
+        self.assertTrue(agg.verified)
+
+    def test_no_red_net_catches_unexpected_failure(self) -> None:
+        # A path-filtered workflow that DID run and failed is not in `expected`,
+        # but the no-red safety net must still fail the verification.
+        runs = [
+            {"name": "CI", "status": "completed", "conclusion": "success", "html_url": "u"},
+            {"name": "Docs", "status": "completed", "conclusion": "failure", "html_url": "dx"},
+        ]
+        agg = vdm.aggregate(["CI"], runs)
+        self.assertFalse(agg.verified)
+        self.assertTrue(any(r["name"] == "Docs" and r["bucket"] == "fail" for r in agg.rows))
+
+    def test_no_red_net_waits_on_unexpected_pending(self) -> None:
+        runs = [
+            {"name": "CI", "status": "completed", "conclusion": "success", "html_url": "u"},
+            {"name": "Docs", "status": "in_progress", "conclusion": "", "html_url": "dx"},
+        ]
+        agg = vdm.aggregate(["CI"], runs)
+        self.assertTrue(agg.pending)
+        self.assertFalse(agg.verified)
+
+
+class VerifyPollLoopTests(unittest.TestCase):
+    def test_resolves_pending_across_polls(self) -> None:
+        # First poll: still running. Second poll: completed success.
+        responses = [
+            [
+                {
+                    "name": "Publish to GHCR",
+                    "status": "in_progress",
+                    "conclusion": "",
+                    "html_url": "u",
+                }
+            ],
+            [
+                {
+                    "name": "Publish to GHCR",
+                    "status": "completed",
+                    "conclusion": "success",
+                    "html_url": "u",
+                }
+            ],
+        ]
+
+        def fake_runs(repo: str, sha: str) -> list[dict]:
+            return responses.pop(0)
+
+        self._patch(vdm, "fetch_runs_for_sha", fake_runs)
+        clock_vals = iter([0.0, 1.0, 2.0, 3.0, 4.0])
+
+        result = vdm.verify(
+            "o/r",
+            "deadbeef",
+            explicit_workflows=["Publish to GHCR"],
+            timeout=100,
+            poll=5,
+            sleep=lambda _s: None,
+            clock=lambda: next(clock_vals),
+        )
+        self.assertTrue(result.verified)
+
+    def test_times_out_pending(self) -> None:
+        def fake_runs(repo: str, sha: str) -> list[dict]:
+            return [{"name": "P", "status": "queued", "conclusion": "", "html_url": "u"}]
+
+        self._patch(vdm, "fetch_runs_for_sha", fake_runs)
+        # clock jumps past the deadline immediately after the first read.
+        clock_vals = iter([0.0, 999.0, 1000.0])
+        result = vdm.verify(
+            "o/r",
+            "sha",
+            explicit_workflows=["P"],
+            timeout=10,
+            poll=1,
+            sleep=lambda _s: None,
+            clock=lambda: next(clock_vals),
+        )
+        self.assertFalse(result.verified)
+        self.assertTrue(result.pending)
+
+    def test_no_expected_raises(self) -> None:
+        def empty_files(repo: str, ref: str) -> dict[str, str]:
+            return {"pr.yml": PR_ONLY_YAML}  # not deployable
+
+        self._patch(vdm, "fetch_workflow_files", empty_files)
+        with self.assertRaises(vdm.GhError):
+            vdm.verify("o/r", "sha", timeout=1, poll=1, sleep=lambda _s: None)
+
+    # -- helper: monkeypatch a module attr for the duration of one test --
+    def _patch(self, mod: object, attr: str, value) -> None:
+        original = getattr(mod, attr)
+        setattr(mod, attr, value)
+        self.addCleanup(setattr, mod, attr, original)
+
+
+class ResolveExpectedTests(unittest.TestCase):
+    def test_require_deployable_narrows_to_post_merge_only(self) -> None:
+        files = {
+            "p.yml": PUBLISH_YAML,  # post-merge-only
+            "ci.yml": CI_YAML,  # merge-triggered but also PR
+            "lint.yml": PR_ONLY_YAML,  # not merge-triggered (PR only)
+            "pipeline.yml": TAG_ONLY_YAML,  # tag-only, not a branch merge
+            "docs.yml": PATH_FILTERED_YAML,  # conditional (paths) → not required
+        }
+        original = vdm.fetch_workflow_files
+        vdm.fetch_workflow_files = lambda repo, ref: files  # type: ignore[assignment]
+        self.addCleanup(setattr, vdm, "fetch_workflow_files", original)
+
+        all_deployable = vdm.resolve_expected("o/r", "sha", None, require_deployable=False)
+        self.assertEqual(all_deployable, ["CI", "Publish to GHCR"])
+
+        post_only = vdm.resolve_expected("o/r", "sha", None, require_deployable=True)
+        self.assertEqual(post_only, ["Publish to GHCR"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/lib/verify_deployable_merge.py
+++ b/.claude/lib/verify_deployable_merge.py
@@ -1,0 +1,514 @@
+#!/usr/bin/env python3
+"""Deterministic post-merge verification for *deployable* merges (main#864).
+
+A PR's pre-merge CI is not the whole story. Some workflows are **push-to-main
+only** — they never run on pull requests, so they give NO pre-merge signal and
+only execute *after* the merge lands on `main`. The canonical example is a
+container-publish workflow whose image vulnerability scan (Trivy) runs on
+`push: branches: [main]` but not on `pull_request`: every per-issue PR can be
+green while the post-merge publish goes red on a freshly-published base-image
+CVE. That is precisely how `noorinalabs-isnad-graph#1131` (libexpat
+CVE-2026-45186) slipped past #1130's green PR and reddened `main`.
+
+`/wave-wrapup` Step 11 merges each wave branch to `main` — those ARE deployable
+merges. Until this tool there was no deterministic, scriptable way to assert
+"the merge I just performed actually went green across the post-merge-only
+workflows too". The operator had to remember to eyeball `gh run list`, which is
+exactly the manual step that rots (`feedback_enforcement_hierarchy`: a check
+with no automation decays).
+
+This CLI closes that gap. Given a repo and a merge commit SHA it:
+
+  1. Determines the *expected* workflow set — either an explicit ``--workflows``
+     list, or (default) by reading ``.github/workflows/*`` at that SHA and
+     selecting the workflows that trigger on push-to-main / tags. With
+     ``--require-deployable`` it narrows to the **post-merge-only** subset
+     (push/tag triggered AND NOT ``pull_request``) — the genuinely blind ones.
+  2. Polls the Actions runs for that exact ``head_sha`` until every expected
+     workflow has a *completed* run (or the timeout elapses).
+  3. Asserts every expected run concluded success/skipped. A FAILED run, or an
+     expected workflow that produced **no** run at all (the silent-drop case —
+     see `feedback_statuscheckrollup_ci_clean`, where an empty result is a hard
+     not-verified, never a pass), fails the check.
+
+It deliberately keys off the real run records for the SHA rather than trusting
+the merge's own exit status: ``gh pr merge`` returns 0 the instant the merge
+commit is created, long before the push-triggered workflows even start.
+
+Usage:
+    python3 .claude/lib/verify_deployable_merge.py <owner/repo> <sha>
+    python3 .claude/lib/verify_deployable_merge.py <owner/repo> <sha> --require-deployable
+    python3 .claude/lib/verify_deployable_merge.py <owner/repo> <sha> --workflows "Publish to GHCR"
+    python3 .claude/lib/verify_deployable_merge.py <owner/repo> <sha> --timeout 1200 --json
+
+Exit codes:
+    0 — VERIFIED: every expected workflow ran for the SHA and concluded success.
+    1 — NOT VERIFIED: a failed run, a missing expected workflow, or still
+        pending at timeout.
+    2 — UNDETERMINED: a gh/API call failed, or no expected workflows could be
+        resolved (nothing to verify).
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import dataclasses
+import json
+import subprocess
+import sys
+import time
+
+import yaml
+
+# Conclusions GitHub may report on a *completed* run. Anything not in PASS and
+# not pending is treated as a failure — including a completed run with a null
+# conclusion, which should never happen but must not silently pass.
+_PASS_CONCLUSIONS = frozenset({"success", "skipped", "neutral"})
+
+
+# ---------------------------------------------------------------------------
+# Pure logic (no network — unit-tested directly)
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class WorkflowTrigger:
+    """A workflow's trigger classification, derived from its ``on:`` block.
+
+    Scoped to the event this tool verifies: a **branch merge to main** (a push
+    to the main branch). A tag-only workflow (``push: {tags: [...]}`` with no
+    branch filter) does NOT run on a branch merge — it runs on a separate
+    release/tag event — so it is deliberately not treated as merge-triggered.
+    """
+
+    name: str
+    path: str
+    on_push_main: bool  # push to the main branch (the merge event)
+    push_path_filtered: bool  # push trigger carries paths/paths-ignore (conditional)
+    on_tag: bool  # push to a tag (a separate deploy path, not a branch merge)
+    on_pull_request: bool  # pull_request / pull_request_target
+
+    @property
+    def is_merge_triggered(self) -> bool:
+        """Runs UNCONDITIONALLY on a merge to main.
+
+        A push-to-main trigger that carries a ``paths:``/``paths-ignore:`` filter
+        is *conditional* — it legitimately may not run for a given merge — so it
+        is excluded from the required set (its absence is not a silent drop). If
+        such a workflow does run and fails, the no-red safety net still catches
+        it.
+        """
+        return self.on_push_main and not self.push_path_filtered
+
+    @property
+    def is_post_merge_only(self) -> bool:
+        """Merge-triggered AND invisible pre-merge (never runs on a PR)."""
+        return self.is_merge_triggered and not self.on_pull_request
+
+
+def _coerce_on_block(parsed: object) -> object:
+    """Return the ``on:`` value from a parsed workflow mapping.
+
+    GitHub Actions' ``on:`` collides with YAML 1.1's boolean literals: PyYAML
+    parses the bare key ``on`` as the boolean ``True``, so ``data["on"]`` is a
+    KeyError and the trigger block hides under ``data[True]``. This is the
+    single most common GHA-YAML parsing bug; handle both spellings.
+    """
+    if not isinstance(parsed, dict):
+        return None
+    if "on" in parsed:
+        return parsed["on"]
+    if True in parsed:
+        return parsed[True]
+    return None
+
+
+def _branches_include_main(node: object) -> bool:
+    """True if a push trigger's branch filter includes main, or has none.
+
+    A push trigger with no ``branches``/``branches-ignore`` filter fires on all
+    branches (so it covers main). A ``branches`` list counts only if it names
+    ``main`` (we do not try to resolve globs beyond an explicit ``**`` / ``*``).
+    """
+    if not isinstance(node, dict):
+        # `push:` with a null/empty value → fires on every branch.
+        return True
+    branches = node.get("branches")
+    if branches is None:
+        # No positive filter → fires on all branches (branches-ignore style).
+        return True
+    if isinstance(branches, str):
+        branches = [branches]
+    if not isinstance(branches, list):
+        return True
+    return any(b in ("main", "*", "**") for b in branches)
+
+
+def classify_trigger(name: str, path: str, yaml_text: str) -> WorkflowTrigger | None:
+    """Parse one workflow file's ``on:`` into a WorkflowTrigger.
+
+    Returns None if the file does not parse as a mapping or declares no usable
+    ``on:`` block — such a file contributes no expected runs.
+    """
+    try:
+        parsed = yaml.safe_load(yaml_text)
+    except yaml.YAMLError:
+        return None
+    on = _coerce_on_block(parsed)
+    if on is None:
+        return None
+
+    # `on:` may be a bare string ("push"), a list (["push","pull_request"]) or a
+    # mapping ({push: {...}, pull_request: {...}}). Normalise to a dict keyed by
+    # event name; for the string/list forms the per-event config is absent.
+    events: dict[str, object] = {}
+    if isinstance(on, str):
+        events[on] = None
+    elif isinstance(on, list):
+        for item in on:
+            if isinstance(item, str):
+                events[item] = None
+    elif isinstance(on, dict):
+        for key, value in on.items():
+            events[str(key)] = value
+
+    on_push_main = False
+    push_path_filtered = False
+    on_tag = False
+    if "push" in events:
+        push_cfg = events["push"]
+        on_push_main = _branches_include_main(push_cfg)
+        if isinstance(push_cfg, dict):
+            on_tag = bool(push_cfg.get("tags"))
+            push_path_filtered = "paths" in push_cfg or "paths-ignore" in push_cfg
+            # A push trigger that names ONLY tags (no branches key) does not fire
+            # on a branch merge — _branches_include_main returns True for the
+            # no-branches case, so correct that here for the tags-only shape.
+            if "branches" not in push_cfg and push_cfg.get("tags"):
+                on_push_main = False
+
+    on_pull_request = "pull_request" in events or "pull_request_target" in events
+
+    display = name or path.rsplit("/", 1)[-1]
+    return WorkflowTrigger(
+        name=display,
+        path=path,
+        on_push_main=on_push_main,
+        push_path_filtered=push_path_filtered,
+        on_tag=on_tag,
+        on_pull_request=on_pull_request,
+    )
+
+
+def workflow_display_name(path: str, yaml_text: str) -> str:
+    """The workflow's ``name:`` if present, else the bare filename.
+
+    GitHub keys an Actions run's ``name`` off the workflow's top-level ``name:``;
+    when absent it uses the file path. We must match runs by the SAME label, so
+    derive it identically here.
+    """
+    try:
+        parsed = yaml.safe_load(yaml_text)
+    except yaml.YAMLError:
+        parsed = None
+    if isinstance(parsed, dict) and isinstance(parsed.get("name"), str):
+        return parsed["name"]
+    return path.rsplit("/", 1)[-1]
+
+
+@dataclasses.dataclass(frozen=True)
+class RunVerdict:
+    bucket: str  # "pass" | "fail" | "pending"
+    conclusion: str
+    status: str
+
+
+def classify_run(status: str, conclusion: str) -> RunVerdict:
+    """Bucket a single workflow run record."""
+    if status != "completed":
+        return RunVerdict("pending", conclusion or "", status or "")
+    if conclusion in _PASS_CONCLUSIONS:
+        return RunVerdict("pass", conclusion, status)
+    return RunVerdict("fail", conclusion or "(none)", status)
+
+
+@dataclasses.dataclass
+class Aggregate:
+    """Overall verdict over the expected workflow set for one SHA."""
+
+    verified: bool
+    pending: bool
+    rows: list[dict]  # per-expected-workflow: name, bucket, conclusion, url
+    missing: list[str]  # expected workflows with no run for the SHA
+
+
+def aggregate(expected: list[str], runs: list[dict]) -> Aggregate:
+    """Combine expected workflow names with the runs found for a SHA.
+
+    ``runs`` are records with ``name``, ``status``, ``conclusion``, ``html_url``.
+    When a workflow has multiple runs for the SHA (re-runs), the most recent —
+    last in API order is newest-first, so index 0 — wins.
+    """
+    by_name: dict[str, dict] = {}
+    for run in runs:
+        nm = run.get("name", "")
+        # API returns newest first; keep the first seen per name.
+        by_name.setdefault(nm, run)
+
+    rows: list[dict] = []
+    missing: list[str] = []
+    any_fail = False
+    any_pending = False
+    expected_set = set(expected)
+
+    # Required set: every expected workflow must be present AND pass. A missing
+    # one is the silent-drop case (empty == hard not-verified).
+    for name in expected:
+        found = by_name.get(name)
+        if found is None:
+            missing.append(name)
+            rows.append({"name": name, "bucket": "missing", "conclusion": "", "url": ""})
+            continue
+        verdict = classify_run(found.get("status", ""), found.get("conclusion", ""))
+        rows.append(
+            {
+                "name": name,
+                "bucket": verdict.bucket,
+                "conclusion": verdict.conclusion,
+                "url": found.get("html_url", ""),
+            }
+        )
+        if verdict.bucket == "fail":
+            any_fail = True
+        elif verdict.bucket == "pending":
+            any_pending = True
+
+    # No-red safety net: ANY run that executed for this SHA but is not in the
+    # required set (e.g. a path-filtered push workflow that did fire) must not be
+    # red, and we wait for it to settle. This catches failures the required-set
+    # detection would otherwise miss without over-requiring conditional workflows.
+    for run in runs:
+        nm = run.get("name", "")
+        if nm in expected_set:
+            continue
+        verdict = classify_run(run.get("status", ""), run.get("conclusion", ""))
+        if verdict.bucket == "fail":
+            any_fail = True
+            rows.append(
+                {
+                    "name": nm,
+                    "bucket": "fail",
+                    "conclusion": verdict.conclusion,
+                    "url": run.get("html_url", ""),
+                }
+            )
+        elif verdict.bucket == "pending":
+            any_pending = True
+
+    pending = any_pending or bool(missing)
+    verified = not any_fail and not pending
+    return Aggregate(verified=verified, pending=pending, rows=rows, missing=missing)
+
+
+# ---------------------------------------------------------------------------
+# I/O (gh subprocess — mocked in tests)
+# ---------------------------------------------------------------------------
+
+
+class GhError(RuntimeError):
+    """A gh/API call failed; readiness cannot be determined (exit 2)."""
+
+
+def _run_gh(args: list[str]) -> str:
+    """Run ``gh <args>`` with an explicit arg list (never a shell string).
+
+    Mirrors ``wave_status._run_gh`` (main#688): no shell means no word-splitting,
+    so a multi-word value can never collapse into a bogus flag.
+    """
+    try:
+        proc = subprocess.run(["gh", *args], capture_output=True, text=True, check=True)
+    except FileNotFoundError as exc:  # gh not installed
+        raise GhError("gh CLI not found on PATH") from exc
+    except subprocess.CalledProcessError as exc:
+        raise GhError(f"gh {' '.join(args)} failed: {exc.stderr.strip()}") from exc
+    return proc.stdout
+
+
+def fetch_workflow_files(repo: str, ref: str) -> dict[str, str]:
+    """Return {path: yaml_text} for every workflow under .github/workflows at ref."""
+    listing_raw = _run_gh(["api", f"repos/{repo}/contents/.github/workflows?ref={ref}"])
+    try:
+        listing = json.loads(listing_raw)
+    except json.JSONDecodeError as exc:
+        raise GhError("could not parse workflows directory listing") from exc
+    if not isinstance(listing, list):
+        raise GhError(".github/workflows is not a directory at this ref")
+
+    files: dict[str, str] = {}
+    for entry in listing:
+        path = entry.get("path", "")
+        if not (path.endswith(".yml") or path.endswith(".yaml")):
+            continue
+        blob_raw = _run_gh(["api", f"repos/{repo}/contents/{path}?ref={ref}"])
+        try:
+            blob = json.loads(blob_raw)
+            content = base64.b64decode(blob.get("content", "")).decode("utf-8")
+        except (json.JSONDecodeError, ValueError) as exc:
+            raise GhError(f"could not decode {path}") from exc
+        files[path] = content
+    return files
+
+
+def fetch_runs_for_sha(repo: str, sha: str) -> list[dict]:
+    """Return the Actions run records for a commit SHA (newest first)."""
+    raw = _run_gh(["api", f"repos/{repo}/actions/runs?head_sha={sha}&per_page=100"])
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise GhError("could not parse actions runs response") from exc
+    runs = data.get("workflow_runs", [])
+    return [
+        {
+            "name": r.get("name", ""),
+            "status": r.get("status", ""),
+            "conclusion": r.get("conclusion", ""),
+            "html_url": r.get("html_url", ""),
+            "event": r.get("event", ""),
+            "path": r.get("path", ""),
+        }
+        for r in runs
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+
+def resolve_expected(
+    repo: str, sha: str, explicit: list[str] | None, require_deployable: bool
+) -> list[str]:
+    """Resolve the set of workflow display-names we expect to run for the SHA."""
+    if explicit:
+        return explicit
+    files = fetch_workflow_files(repo, sha)
+    expected: list[str] = []
+    for path, text in files.items():
+        trigger = classify_trigger(workflow_display_name(path, text), path, text)
+        if trigger is None or not trigger.is_merge_triggered:
+            continue
+        if require_deployable and not trigger.is_post_merge_only:
+            continue
+        expected.append(trigger.name)
+    return sorted(set(expected))
+
+
+def verify(
+    repo: str,
+    sha: str,
+    *,
+    explicit_workflows: list[str] | None = None,
+    require_deployable: bool = False,
+    timeout: int = 900,
+    poll: int = 20,
+    sleep=time.sleep,
+    clock=time.monotonic,
+) -> Aggregate:
+    """Poll until the expected workflows for SHA are all complete, then verdict.
+
+    ``sleep``/``clock`` are injectable so tests drive the poll loop without real
+    time. Raises GhError (→ exit 2) if expected resolution finds nothing.
+    """
+    expected = resolve_expected(repo, sha, explicit_workflows, require_deployable)
+    if not expected:
+        raise GhError(
+            "no expected workflows resolved — nothing to verify "
+            "(check the ref has workflows, or pass --workflows)"
+        )
+
+    deadline = clock() + timeout
+    result = aggregate(expected, fetch_runs_for_sha(repo, sha))
+    while result.pending and clock() < deadline:
+        sleep(poll)
+        result = aggregate(expected, fetch_runs_for_sha(repo, sha))
+    return result
+
+
+def _format_report(repo: str, sha: str, result: Aggregate) -> str:
+    lines = [f"Deployable-merge verification — {repo} @ {sha[:8]}"]
+    for row in result.rows:
+        mark = {"pass": "✓", "fail": "✗", "pending": "…", "missing": "∅"}.get(row["bucket"], "?")
+        detail = row["conclusion"] or row["bucket"]
+        lines.append(f"  {mark} {row['name']}: {detail}")
+        if row["bucket"] in ("fail", "missing") and row["url"]:
+            lines.append(f"      {row['url']}")
+    if result.missing:
+        lines.append(
+            "  ! missing workflows never produced a run for this SHA "
+            "(silent-drop / not-triggered) — treated as NOT verified."
+        )
+    if any(r["bucket"] == "fail" for r in result.rows):
+        lines.append("  → inspect: gh run view <run-id> --repo " + repo + " --log-failed")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Verify a deployable merge's post-merge workflows went green."
+    )
+    parser.add_argument("repo", help="owner/repo, e.g. noorinalabs/noorinalabs-isnad-graph")
+    parser.add_argument("sha", help="merge commit SHA on the deployable branch")
+    parser.add_argument(
+        "--workflows",
+        default="",
+        help="comma-separated workflow display-names to verify (skips auto-detect)",
+    )
+    parser.add_argument(
+        "--require-deployable",
+        action="store_true",
+        help="auto-detect only post-merge-only workflows (push/tag AND not pull_request)",
+    )
+    parser.add_argument("--timeout", type=int, default=900, help="seconds to wait (default 900)")
+    parser.add_argument("--poll", type=int, default=20, help="poll interval seconds (default 20)")
+    parser.add_argument("--json", action="store_true", help="emit JSON instead of a table")
+    args = parser.parse_args(argv)
+
+    explicit = [w.strip() for w in args.workflows.split(",") if w.strip()] or None
+
+    try:
+        result = verify(
+            args.repo,
+            args.sha,
+            explicit_workflows=explicit,
+            require_deployable=args.require_deployable,
+            timeout=args.timeout,
+            poll=args.poll,
+        )
+    except GhError as exc:
+        if args.json:
+            print(json.dumps({"verified": False, "undetermined": True, "error": str(exc)}))
+        else:
+            print(f"UNDETERMINED: {exc}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "verified": result.verified,
+                    "pending": result.pending,
+                    "missing": result.missing,
+                    "rows": result.rows,
+                }
+            )
+        )
+    else:
+        print(_format_report(args.repo, args.sha, result))
+        print("VERIFIED" if result.verified else "NOT VERIFIED")
+
+    return 0 if result.verified else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/wave-wrapup/SKILL.md
+++ b/.claude/skills/wave-wrapup/SKILL.md
@@ -451,6 +451,60 @@ export STRANDING_OVERRIDE_RATIONALE="P3W7 work descoped post-#339 audit; \
 
 The override is intentionally noisy: rationale is required (no empty string), logged to the wrapup report, and persisted to `cross-repo-status.json` under `wave_{M}_stranding_override` so subsequent /wave-retro and audit passes can surface it.
 
+### 11.5a. Deployable-merge verification gate — post-merge workflows went green (every wave)
+
+A wave→main merge is a **deployable merge**: it triggers push-to-main workflows that **never ran on the per-issue PRs** (publish/Trivy, schema-drift, structural-ontology, …). Their CI gives **no pre-merge signal**, so a wave can be reachable-on-main (Step 11.5 green) yet have reddened `main` post-merge. This is exactly how `isnad-graph#1131` (libexpat `CVE-2026-45186`) slipped past `#1130`'s green PR and failed the GHCR publish on `main` (main#864).
+
+After Step 11.5 confirms reachability, verify each repo's wave→main merge commit actually went green across its post-merge-only workflows, using the deterministic oracle `.claude/lib/verify_deployable_merge.py` (it polls the Actions runs for the exact merge SHA; a failed run, or a required workflow that produced **no** run at all, is a hard not-verified — the same empty-is-not-ready discipline as `pr_ci_state.py`). `gh pr merge` returns 0 the instant the merge commit exists — long before these workflows even start — so the merge's own exit status proves nothing.
+
+```bash
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+WAVE_REPOS_IN_SCOPE=$(jq -r ".wave_{M}_repos_in_scope[]" "$REPO_ROOT/cross-repo-status.json")
+BRANCH="deployments/phase-{P}/wave-{M}"
+
+UNVERIFIED=()
+while IFS= read -r R; do
+  # The deployable merge commit is origin/main's HEAD for the repo after Step 11
+  # merged the wave→main PR. Resolve it at origin (not the local clone).
+  MAIN_SHA=$(gh api "repos/noorinalabs/$R/git/refs/heads/main" --jq '.object.sha' 2>/dev/null || true)
+  [ -z "$MAIN_SHA" ] && { echo "$R: cannot read main — skip"; continue; }
+
+  # --require-deployable verifies the post-merge-ONLY workflows (push/tag AND not
+  # pull_request) — the genuinely blind ones. Drop the flag to verify every
+  # merge-triggered workflow. The no-red safety net fails on ANY run that
+  # executed for the SHA and went red, so path-filtered workflows that fired are
+  # still covered.
+  if python3 "$REPO_ROOT/.claude/lib/verify_deployable_merge.py" \
+       "noorinalabs/$R" "$MAIN_SHA" --require-deployable --timeout 1200 --poll 30; then
+    echo "$R: deployable merge verified green @ ${MAIN_SHA:0:8}"
+  else
+    UNVERIFIED+=("$R @ ${MAIN_SHA:0:8}")
+  fi
+done <<< "$WAVE_REPOS_IN_SCOPE"
+
+if [ ${#UNVERIFIED[@]} -gt 0 ]; then
+  echo "════════════════════════════════════════════════════════════"
+  echo "BLOCKED: /wave-wrapup cannot close wave {M} — deployable merge NOT verified:"
+  for u in "${UNVERIFIED[@]}"; do echo "  $u"; done
+  echo ""
+  echo "A post-merge workflow failed (or never ran) on main after the wave→main merge."
+  echo "This is a RED main gate — a stop, not a speed bump (charter no-force-merge)."
+  echo "Fix-forward options:"
+  echo "  (a) Fix the regression on main via a normal bug→PR→merge cycle (e.g. a"
+  echo "      base-image CVE re-pin like isnad-graph#1132), then re-run /wave-wrapup."
+  echo "  (b) If the failure is a documented external/standing item (advisory-DB"
+  echo "      drift, a no-fix base-image CVE under an active --ignore-vuln), set"
+  echo "      DEPLOYABLE_VERIFY_OVERRIDE_RATIONALE=\"<reason + tracking issue>\" and"
+  echo "      re-invoke. The override is logged to the report and to"
+  echo "      cross-repo-status.json under wave_{M}_deployable_verify_override."
+  echo "════════════════════════════════════════════════════════════"
+  [ -z "${DEPLOYABLE_VERIFY_OVERRIDE_RATIONALE:-}" ] && exit 1
+  echo "OVERRIDDEN: $DEPLOYABLE_VERIFY_OVERRIDE_RATIONALE"
+fi
+```
+
+A genuinely external red (e.g. a newly-published advisory the fix has not yet propagated for — `feedback_pip_audit_strict_advisory_db_drift`, `feedback_trivy_base_image_cve_org_wide_gate`) is the only case for the override, and it MUST name a tracking issue. A red caused by the wave's own change is fixed forward — never overridden. Include the per-repo result in the Step 10 report; `/wave-retro` records it in the wave history row.
+
 ### 11.6. Staging-promotion gate (Phase-3 end-state criterion #3)
 
 A wave is **not closeable until its merged code has been promoted to staging green**. This is the wrapup-time enforcement of Phase-3 end-state criterion #3 (`main#325`) and the charter rule `pull-requests.md § Wave-Wrapup Staging-Promotion Gate`. It runs AFTER the Step 11.5 reachability-to-main gate (code must be on main before it can be promoted to staging) and BEFORE the ontology rebuild.

--- a/ontology/checksums.json
+++ b/ontology/checksums.json
@@ -1,5 +1,5 @@
 {
-  "description": "Tracks file checksums for ontology change detection. last_tracked = current file hash (updated by tracker hook). last_resolved = hash when ontology was last rebuilt from this file (updated by resolver). When last_tracked != last_resolved, the file is dirty. SCOPE (#857, #820/C×T2): tracking + /ontology-rebuild cover the hand-curated SEMANTIC OVERLAY only (ontology/domain.yaml, ontology/services.yaml, ontology/conventions.md, ontology/repos/*.yaml, other hand-edited *.md). The GENERATED structural layer at ontology/structural/ (owned generator #855) is NOT tracked here — it is always-current-by-regeneration, so the tracker skips it (see ontology_tracker.py SKIP_PATTERNS).",
+  "description": "Tracks file checksums for ontology change detection. last_tracked = current file hash (updated by tracker hook). last_resolved = hash when ontology was last rebuilt from this file (updated by resolver). When last_tracked != last_resolved, the file is dirty. SCOPE (#857, #820/C\u00d7T2): tracking + /ontology-rebuild cover the hand-curated SEMANTIC OVERLAY only (ontology/domain.yaml, ontology/services.yaml, ontology/conventions.md, ontology/repos/*.yaml, other hand-edited *.md). The GENERATED structural layer at ontology/structural/ (owned generator #855) is NOT tracked here \u2014 it is always-current-by-regeneration, so the tracker skips it (see ontology_tracker.py SKIP_PATTERNS).",
   "files": {
     ".claude/drafts/secrets-migration-tonight-2026-04-23.md": {
       "last_resolved": "acc0d25da0c7fcf3792ade1703f7c75f2215a29daafe0367db907f4e8d2e990f",
@@ -122,10 +122,10 @@
       "resolved_at": "2026-06-04T20:50:14.260341+00:00"
     },
     ".claude/skills/wave-wrapup/SKILL.md": {
+      "last_tracked": "d2c84cb8cf5b02477bcb460aa4cd5e413784a067ff93be1a82631fc3ebe2cbf8",
       "last_resolved": "06ec27bab75ff4a97eb5fdfab7fea91db3178b42119c354de8c31aea3debbad9",
-      "last_tracked": "06ec27bab75ff4a97eb5fdfab7fea91db3178b42119c354de8c31aea3debbad9",
-      "resolved_at": "2026-05-11T01:20:44.549652+00:00",
-      "tracked_at": "2026-05-11T01:20:44.549652+00:00"
+      "tracked_at": "2026-06-25T01:49:36.462074+00:00",
+      "resolved_at": "2026-05-11T01:20:44.549652+00:00"
     },
     ".claude/team/charter.md": {
       "last_tracked": "a572ba52385b8ed797904abd53b9b35a5f0ffb80f7288193270db7408e53f848",
@@ -1054,6 +1054,18 @@
       "last_resolved": "cb30d9a2cfbe4e97902ee0927c7fd14bb4fbaee5514e02fc78538481c5cf848a",
       "tracked_at": "2026-06-23T19:40:14.949430+00:00",
       "resolved_at": "2026-06-23T20:07:27Z"
+    },
+    ".claude/lib/verify_deployable_merge.py": {
+      "last_tracked": "c44342fcbbefb30de6ed3887faf0c82707b0ae87346ef78d83de6afdf746e772",
+      "last_resolved": "",
+      "tracked_at": "2026-06-25T01:47:29.245692+00:00",
+      "resolved_at": ""
+    },
+    ".claude/lib/tests/test_verify_deployable_merge.py": {
+      "last_tracked": "99b3ca898e3209058f78d64beb06cc520523ce3d38cfb9546da92941c59a5954",
+      "last_resolved": "",
+      "tracked_at": "2026-06-25T01:48:21.358024+00:00",
+      "resolved_at": ""
     }
   },
   "last_cleanup": {


### PR DESCRIPTION
## What

A deterministic, scriptable check that a **deployable merge** (wave→main, or any push-to-main) actually went green across the workflows that **only run post-merge** — and wires it into `/wave-wrapup`.

Closes #864.

## Why

Some workflows trigger on `push: branches: [main]` (and/or tags) but **not** `pull_request` — e.g. container publish + its Trivy scan. They give **zero pre-merge signal**, so `main` can go red right after a fully-green PR merges. That just happened: **isnad-graph#1131** — `#1130`'s PR was green, but the post-merge GHCR publish failed on a freshly-published base-image CVE (`libexpat` CVE-2026-45186). `gh pr merge` returns 0 the instant the merge commit exists, long before these workflows even start, so the merge's own exit status proves nothing.

## How

`.claude/lib/verify_deployable_merge.py <owner/repo> <sha>`:
1. Resolve the **expected** workflow set — explicit `--workflows`, or auto-detect from `.github/workflows/*` at the SHA. A merge to main is a *branch* push, so the required set is **branch-push-to-main workflows without `paths:` filters**. `--require-deployable` narrows to **post-merge-only** (push/tag AND not `pull_request`).
2. Poll the Actions runs for that exact `head_sha` until every required workflow has a *completed* run (or timeout).
3. Assert green. A failed run, or a required workflow that produced **no** run at all (silent drop — empty is hard not-verified, same discipline as `pr_ci_state.py`), fails. A **no-red safety net** additionally fails on *any* run that executed for the SHA and went red — so path-filtered workflows that did fire are still covered.

Exit codes: `0` verified / `1` not verified / `2` undetermined.

Correctly excludes **tag-only** workflows (isnad-graph's `Pipeline`, `push: tags: [data-v*]` — a tag push is not a branch merge) and **path-filtered** push workflows from the required set.

## Wiring

`/wave-wrapup` **Step 11.5a** (between the reachability gate and the staging gate): per repo, run `--require-deployable` against the wave→main merge SHA; a red/silently-dropped post-merge workflow blocks wave close. Override (`DEPLOYABLE_VERIFY_OVERRIDE_RATIONALE`) only for a documented external/standing red (advisory-DB drift, no-fix CVE under an active `--ignore-vuln`), and it must name a tracking issue. A red from the wave's own change is fixed forward, never overridden.

## Tests / parity

`.claude/lib/tests/test_verify_deployable_merge.py` — 25 cases, no network (gh functions monkeypatched, poll clock injected): the GHA-YAML `on: True` boolean gotcha, tag-only vs branch-merge, path-filter exclusion, failed/missing/pending verdicts, the no-red net, and the poll loop. ruff + mypy + pytest all green locally (full local⇄CI parity).

## Verified live

- Catches the **pre-fix** red merge `471a85a` → `NOT VERIFIED` (with the failing run URL).
- Passes the **fixed** merge `e264e617` → `VERIFIED` (`--require-deployable`: just `Publish to GHCR`; default: CI + Publish + schema-drift + structural-ontology; `Pipeline` correctly excluded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
