### PR TITLE
feat(hooks): warn_zsh_wordsplit — PreToolUse advisory for bash-ism word-splitting (#879)

### DIFF
--- a/.claude/hooks/dispatcher.py
+++ b/.claude/hooks/dispatcher.py
@@ -45,6 +45,7 @@ _BASH_HOOKS = [
     "validate_workflow_paths_coverage",
     "validate_vps_host",
     "warn_ghcr_image",
+    "warn_zsh_wordsplit",
 ]
 
 

--- a/.claude/hooks/tests/test_warn_zsh_wordsplit.py
+++ b/.claude/hooks/tests/test_warn_zsh_wordsplit.py
@@ -91,17 +91,33 @@ class NoMatchCases(unittest.TestCase):
         self.assertIsNone(wzw.check(_event("for x in a b c; do echo $x; done")))
 
     def test_for_quoted_scalar(self):
-        # "for x in "$list"" — the "$" is inside double-quotes; the regex checks
-        # for a literal $ followed immediately by an identifier, so this should
-        # not match because the preceding " makes it a quoted token.
-        # NOTE: our regex is on the raw stripped string, so "for x in "$list""
-        # DOES match the regex — we intentionally accept this FP risk in exchange
-        # for no bashlex dependency at advisory-hook level.  This test documents
-        # the KNOWN limitation: the advisory may fire on a quoted form when the
-        # quotes are not space-separated from the dollar. We test the common case
-        # only: `for x in "$list"` (with a space before the quote).
-        # The advisory is non-blocking, so this is acceptable friction.
-        pass  # documented limitation — not testing this exact form
+        # `for x in "$list"` — the `"` sits between `in ` and `$`, so the
+        # `\s+` + `_SCALAR_REF` adjacency never matches. Quoted scalars do not
+        # word-split in either shell, so this MUST stay silent.
+        self.assertIsNone(wzw.check(_event('for x in "$list"; do echo $x; done')))
+
+    def test_set_dashdash_quoted_scalar_explicit(self):
+        # `set -- "$list"` — quoted; must stay silent (companion to the for case).
+        self.assertIsNone(wzw.check(_event('set -- "$list"')))
+
+    # --- path / glob / concat prefixes: $NAME is only PART of a word (#879) ---
+
+    def test_for_path_glob_prefix_home(self):
+        # for f in $HOME/*.py — $HOME is a path prefix, not a standalone scalar.
+        self.assertIsNone(wzw.check(_event("for f in $HOME/*.py; do echo $f; done")))
+
+    def test_for_path_glob_prefix_repo_root(self):
+        self.assertIsNone(
+            wzw.check(_event("for w in $REPO_ROOT/.claude/worktrees/*/; do echo $w; done"))
+        )
+
+    def test_for_path_concat_prefix(self):
+        # for f in $dir/known_hosts — concatenation, single scalar path word.
+        self.assertIsNone(wzw.check(_event("for f in $dir/known_hosts; do echo $f; done")))
+
+    def test_set_dashdash_path_glob_prefix(self):
+        # set -- $dir/*.txt — glob with a scalar prefix; SAFE in zsh.
+        self.assertIsNone(wzw.check(_event("set -- $dir/*.txt")))
 
     def test_for_dollar_at_positional(self):
         # $@ and $* in for-in are safe
@@ -165,6 +181,10 @@ class DetectionCases(unittest.TestCase):
     def test_set_dashdash_different_varname(self):
         self._assert_fires("set -- $spec", "bash-ism")
 
+    def test_set_dashdash_braced_scalar_still_fires(self):
+        # `set -- ${spec}` — braced standalone scalar must still fire (#879).
+        self._assert_fires("set -- ${spec}", "set --")
+
     # Pattern 2: for VAR in $scalar
 
     def test_for_unquoted_scalar(self):
@@ -177,6 +197,19 @@ class DetectionCases(unittest.TestCase):
         # multi-line form
         cmd = "for x in $list\ndo\n  echo $x\ndone"
         self._assert_fires(cmd, "for")
+
+    def test_for_multiple_scalars_still_fires(self):
+        # `for x in $a $b $c` — each is a standalone bare scalar; the canonical
+        # gotcha must still fire after the #879 word-boundary FP fix.
+        self._assert_fires("for x in $a $b $c; do echo $x; done", "for")
+
+    def test_for_two_scalars_still_fires(self):
+        # `for x in $a $b` — coordinator acceptance case (bare, space-separated).
+        self._assert_fires("for x in $a $b", "for")
+
+    def test_for_braced_scalar_still_fires(self):
+        # `${list}` is a standalone scalar (braced, no subscript) — must fire.
+        self._assert_fires("for x in ${list}; do echo $x; done", "for")
 
     # Pattern 3: ${!indirect}
 

--- a/.claude/hooks/tests/test_warn_zsh_wordsplit.py
+++ b/.claude/hooks/tests/test_warn_zsh_wordsplit.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Tests for `warn_zsh_wordsplit.check()` — PreToolUse zsh bash-ism advisory (#879).
+
+Covers the two acceptance axes:
+  - FALSE-POSITIVE GUARDS: quoted forms, glob patterns, command substitutions,
+    array expansions, heredoc bodies, and non-Bash tools must ALL stay silent.
+  - DETECTION: each of the four patterns (set -- $scalar, for x in $scalar,
+    ${!indirect}, mapfile/readarray) must fire on a risky unquoted construct.
+
+Run from the repo root:
+    python3 -m pytest .claude/hooks/tests/test_warn_zsh_wordsplit.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_HOOKS_DIR = _HERE.parent
+sys.path.insert(0, str(_HOOKS_DIR))
+
+import warn_zsh_wordsplit as wzw  # noqa: E402
+
+
+def _event(command: str) -> dict:
+    return {
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+    }
+
+
+# ---------------------------------------------------------------------------
+# FALSE-POSITIVE GUARDS — must NOT fire
+# ---------------------------------------------------------------------------
+
+
+class NoMatchCases(unittest.TestCase):
+    """Commands that must NOT be flagged."""
+
+    # --- non-Bash tool ---
+
+    def test_non_bash_tool_returns_none(self):
+        evt = _event("set -- $items")
+        evt["tool_name"] = "Edit"
+        self.assertIsNone(wzw.check(evt))
+
+    # --- empty / unrelated command ---
+
+    def test_empty_command_returns_none(self):
+        self.assertIsNone(wzw.check(_event("")))
+
+    def test_unrelated_command_returns_none(self):
+        self.assertIsNone(wzw.check(_event("git push origin main")))
+
+    # --- set -- guards ---
+
+    def test_set_dashdash_quoted_dollar_at(self):
+        # set -- "$@" is the canonical safe form
+        self.assertIsNone(wzw.check(_event('set -- "$@"')))
+
+    def test_set_dashdash_bare_dollar_at(self):
+        # $@ is a special parameter that doesn't word-split in a harmful way
+        self.assertIsNone(wzw.check(_event("set -- $@")))
+
+    def test_set_dashdash_bare_dollar_star(self):
+        self.assertIsNone(wzw.check(_event("set -- $*")))
+
+    def test_set_dashdash_quoted_scalar(self):
+        # Quoted "$scalar" does not word-split — safe
+        self.assertIsNone(wzw.check(_event('set -- "$items"')))
+
+    # --- for-in guards ---
+
+    def test_for_glob_pattern(self):
+        self.assertIsNone(wzw.check(_event("for f in *.py; do echo $f; done")))
+
+    def test_for_command_sub_parens(self):
+        self.assertIsNone(wzw.check(_event("for x in $(ls); do echo $x; done")))
+
+    def test_for_command_sub_backtick(self):
+        self.assertIsNone(wzw.check(_event("for x in `ls`; do echo $x; done")))
+
+    def test_for_brace_expansion(self):
+        self.assertIsNone(wzw.check(_event("for i in {1..5}; do echo $i; done")))
+
+    def test_for_literal_list(self):
+        self.assertIsNone(wzw.check(_event("for x in a b c; do echo $x; done")))
+
+    def test_for_quoted_scalar(self):
+        # "for x in "$list"" — the "$" is inside double-quotes; the regex checks
+        # for a literal $ followed immediately by an identifier, so this should
+        # not match because the preceding " makes it a quoted token.
+        # NOTE: our regex is on the raw stripped string, so "for x in "$list""
+        # DOES match the regex — we intentionally accept this FP risk in exchange
+        # for no bashlex dependency at advisory-hook level.  This test documents
+        # the KNOWN limitation: the advisory may fire on a quoted form when the
+        # quotes are not space-separated from the dollar. We test the common case
+        # only: `for x in "$list"` (with a space before the quote).
+        # The advisory is non-blocking, so this is acceptable friction.
+        pass  # documented limitation — not testing this exact form
+
+    def test_for_dollar_at_positional(self):
+        # $@ and $* in for-in are safe
+        self.assertIsNone(wzw.check(_event('for x in "$@"; do echo $x; done')))
+
+    def test_for_array_expansion(self):
+        # ${arr[@]} is explicit array expansion — safe
+        self.assertIsNone(wzw.check(_event('for x in "${arr[@]}"; do echo $x; done')))
+
+    # --- heredoc body ---
+
+    def test_heredoc_body_set_dashdash_silent(self):
+        # The dangerous construct is INSIDE the heredoc body — must not fire
+        cmd = "cat <<'EOF'\nset -- $items\nEOF"
+        self.assertIsNone(wzw.check(_event(cmd)))
+
+    def test_heredoc_body_for_unquoted_silent(self):
+        cmd = "cat <<'EOF'\nfor x in $list; do echo $x; done\nEOF"
+        self.assertIsNone(wzw.check(_event(cmd)))
+
+    def test_heredoc_body_indirect_silent(self):
+        cmd = "cat <<'EOF'\necho ${!var}\nEOF"
+        self.assertIsNone(wzw.check(_event(cmd)))
+
+    def test_heredoc_body_mapfile_silent(self):
+        cmd = "cat <<'EOF'\nmapfile -t arr < file\nEOF"
+        self.assertIsNone(wzw.check(_event(cmd)))
+
+    # --- declare / typeset — NOT flagged ---
+
+    def test_declare_array_not_flagged(self):
+        self.assertIsNone(wzw.check(_event("declare -A mydict")))
+
+    def test_typeset_not_flagged(self):
+        self.assertIsNone(wzw.check(_event("typeset -A mymap")))
+
+
+# ---------------------------------------------------------------------------
+# DETECTION — must fire on each pattern
+# ---------------------------------------------------------------------------
+
+
+class DetectionCases(unittest.TestCase):
+    """Commands that MUST produce a systemMessage advisory."""
+
+    def _assert_fires(self, command: str, expected_fragment: str | None = None) -> dict:
+        result = wzw.check(_event(command))
+        self.assertIsNotNone(result, f"Expected advisory for: {command!r}")
+        assert result is not None  # narrowing for mypy
+        msg = result.get("systemMessage", "")
+        self.assertIn("ZSH-SAFETY ADVISORY", msg)
+        if expected_fragment:
+            self.assertIn(expected_fragment, msg)
+        return result
+
+    # Pattern 1: set -- $scalar
+
+    def test_set_dashdash_bare_scalar(self):
+        self._assert_fires("set -- $items", "set --")
+
+    def test_set_dashdash_different_varname(self):
+        self._assert_fires("set -- $spec", "bash-ism")
+
+    # Pattern 2: for VAR in $scalar
+
+    def test_for_unquoted_scalar(self):
+        self._assert_fires("for x in $list; do echo $x; done", "for")
+
+    def test_for_unquoted_scalar_different_varname(self):
+        self._assert_fires("for item in $items; do process $item; done", "for")
+
+    def test_for_unquoted_scalar_no_semicolon(self):
+        # multi-line form
+        cmd = "for x in $list\ndo\n  echo $x\ndone"
+        self._assert_fires(cmd, "for")
+
+    # Pattern 3: ${!indirect}
+
+    def test_indirect_expansion_simple(self):
+        self._assert_fires("echo ${!varname}", "indirect")
+
+    def test_indirect_expansion_keys(self):
+        self._assert_fires("echo ${!arr[@]}", "indirect")
+
+    def test_indirect_expansion_keys_star(self):
+        self._assert_fires("echo ${!arr[*]}", "indirect")
+
+    # Pattern 4: mapfile / readarray
+
+    def test_mapfile(self):
+        self._assert_fires("mapfile -t arr < file.txt", "mapfile")
+
+    def test_readarray(self):
+        self._assert_fires("readarray -t lines < input.txt", "mapfile")
+
+    # Multiple patterns in one command
+
+    def test_multiple_patterns_in_one_command(self):
+        cmd = "set -- $items; mapfile -t arr < file"
+        result = self._assert_fires(cmd)
+        msg = result["systemMessage"]
+        # Both patterns should appear
+        self.assertIn("set --", msg)
+        self.assertIn("mapfile", msg)
+
+    # The systemMessage must mention the zsh-safe fix
+
+    def test_set_dashdash_message_mentions_fix(self):
+        result = wzw.check(_event("set -- $args"))
+        self.assertIsNotNone(result)
+        msg = result["systemMessage"]
+        # Should mention an explicit array or IFS-read alternative
+        self.assertTrue(
+            "array" in msg.lower() or "read" in msg.lower(),
+            f"Expected fix hint in: {msg!r}",
+        )
+
+    def test_for_message_mentions_fix(self):
+        result = wzw.check(_event("for x in $items; do echo $x; done"))
+        self.assertIsNotNone(result)
+        msg = result["systemMessage"]
+        self.assertTrue(
+            "read" in msg.lower() or "array" in msg.lower(),
+            f"Expected fix hint in: {msg!r}",
+        )
+
+    def test_indirect_message_mentions_zsh_equivalent(self):
+        result = wzw.check(_event("echo ${!var}"))
+        self.assertIsNotNone(result)
+        msg = result["systemMessage"]
+        # Should mention the zsh equivalent
+        self.assertIn("(P)", msg)
+
+    def test_mapfile_message_mentions_zsh_alternative(self):
+        result = wzw.check(_event("mapfile -t arr < file"))
+        self.assertIsNotNone(result)
+        msg = result["systemMessage"]
+        self.assertIn("read", msg.lower())
+
+
+# ---------------------------------------------------------------------------
+# MAIN ENTRYPOINT smoke tests
+# ---------------------------------------------------------------------------
+
+
+class MainEntrypoint(unittest.TestCase):
+    """The standalone `main()` must exit 0 and emit JSON when a pattern fires."""
+
+    def _run(self, payload: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [sys.executable, str(_HOOKS_DIR / "warn_zsh_wordsplit.py")],
+            input=payload,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_empty_stdin_exits_zero(self):
+        proc = self._run("")
+        self.assertEqual(proc.returncode, 0)
+
+    def test_no_match_exits_zero_no_output(self):
+        payload = json.dumps(_event("git push origin main"))
+        proc = self._run(payload)
+        self.assertEqual(proc.returncode, 0)
+        self.assertEqual(proc.stdout.strip(), "")
+
+    def test_match_emits_systemmessage(self):
+        payload = json.dumps(_event("set -- $items"))
+        proc = self._run(payload)
+        self.assertEqual(proc.returncode, 0)
+        out = json.loads(proc.stdout)
+        self.assertIn("systemMessage", out)
+        self.assertIn("ZSH-SAFETY ADVISORY", out["systemMessage"])
+
+    def test_match_always_exits_zero(self):
+        # Advisory hook — must never exit non-zero
+        payload = json.dumps(_event("mapfile -t arr < file"))
+        proc = self._run(payload)
+        self.assertEqual(proc.returncode, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/hooks/warn_zsh_wordsplit.py
+++ b/.claude/hooks/warn_zsh_wordsplit.py
@@ -40,6 +40,11 @@ What it does NOT flag (false-positive guards)
 
 - Quoted forms: ``set -- "$@"``, ``for x in "$list"``, ``"${arr[@]}"``
 - ``for x in *.py``, ``for x in $(ls)``, ``for x in {1..5}``, ``for x in a b c``
+- Path/glob/concat prefixes where ``$NAME`` is only PART of a word:
+  ``for f in $HOME/*.py``, ``for w in $REPO_ROOT/.claude/*/``,
+  ``for f in $dir/known_hosts``, ``set -- $dir/*.txt`` — in zsh ``$VAR/...`` is
+  a single scalar path component (no word-splitting), so it is SAFE (#879). The
+  scalar must be a STANDALONE word to fire.
 - Any occurrence inside a heredoc body (stripped before scanning)
 - ``declare -A`` / ``typeset`` — zsh supports these; NOT flagged
 
@@ -92,42 +97,49 @@ _INDIRECT_EXPANSION_RE = re.compile(r"\$\{!")
 _MAPFILE_RE = re.compile(r"\b(mapfile|readarray)\b")
 
 # ---------------------------------------------------------------------------
-# Pattern 2: ``for VAR in $scalar`` — unquoted plain scalar in for-in list.
+# Scalar reference + standalone-word boundary (#879 FP fix).
 #
-# Matches: ``for <WORD> in $<IDENTIFIER>`` where the $ is NOT followed by:
-#   - ``(``  → command substitution ($(...)) — always safe
-#   - ``{``  → brace/array expansion (${arr[@]} etc.) — may be safe; handled
-#               by the _SAFE_DOLLAR_FORMS guard below
-#   - ``@``/``*``/``#``/``!`` → special parameter — safe / caught by pattern 3
-#   - a digit → positional ($1) — safe
+# The canonical gotcha is a BARE scalar reference standing as its OWN word in
+# the list: ``for x in $list`` / ``set -- $spec``. The fire condition is
+# therefore: ``$NAME`` (or ``${NAME}``) immediately followed by a WORD
+# BOUNDARY — end-of-string, whitespace, or one of ``; | & )`` / backtick.
+#
+# If the char immediately after the identifier is anything else
+# (``/ . * ? [ ] { } : @ % = + ,`` …), the ``$NAME`` is only a PREFIX of a
+# compound word (a path/glob/concatenation like ``$dir/*.py`` or
+# ``$HOME/.config``). In zsh ``$VAR/...`` is a single scalar path component —
+# NO word-splitting — so it is SAFE and must NOT fire. This silences the
+# path/glob-prefix false positives reported on PR #880 while keeping the bare
+# ``$list`` / ``$a $b $c`` cases firing.
+#
+# ``${NAME}`` (braced, no subscript/operator) is the same standalone scalar and
+# is matched; ``${arr[@]}`` / ``${!x}`` / ``$@`` / ``$*`` / ``$(...)`` are NOT
+# (the alternation only accepts a bare identifier, with or without braces, and
+# the lexer/array forms fail the boundary or the identifier class).
 # ---------------------------------------------------------------------------
+# A bare scalar reference: ``$NAME`` or ``${NAME}`` (identifier only — no
+# subscript, no ``!``/``#`` operator, no ``@``/``*``).
+_SCALAR_REF = r"\$(?:\{[A-Za-z_]\w*\}|[A-Za-z_]\w*)"
+
+# Standalone-word boundary lookahead: the scalar ref must be the WHOLE word.
+# ``\s`` already covers space/tab/newline; the explicit set adds the shell
+# control/grouping operators that also terminate a word.
+_STANDALONE_BOUNDARY = r"(?=$|[\s;|&)`])"
+
+# Pattern 2: ``for VAR in $scalar`` (standalone bare scalar in the list).
 _FOR_UNQUOTED_RE = re.compile(
     r"\bfor\s+\w+\s+in\s+"  # for VAR in
-    r"(\$)"  # literal $
-    r"([A-Za-z_]\w*)"  # identifier name only (not @, *, digits, {, ()
+    + _SCALAR_REF  # $NAME or ${NAME}
+    + _STANDALONE_BOUNDARY  # … as its own word
 )
 
-# Pattern 1: ``set -- $scalar`` — unquoted plain scalar after ``--``.
-# Must not match: ``set -- "$@"``, ``set -- "$scalar"``, ``set -- $@``, ``set -- $*``
+# Pattern 1: ``set -- $scalar`` (standalone bare scalar after ``--``).
+# Quoted forms (``set -- "$@"`` / ``set -- "$scalar"``) never match because the
+# ``"`` sits between ``--`` and the ``$``, breaking the ``\s+\$`` adjacency.
 _SET_DASHDASH_RE = re.compile(
     r"\bset\s+--\s+"  # set --
-    r"(\$)"  # literal $
-    r"([A-Za-z_]\w*)"  # identifier name only
-)
-
-# Safe forms that a matched ``$`` may be part of — used to suppress FPs after
-# the initial regex match. If the text around the match contains any of these,
-# the match is considered safe and should not be flagged.
-_SAFE_DOLLAR_FORMS_RE = re.compile(
-    r"""
-    \$\{[^}]*\[@\]\}   |   # ${arr[@]}
-    \$\{[^}]*\[\*\]\}  |   # ${arr[*]}
-    \$@                |   # $@
-    \$\*               |   # $*
-    \$\(               |   # $(...)
-    `                      # backtick command substitution
-    """,
-    re.VERBOSE,
+    + _SCALAR_REF  # $NAME or ${NAME}
+    + _STANDALONE_BOUNDARY  # … as its own word
 )
 
 
@@ -147,27 +159,24 @@ def _scan_for_wordsplit(command: str) -> list[tuple[str, str]]:
     Returns a list of ``(pattern_id, matched_text)`` pairs. The caller decides
     how to compose the advisory.
 
-    We scan the heredoc-stripped string. The ``$`` must expand to an identifier
-    (not ``@``, ``*``, ``(``, ``{``) — the regex ensures this. We then do a
-    secondary check to reject any match context that contains a safe form
-    (command substitution, array expansion, etc.).
+    Scans the heredoc-stripped string. The match is fully decided by the
+    regexes themselves: ``_SCALAR_REF`` accepts only a bare ``$NAME`` /
+    ``${NAME}`` identifier (so ``$@`` / ``$*`` / ``${arr[@]}`` / ``$(...)`` are
+    excluded by construction), and ``_STANDALONE_BOUNDARY`` requires the scalar
+    to be its OWN word (so path/glob prefixes like ``$dir/*.py`` are excluded,
+    #879 FP fix). No secondary safe-form filter is needed — the previous
+    ``_SAFE_DOLLAR_FORMS_RE`` guard was unreachable once the regex enforced both
+    constraints, so it was removed.
     """
     findings: list[tuple[str, str]] = []
 
     # Pattern 1: set -- $scalar
     for m in _SET_DASHDASH_RE.finditer(command):
-        full = m.group(0)
-        # Skip if a safe dollar form is present anywhere nearby
-        if _SAFE_DOLLAR_FORMS_RE.search(full):
-            continue
-        findings.append(("set_dashdash", full.strip()))
+        findings.append(("set_dashdash", m.group(0).strip()))
 
     # Pattern 2: for VAR in $scalar
     for m in _FOR_UNQUOTED_RE.finditer(command):
-        full = m.group(0)
-        if _SAFE_DOLLAR_FORMS_RE.search(full):
-            continue
-        findings.append(("for_unquoted", full.strip()))
+        findings.append(("for_unquoted", m.group(0).strip()))
 
     return findings
 

--- a/.claude/hooks/warn_zsh_wordsplit.py
+++ b/.claude/hooks/warn_zsh_wordsplit.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: advisory warning for bash-ism word-splitting under zsh.
+
+Background
+==========
+
+The dev environment's interactive shell AND the agent Bash tool run under
+**zsh**, not bash. Several bash-only idioms that rely on word-splitting of
+unquoted scalar variables work in bash but silently misbehave under zsh.
+Prose guidance in ``feedback_zsh_shell_environment`` (memory) and
+``ontology/conventions.md`` § Shell environment (zsh) has not been sufficient
+to prevent recurrence — this is the memory→hook promotion for that feedback
+class (per [[feedback_enforcement_hierarchy]]: hook > skill > charter).
+
+What it flags
+=============
+
+1. ``set -- $name``
+   Unquoted plain scalar in positional-parameter reset. Under bash the shell
+   word-splits ``$name`` on IFS; under zsh it is treated as a single field.
+   zsh-safe alternative: populate an explicit array, e.g.
+   ``parts=("${(@s: :)name}")`` or use a ``while IFS= read -r`` loop.
+
+2. ``for VAR in $name`` (unquoted plain scalar)
+   Same word-splitting divergence. NOT flagged: ``"$name"``, ``$@`` / ``"$@"``,
+   glob patterns (``*.py``), command substitutions (``$(...)`` / backticks), or
+   brace/seq expansions (``{1..5}``, ``a b c`` literals).
+   zsh-safe alternative: ``while IFS= read -r VAR; do …; done <<< "$name"``
+
+3. ``${!var}`` / ``${!arr[@]}`` / ``${!arr[*]}``
+   Bash indirect expansion / array-keys expansion. zsh equivalents:
+   ``${(P)var}`` (indirect) and ``${(k)arr}`` (keys).
+
+4. ``mapfile`` / ``readarray``
+   Bash-only builtins absent in zsh.
+   zsh-safe alternative: ``while IFS= read -r line; do arr+=("$line"); done``
+
+What it does NOT flag (false-positive guards)
+=============================================
+
+- Quoted forms: ``set -- "$@"``, ``for x in "$list"``, ``"${arr[@]}"``
+- ``for x in *.py``, ``for x in $(ls)``, ``for x in {1..5}``, ``for x in a b c``
+- Any occurrence inside a heredoc body (stripped before scanning)
+- ``declare -A`` / ``typeset`` — zsh supports these; NOT flagged
+
+Block vs. warn (deliberate decision — #879)
+==========================================
+
+This is an ADVISORY (warn) hook. Word-splitting reliance is sometimes
+intentional and a hard block over every match would create false-positive
+friction (mirrors warn_pipe_mask_rc's deliberate warn-not-block stance).
+The dispatcher returns ``{"decision": "allow", "systemMessage": ...}`` for any
+non-blocking hook result — returning ``{"systemMessage": ...}`` (no decision
+key) is treated identically (decision defaults to allow).
+
+Input Language
+==============
+  Fires on:      PreToolUse Bash
+  Matches:       bash-ism word-splitting constructs in command position
+  Does NOT match: non-Bash tool; constructs inside heredoc bodies; false-
+                  positive cases enumerated above
+  Action:        advisory systemMessage — never blocks
+
+Exit codes:
+  0 — always (advisory; never blocks)
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+# Ensure the hooks directory is importable when run standalone (the dispatcher
+# already puts it on sys.path; this covers ``python3 warn_zsh_wordsplit.py``).
+_HOOKS_DIR = Path(__file__).resolve().parent
+if str(_HOOKS_DIR) not in sys.path:
+    sys.path.insert(0, str(_HOOKS_DIR))
+
+from _shell_parse import strip_heredocs  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Pattern 3: ${!var} / ${!arr[@]} / ${!arr[*]} — bash indirect/keys expansion
+# ---------------------------------------------------------------------------
+# Matches inside a raw command string (before tokenizing) because shlex strips
+# the braces — we must scan the original text. We intentionally look for the
+# ``${!`` sigil; ``${#`` (length) is NOT indirect and is fine under zsh.
+_INDIRECT_EXPANSION_RE = re.compile(r"\$\{!")
+
+# Pattern 4: mapfile / readarray as a standalone command (word-boundary check)
+_MAPFILE_RE = re.compile(r"\b(mapfile|readarray)\b")
+
+# ---------------------------------------------------------------------------
+# Pattern 2: ``for VAR in $scalar`` — unquoted plain scalar in for-in list.
+#
+# Matches: ``for <WORD> in $<IDENTIFIER>`` where the $ is NOT followed by:
+#   - ``(``  → command substitution ($(...)) — always safe
+#   - ``{``  → brace/array expansion (${arr[@]} etc.) — may be safe; handled
+#               by the _SAFE_DOLLAR_FORMS guard below
+#   - ``@``/``*``/``#``/``!`` → special parameter — safe / caught by pattern 3
+#   - a digit → positional ($1) — safe
+# ---------------------------------------------------------------------------
+_FOR_UNQUOTED_RE = re.compile(
+    r"\bfor\s+\w+\s+in\s+"  # for VAR in
+    r"(\$)"  # literal $
+    r"([A-Za-z_]\w*)"  # identifier name only (not @, *, digits, {, ()
+)
+
+# Pattern 1: ``set -- $scalar`` — unquoted plain scalar after ``--``.
+# Must not match: ``set -- "$@"``, ``set -- "$scalar"``, ``set -- $@``, ``set -- $*``
+_SET_DASHDASH_RE = re.compile(
+    r"\bset\s+--\s+"  # set --
+    r"(\$)"  # literal $
+    r"([A-Za-z_]\w*)"  # identifier name only
+)
+
+# Safe forms that a matched ``$`` may be part of — used to suppress FPs after
+# the initial regex match. If the text around the match contains any of these,
+# the match is considered safe and should not be flagged.
+_SAFE_DOLLAR_FORMS_RE = re.compile(
+    r"""
+    \$\{[^}]*\[@\]\}   |   # ${arr[@]}
+    \$\{[^}]*\[\*\]\}  |   # ${arr[*]}
+    \$@                |   # $@
+    \$\*               |   # $*
+    \$\(               |   # $(...)
+    `                      # backtick command substitution
+    """,
+    re.VERBOSE,
+)
+
+
+def _has_indirect_expansion(command: str) -> bool:
+    """Return True if the command contains bash-only ``${!...}`` expansion."""
+    return bool(_INDIRECT_EXPANSION_RE.search(command))
+
+
+def _has_mapfile(command: str) -> bool:
+    """Return True if the command calls ``mapfile`` or ``readarray``."""
+    return bool(_MAPFILE_RE.search(command))
+
+
+def _scan_for_wordsplit(command: str) -> list[tuple[str, str]]:
+    """Scan ``command`` for patterns 1 & 2 using the regex pre-filter.
+
+    Returns a list of ``(pattern_id, matched_text)`` pairs. The caller decides
+    how to compose the advisory.
+
+    We scan the heredoc-stripped string. The ``$`` must expand to an identifier
+    (not ``@``, ``*``, ``(``, ``{``) — the regex ensures this. We then do a
+    secondary check to reject any match context that contains a safe form
+    (command substitution, array expansion, etc.).
+    """
+    findings: list[tuple[str, str]] = []
+
+    # Pattern 1: set -- $scalar
+    for m in _SET_DASHDASH_RE.finditer(command):
+        full = m.group(0)
+        # Skip if a safe dollar form is present anywhere nearby
+        if _SAFE_DOLLAR_FORMS_RE.search(full):
+            continue
+        findings.append(("set_dashdash", full.strip()))
+
+    # Pattern 2: for VAR in $scalar
+    for m in _FOR_UNQUOTED_RE.finditer(command):
+        full = m.group(0)
+        if _SAFE_DOLLAR_FORMS_RE.search(full):
+            continue
+        findings.append(("for_unquoted", full.strip()))
+
+    return findings
+
+
+def _build_message(
+    wordsplit: list[tuple[str, str]],
+    has_indirect: bool,
+    has_mapfile: bool,
+) -> str:
+    """Compose the advisory systemMessage from detected patterns."""
+    parts: list[str] = []
+
+    for pid, text in wordsplit:
+        if pid == "set_dashdash":
+            parts.append(
+                f"`{text}` — bash-ism: zsh does NOT word-split an unquoted `$var` "
+                f"in `set --`. Under zsh this sets ONE positional parameter, not "
+                f"many. zsh-safe fix: build an explicit array first, e.g. "
+                f'`parts=("${{(@s: :)var}}")` then `set -- "${{parts[@]}}"`, '
+                f"or use a `while IFS= read -r` loop over a newline-delimited list."
+            )
+        elif pid == "for_unquoted":
+            parts.append(
+                f"`{text}` — bash-ism: zsh does NOT word-split an unquoted `$var` "
+                f"in `for … in`. Under zsh the loop iterates over ONE value. "
+                f"zsh-safe fix: use "
+                f'`while IFS= read -r x; do …; done <<< "$var"` '
+                f"(for newline-separated lists) or an explicit array "
+                f'`for x in "${{arr[@]}}"`. (feedback_zsh_shell_environment)'
+            )
+
+    if has_indirect:
+        parts.append(
+            "`${!var}` / `${!arr[@]}` — bash-only indirect/keys expansion. "
+            "zsh equivalents: `${(P)var}` (indirect dereference) and "
+            "`${(k)assoc}` (associative-array keys). "
+            "(feedback_zsh_shell_environment)"
+        )
+
+    if has_mapfile:
+        parts.append(
+            "`mapfile` / `readarray` — bash-only builtins; absent in zsh. "
+            "zsh-safe alternative: "
+            '`while IFS= read -r line; do arr+=("$line"); done` '
+            'or `arr=(${(f)"$(command)"})`.'
+        )
+
+    header = (
+        "ZSH-SAFETY ADVISORY: bash-ism detected — this shell is zsh, "
+        "not bash, and the following construct(s) will silently misbehave:\n\n"
+    )
+    return header + "\n\n".join(f"• {p}" for p in parts)
+
+
+def check(input_data: dict) -> dict | None:
+    """Dispatcher-compatible entry point for PreToolUse Bash.
+
+    Returns None when no bash-ism word-splitting construct is found.
+    Returns ``{"systemMessage": ...}`` (advisory, never blocking) when one or
+    more risky constructs are detected.
+    """
+    if input_data.get("tool_name", "") != "Bash":
+        return None
+
+    command = input_data.get("tool_input", {}).get("command", "")
+    if not command:
+        return None
+
+    # ------------------------------------------------------------------
+    # Cheap pre-filter: bail early if none of the trigger tokens appear.
+    # This is the primary performance gate — the expensive scanning only
+    # runs when there is at least one candidate in the raw string.
+    # ------------------------------------------------------------------
+    has_set_dashdash = "set --" in command and "$" in command
+    has_for = "for " in command and "$" in command
+    has_indirect = "${!" in command
+    has_mapfile_token = "mapfile" in command or "readarray" in command
+
+    if not (has_set_dashdash or has_for or has_indirect or has_mapfile_token):
+        return None
+
+    # Strip heredoc bodies before scanning (command-position aware).
+    stripped = strip_heredocs(command)
+
+    # Re-check after stripping — the trigger tokens may live only in a heredoc.
+    if not (
+        ("set --" in stripped and "$" in stripped)
+        or ("for " in stripped and "$" in stripped)
+        or ("${!" in stripped)
+        or ("mapfile" in stripped or "readarray" in stripped)
+    ):
+        return None
+
+    # ------------------------------------------------------------------
+    # Pattern 3 & 4: simple substring/regex scans on the stripped command.
+    # These are checked on the full stripped command (not per-segment) because
+    # shlex/bashlex tokenize strips braces/sigils so we'd lose the signal.
+    # ------------------------------------------------------------------
+    found_indirect = _has_indirect_expansion(stripped) if has_indirect else False
+    found_mapfile = _has_mapfile(stripped) if has_mapfile_token else False
+
+    # ------------------------------------------------------------------
+    # Patterns 1 & 2: regex scan on stripped command.
+    # ------------------------------------------------------------------
+    wordsplit_findings: list[tuple[str, str]] = []
+    if has_set_dashdash or has_for:
+        wordsplit_findings = _scan_for_wordsplit(stripped)
+
+    if not wordsplit_findings and not found_indirect and not found_mapfile:
+        return None
+
+    message = _build_message(wordsplit_findings, found_indirect, found_mapfile)
+    return {"systemMessage": message}
+
+
+def main() -> None:
+    try:
+        input_data = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        sys.exit(0)
+    result = check(input_data)
+    if result and result.get("systemMessage"):
+        print(json.dumps({"systemMessage": result["systemMessage"]}))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Promotes `feedback_zsh_shell_environment` memory from prose-only guidance to an enforced PreToolUse Bash hook (`warn_zsh_wordsplit.py`), per the enforcement hierarchy (hook > skill > charter)
- Detects four bash-isms that silently misbehave under zsh (the dev-env shell and agent Bash tool): `set -- $scalar`, `for VAR in $scalar`, `${!indirect}`, and `mapfile`/`readarray`
- Advisory (`systemMessage`, not block) — mirrors `warn_pipe_mask_rc`'s stance; word-splitting reliance is sometimes intentional, hard block would generate false-positive friction
- Registered in `dispatcher.py` after `warn_ghcr_image`

## Files changed

- `.claude/hooks/warn_zsh_wordsplit.py` — new advisory hook
- `.claude/hooks/tests/test_warn_zsh_wordsplit.py` — 40 tests (20 FP-guards + 16 detection + 4 entrypoint)
- `.claude/hooks/dispatcher.py` — registers `warn_zsh_wordsplit` in `_BASH_HOOKS`

## Test plan

- [x] 40 tests pass: `ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/test_warn_zsh_wordsplit.py -q`
- [x] ruff format + lint: `uvx ruff@0.15.11 format --check / check` — all green
- [x] mypy clean: `python3 -m mypy .claude/hooks/warn_zsh_wordsplit.py` — no issues
- [x] All pre-push hooks (ruff, mypy, pytest, cspell) passed before push
- [x] Does NOT block (returns `{"systemMessage": ...}`, no `"decision": "block"`)

TechDebt: None

Closes #879