### PR TITLE
fix(lib): deployable-verify treats "nothing required" as pass, not error (#864)

### DIFF
--- a/.claude/lib/tests/test_verify_deployable_merge.py
+++ b/.claude/lib/tests/test_verify_deployable_merge.py
@@ -299,13 +299,37 @@ class VerifyPollLoopTests(unittest.TestCase):
         self.assertFalse(result.verified)
         self.assertTrue(result.pending)
 
-    def test_no_expected_raises(self) -> None:
-        def empty_files(repo: str, ref: str) -> dict[str, str]:
-            return {"pr.yml": PR_ONLY_YAML}  # not deployable
+    def test_no_required_verifies_when_nothing_red(self) -> None:
+        # A repo with no post-merge-only workflow (only PR-visible CI) and a
+        # clean run set: "nothing required" → verified, NOT an error.
+        def only_pr(repo: str, ref: str) -> dict[str, str]:
+            return {"pr.yml": PR_ONLY_YAML, "tag.yml": TAG_ONLY_YAML}
 
-        self._patch(vdm, "fetch_workflow_files", empty_files)
-        with self.assertRaises(vdm.GhError):
-            vdm.verify("o/r", "sha", timeout=1, poll=1, sleep=lambda _s: None)
+        def clean_runs(repo: str, sha: str) -> list[dict]:
+            return []
+
+        self._patch(vdm, "fetch_workflow_files", only_pr)
+        self._patch(vdm, "fetch_runs_for_sha", clean_runs)
+        result = vdm.verify("o/r", "sha", timeout=1, poll=1, sleep=lambda _s: None)
+        self.assertTrue(result.verified)
+        self.assertEqual(result.expected, [])
+
+    def test_no_required_but_red_run_is_caught_by_net(self) -> None:
+        # Even with nothing "required", a run that executed and failed must fail
+        # verification via the no-red safety net.
+        def only_pr(repo: str, ref: str) -> dict[str, str]:
+            return {"pr.yml": PR_ONLY_YAML}
+
+        def red_run(repo: str, sha: str) -> list[dict]:
+            return [
+                {"name": "Deploy", "status": "completed", "conclusion": "failure", "html_url": "u"}
+            ]
+
+        self._patch(vdm, "fetch_workflow_files", only_pr)
+        self._patch(vdm, "fetch_runs_for_sha", red_run)
+        result = vdm.verify("o/r", "sha", timeout=1, poll=1, sleep=lambda _s: None)
+        self.assertFalse(result.verified)
+        self.assertEqual(result.expected, [])
 
     # -- helper: monkeypatch a module attr for the duration of one test --
     def _patch(self, mod: object, attr: str, value) -> None:

--- a/.claude/lib/verify_deployable_merge.py
+++ b/.claude/lib/verify_deployable_merge.py
@@ -42,11 +42,13 @@ Usage:
     python3 .claude/lib/verify_deployable_merge.py <owner/repo> <sha> --timeout 1200 --json
 
 Exit codes:
-    0 — VERIFIED: every expected workflow ran for the SHA and concluded success.
-    1 — NOT VERIFIED: a failed run, a missing expected workflow, or still
-        pending at timeout.
-    2 — UNDETERMINED: a gh/API call failed, or no expected workflows could be
-        resolved (nothing to verify).
+    0 — VERIFIED: every required workflow ran and concluded success AND no run
+        that executed for the SHA went red. This includes the "nothing required"
+        case (no post-merge-only / merge-triggered workflow at this ref, e.g. a
+        meta repo) — verified by the no-red safety net alone.
+    1 — NOT VERIFIED: a failed run, a required workflow that produced no run at
+        all (silent drop), or still pending at timeout.
+    2 — UNDETERMINED: a gh/API call failed — cannot determine.
 """
 
 from __future__ import annotations
@@ -241,6 +243,7 @@ class Aggregate:
     pending: bool
     rows: list[dict]  # per-expected-workflow: name, bucket, conclusion, url
     missing: list[str]  # expected workflows with no run for the SHA
+    expected: list[str]  # the required workflow set (empty == nothing required)
 
 
 def aggregate(expected: list[str], runs: list[dict]) -> Aggregate:
@@ -308,7 +311,13 @@ def aggregate(expected: list[str], runs: list[dict]) -> Aggregate:
 
     pending = any_pending or bool(missing)
     verified = not any_fail and not pending
-    return Aggregate(verified=verified, pending=pending, rows=rows, missing=missing)
+    return Aggregate(
+        verified=verified,
+        pending=pending,
+        rows=rows,
+        missing=missing,
+        expected=list(expected),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -421,12 +430,12 @@ def verify(
     time. Raises GhError (→ exit 2) if expected resolution finds nothing.
     """
     expected = resolve_expected(repo, sha, explicit_workflows, require_deployable)
-    if not expected:
-        raise GhError(
-            "no expected workflows resolved — nothing to verify "
-            "(check the ref has workflows, or pass --workflows)"
-        )
-
+    # An empty required set is NOT an error: a repo may have no post-merge-only
+    # workflow (e.g. a meta repo whose CI is path-partitioned and PR-visible).
+    # We still fetch the runs and apply the no-red safety net — a red run is
+    # caught regardless of whether anything was "required" — so "nothing
+    # required" resolves to verified iff nothing that ran went red. GhError
+    # (a real gh/API failure → exit 2) is raised only by the fetch calls.
     deadline = clock() + timeout
     result = aggregate(expected, fetch_runs_for_sha(repo, sha))
     while result.pending and clock() < deadline:
@@ -437,6 +446,8 @@ def verify(
 
 def _format_report(repo: str, sha: str, result: Aggregate) -> str:
     lines = [f"Deployable-merge verification — {repo} @ {sha[:8]}"]
+    if not result.expected:
+        lines.append("  (no required post-merge workflows at this ref — no-red safety net only)")
     for row in result.rows:
         mark = {"pass": "✓", "fail": "✗", "pending": "…", "missing": "∅"}.get(row["bucket"], "?")
         detail = row["conclusion"] or row["bucket"]

--- a/.claude/skills/wave-wrapup/SKILL.md
+++ b/.claude/skills/wave-wrapup/SKILL.md
@@ -473,13 +473,16 @@ while IFS= read -r R; do
   # pull_request) — the genuinely blind ones. Drop the flag to verify every
   # merge-triggered workflow. The no-red safety net fails on ANY run that
   # executed for the SHA and went red, so path-filtered workflows that fired are
-  # still covered.
-  if python3 "$REPO_ROOT/.claude/lib/verify_deployable_merge.py" \
-       "noorinalabs/$R" "$MAIN_SHA" --require-deployable --timeout 1200 --poll 30; then
-    echo "$R: deployable merge verified green @ ${MAIN_SHA:0:8}"
-  else
-    UNVERIFIED+=("$R @ ${MAIN_SHA:0:8}")
-  fi
+  # still covered. Exit codes: 0 = verified (incl. "nothing required" + no red),
+  # 1 = NOT verified (a red or silently-dropped required run), 2 = UNDETERMINED
+  # (gh/API failure — cannot tell, so surface and treat as blocking).
+  python3 "$REPO_ROOT/.claude/lib/verify_deployable_merge.py" \
+    "noorinalabs/$R" "$MAIN_SHA" --require-deployable --timeout 1200 --poll 30
+  case $? in
+    0) echo "$R: deployable merge verified green @ ${MAIN_SHA:0:8}" ;;
+    1) UNVERIFIED+=("$R @ ${MAIN_SHA:0:8} — a post-merge workflow failed / was dropped") ;;
+    2) UNVERIFIED+=("$R @ ${MAIN_SHA:0:8} — UNDETERMINED (gh/API error; re-run or investigate)") ;;
+  esac
 done <<< "$WAVE_REPOS_IN_SCOPE"
 
 if [ ${#UNVERIFIED[@]} -gt 0 ]; then

--- a/ontology/checksums.json
+++ b/ontology/checksums.json
@@ -122,9 +122,9 @@
       "resolved_at": "2026-06-04T20:50:14.260341+00:00"
     },
     ".claude/skills/wave-wrapup/SKILL.md": {
-      "last_tracked": "d2c84cb8cf5b02477bcb460aa4cd5e413784a067ff93be1a82631fc3ebe2cbf8",
+      "last_tracked": "ca9fa31381e522e3c595ecbf3ae2e09e990b1dbd38a5f952472389c6f910bfee",
       "last_resolved": "06ec27bab75ff4a97eb5fdfab7fea91db3178b42119c354de8c31aea3debbad9",
-      "tracked_at": "2026-06-25T01:49:36.462074+00:00",
+      "tracked_at": "2026-06-25T01:55:45.020052+00:00",
       "resolved_at": "2026-05-11T01:20:44.549652+00:00"
     },
     ".claude/team/charter.md": {
@@ -1056,15 +1056,15 @@
       "resolved_at": "2026-06-23T20:07:27Z"
     },
     ".claude/lib/verify_deployable_merge.py": {
-      "last_tracked": "c44342fcbbefb30de6ed3887faf0c82707b0ae87346ef78d83de6afdf746e772",
+      "last_tracked": "7c2545f87d17c5c35967612f88381444ff510ceb81ba6553ba37497b0d5c3302",
       "last_resolved": "",
-      "tracked_at": "2026-06-25T01:47:29.245692+00:00",
+      "tracked_at": "2026-06-25T01:56:11.801126+00:00",
       "resolved_at": ""
     },
     ".claude/lib/tests/test_verify_deployable_merge.py": {
-      "last_tracked": "99b3ca898e3209058f78d64beb06cc520523ce3d38cfb9546da92941c59a5954",
+      "last_tracked": "8a97a272c7187be03f1cff9ec7efb482172a66a7c981b41f89b77cd12b238b68",
       "last_resolved": "",
-      "tracked_at": "2026-06-25T01:48:21.358024+00:00",
+      "tracked_at": "2026-06-25T01:55:34.019804+00:00",
       "resolved_at": ""
     }
   },


