### PR TITLE
fix(ontology_gen): depth-aware top-level-comma splitter for TS extends bases (#887)

### DIFF
--- a/.claude/lib/ontology_gen/typescript_ext.py
+++ b/.claude/lib/ontology_gen/typescript_ext.py
@@ -74,13 +74,43 @@ def _line_of(text: str, pos: int) -> int:
     return text.count("\n", 0, pos) + 1
 
 
+def _split_top_level_commas(raw: str) -> list[str]:
+    """Split ``raw`` on commas that sit at bracket-nesting depth 0.
+
+    Commas nested inside ``<>`` / ``()`` / ``[]`` / ``{}`` are NOT split points, so a
+    base list like ``Bar<Map<K, V>>, Baz`` splits into ``["Bar<Map<K, V>>", "Baz"]``
+    rather than naively at the inner ``, `` (#887). Empty / whitespace-only segments
+    are dropped. Shared by both the ``extends``/``implements`` base-list parser and the
+    parameter splitter so neither re-implements the depth tracking.
+    """
+    parts: list[str] = []
+    depth = 0
+    current = ""
+    for ch in raw:
+        if ch in "([{<":
+            depth += 1
+        elif ch in ")]}>":
+            depth = max(0, depth - 1)
+        if ch == "," and depth == 0:
+            if current.strip():
+                parts.append(current)
+            current = ""
+        else:
+            current += ch
+    if current.strip():
+        parts.append(current)
+    return parts
+
+
 def _parse_extends_bases(raw: str) -> list[str]:
     """Return base names from a raw ``extends A, B<T>`` clause (drops generics).
 
-    Splits on top-level commas and strips generic type-parameters so ``Foo<T>`` → ``Foo``.
+    Splits on top-level commas (depth-aware, so a comma inside a nested generic such as
+    ``Map<K, V>`` does not split — #887) and strips generic type-parameters so
+    ``Foo<T>`` → ``Foo``.
     """
     bases: list[str] = []
-    for part in raw.split(","):
+    for part in _split_top_level_commas(raw):
         name = part.strip().split("<")[0].strip()
         if name and re.match(r"^[A-Za-z_$][\w$]*$", name):
             bases.append(name)
@@ -88,27 +118,8 @@ def _parse_extends_bases(raw: str) -> list[str]:
 
 
 def _split_params(raw: str) -> list[str]:
-    raw = raw.strip()
-    if not raw:
-        return []
-    params: list[str] = []
-    depth = 0
-    current = ""
-    # Split on top-level commas only (object/array/generic destructuring may nest).
-    for ch in raw:
-        if ch in "([{<":
-            depth += 1
-        elif ch in ")]}>":
-            depth -= 1
-        if ch == "," and depth == 0:
-            params.append(current)
-            current = ""
-        else:
-            current += ch
-    if current.strip():
-        params.append(current)
     out: list[str] = []
-    for part in params:
+    for part in _split_top_level_commas(raw):
         # Keep just the parameter name (drop type annotations / defaults).
         name = part.strip().split(":")[0].split("=")[0].strip()
         name = name.lstrip(".")  # rest params ...args

--- a/.claude/lib/tests/test_ontology_gen.py
+++ b/.claude/lib/tests/test_ontology_gen.py
@@ -30,7 +30,11 @@ from ontology_gen.model import (  # noqa: E402
     serialize_graph,
 )
 from ontology_gen.python_ext import extract_python  # noqa: E402
-from ontology_gen.typescript_ext import extract_typescript  # noqa: E402
+from ontology_gen.typescript_ext import (  # noqa: E402
+    _parse_extends_bases,
+    _split_top_level_commas,
+    extract_typescript,
+)
 
 
 class TestModel(unittest.TestCase):
@@ -299,6 +303,55 @@ type MaybeNull<T> = T | null;
         by_name = {s.qualname: s for s in iter_symbols(py_info.symbols)}
         self.assertEqual(by_name["Foo"].kind, "class")
         self.assertEqual(by_name["Foo.bar"].kind, "method")
+
+
+class TestExtendsBaseSplitter(unittest.TestCase):
+    """Depth-aware top-level-comma splitting of ``extends``/``implements`` lists (#887)."""
+
+    def test_nested_generic_not_split(self) -> None:
+        # The inner ``, `` of ``Map<K, V>`` must NOT be a split point.
+        self.assertEqual(_parse_extends_bases("Bar<Map<K, V>>, Baz"), ["Bar", "Baz"])
+
+    def test_two_generics_each_with_args(self) -> None:
+        self.assertEqual(_parse_extends_bases("Foo<A, B>, Bar<C>"), ["Foo", "Bar"])
+
+    def test_paren_and_bracket_nesting(self) -> None:
+        # Commas inside ``()`` and ``[]`` are likewise depth-protected.
+        self.assertEqual(
+            _parse_extends_bases("Foo<[A, B]>, Bar<(C, D)>, Baz"),
+            ["Foo", "Bar", "Baz"],
+        )
+
+    def test_deeply_nested_generic(self) -> None:
+        self.assertEqual(
+            _parse_extends_bases("A<B<C, D<E, F>>>, G"),
+            ["A", "G"],
+        )
+
+    def test_plain_list_unchanged(self) -> None:
+        self.assertEqual(_parse_extends_bases("Alpha, Beta, Gamma"), ["Alpha", "Beta", "Gamma"])
+
+    def test_single_base(self) -> None:
+        self.assertEqual(_parse_extends_bases("OnlyBase"), ["OnlyBase"])
+
+    def test_empty_clause(self) -> None:
+        self.assertEqual(_parse_extends_bases(""), [])
+        self.assertEqual(_parse_extends_bases("   "), [])
+
+    def test_splitter_keeps_nested_segment_intact(self) -> None:
+        # The low-level splitter returns the whole nested segment as one part.
+        self.assertEqual(
+            _split_top_level_commas("Bar<Map<K, V>>, Baz"),
+            ["Bar<Map<K, V>>", " Baz"],
+        )
+
+    def test_interface_with_nested_generic_base(self) -> None:
+        # End-to-end through the extractor: a real interface declaration.
+        src = "export interface Repo extends Bar<Map<K, V>>, Baz {\n  x: number;\n}\n"
+        info = extract_typescript("src/repo.ts", src)
+        by_name = {s.name: s for s in info.symbols}
+        self.assertIn("Repo", by_name)
+        self.assertEqual(by_name["Repo"].bases, ["Bar", "Baz"])
 
 
 class TestCypherExtractor(unittest.TestCase):


### PR DESCRIPTION
## Summary

`_parse_extends_bases` (ontology_gen TS extractor, `typescript_ext.py`) split `extends`/`implements` base lists on **every** comma, which could split inside a nested generic — e.g. `Bar<Map<K, V>>, Baz` at the inner `, `. The `^[A-Za-z_$][\w$]*$` identifier guard discarded the residue so outputs happened to be correct, but the parser was fragile.

This is **Option (a)** from the issue — the small, zero-dep top-level-comma splitter — **not** the deferred tree-sitter backend swap (kept consistent with the intentional zero-dependency pragmatic scanner, conventions.md §49).

## Approach

- New shared helper `_split_top_level_commas(raw)` tracks `<>` / `()` / `[]` / `{}` nesting depth and only treats a comma at depth 0 as a split point (empty/whitespace segments dropped).
- `_parse_extends_bases` now splits via the helper before stripping generics, so `Bar<Map<K, V>>, Baz` → `["Bar", "Baz"]`.
- Routed the existing `_split_params` through the same helper too, deduping its previously-inline depth tracker (single source of truth; covered by existing param tests).

## Tests (`.claude/lib/tests/test_ontology_gen.py`, new `TestExtendsBaseSplitter`)

- `Bar<Map<K, V>>, Baz` → `["Bar", "Baz"]`
- `Foo<A, B>, Bar<C>` → `["Foo", "Bar"]`
- `()` and `[]` nesting; deeply-nested generic `A<B<C, D<E, F>>>, G` → `["A", "G"]`
- plain list / single base / empty clause regressions
- low-level splitter keeps the nested segment intact
- end-to-end interface declaration: `interface Repo extends Bar<Map<K, V>>, Baz` → bases `["Bar", "Baz"]`

## Verification

- `pytest .claude/lib/tests/` — 618 passed (48 in the TS module)
- `ruff format --check`, `ruff check`, `mypy` — clean
- All pre-commit + pre-push hooks green on push

## Reviewers

- Primary: **Aino Virtanen**
- Secondary: **Nurul Hakim**

Closes #887

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NwiLxghxyUaTLc78FWeDVW
