### PR TITLE
fix(ontology): standardize merge-driver to plain-script form (#871)

### DIFF
--- a/.claude/lib/ontology_gen/merge_driver.py
+++ b/.claude/lib/ontology_gen/merge_driver.py
@@ -10,11 +10,47 @@ it parses both sides (and the base), unions nodes by ``id`` and edges by
 so concurrent regenerations merge cleanly and deterministically.
 
 Wiring (the ``.gitattributes`` + ``git config`` lines) lands in #856; this is the script
-that wiring points at. To register it manually:
+that wiring points at.
 
+Canonical invocation form (#871)
+---------------------------------
+The **plain-script form** is canonical across all repos::
+
+    python3 <path-to>/merge_driver.py %O %A %B %P
+
+This script is self-contained: the ``ImportError`` fallback below (#860) bootstraps
+``.claude/lib`` onto ``sys.path`` via ``Path(__file__).resolve().parent.parent``, so
+package-relative imports resolve without any ``PYTHONPATH`` manipulation. Git invokes
+the driver via the shell, so a relative path works when the driver lives in the same
+repo; child repos that locate the driver from the sibling noorinalabs-main checkout use
+an absolute path resolved at registration time via ``locate_generator()``.
+
+**noorinalabs-main** (driver lives here — relative path from repo root)::
+
+    git config merge.ontology-codegraph.name 'ontology code-graph union merge'
     git config merge.ontology-codegraph.driver \\
         'python3 .claude/lib/ontology_gen/merge_driver.py %O %A %B %P'
-    echo 'ontology/structural/code-graph.json merge=ontology-codegraph' >> .gitattributes
+
+    # or via the Makefile target:
+    make setup-ontology-merge-driver
+
+**Child repos** (driver lives in the sibling noorinalabs-main — absolute path resolved
+at registration time by ``scripts/structural_ontology.py register-merge-driver`` using
+``locate_generator()`` / ``$ONTOLOGY_GEN_LIB``)::
+
+    # Run once per clone (``make setup-hooks`` calls this automatically):
+    python3 scripts/structural_ontology.py register-merge-driver
+
+    # Which emits (with the absolute path substituted at registration time):
+    git config merge.ontology-codegraph.name 'ontology code-graph union merge'
+    git config merge.ontology-codegraph.driver \\
+        'python3 /abs/path/noorinalabs-main/.claude/lib/ontology_gen/merge_driver.py %O %A %B %P'
+
+The Python module form (``PYTHONPATH=<lib> python3 -m ontology_gen.merge_driver``) also
+works but is NOT canonical — it requires explicit ``PYTHONPATH`` at registration time and
+bakes that into the git config. The plain-script self-contained fallback makes it
+unnecessary. See ``docs/devops/ontology-structural.md`` for the full rationale and the
+six-repo fan-out checklist (#871, #820 C×T2).
 
 Git calls the driver as ``driver %O %A %B [%P]`` where %O=base, %A=ours (result is
 written back here), %B=theirs. Exit 0 = merged cleanly.

--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -220,3 +220,6 @@ provectuslabs
 # --- Ontology-vs-graphify spike (#728): LLM-doc + code-graph terms ---
 llms
 graphify
+
+# --- Merge-driver canonical form (#871): compound driver name ---
+codegraph

--- a/.gitattributes
+++ b/.gitattributes
@@ -21,5 +21,13 @@
 #     git config merge.ontology-codegraph.name 'ontology code-graph union merge'
 #     git config merge.ontology-codegraph.driver \
 #       'python3 .claude/lib/ontology_gen/merge_driver.py %O %A %B %P'
+#
+# CANONICAL FORM (#871): plain-script, NOT ``python3 -m``. The script is
+# self-contained (ImportError fallback #860 bootstraps sys.path via
+# Path(__file__).resolve()), so no PYTHONPATH setup is required.
+# Child repos use the same plain-script form with an absolute path resolved
+# at registration time via ``python3 scripts/structural_ontology.py
+# register-merge-driver`` (or ``make setup-hooks``). See
+# docs/devops/ontology-structural.md (#871, #820 C×T2).
 ontology/structural/code-graph.json merge=ontology-codegraph
 ontology/structural/cross-repo-graph.json merge=ontology-codegraph

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,11 @@ setup-hooks:
 # per-clone local git config (it cannot be committed), so run this once per clone
 # (main#856, #820 C×T2). Without it git falls back to the default text merge and
 # the sorted JSON spuriously conflicts on parallel regenerations.
+#
+# CANONICAL FORM (#871): plain-script — self-contained via the ImportError
+# fallback in merge_driver.py (#860), no PYTHONPATH needed. Child repos use the
+# same form with an absolute path resolved by ``structural_ontology.py
+# register-merge-driver``. See docs/devops/ontology-structural.md.
 setup-ontology-merge-driver:
 	git config merge.ontology-codegraph.name 'ontology code-graph union merge'
 	git config merge.ontology-codegraph.driver \

--- a/docs/devops/ontology-structural.md
+++ b/docs/devops/ontology-structural.md
@@ -1,0 +1,156 @@
+# Structural ontology — merge-driver canonical form and fan-out checklist
+
+This document is the canonical reference for the union merge-driver that prevents
+spurious merge conflicts on `ontology/structural/code-graph.json` (#855, #856, #820
+C×T2). It was authored to standardize the invocation form across all repos after a
+divergence was identified between noorinalabs-main and the isnad-graph pilot (#871).
+
+## Background
+
+`code-graph.json` is a single committed artifact that every feature branch regenerates
+independently. A plain text 3-way merge produces spurious conflicts on the sorted
+node/edge arrays even when the two branches touched different source files (the
+`feedback_parallel_panels_shared_file` hazard). The `ontology-codegraph` union
+merge-driver (`.claude/lib/ontology_gen/merge_driver.py`) handles this by:
+
+- Parsing both the ours, theirs, and base graphs
+- Union-merging nodes by `id` and edges by `(src, dst, type)`
+- Re-serializing in canonical order, so the result is byte-identical to a fresh
+  regeneration
+
+The driver name (`ontology-codegraph`) is declared in `.gitattributes`; the driver
+command is per-clone local git config (it cannot live in a committed file).
+
+## Canonical invocation form (#871)
+
+```
+git config merge.ontology-codegraph.name 'ontology code-graph union merge'
+git config merge.ontology-codegraph.driver \
+    'python3 <path-to>/merge_driver.py %O %A %B %P'
+```
+
+The **plain-script form** is canonical for all repos. The script is self-contained:
+`merge_driver.py` carries an `ImportError` fallback (#860) that bootstraps `.claude/lib`
+onto `sys.path` via `Path(__file__).resolve().parent.parent`, so the package-relative
+import of `ontology_gen.model` resolves without any `PYTHONPATH` setup.
+
+### Why plain-script and not `python3 -m`?
+
+The isnad-graph pilot (#1128) used `PYTHONPATH={gen_lib} python3 -m ontology_gen.merge_driver`
+because, at the time it was written, `merge_driver.py` did not have the self-contained
+fallback — a bare `python3 .../merge_driver.py` invocation raised `ImportError` on the
+package-relative `from .model import`. The `#860` fallback fixed that. The module form
+now has no advantage over the plain-script form and requires explicit `PYTHONPATH`
+manipulation that makes the git config harder to read and verify. The canonical form
+going forward is plain-script.
+
+### noorinalabs-main (driver lives here)
+
+The driver is in this repo at `.claude/lib/ontology_gen/merge_driver.py`. Register with
+a relative path (git runs drivers from the repo root):
+
+```bash
+# Via the Makefile target (preferred):
+make setup-ontology-merge-driver
+
+# Or manually:
+git config merge.ontology-codegraph.name 'ontology code-graph union merge'
+git config merge.ontology-codegraph.driver \
+    'python3 .claude/lib/ontology_gen/merge_driver.py %O %A %B %P'
+```
+
+### Child repos (driver lives in the sibling noorinalabs-main checkout)
+
+Child repos do not contain a copy of `merge_driver.py` (the generator is intentionally
+not vendored — single source of truth, see `#854`). `scripts/structural_ontology.py
+register-merge-driver` locates the driver via `locate_generator()` (which walks up to
+the sibling noorinalabs-main or uses `$ONTOLOGY_GEN_LIB`) and registers an
+absolute-path plain-script command:
+
+```bash
+# Via setup-hooks (preferred — make setup-hooks calls this automatically):
+make setup-hooks
+
+# Or directly:
+python3 scripts/structural_ontology.py register-merge-driver
+```
+
+The resulting git config entry will look like:
+
+```
+[merge "ontology-codegraph"]
+    name = ontology code-graph union merge
+    driver = python3 /abs/path/noorinalabs-main/.claude/lib/ontology_gen/merge_driver.py %O %A %B %P
+```
+
+The absolute path is resolved at registration time. After `make setup-hooks` (or the
+equivalent per-repo target), run `git config merge.ontology-codegraph.driver` to verify
+the path is correct and points to the live noorinalabs-main checkout.
+
+### $ONTOLOGY_GEN_LIB override
+
+Set `ONTOLOGY_GEN_LIB=<path-to>/noorinalabs-main/.claude/lib` before running
+`register-merge-driver` (or `make setup-hooks`) to override auto-discovery. CI uses this
+to point at the sibling-checkout path:
+
+```yaml
+- uses: actions/checkout@v4
+  with:
+    repository: noorinalabs/noorinalabs-main
+    path: _main
+- run: ONTOLOGY_GEN_LIB=_main/.claude/lib python3 scripts/structural_ontology.py register-merge-driver
+```
+
+## Six-repo fan-out checklist (#820 C×T2)
+
+For each child repo receiving the structural ontology layer, the following must be in
+place (matching the isnad-graph pilot pattern, updated to the canonical invocation form):
+
+- [ ] `scripts/structural_ontology.py` — consumer wrapper with `locate_generator()`,
+  `emit`, `check`, and `register-merge-driver` subcommands. `register-merge-driver`
+  MUST emit the **plain-script** form (not the module form).
+- [ ] `.gitattributes` — `ontology/structural/code-graph.json merge=ontology-codegraph`
+- [ ] `Makefile` — `setup-hooks` target that calls
+  `python3 scripts/structural_ontology.py register-merge-driver`
+- [ ] `.github/workflows/structural-ontology.yml` — CI job that checks out
+  noorinalabs-main as a sibling, passes `--gen-lib _main/.claude/lib`, and runs
+  `python3 scripts/structural_ontology.py check --require-generator`
+- [ ] `.pre-commit-config.yaml` — `structural-ontology-staleness` hook that runs the
+  same `check` subcommand (local dev degraded skip if generator absent; CI is
+  authoritative)
+- [ ] `pre_commit_ci_sync.py` — `structural-ontology` kind registered so the sync-drift
+  gate enforces local/CI parity for this check
+
+### Updating `register-merge-driver` in existing child repos
+
+The isnad-graph pilot's `cmd_register_merge_driver` uses the module form. Update it to
+the plain-script form before the fan-out lands additional repos on the old form:
+
+```python
+# Before (module form — NOT canonical):
+driver = f"PYTHONPATH={gen_lib} python3 -m ontology_gen.merge_driver %O %A %B %P"
+
+# After (plain-script form — canonical, #871):
+driver = f"python3 {gen_lib}/ontology_gen/merge_driver.py %O %A %B %P"
+```
+
+The isnad-graph update is tracked as a follow-on to this PR (see #871 acceptance
+criterion "per-child-repo rollout follows the same standardized shape").
+
+## Verification
+
+After registering the driver in any repo, verify it resolves and runs correctly:
+
+```bash
+# 1. Confirm the config entry:
+git config merge.ontology-codegraph.driver
+
+# 2. Confirm the script path exists and is executable:
+python3 "$(git config merge.ontology-codegraph.driver | awk '{print $2}')" 2>&1 | head -1
+# Expected: "usage: merge_driver.py <base %O> <ours %A> <theirs %B> [pathname %P]"
+
+# 3. End-to-end test (union of two identical graphs is idempotent):
+cp ontology/structural/code-graph.json /tmp/cg_test.json
+git merge-file -p /tmp/cg_test.json /tmp/cg_test.json /tmp/cg_test.json 2>/dev/null
+echo "exit $?"  # should be 0
+```


### PR DESCRIPTION
## Summary

- Standardizes the union merge-driver invocation form to **plain-script** across all repos, resolving the divergence between noorinalabs-main (plain-script via `#860` fallback) and the isnad-graph pilot (module form) that would have propagated through the six-repo C×T2 fan-out (#820)
- Documents the canonical form, rationale, and fan-out checklist in `docs/devops/ontology-structural.md` (new)
- Updates `merge_driver.py` docstring, `.gitattributes`, and `Makefile` comments so the canonical form is authoritative at the source

Canonical form: `python3 <path>/merge_driver.py %O %A %B %P` — the ImportError fallback (#860) makes the script self-contained (no `PYTHONPATH`); child repos use an absolute path resolved at registration time by `scripts/structural_ontology.py register-merge-driver`.

Does NOT edit child repos — per-child rollout follows the template in `docs/devops/ontology-structural.md`. Part of #871.

Requestor: Nino Kavtaradze
Requestee: N/A (security/tooling consistency PR)

Peer reviewer: Lucas Ferreira
Secondary reviewer: Wanjiku Mwangi

TechDebt: isnad-graph `structural_ontology.py` `cmd_register_merge_driver` still emits the module form; fan-out repos must update to the plain-script template from `docs/devops/ontology-structural.md` before their `setup-hooks` target is stable.

## Test plan

- [x] `ruff format --check` passes on `.claude/lib/ontology_gen/merge_driver.py`
- [x] `ruff lint` passes
- [x] `mypy` passes (144 source files, 0 issues)
- [x] All 2075 tests pass (hooks + lib)
- [x] All pre-push hooks pass (mypy, pytest, pytest-skills, memory-budget, headcount-budget, doc-freshness, office-drift, mermaid-render, cspell)
- [x] `make setup-ontology-merge-driver` in noorinalabs-main registers the canonical form and driver resolves correctly
- [ ] CI statusCheckRollup green (pending)