### PR DESCRIPTION
## What

Follow-up correctness fix to #865: a deployable-merge verification where **nothing is required** (a repo with no post-merge-only / merge-triggered workflow — e.g. a meta repo whose CI is path-partitioned and PR-visible) now resolves to **VERIFIED (exit 0)** instead of an error, while still catching any red run via the no-red safety net.

Refs #864.

## Why

Dogfooding `verify_deployable_merge.py` against its **own** merge to `noorinalabs-main` returned exit 2 ("no expected workflows resolved"). The new `/wave-wrapup` Step 11.5a `if/else` would treat any non-zero as a block — so the gate would **false-block every meta / single-repo wave repo**. `noorinalabs-main` itself was in scope for P6W17, so this would have bitten the very next wrapup.

## Changes

- `verify()` no longer raises on an empty required set. It fetches the runs and applies the no-red safety net unconditionally — a red run fails verification whether or not anything was "required"; an empty required set with no red run is verified. **Exit 2 is now strictly real gh/API failure.**
- `Aggregate` carries `expected`, so the report prints the "nothing required" case explicitly (`no-red safety net only`).
- Step 11.5a wiring → explicit exit-code handling: `0` ok / `1` block / `2` undetermined-investigate.
- Tests: replaced the now-obsolete `no-expected-raises` with two — nothing-required-and-clean → verified, and nothing-required-but-a-red-run → caught by the net.

## Verified

`python3 .claude/lib/verify_deployable_merge.py noorinalabs/noorinalabs-main 1863528 --require-deployable` → `(no required post-merge workflows at this ref — no-red safety net only) / VERIFIED / exit 0`. ruff + mypy + pytest (26) green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
