### PR TITLE
feat(#868): auto-create Project-2 Wave field option before kickoff label-apply

### DIFF
--- a/.claude/lib/tests/test_wave_field_option.py
+++ b/.claude/lib/tests/test_wave_field_option.py
@@ -1,0 +1,501 @@
+"""Tests for wave_field_option — wave board option auto-create helper (#868).
+
+Covers:
+  1. Option-name grammar for all three label forms (#810).
+  2. check_wave_option — present, absent, error, bad label.
+  3. ensure_wave_option — idempotent no-op, create+verify, missing auth scope,
+     introspect failure, mutation failure, read-back verification failure.
+  4. Full-list-preserve — existing options are included unchanged in the mutation.
+  5. CLI exit codes: ensure exit 0/1, check exit 0/2/1.
+  6. ensure_wave_option preserves existing options in the mutation body.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import wave_field_option as wfo  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _field_response(options: list[dict]) -> str:
+    """Fake GraphQL introspect response with the given options list."""
+    return json.dumps(
+        {
+            "data": {
+                "organization": {
+                    "projectV2": {
+                        "id": "PVT_test123",
+                        "field": {
+                            "id": "FIELD_test456",
+                            "options": options,
+                        },
+                    }
+                }
+            }
+        }
+    )
+
+
+_EXISTING_OPTIONS = [
+    {"id": "OPT_w16", "name": "W16", "color": "BLUE", "description": ""},
+    {"id": "OPT_w17", "name": "W17", "color": "GREEN", "description": "Wave 17"},
+]
+
+
+def _runner_present() -> str:
+    """Introspect runner: W18 already exists in options."""
+    options = _EXISTING_OPTIONS + [
+        {"id": "OPT_w18", "name": "W18", "color": "PURPLE", "description": ""}
+    ]
+    return _field_response(options)
+
+
+def _runner_absent(query: str, variables: dict) -> str:  # noqa: ARG001
+    """Introspect runner: W18 absent, only W16/W17 present."""
+    return _field_response(_EXISTING_OPTIONS)
+
+
+def _runner_absent_then_present() -> object:
+    """Returns a runner that yields 'absent' on first call, 'present' on second.
+
+    Used to simulate the read-back-verify step after a successful mutation.
+    """
+    calls = [0]
+
+    def runner(query: str, variables: dict) -> str:  # noqa: ARG001
+        calls[0] += 1
+        if calls[0] == 1:
+            return _field_response(_EXISTING_OPTIONS)
+        # Second call (read-back): include W18
+        return _field_response(
+            _EXISTING_OPTIONS
+            + [{"id": "OPT_w18_new", "name": "W18", "color": "PURPLE", "description": ""}]
+        )
+
+    return runner
+
+
+def _ok_mutation_runner(body: str) -> str:  # noqa: ARG001
+    """Stdin runner: mutation succeeds."""
+    return json.dumps(
+        {
+            "data": {
+                "updateProjectV2Field": {
+                    "projectV2Field": {
+                        "id": "FIELD_test456",
+                        "options": [
+                            {"id": "OPT_w16", "name": "W16"},
+                            {"id": "OPT_w17", "name": "W17"},
+                            {"id": "OPT_w18_new", "name": "W18"},
+                        ],
+                    }
+                }
+            }
+        }
+    )
+
+
+def _error_mutation_runner(body: str) -> str:  # noqa: ARG001
+    """Stdin runner: mutation returns GraphQL errors."""
+    return json.dumps({"errors": [{"message": "Field not found"}]})
+
+
+def _auth_has_scope() -> str:
+    return "Token scopes: 'gist', 'project', 'read:org', 'repo', 'workflow'"
+
+
+def _auth_no_scope() -> str:
+    return "Token scopes: 'gist', 'read:org', 'repo', 'workflow'"
+
+
+# ---------------------------------------------------------------------------
+# Option-name grammar tests
+# ---------------------------------------------------------------------------
+
+
+class TestWaveLabelToOptionName(unittest.TestCase):
+    """Grammar: wave-{X} → W{X}, p{N}-wave-{M} → P{N}W{M}, wave-x → WX."""
+
+    def test_global_form(self) -> None:
+        self.assertEqual(wfo._wave_label_to_option_name("wave-18"), "W18")
+
+    def test_global_form_large_number(self) -> None:
+        self.assertEqual(wfo._wave_label_to_option_name("wave-99"), "W99")
+
+    def test_legacy_form(self) -> None:
+        self.assertEqual(wfo._wave_label_to_option_name("p6-wave-17"), "P6W17")
+
+    def test_legacy_form_multi_digit_phase(self) -> None:
+        self.assertEqual(wfo._wave_label_to_option_name("p12-wave-5"), "P12W5")
+
+    def test_placeholder(self) -> None:
+        self.assertEqual(wfo._wave_label_to_option_name("wave-x"), "WX")
+
+    def test_invalid_returns_none(self) -> None:
+        self.assertIsNone(wfo._wave_label_to_option_name("bug"))
+        self.assertIsNone(wfo._wave_label_to_option_name("wave-18-special"))
+        self.assertIsNone(wfo._wave_label_to_option_name("p6-wave-17-frozen"))
+        self.assertIsNone(wfo._wave_label_to_option_name(""))
+
+    def test_anchored_rejects_suffix(self) -> None:
+        # "wave-x" placeholder only — "wave-x-draft" must NOT match
+        self.assertIsNone(wfo._wave_label_to_option_name("wave-x-draft"))
+
+
+# ---------------------------------------------------------------------------
+# _introspect_field tests
+# ---------------------------------------------------------------------------
+
+
+class TestIntrospectField(unittest.TestCase):
+    def test_returns_ids_and_options(self) -> None:
+        runner = lambda q, v: _runner_absent(q, v)  # noqa: E731
+        result = wfo._introspect_field(runner=runner)
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result["project_id"], "PVT_test123")
+        self.assertEqual(result["field_id"], "FIELD_test456")
+        self.assertEqual(len(result["options"]), 2)
+        self.assertEqual(result["options"][0]["name"], "W16")
+
+    def test_returns_none_on_runner_error(self) -> None:
+        def bad_runner(q: str, v: dict) -> str:
+            raise OSError("network down")
+
+        result = wfo._introspect_field(runner=bad_runner)
+        self.assertIsNone(result)
+
+    def test_returns_none_on_empty_response(self) -> None:
+        result = wfo._introspect_field(runner=lambda q, v: "")
+        self.assertIsNone(result)
+
+    def test_returns_none_on_bad_json(self) -> None:
+        result = wfo._introspect_field(runner=lambda q, v: "not-json{")
+        self.assertIsNone(result)
+
+
+# ---------------------------------------------------------------------------
+# check_wave_option tests
+# ---------------------------------------------------------------------------
+
+
+class TestCheckWaveOption(unittest.TestCase):
+    def test_present_when_option_exists(self) -> None:
+        options_with_w18 = _EXISTING_OPTIONS + [
+            {"id": "OPT_w18", "name": "W18", "color": "PURPLE", "description": ""}
+        ]
+        runner = lambda q, v: _field_response(options_with_w18)  # noqa: E731
+        res = wfo.check_wave_option("wave-18", runner=runner)
+        self.assertEqual(res["status"], "present")
+        self.assertEqual(res["option_name"], "W18")
+        self.assertEqual(res["option_id"], "OPT_w18")
+
+    def test_absent_when_option_missing(self) -> None:
+        res = wfo.check_wave_option("wave-18", runner=_runner_absent)
+        self.assertEqual(res["status"], "absent")
+        self.assertEqual(res["option_name"], "W18")
+
+    def test_error_on_bad_label(self) -> None:
+        res = wfo.check_wave_option("not-a-wave-label", runner=_runner_absent)
+        self.assertEqual(res["status"], "error")
+        self.assertIn("not-a-wave-label", res["detail"])
+
+    def test_error_on_introspect_failure(self) -> None:
+        res = wfo.check_wave_option("wave-18", runner=lambda q, v: "")
+        self.assertEqual(res["status"], "error")
+        self.assertIn("introspect", res["detail"])
+
+    def test_legacy_label(self) -> None:
+        options = [{"id": "OPT_p6w17", "name": "P6W17", "color": "BLUE", "description": ""}]
+        runner = lambda q, v: _field_response(options)  # noqa: E731
+        res = wfo.check_wave_option("p6-wave-17", runner=runner)
+        self.assertEqual(res["status"], "present")
+        self.assertEqual(res["option_name"], "P6W17")
+
+    def test_placeholder_label(self) -> None:
+        options = [{"id": "OPT_wx", "name": "WX", "color": "GRAY", "description": ""}]
+        runner = lambda q, v: _field_response(options)  # noqa: E731
+        res = wfo.check_wave_option("wave-x", runner=runner)
+        self.assertEqual(res["status"], "present")
+        self.assertEqual(res["option_name"], "WX")
+
+
+# ---------------------------------------------------------------------------
+# ensure_wave_option tests
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureWaveOption(unittest.TestCase):
+    def test_idempotent_when_already_present(self) -> None:
+        options_with_w18 = _EXISTING_OPTIONS + [
+            {"id": "OPT_w18", "name": "W18", "color": "PURPLE", "description": ""}
+        ]
+        runner = lambda q, v: _field_response(options_with_w18)  # noqa: E731
+        # stdin_runner should NOT be called (no mutation needed).
+        stdin_runner = MagicMock()
+        res = wfo.ensure_wave_option("wave-18", runner=runner, stdin_runner=stdin_runner)
+        self.assertEqual(res["status"], "present")
+        self.assertEqual(res["option_name"], "W18")
+        stdin_runner.assert_not_called()
+
+    def test_creates_when_absent(self) -> None:
+        two_phase_runner = _runner_absent_then_present()
+        res = wfo.ensure_wave_option(
+            "wave-18",
+            auth_runner=_auth_has_scope,
+            runner=two_phase_runner,
+            stdin_runner=_ok_mutation_runner,
+        )
+        self.assertEqual(res["status"], "created")
+        self.assertEqual(res["option_name"], "W18")
+
+    def test_error_on_bad_label(self) -> None:
+        res = wfo.ensure_wave_option(
+            "not-a-label", runner=_runner_absent, stdin_runner=_ok_mutation_runner
+        )
+        self.assertEqual(res["status"], "error")
+        self.assertIn("not-a-label", res["detail"])
+
+    def test_error_when_introspect_fails(self) -> None:
+        res = wfo.ensure_wave_option("wave-18", runner=lambda q, v: "")
+        self.assertEqual(res["status"], "error")
+        self.assertIn("introspect", res["detail"])
+
+    def test_error_when_no_auth_scope(self) -> None:
+        res = wfo.ensure_wave_option(
+            "wave-18",
+            auth_runner=_auth_no_scope,
+            runner=_runner_absent,
+            stdin_runner=_ok_mutation_runner,
+        )
+        self.assertEqual(res["status"], "error")
+        self.assertIn("project scope", res["detail"])
+
+    def test_error_when_mutation_fails(self) -> None:
+        res = wfo.ensure_wave_option(
+            "wave-18",
+            auth_runner=_auth_has_scope,
+            runner=_runner_absent,
+            stdin_runner=_error_mutation_runner,
+        )
+        self.assertEqual(res["status"], "error")
+        self.assertIn("mutation failed", res["detail"])
+
+    def test_error_when_readback_fails(self) -> None:
+        """Option appears to mutate OK but read-back finds it absent."""
+        calls = [0]
+
+        def runner(q: str, v: dict) -> str:
+            calls[0] += 1
+            if calls[0] == 1:
+                return _field_response(_EXISTING_OPTIONS)
+            # Read-back still returns W18 absent
+            return _field_response(_EXISTING_OPTIONS)
+
+        res = wfo.ensure_wave_option(
+            "wave-18",
+            auth_runner=_auth_has_scope,
+            runner=runner,
+            stdin_runner=_ok_mutation_runner,
+        )
+        self.assertEqual(res["status"], "error")
+        self.assertIn("read-back", res["detail"].lower())
+
+    def test_full_list_preserve(self) -> None:
+        """The mutation body must include all existing options, not just the new one."""
+        captured: list[str] = []
+
+        def stdin_runner(body: str) -> str:
+            captured.append(body)
+            return _ok_mutation_runner(body)
+
+        # read-back runner: on second call include W18
+        two_phase_runner = _runner_absent_then_present()
+        wfo.ensure_wave_option(
+            "wave-18",
+            auth_runner=_auth_has_scope,
+            runner=two_phase_runner,
+            stdin_runner=stdin_runner,
+        )
+        self.assertEqual(len(captured), 1)
+        body = json.loads(captured[0])
+        options_sent = body["variables"]["input"]["singleSelectOptions"]
+        names_sent = [o["name"] for o in options_sent]
+        # Existing W16, W17 must be preserved; new W18 must be appended.
+        self.assertIn("W16", names_sent)
+        self.assertIn("W17", names_sent)
+        self.assertIn("W18", names_sent)
+        # New option color must be PURPLE (wave-label badge colour).
+        new_opt = next(o for o in options_sent if o["name"] == "W18")
+        self.assertEqual(new_opt["color"], wfo.NEW_OPTION_COLOR)
+
+    def test_existing_option_colors_preserved(self) -> None:
+        """Existing option colors/descriptions survive the full-list PUT."""
+        captured: list[str] = []
+
+        def stdin_runner(body: str) -> str:
+            captured.append(body)
+            return _ok_mutation_runner(body)
+
+        two_phase_runner = _runner_absent_then_present()
+        wfo.ensure_wave_option(
+            "wave-18",
+            auth_runner=_auth_has_scope,
+            runner=two_phase_runner,
+            stdin_runner=stdin_runner,
+        )
+        body = json.loads(captured[0])
+        options_sent = body["variables"]["input"]["singleSelectOptions"]
+        w17_sent = next(o for o in options_sent if o["name"] == "W17")
+        self.assertEqual(w17_sent["color"], "GREEN")
+        self.assertEqual(w17_sent["description"], "Wave 17")
+
+    def test_legacy_label_creates_correct_option(self) -> None:
+        options = [{"id": "OPT_w16", "name": "W16", "color": "BLUE", "description": ""}]
+
+        calls = [0]
+
+        def runner(q: str, v: dict) -> str:
+            calls[0] += 1
+            if calls[0] == 1:
+                return _field_response(options)
+            # read-back: include P6W17
+            return _field_response(
+                options
+                + [{"id": "OPT_p6w17", "name": "P6W17", "color": "PURPLE", "description": ""}]
+            )
+
+        captured: list[str] = []
+
+        def stdin_runner(body: str) -> str:
+            captured.append(body)
+            return _ok_mutation_runner(body)
+
+        res = wfo.ensure_wave_option(
+            "p6-wave-17",
+            auth_runner=_auth_has_scope,
+            runner=runner,
+            stdin_runner=stdin_runner,
+        )
+        self.assertEqual(res["status"], "created")
+        self.assertEqual(res["option_name"], "P6W17")
+        body = json.loads(captured[0])
+        options_sent = body["variables"]["input"]["singleSelectOptions"]
+        names_sent = [o["name"] for o in options_sent]
+        self.assertIn("P6W17", names_sent)
+
+
+# ---------------------------------------------------------------------------
+# CLI tests
+# ---------------------------------------------------------------------------
+
+
+class TestCli(unittest.TestCase):
+    def _make_ensure_ok_runners(self) -> tuple:
+        """Runners for a successful 'ensure' flow where the option is absent then present."""
+        return (
+            _auth_has_scope,
+            _runner_absent_then_present(),
+            _ok_mutation_runner,
+        )
+
+    def test_ensure_exits_0_when_present(self) -> None:
+        # Monkey-patch the internal functions for CLI routing
+        original_ensure = wfo.ensure_wave_option
+
+        def fake_ensure(label: str, org: str, project: int) -> dict:
+            return {"status": "present", "option_name": "W18"}
+
+        wfo.ensure_wave_option = fake_ensure  # type: ignore[assignment]
+        try:
+            rc = wfo.main(["ensure", "wave-18"])
+        finally:
+            wfo.ensure_wave_option = original_ensure  # type: ignore[assignment]
+        self.assertEqual(rc, 0)
+
+    def test_ensure_exits_0_when_created(self) -> None:
+        original_ensure = wfo.ensure_wave_option
+
+        def fake_ensure(label: str, org: str, project: int) -> dict:
+            return {"status": "created", "option_name": "W18"}
+
+        wfo.ensure_wave_option = fake_ensure  # type: ignore[assignment]
+        try:
+            rc = wfo.main(["ensure", "wave-18"])
+        finally:
+            wfo.ensure_wave_option = original_ensure  # type: ignore[assignment]
+        self.assertEqual(rc, 0)
+
+    def test_ensure_exits_1_on_error(self) -> None:
+        original_ensure = wfo.ensure_wave_option
+
+        def fake_ensure(label: str, org: str, project: int) -> dict:
+            return {"status": "error", "detail": "boom"}
+
+        wfo.ensure_wave_option = fake_ensure  # type: ignore[assignment]
+        try:
+            rc = wfo.main(["ensure", "wave-18"])
+        finally:
+            wfo.ensure_wave_option = original_ensure  # type: ignore[assignment]
+        self.assertEqual(rc, 1)
+
+    def test_check_exits_0_when_present(self) -> None:
+        original_check = wfo.check_wave_option
+
+        def fake_check(label: str, org: str, project: int) -> dict:
+            return {"status": "present", "option_name": "W18", "option_id": "x"}
+
+        wfo.check_wave_option = fake_check  # type: ignore[assignment]
+        try:
+            rc = wfo.main(["check", "wave-18"])
+        finally:
+            wfo.check_wave_option = original_check  # type: ignore[assignment]
+        self.assertEqual(rc, 0)
+
+    def test_check_exits_2_when_absent(self) -> None:
+        original_check = wfo.check_wave_option
+
+        def fake_check(label: str, org: str, project: int) -> dict:
+            return {"status": "absent", "option_name": "W18"}
+
+        wfo.check_wave_option = fake_check  # type: ignore[assignment]
+        try:
+            rc = wfo.main(["check", "wave-18"])
+        finally:
+            wfo.check_wave_option = original_check  # type: ignore[assignment]
+        self.assertEqual(rc, 2)
+
+    def test_check_exits_1_on_error(self) -> None:
+        original_check = wfo.check_wave_option
+
+        def fake_check(label: str, org: str, project: int) -> dict:
+            return {"status": "error", "detail": "boom"}
+
+        wfo.check_wave_option = fake_check  # type: ignore[assignment]
+        try:
+            rc = wfo.main(["check", "wave-18"])
+        finally:
+            wfo.check_wave_option = original_check  # type: ignore[assignment]
+        self.assertEqual(rc, 1)
+
+    def test_ensure_bad_label_exits_1(self) -> None:
+        rc = wfo.main(["ensure", "not-a-wave-label"])
+        self.assertEqual(rc, 1)
+
+    def test_check_bad_label_exits_1(self) -> None:
+        rc = wfo.main(["check", "not-a-wave-label"])
+        self.assertEqual(rc, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/lib/wave_field_option.py
+++ b/.claude/lib/wave_field_option.py
@@ -1,0 +1,486 @@
+#!/usr/bin/env python3
+"""Ensure the Project-2 Wave single-select field has an option for a wave label.
+
+Used by /wave-kickoff to pre-create the Wave board option BEFORE wave labels
+are applied to issues — eliminating the repeated "Project 2 Wave field has no
+option 'W{X}'" PostToolUse captures (8 such in P6W17 alone, issue #868).
+
+Design
+======
+- Idempotent: exits 0 / returns ``status="present"`` when the option already
+  exists. No-op on repeated calls.
+- Full-list-preserve: ``updateProjectV2Field`` REPLACES the whole options list,
+  so existing options are read first and re-sent in full plus the new entry.
+  Omitting any existing option would wipe it (memory
+  ``feedback_projectv2_field_option``).
+- Read-back-verified: after the mutation the field is re-introspected to
+  confirm the option appears.
+- Auth-preflight: checks ``gh auth status`` for ``project`` scope before any
+  mutation; fails with a clear message if missing.
+
+Option-name grammar (#810)
+==========================
+  ``wave-{X}``       →  ``W{X}``      (e.g. ``wave-18`` → ``W18``)
+  ``p{N}-wave-{M}``  →  ``P{N}W{M}``  (e.g. ``p6-wave-17`` → ``P6W17``)
+  ``wave-x``         →  ``WX``
+
+This grammar mirrors ``wave_label_to_option_name`` in
+``.claude/hooks/_wave_label_parse.py`` (the canonical authoritative copy);
+the duplication is intentional to keep this lib module self-contained and
+avoid a cross-layer hooks→lib import.
+
+CLI
+===
+::
+
+    python3 wave_field_option.py ensure <wave-label>  [--project N] [--org ORG]
+
+        Ensures the Wave option for ``<wave-label>`` exists on the project.
+        Exits 0 on success (present or created+verified), 1 on error.
+
+    python3 wave_field_option.py check <wave-label>   [--project N] [--org ORG]
+
+        Read-only check: exits 0 if option present, 2 if absent, 1 on error.
+
+Integration
+===========
+Called in ``/wave-kickoff`` Step 2a (between label-create and auth-scope audit)
+so that ``post_label_change_wave_field_sync`` finds the option already present
+when it fires on the label-apply in Step 7.
+
+Provenance: issue #868, P6W17 retro proposed change #1, owner-adopted
+2026-06-25. Implemented in P7W18 framework wave by Nurul Hakim
+(Observability Engineer).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Option-name grammar (#810) — mirrors _wave_label_parse.wave_label_to_option_name
+# ---------------------------------------------------------------------------
+
+_LEGACY_WAVE_RE = re.compile(r"^p(\d+)-wave-(\d+)$")
+_GLOBAL_WAVE_RE = re.compile(r"^wave-(\d+)$")
+_PLACEHOLDER_LABEL = "wave-x"
+
+
+def _wave_label_to_option_name(label: str) -> str | None:
+    """Convert a wave label to the Project-2 Wave single-select option name.
+
+    Returns ``None`` when ``label`` is not a recognised wave label shape.
+    Duplicates ``wave_label_to_option_name`` from ``.claude/hooks/_wave_label_parse``
+    so this lib module is self-contained.
+    """
+    if label == _PLACEHOLDER_LABEL:
+        return "WX"
+    m = _LEGACY_WAVE_RE.match(label)
+    if m:
+        return f"P{m.group(1)}W{m.group(2)}"
+    m = _GLOBAL_WAVE_RE.match(label)
+    if m:
+        return f"W{m.group(1)}"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# GraphQL helpers
+# ---------------------------------------------------------------------------
+
+ORG = "noorinalabs"
+PROJECT_NUMBER = 2
+
+# Default color for newly-created Wave options.  PURPLE matches the wave-label
+# badge colour (``8B5CF6``) set in ``gh label create`` at wave-kickoff Step 2.
+NEW_OPTION_COLOR = "PURPLE"
+NEW_OPTION_DESCRIPTION = ""
+
+_INTROSPECT_QUERY = """
+query($org: String!, $project: Int!) {
+  organization(login: $org) {
+    projectV2(number: $project) {
+      id
+      field(name: "Wave") {
+        ... on ProjectV2SingleSelectField {
+          id
+          options { id name color description }
+        }
+      }
+    }
+  }
+}
+"""
+
+# The mutation replaces the ENTIRE options list; callers must include all
+# existing options plus the new one in the ``singleSelectOptions`` input.
+_UPDATE_FIELD_MUTATION = """
+mutation($input: UpdateProjectV2FieldInput!) {
+  updateProjectV2Field(input: $input) {
+    projectV2Field {
+      ... on ProjectV2SingleSelectField {
+        id
+        options { id name }
+      }
+    }
+  }
+}
+"""
+
+
+def _run_graphql_simple(
+    query: str,
+    variables: dict[str, Any],
+    runner: Any = None,
+) -> dict | None:
+    """Run a simple GraphQL query/mutation via ``gh api graphql -f/-F``.
+
+    Suitable for queries whose variables are all scalars (strings + ints).
+    Returns the parsed response dict or ``None`` on error.
+
+    *runner* is an injection point for tests: it receives ``(query, variables)``
+    and must return the raw stdout string (or raise on error).
+    """
+    if runner is not None:
+        try:
+            raw = runner(query, variables)
+        except Exception:  # noqa: BLE001
+            return None
+    else:
+        argv = ["gh", "api", "graphql"]
+        for k, v in variables.items():
+            if isinstance(v, bool):
+                argv += ["-F", f"{k}={'true' if v else 'false'}"]
+            elif isinstance(v, int):
+                argv += ["-F", f"{k}={v}"]
+            else:
+                argv += ["-f", f"{k}={v}"]
+        argv += ["-f", f"query={query}"]
+        try:
+            result = subprocess.run(argv, capture_output=True, text=True, timeout=20)
+        except (subprocess.SubprocessError, FileNotFoundError, OSError):
+            return None
+        if result.returncode != 0:
+            return None
+        raw = result.stdout
+
+    if not raw:
+        return None
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+
+
+def _run_graphql_stdin(
+    body: str,
+    stdin_runner: Any = None,
+) -> dict | None:
+    """Run a GraphQL mutation by posting a full JSON body via stdin.
+
+    Used for mutations whose variables contain nested objects/arrays that
+    ``-f``/``-F`` cannot express (e.g. ``singleSelectOptions``).
+
+    *stdin_runner* is the injection point for tests: it receives the raw
+    JSON body string and must return the raw stdout string (or raise).
+    """
+    if stdin_runner is not None:
+        try:
+            raw = stdin_runner(body)
+        except Exception:  # noqa: BLE001
+            return None
+    else:
+        try:
+            result = subprocess.run(
+                ["gh", "api", "graphql", "--input", "-"],
+                input=body,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+        except (subprocess.SubprocessError, FileNotFoundError, OSError):
+            return None
+        if result.returncode != 0:
+            return None
+        raw = result.stdout
+
+    if not raw:
+        return None
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+
+
+def _has_project_scope(auth_runner: Any = None) -> bool:
+    """True iff ``gh auth status -h github.com`` reports the ``project`` scope."""
+    if auth_runner is not None:
+        try:
+            stdout = auth_runner()
+        except Exception:  # noqa: BLE001
+            return False
+    else:
+        try:
+            result = subprocess.run(
+                ["gh", "auth", "status", "-h", "github.com"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            stdout = (result.stdout or "") + (result.stderr or "")
+        except (subprocess.SubprocessError, FileNotFoundError, OSError):
+            return False
+
+    return "'project'" in stdout
+
+
+def _introspect_field(
+    org: str = ORG,
+    project: int = PROJECT_NUMBER,
+    runner: Any = None,
+) -> dict | None:
+    """Return ``{project_id, field_id, options: [{id, name, color, description}]}``
+    or ``None`` on failure.
+
+    *runner* — same injection point as ``_run_graphql_simple``.
+    """
+    data = _run_graphql_simple(
+        _INTROSPECT_QUERY,
+        {"org": org, "project": project},
+        runner=runner,
+    )
+    if not data:
+        return None
+    proj = (data.get("data") or {}).get("organization", {}).get("projectV2")
+    if not proj:
+        return None
+    project_id = proj.get("id")
+    field = proj.get("field") or {}
+    field_id = field.get("id")
+    options = field.get("options") or []
+    if not project_id or not field_id:
+        return None
+    return {"project_id": project_id, "field_id": field_id, "options": options}
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def check_wave_option(
+    wave_label: str,
+    org: str = ORG,
+    project: int = PROJECT_NUMBER,
+    runner: Any = None,
+) -> dict:
+    """Read-only check: is the Wave option for *wave_label* present on the board?
+
+    Returns a result dict::
+
+        {"status": "present",  "option_name": "W18", "option_id": "..."}
+        {"status": "absent",   "option_name": "W18"}
+        {"status": "error",    "detail": "..."}
+
+    Never modifies the board.
+    """
+    option_name = _wave_label_to_option_name(wave_label)
+    if option_name is None:
+        return {"status": "error", "detail": f"Not a valid wave label: {wave_label!r}"}
+
+    field = _introspect_field(org=org, project=project, runner=runner)
+    if field is None:
+        return {"status": "error", "detail": f"Failed to introspect project {project} Wave field"}
+
+    for opt in field["options"]:
+        if opt.get("name") == option_name:
+            return {"status": "present", "option_name": option_name, "option_id": opt.get("id", "")}
+
+    return {"status": "absent", "option_name": option_name}
+
+
+def ensure_wave_option(
+    wave_label: str,
+    org: str = ORG,
+    project: int = PROJECT_NUMBER,
+    auth_runner: Any = None,
+    runner: Any = None,
+    stdin_runner: Any = None,
+) -> dict:
+    """Idempotently ensure the Wave option for *wave_label* exists on the board.
+
+    Returns a result dict::
+
+        {"status": "present",  "option_name": "W18"}   # already existed — no-op
+        {"status": "created",  "option_name": "W18"}   # created + read-back-verified
+        {"status": "error",    "detail": "..."}
+
+    Injection points for tests:
+
+    - *auth_runner*   — callable ``() -> str`` returning ``gh auth status`` output
+    - *runner*        — callable ``(query, variables) -> str`` for GraphQL reads
+    - *stdin_runner*  — callable ``(body_json) -> str`` for GraphQL mutations
+    """
+    option_name = _wave_label_to_option_name(wave_label)
+    if option_name is None:
+        return {"status": "error", "detail": f"Not a valid wave label: {wave_label!r}"}
+
+    # Step 1: check if already present (idempotent fast path).
+    field = _introspect_field(org=org, project=project, runner=runner)
+    if field is None:
+        return {
+            "status": "error",
+            "detail": (
+                f"Failed to introspect project {project} Wave field (auth issue or network error)"
+            ),
+        }
+
+    for opt in field["options"]:
+        if opt.get("name") == option_name:
+            return {"status": "present", "option_name": option_name}
+
+    # Step 2: auth scope check before any mutation.
+    if not _has_project_scope(auth_runner=auth_runner):
+        return {
+            "status": "error",
+            "detail": ("gh project scope required; run 'gh auth refresh -s project' then retry."),
+        }
+
+    # Step 3: build the full options list = existing + new.
+    # updateProjectV2Field REPLACES the whole list — re-send every existing
+    # option (preserving name/color/description) plus the new entry.
+    existing_options = [
+        {
+            "name": opt.get("name", ""),
+            "color": opt.get("color", "GRAY"),
+            "description": opt.get("description", ""),
+        }
+        for opt in field["options"]
+    ]
+    new_option: dict[str, str] = {
+        "name": option_name,
+        "color": NEW_OPTION_COLOR,
+        "description": NEW_OPTION_DESCRIPTION,
+    }
+    all_options = existing_options + [new_option]
+
+    mutation_body = json.dumps(
+        {
+            "query": _UPDATE_FIELD_MUTATION,
+            "variables": {
+                "input": {
+                    "fieldId": field["field_id"],
+                    "singleSelectOptions": all_options,
+                }
+            },
+        }
+    )
+
+    result = _run_graphql_stdin(mutation_body, stdin_runner=stdin_runner)
+    if not result or "errors" in result:
+        errors_str = json.dumps(result.get("errors") if result else [])[:300]
+        return {
+            "status": "error",
+            "detail": f"updateProjectV2Field mutation failed: {errors_str}",
+        }
+
+    # Step 4: read-back verify the option stuck.
+    field_after = _introspect_field(org=org, project=project, runner=runner)
+    if field_after is None:
+        return {
+            "status": "error",
+            "detail": (
+                "Option create mutation appeared to succeed but read-back introspection failed"
+            ),
+        }
+    for opt in field_after["options"]:
+        if opt.get("name") == option_name:
+            return {"status": "created", "option_name": option_name}
+
+    return {
+        "status": "error",
+        "detail": (
+            f"Mutation appeared to succeed but option {option_name!r} "
+            f"not found on read-back; current options: "
+            f"{[o.get('name') for o in field_after['options']]}"
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point for CLI use from ``/wave-kickoff`` Step 2a.
+
+    Exit codes:
+      0  — success (present or created)
+      1  — error (bad label, auth failure, network, mutation failed, etc.)
+      2  — ``check`` subcommand: option absent (no mutation performed)
+    """
+    parser = argparse.ArgumentParser(
+        description=(
+            "Ensure the Project-2 Wave single-select field has an option for a wave label."
+        )
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    for name, help_text in [
+        ("ensure", "Create the option if absent (idempotent)."),
+        ("check", "Read-only check: exit 0 present, 2 absent, 1 error."),
+    ]:
+        p = sub.add_parser(name, help=help_text)
+        p.add_argument("wave_label", help="Wave label, e.g. wave-18 or p6-wave-17")
+        p.add_argument(
+            "--project",
+            type=int,
+            default=PROJECT_NUMBER,
+            help="GitHub project number",
+        )
+        p.add_argument("--org", default=ORG, help="GitHub org login")
+
+    args = parser.parse_args(argv)
+
+    if args.cmd == "check":
+        res = check_wave_option(args.wave_label, org=args.org, project=args.project)
+        if res["status"] == "present":
+            print(
+                f"PRESENT: Wave option '{res['option_name']}' "
+                f"already exists on project {args.project}."
+            )
+            return 0
+        if res["status"] == "absent":
+            print(
+                f"ABSENT: Wave option '{res['option_name']}' not found on project {args.project}."
+            )
+            return 2
+        print(f"ERROR: {res['detail']}", file=sys.stderr)
+        return 1
+
+    # ensure
+    res = ensure_wave_option(args.wave_label, org=args.org, project=args.project)
+    if res["status"] == "present":
+        print(
+            f"OK (present): Wave option '{res['option_name']}' "
+            f"already exists on project {args.project}."
+        )
+        return 0
+    if res["status"] == "created":
+        print(
+            f"OK (created): Wave option '{res['option_name']}' created on "
+            f"project {args.project} and read-back verified."
+        )
+        return 0
+    print(f"ERROR: {res['detail']}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/wave-kickoff/SKILL.md
+++ b/.claude/skills/wave-kickoff/SKILL.md
@@ -278,6 +278,40 @@ If missing, create it:
 gh label create "wave-{X}" --description "Wave {X} (global id)" --color "8B5CF6"
 ```
 
+### 2a. Pre-create the Project-2 Wave field option (MANDATORY — before label-apply)
+
+**Run this BEFORE Step 7 (label-apply).** The `post_label_change_wave_field_sync`
+PostToolUse hook syncs the Wave single-select field when a wave label is applied;
+if the option for the new wave does not exist yet the hook can't sync and emits
+"Project 2 Wave field has no option 'W{X}'" for every labeled issue — 8 such
+captures in P6W17 alone (issue #868, P6W17 retro proposed change #1).
+
+Option-name grammar (#810): `wave-{X}` → `W{X}`; `p{N}-wave-{M}` → `P{N}W{M}`;
+`wave-x` → `WX`.
+
+```bash
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+# Idempotent: no-op if W{X} already exists; creates it if absent and
+# read-back-verifies it stuck.  Exits 1 on auth/network/mutation error.
+python3 "$REPO_ROOT/.claude/lib/wave_field_option.py" ensure "wave-{X}"
+```
+
+**Stop-the-line if this exits non-zero.** A non-zero exit means either the `project`
+OAuth scope is missing (`gh auth refresh -s project` to fix) or the GraphQL
+mutation failed. Label-apply MUST NOT proceed while the option is absent — every
+labeled issue will fire an unresolvable hook capture.
+
+**Verification (read-only check after creation):**
+
+```bash
+python3 "$REPO_ROOT/.claude/lib/wave_field_option.py" check "wave-{X}"
+# exit 0 = present (proceed); exit 2 = absent (stop); exit 1 = error (stop)
+```
+
+Implementation: `.claude/lib/wave_field_option.py` (issue #868). Uses
+`updateProjectV2Field` with the full-list-preserve recipe — re-reads all
+existing options and re-sends them plus the new one so no option is wiped.
+
 ### 3. Pre-wave auth/scope audit
 
 Verify the gh token has the scopes needed for this wave's operations. GitHub periodically hardens scope enforcement (e.g., Projects v2 requires the explicit `project` write scope; classic-Projects API deprecation). A missing scope mid-wave consumes orchestrator + user time chasing OAuth flows.


### PR DESCRIPTION
## Summary

- Adds `.claude/lib/wave_field_option.py` — a deterministic Python helper that idempotently ensures the Project-2 `Wave` single-select field has a matching option for a given wave label, using the `updateProjectV2Field` GraphQL mutation with the full-list-preserve recipe (re-reads all existing options + appends the new one; omitting an existing option would wipe it).
- Wires it into `/wave-kickoff` as new Step 2a, placed between label-create (Step 2) and auth-scope audit (Step 3), with a stop-the-line gate so label-apply never runs against a missing option.
- Eliminates the recurring `post_label_change_wave_field_sync` Annunaki capture class: "Project 2 Wave field has no option 'W{X}'" — 8 captures in P6W17 alone.

Part of #868

## Design

- **Idempotent**: no-op (exit 0) if the option already exists.
- **Full-list-preserve**: `updateProjectV2Field` replaces the entire options list, so the helper reads all current options and re-sends them + the new one. No existing option is lost.
- **Read-back-verified**: after the mutation, the field is re-introspected to confirm the option stuck.
- **Auth-preflight**: checks `project` OAuth scope before any mutation; exits 1 with a clear `gh auth refresh -s project` message if missing.
- **Option-name grammar** per #810: `wave-{X}` → `W{X}`; `p{N}-wave-{M}` → `P{N}W{M}`; `wave-x` → `WX`.
- **All external calls injectable** (`auth_runner`, `runner`, `stdin_runner`) for hermetic unit tests — no subprocess in tests.

## Test plan

- [ ] 35 unit tests in `.claude/lib/tests/test_wave_field_option.py` — all pass (`2110 passed, 83 subtests passed` full suite).
- [ ] Grammar coverage: `wave-18` → `W18`, `p6-wave-17` → `P6W17`, `wave-x` → `WX`, suffixed labels rejected.
- [ ] Idempotency: mutation runner not called when option already present.
- [ ] Full-list-preserve: existing W16/W17 options appear unchanged in mutation body when adding W18.
- [ ] Existing option colors/descriptions survive the PUT.
- [ ] Auth-scope failure → `status="error"` with clear message, no mutation.
- [ ] Mutation failure → `status="error"`.
- [ ] Read-back failure (mutation appears to succeed but option not present afterward) → `status="error"`.
- [ ] CLI exit codes: `ensure` → 0/1; `check` → 0/2/1.
- [ ] Pre-push gate: ruff-format, ruff-lint, mypy, pytest, memory-budget, office-drift, mermaid-render — all green.
- [ ] Sync-drift gate: OK (no new CI kind added; existing `pytest` hook covers `test_wave_field_option.py`).

TechDebt: `_wave_label_to_option_name` in `wave_field_option.py` duplicates the grammar from `_wave_label_parse.wave_label_to_option_name` to keep the lib module self-contained. If the grammar grows, consider a shared `_wave_option_name.py` in lib extracted from hooks.

Peer reviewer: Wanjiku Mwangi
Secondary reviewer: Bereket Tadesse

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H33UdbeP32RmdEHJLhMwT7