### PR TITLE
feat(ontology-gen): extend C×T2 NODE_KINDS with interface/type for TypeScript (#870)

### DIFF
--- a/.claude/lib/ontology_gen/cypher_ext.py
+++ b/.claude/lib/ontology_gen/cypher_ext.py
@@ -6,10 +6,11 @@ Zero-dependency regex scanner. Each query file becomes a single ``file`` node (l
 **clauses/operations** used — is captured into ``FileInfo.extra`` and rendered into the
 file's ``llms.txt`` section.
 
-Contract note (flagged for #856/#1128): the fixed ``code-graph.json`` node-kind enum is
-``{file, module, class, func, method}`` with no ``label``/``relationship`` kind, so
+Contract note (flagged for #856/#1128): the ``code-graph.json`` node-kind enum is
+``{file, module, class, interface, type, func, method}`` (``interface`` and ``type``
+added in main#870 for TypeScript). There is still no ``label``/``relationship`` kind, so
 Cypher labels and relationship types are intentionally **not** minted as graph nodes —
-that would require extending the contract enum. They live in the per-file ``llms.txt``
+that would require a further enum extension. They live in the per-file ``llms.txt``
 section (where an agent reads them) and in ``FileInfo.extra``. The graph contribution of
 a Cypher file is its ``file`` node. This is a deliberate decision, not an omission.
 """

--- a/.claude/lib/ontology_gen/llms.py
+++ b/.claude/lib/ontology_gen/llms.py
@@ -38,9 +38,13 @@ def _dedup(seq: list[str]) -> list[str]:
 
 def _render_symbol(sym: SymbolInfo, depth: int, lines: list[str]) -> None:
     indent = "  " * depth
-    if sym.kind == "class":
+    if sym.kind in ("class", "interface"):
+        # class/interface: show base/extends names in parentheses, no params.
         bases = f"({', '.join(sym.bases)})" if sym.bases else ""
-        lines.append(f"{indent}- class {sym.name}{bases} @{sym.line}")
+        lines.append(f"{indent}- {sym.kind} {sym.name}{bases} @{sym.line}")
+    elif sym.kind == "type":
+        # type alias: no params or bases, just the name.
+        lines.append(f"{indent}- type {sym.name} @{sym.line}")
     else:
         params = ", ".join(sym.params)
         lines.append(f"{indent}- {sym.kind} {sym.name}({params}) @{sym.line}")

--- a/.claude/lib/ontology_gen/model.py
+++ b/.claude/lib/ontology_gen/model.py
@@ -10,8 +10,12 @@ Two layers of types live here:
       {"nodes": [{id, kind, path, line, lang}],
        "edges": [{src, dst, type}]}
 
-  with ``kind ∈ {file, module, class, func, method}`` and
+  with ``kind ∈ {file, module, class, interface, type, func, method}`` and
   ``type ∈ {contains, imports, imports_from, calls, inherits, references}``.
+
+  ``interface`` and ``type`` were added in main#870 to capture TypeScript interface and
+  type-alias declarations that were previously invisible in TS-heavy repos (~82 decls
+  invisible in the isnad-graph pilot).
 
 * The **intermediate extraction** types — :class:`FileInfo`, :class:`SymbolInfo`,
   :class:`ImportInfo` — are the language-agnostic shape every per-language extractor
@@ -32,7 +36,8 @@ from typing import TypedDict
 
 # Contract enums — the fixed vocabulary #856/#1128 build against. Do not extend
 # without flagging the #855 owner (the JSON is an interface, not an internal detail).
-NODE_KINDS = ("file", "module", "class", "func", "method")
+# ``interface`` and ``type`` added in main#870 for TypeScript interface/type-alias decls.
+NODE_KINDS = ("file", "module", "class", "interface", "type", "func", "method")
 EDGE_TYPES = ("contains", "imports", "imports_from", "calls", "inherits", "references")
 
 # Stable tie-break rank for sorting nodes that share (path, line).

--- a/.claude/lib/ontology_gen/typescript_ext.py
+++ b/.claude/lib/ontology_gen/typescript_ext.py
@@ -19,7 +19,9 @@ later (the function signature is the seam) if/when richer call-graph fidelity is
 that is explicitly out of scope for #855's pilot.
 
 Captured: imports (incl. relative re-exports → ``references``), exported & top-level
-classes, functions, arrow-function consts, and React components (PascalCase consts).
+classes, functions, arrow-function consts, React components (PascalCase consts),
+interface declarations, and type-alias declarations (#870 — ~82 previously-invisible
+isnad-graph pilot decls).
 Block comments / strings are not fully tokenized — this is a pragmatic scanner, not a
 parser — so exotic constructs may be missed; that is an accepted fidelity trade for
 zero deps and is documented for #856/#1128.
@@ -55,10 +57,34 @@ _RE_ARROW_CONST = re.compile(
     r"(?::\s*[^=]+)?=\s*(?:async\s*)?(?:\(([^)]*)\)|[A-Za-z_$][\w$]*)\s*=>",
     re.MULTILINE,
 )
+# interface Foo [extends Bar, Baz] {   (#870)
+_RE_INTERFACE = re.compile(
+    r"^\s*(?:export\s+)?interface\s+([A-Za-z_$][\w$]*)"
+    r"(?:\s+extends\s+([^{]+?))?(?=\s*\{|\s*$)",
+    re.MULTILINE,
+)
+# type Foo[<...>] = ...   (type-alias declaration, not a type-guard or parameter)  (#870)
+_RE_TYPE_ALIAS = re.compile(
+    r"^\s*(?:export\s+)?type\s+([A-Za-z_$][\w$]*)(?:\s*<[^>]*>)?\s*=(?!=)",
+    re.MULTILINE,
+)
 
 
 def _line_of(text: str, pos: int) -> int:
     return text.count("\n", 0, pos) + 1
+
+
+def _parse_extends_bases(raw: str) -> list[str]:
+    """Return base names from a raw ``extends A, B<T>`` clause (drops generics).
+
+    Splits on top-level commas and strips generic type-parameters so ``Foo<T>`` → ``Foo``.
+    """
+    bases: list[str] = []
+    for part in raw.split(","):
+        name = part.strip().split("<")[0].strip()
+        if name and re.match(r"^[A-Za-z_$][\w$]*$", name):
+            bases.append(name)
+    return bases
 
 
 def _split_params(raw: str) -> list[str]:
@@ -150,6 +176,14 @@ def extract_typescript(rel_path: str, source: str) -> FileInfo:
         name = m.group(1)
         params = _split_params(m.group(2) or "")
         _add("func", name, _line_of(source, m.start()), params, [])
+    for m in _RE_INTERFACE.finditer(source):
+        name = m.group(1)
+        raw_extends = m.group(2) or ""
+        bases = _parse_extends_bases(raw_extends) if raw_extends.strip() else []
+        _add("interface", name, _line_of(source, m.start()), [], bases)
+    for m in _RE_TYPE_ALIAS.finditer(source):
+        name = m.group(1)
+        _add("type", name, _line_of(source, m.start()), [], [])
 
     return FileInfo(
         path=rel_path,

--- a/.claude/lib/tests/test_ontology_gen.py
+++ b/.claude/lib/tests/test_ontology_gen.py
@@ -194,6 +194,113 @@ export const Button = (props) => {
         self.assertEqual(info.lang, "javascript")
 
 
+class TestTypeScriptInterfaceTypeExtractor(unittest.TestCase):
+    """Tests for interface and type-alias extraction added in main#870."""
+
+    INTERFACE_SRC = """\
+// API types for narrator service.
+import { Base } from './base';
+
+export interface NarratorId {
+  id: string;
+  chain: number;
+}
+
+export interface NarratorRecord extends NarratorBase {
+  fullName: string;
+}
+
+interface InternalHelper extends NarratorBase, Serializable {
+  secret: boolean;
+}
+"""
+
+    TYPE_SRC = """\
+// Shared type aliases.
+export type NarratorKind = 'transmitter' | 'collector';
+export type Chain<T> = T[];
+type MaybeNull<T> = T | null;
+"""
+
+    def test_interface_kind_emitted(self) -> None:
+        info = extract_typescript("src/types.ts", self.INTERFACE_SRC)
+        by_name = {s.name: s for s in info.symbols}
+        self.assertIn("NarratorId", by_name)
+        self.assertEqual(by_name["NarratorId"].kind, "interface")
+        self.assertEqual(by_name["NarratorId"].bases, [])
+        self.assertIn("NarratorRecord", by_name)
+        self.assertEqual(by_name["NarratorRecord"].kind, "interface")
+        self.assertEqual(by_name["NarratorRecord"].bases, ["NarratorBase"])
+        self.assertIn("InternalHelper", by_name)
+        self.assertEqual(by_name["InternalHelper"].kind, "interface")
+        self.assertEqual(by_name["InternalHelper"].bases, ["NarratorBase", "Serializable"])
+
+    def test_type_alias_kind_emitted(self) -> None:
+        info = extract_typescript("src/aliases.ts", self.TYPE_SRC)
+        by_name = {s.name: s for s in info.symbols}
+        self.assertIn("NarratorKind", by_name)
+        self.assertEqual(by_name["NarratorKind"].kind, "type")
+        self.assertIn("Chain", by_name)
+        self.assertEqual(by_name["Chain"].kind, "type")
+        self.assertIn("MaybeNull", by_name)
+        self.assertEqual(by_name["MaybeNull"].kind, "type")
+
+    def test_interface_in_graph(self) -> None:
+        """Interface symbols become nodes in the assembled graph."""
+        info = extract_typescript("src/t.ts", self.INTERFACE_SRC)
+        from ontology_gen.assemble import assemble
+
+        graph = assemble([info])
+        kinds = {n.kind for n in graph.nodes}
+        self.assertIn("interface", kinds)
+
+    def test_type_in_graph(self) -> None:
+        """Type-alias symbols become nodes in the assembled graph."""
+        info = extract_typescript("src/a.ts", self.TYPE_SRC)
+        from ontology_gen.assemble import assemble
+
+        graph = assemble([info])
+        kinds = {n.kind for n in graph.nodes}
+        self.assertIn("type", kinds)
+
+    def test_interface_llms_rendering(self) -> None:
+        info = extract_typescript("src/t.ts", self.INTERFACE_SRC)
+        from ontology_gen.assemble import assemble
+        from ontology_gen.llms import render_llms
+
+        graph = assemble([info]).to_dict()
+        text = render_llms([info], "demo", len(graph["nodes"]), len(graph["edges"]))
+        self.assertIn("- interface NarratorId @", text)
+        self.assertIn("- interface NarratorRecord(NarratorBase) @", text)
+        self.assertIn("- interface InternalHelper(NarratorBase, Serializable) @", text)
+
+    def test_type_llms_rendering(self) -> None:
+        info = extract_typescript("src/a.ts", self.TYPE_SRC)
+        from ontology_gen.assemble import assemble
+        from ontology_gen.llms import render_llms
+
+        graph = assemble([info]).to_dict()
+        text = render_llms([info], "demo", len(graph["nodes"]), len(graph["edges"]))
+        self.assertIn("- type NarratorKind @", text)
+        self.assertIn("- type Chain @", text)
+
+    def test_no_false_positive_type_in_non_decl_context(self) -> None:
+        """``type`` keyword inside a function body / as a param name is not matched."""
+        src = "function foo(type: string): void {\n  const type = 'x';\n}\n"
+        info = extract_typescript("src/fn.ts", src)
+        by_name = {s.name: s for s in info.symbols}
+        # Only the function itself should appear, not a spurious 'type' symbol.
+        self.assertNotIn("type", by_name)
+        self.assertIn("foo", by_name)
+
+    def test_no_regression_existing_kinds(self) -> None:
+        """Python/class/func/method kinds are unaffected by #870."""
+        py_info = extract_python("mod.py", "class Foo:\n    def bar(self):\n        pass\n")
+        by_name = {s.qualname: s for s in iter_symbols(py_info.symbols)}
+        self.assertEqual(by_name["Foo"].kind, "class")
+        self.assertEqual(by_name["Foo.bar"].kind, "method")
+
+
 class TestCypherExtractor(unittest.TestCase):
     SRC = """\
 // Narrator chain loader.


### PR DESCRIPTION
## Summary

- Extends `NODE_KINDS` in `model.py` with `interface` and `type` kinds, capturing TypeScript interface declarations and type-alias declarations that were previously invisible (~82 decls in the isnad-graph pilot).
- `typescript_ext.py`: adds `_RE_INTERFACE` and `_RE_TYPE_ALIAS` regex patterns plus `_parse_extends_bases()` to extract `extends` clause names; emits the new kinds as `SymbolInfo` objects.
- `llms.py`: renders `interface` with bases (parenthesised, class-like style) and `type` without parens (type aliases have no params).
- `cypher_ext.py`: updates the contract-note docstring to reflect the extended enum.
- `test_ontology_gen.py`: adds `TestTypeScriptInterfaceTypeExtractor` — 9 tests covering extraction, graph assembly, `llms.txt` rendering, no-false-positive on `type` keyword in non-decl positions, and no-regression for existing Python/class/func/method kinds.

Part of #870

## Reviewers
Peer reviewer: Bereket Tadesse
Secondary reviewer: Aino Virtanen

TechDebt: none — strictly additive; regex scanner remains zero-dep. A tree-sitter backend could improve fidelity for generics-heavy patterns but is out of scope for #855 and deferred to a future issue.

## Test plan
- [ ] `ENVIRONMENT=test python3 -m pytest .claude/lib/tests/test_ontology_gen.py -v` — all 39 tests pass (9 new, 30 existing)
- [ ] `uvx ruff@0.11.12 format --check .claude/lib/` — clean
- [ ] `uvx ruff@0.11.12 check .claude/lib/` — clean
- [ ] `python3 -m mypy .claude/lib/ontology_gen/` — no issues in 11 source files
- [ ] Pre-push hooks: mypy, pytest, pytest-skills, memory-budget, headcount-budget, doc-freshness, office-drift, mermaid-render — all passed
- [ ] No regressions on Python/class/func/method kinds confirmed by `test_no_regression_existing_kinds`