### PR TITLE
fix(wave_seq): reservation-aware allocate so retro-reserved wave id is not skipped (#885)

### DIFF
--- a/.claude/lib/tests/test_wave_seq.py
+++ b/.claude/lib/tests/test_wave_seq.py
@@ -135,6 +135,89 @@ class TestNoCrossPhaseCollision(unittest.TestCase):
         self.assertEqual(status["wave_17_phase_ordinal"], 2)
 
 
+class TestRetroReservationAwareness(unittest.TestCase):
+    """Regression for main#885: ``/wave-retro`` Step 9 reserves the next id by
+    writing ``wave_{N}_meta_issue`` WITHOUT bumping ``global_wave_seq`` (it stays
+    N-1). The subsequent ``/wave-scope`` ``allocate`` must claim N — NOT skip to
+    N+1 as it did in the P7 W18→W19 transition (allocated 20 instead of 19)."""
+
+    def _post_retro_reservation(self) -> dict:
+        """Status exactly as /wave-retro Step 9 leaves it: P7W18 committed
+        (global_wave_seq=18, wave_18 stamped phase 7 ordinal 1), and wave_19
+        reserved via its meta_issue key ONLY — counter NOT advanced, no phase
+        stamp on 19 yet (mirrors the upsert the retro skill actually performs)."""
+        return {
+            "current_phase": 7,
+            "current_wave": "wave-18",
+            "global_wave_seq": 18,
+            "wave_18_phase": 7,
+            "wave_18_phase_ordinal": 1,
+            "wave_18_scope": {"phase": 7, "theme": "P7W1"},
+            # Retro Step 9 reservation: meta_issue key, counter still 18.
+            "wave_19_meta_issue": "noorinalabs-main#882",
+        }
+
+    def test_reserved_wave_detects_pending_reservation(self) -> None:
+        self.assertEqual(wave_seq.reserved_wave(self._post_retro_reservation()), 19)
+
+    def test_reserved_wave_none_without_meta_issue_key(self) -> None:
+        status = self._post_retro_reservation()
+        del status["wave_19_meta_issue"]
+        self.assertIsNone(wave_seq.reserved_wave(status))
+
+    def test_reserved_wave_none_when_counter_absent(self) -> None:
+        # No committed counter → cannot distinguish reserved from committed;
+        # fall back to the seed-safe monotonic path.
+        status = self._post_retro_reservation()
+        del status["global_wave_seq"]
+        self.assertIsNone(wave_seq.reserved_wave(status))
+
+    def test_allocation_target_returns_reserved_id(self) -> None:
+        # The headline bug: bare next_global_wave skips to 20; the
+        # reservation-aware target claims the reserved 19.
+        status = self._post_retro_reservation()
+        self.assertEqual(wave_seq.next_global_wave(status), 20)  # the old (wrong) value
+        self.assertEqual(wave_seq.allocation_target(status), 19)
+
+    def test_allocation_target_falls_through_when_no_reservation(self) -> None:
+        # Normal mid-wave state (no pending meta_issue at counter+1) is unchanged.
+        status = _grandfathered_p6_status()
+        self.assertEqual(wave_seq.allocation_target(status), wave_seq.next_global_wave(status))
+
+    def test_peek_returns_reserved_id_not_skip(self) -> None:
+        with TemporaryDirectory() as d:
+            path = Path(d) / "cross-repo-status.json"
+            path.write_text(json.dumps(self._post_retro_reservation(), indent=2) + "\n")
+            import io
+            from contextlib import redirect_stdout
+
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = wave_seq.main(["peek", str(path)])
+            self.assertEqual(rc, 0)
+            self.assertEqual(buf.getvalue().strip(), "19")
+
+    def test_allocate_write_claims_reserved_id_and_advances_counter(self) -> None:
+        with TemporaryDirectory() as d:
+            path = Path(d) / "cross-repo-status.json"
+            path.write_text(json.dumps(self._post_retro_reservation(), indent=2) + "\n")
+
+            rc = wave_seq.main(["allocate", str(path), "--phase", "7", "--write"])
+            self.assertEqual(rc, 0)
+
+            after = json.loads(path.read_text())
+            # Counter advances to the RESERVED id (19), not past it (20).
+            self.assertEqual(after["global_wave_seq"], 19)
+            self.assertEqual(after["wave_19_phase"], 7)
+            # P7 already has wave 18 (ordinal 1); the reserved 19 is ordinal 2.
+            self.assertEqual(after["wave_19_phase_ordinal"], 2)
+            # No wave_20_* keys were ever created.
+            self.assertNotIn("wave_20_phase", after)
+            self.assertNotIn("wave_20_phase_ordinal", after)
+            # The reservation key is preserved.
+            self.assertEqual(after["wave_19_meta_issue"], "noorinalabs-main#882")
+
+
 class TestAllocateWritesPreserveShape(unittest.TestCase):
     """End-to-end --write goes through upsert_status_keys, so the compact-inline
     file shape is preserved and the result is valid JSON."""

--- a/.claude/lib/wave_seq.py
+++ b/.claude/lib/wave_seq.py
@@ -36,12 +36,28 @@ collide with any historical ``wave_1``..``wave_9``. Prior-phase graveyard keys
 are preserved (git history + the phase docs hold them; they are inert because no
 future wave is ever numbered ≤ 15).
 
+Reservation-awareness (main#885)
+--------------------------------
+``/wave-retro`` Step 9 *reserves* the next wave id by writing a
+``wave_{N}_meta_issue`` key **without** bumping ``global_wave_seq`` (the counter
+stays at N-1). A naive ``next = current_seq + 1`` then SKIPS the reserved id,
+because ``seed_value()`` counts the reserved ``wave_{N}_*`` key as an
+already-allocated id (so ``max(global_wave_seq=N-1, seed=N) + 1 = N+1`` — the
+P7 W18→W19 transition allocated 20 instead of 19). The allocator is therefore
+**reservation-aware**: if the id one above the *committed* counter
+(``global_wave_seq + 1``) already carries a ``wave_{N}_meta_issue`` reservation,
+``allocate``/``peek`` claim THAT id rather than incrementing past it. This makes
+the tool correct regardless of caller ordering — the keyspace and
+``global_wave_seq`` can never disagree by construction.
+
 CLI:
   wave_seq.py peek     <status_path>
       Print the next global wave id that WOULD be allocated (no write).
+      Honours a pending retro reservation (see Reservation-awareness above).
   wave_seq.py allocate <status_path> --phase P [--write]
-      Allocate the next global wave id for phase P. ``--write`` persists the
-      incremented ``global_wave_seq`` AND stamps ``wave_{X}_phase`` +
+      Allocate the next global wave id for phase P (a pending retro reservation
+      if one exists, else the monotonic next). ``--write`` persists the
+      ``global_wave_seq`` advance AND stamps ``wave_{X}_phase`` +
       ``wave_{X}_phase_ordinal`` (auto-computed: 1 + waves already in phase P).
       Without ``--write`` it is a dry-run that only prints the id + ordinal.
 """
@@ -108,6 +124,42 @@ def next_global_wave(status: dict) -> int:
     return current_seq(status) + 1
 
 
+def reserved_wave(status: dict) -> int | None:
+    """A wave id reserved by ``/wave-retro`` Step 9 but not yet committed (#885).
+
+    The retro reserves the next id by writing a ``wave_{N}_meta_issue`` key while
+    leaving the **committed** counter (``global_wave_seq``) at N-1 — the id is
+    claimed in the keyspace before the counter advances. That makes ``seed_value``
+    treat N as already-allocated, so a naive ``next_global_wave`` would SKIP it
+    (``+1`` past it). Detect the pending reservation as: the id one above the
+    *explicit committed counter* whose ``wave_{N}_meta_issue`` key already exists.
+
+    Only the explicit ``global_wave_seq`` is consulted (NOT the seed-inflated
+    ``current_seq``) — using the seed would re-introduce the skip this guards
+    against. Returns ``None`` when there is no committed counter (migration: fall
+    back to the seed-safe monotonic next) or no reservation at ``committed + 1``.
+    """
+    committed = status.get("global_wave_seq")
+    if not isinstance(committed, int):
+        return None
+    candidate = committed + 1
+    if f"wave_{candidate}_meta_issue" in status:
+        return candidate
+    return None
+
+
+def allocation_target(status: dict) -> int:
+    """The id ``allocate``/``peek`` will claim.
+
+    A pending retro reservation (``reserved_wave``) if one exists — so the tool
+    is correct regardless of caller ordering — else the monotonic
+    ``next_global_wave``. This is the single source of truth that keeps the
+    keyspace and ``global_wave_seq`` from disagreeing (#885).
+    """
+    reserved = reserved_wave(status)
+    return reserved if reserved is not None else next_global_wave(status)
+
+
 def phase_of(status: dict, wave: int) -> int | None:
     """The phase a recorded global wave belongs to, or None if unstamped.
 
@@ -139,13 +191,13 @@ def _load(status_path: Path) -> dict:
 
 def _cmd_peek(args: argparse.Namespace) -> int:
     status = _load(args.status)
-    print(next_global_wave(status))
+    print(allocation_target(status))
     return 0
 
 
 def _cmd_allocate(args: argparse.Namespace) -> int:
     status = _load(args.status)
-    wave_id = next_global_wave(status)
+    wave_id = allocation_target(status)
     ordinal = phase_ordinal(status, args.phase)
 
     print(f"global wave id: {wave_id}")

--- a/.claude/skills/wave-retro/SKILL.md
+++ b/.claude/skills/wave-retro/SKILL.md
@@ -332,6 +332,12 @@ MD
     --body "$STUB_BODY")
   NEW_NUM=$(echo "$NEW_URL" | grep -oE '[0-9]+$')
   gh project item-add 2 --owner noorinalabs --url "$NEW_URL" 2>/dev/null || true
+  # NOTE (main#885): this reserves the id via the meta_issue key only and does
+  # NOT bump global_wave_seq (the counter advances at /wave-scope `allocate
+  # --write`). That split is SAFE because `wave_seq.py` is reservation-aware:
+  # `allocate`/`peek` detect this `wave_${NEXT_WAVE}_meta_issue` reservation at
+  # `global_wave_seq + 1` and claim THAT id instead of skipping past it. Do not
+  # "fix" this by adding a counter bump here — that would double-advance.
   python3 "$REPO_ROOT/.claude/lib/upsert_status_keys.py" "$REPO_ROOT/cross-repo-status.json" \
     "wave_${NEXT_WAVE}_meta_issue=\"noorinalabs-main#$NEW_NUM\""
   echo "AUTO-DRAFTED next-wave meta-issue stub: $NEW_URL"


### PR DESCRIPTION
## Summary

Fixes the `wave_seq.py` double-allocation (#885): `/wave-retro` Step 9 *reserves* the next wave id by writing `wave_{N}_meta_issue` **without** bumping `global_wave_seq` (counter stays N-1). `seed_value()` then counts that reserved `wave_{N}_*` key as already-allocated, so `allocate` computed `max(global_wave_seq, max_existing_key)+1` and **skipped** N — allocating 20 instead of 19 in the P7 W18→W19 transition.

## Approach — Option 2 (reservation-aware allocate)

Chose **Option 2** (mechanical fix in `wave_seq.py`) over Option 1 (skill-doc discipline) because it makes the tool correct **regardless of caller ordering** — the keyspace and `global_wave_seq` can never disagree by construction (single source of truth in code, not a retro-skill convention that can rot).

- `reserved_wave(status)` — the id at the **explicit committed counter** `global_wave_seq + 1` whose `wave_{N}_meta_issue` key already exists. Deliberately reads `global_wave_seq` (NOT the seed-inflated `current_seq`, which would re-introduce the skip). Returns `None` when there is no committed counter (migration safety) or no reservation.
- `allocation_target(status)` — pending reservation if present, else `next_global_wave`.
- `peek` / `allocate` now both use `allocation_target` so they stay consistent.
- Folded in an Option-1 **clarifying note** in `wave-retro/SKILL.md` Step 9: the reserve-without-bump split is now safe because the allocator is reservation-aware (and a warning not to "fix" it by adding a counter bump, which would double-advance).

## Tests (`.claude/lib/tests/test_wave_seq.py` — `TestRetroReservationAwareness`)

- `reserved_wave` detects the pending reservation; returns `None` without the meta_issue key or without a committed counter.
- **Headline regression**: post-retro state (`global_wave_seq=18`, `wave_19_meta_issue` set, counter NOT advanced) → `next_global_wave` is the old wrong `20`, but `allocation_target`/`peek` return **19**.
- `allocate --write` claims **19**, advances the counter to 19, stamps `wave_19_phase=7` / `phase_ordinal=2`, and **never** creates `wave_20_*` keys.
- Pass-through unchanged for normal mid-wave state (no reservation).

Full suite green: `2181 passed` (lib + hooks), ruff format/lint, mypy, cspell, sync-drift gate all clean.

## Reviewers

- Primary: **Weronika Zielinska**
- Secondary: **Lucas Ferreira**

Closes #885

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NwiLxghxyUaTLc78FWeDVW
