### PR TITLE
fix(board-audit): paginate GraphQL + in-memory drift + resilient loop (#888)

### DIFF
--- a/.claude/lib/lint_skill_graphql_pagination.py
+++ b/.claude/lib/lint_skill_graphql_pagination.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Lint skill markdown for the GraphQL `first: > 100` over-cap footgun.
+
+GitHub's GraphQL API caps every *connection* `first:` at **100** — a query that asks
+for more (e.g. `items(first: 500)`) errors with *"Requesting 500 records on the
+connection exceeds the `first` limit of 100 records"* and returns **zero** rows. In
+`/board-audit` (noorinalabs-main#888) that silent zero read as "every issue is an
+orphan". The fix is always cursor pagination (`first: 100` + `pageInfo`/`$endCursor` +
+`--paginate`); this lint is the cheap regression guard the issue asked for.
+
+What it flags
+=============
+Inside any fenced code block that contains a `gh api graphql` invocation, any
+`first: <n>` whose integer value is **strictly greater than 100**. `first: 100` is the
+legal maximum and is NOT flagged; `first: 30` (e.g. a small inner `fieldValues`
+connection) is fine. Restricting to `gh api graphql` blocks avoids flagging an unrelated
+`first:` that happens to appear in prose or a non-GraphQL recipe.
+
+Today only `.claude/skills/board-audit/SKILL.md` is in scope; the lint exists so a future
+skill author can't reintroduce the over-cap.
+
+CLI
+===
+    python3 .claude/lib/lint_skill_graphql_pagination.py <file.md> [<file.md> ...]
+
+Glob over the skills tree (zsh recursive glob; bash needs `shopt -s globstar`):
+
+    python3 .claude/lib/lint_skill_graphql_pagination.py .claude/skills/**/*.md
+
+Exit codes:
+    0 — no over-cap `first:` found in any file
+    1 — at least one violation (each printed as `path:line: first: <n> — <why>`)
+    2 — usage / file-not-found error
+
+Same CLI/exit-code shape as `.claude/lib/check_dockerfile_base_pin.py` so it wires
+identically into pre-commit + CI when promoted to a blocking gate (a #888 follow-up).
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# A fenced code block opens/closes on a line that is only a ``` (optionally with an info
+# string like ```bash). We track open/close to scope the scan to code, not prose.
+_FENCE_RE = re.compile(r"^\s*```")
+# `gh api graphql` anywhere in the block marks it as a GraphQL recipe.
+_GRAPHQL_RE = re.compile(r"\bgh\s+api\s+graphql\b")
+# `first:` followed by an integer literal — capture the number to compare numerically.
+_FIRST_RE = re.compile(r"\bfirst:\s*(\d+)")
+
+CONNECTION_CAP = 100
+
+
+class Violation:
+    """One over-cap `first:` occurrence."""
+
+    def __init__(self, path: str, lineno: int, value: int) -> None:
+        self.path = path
+        self.lineno = lineno
+        self.value = value
+
+    def __str__(self) -> str:
+        return (
+            f"{self.path}:{self.lineno}: first: {self.value} — exceeds the GraphQL "
+            f"connection cap of {CONNECTION_CAP}; use first: 100 + cursor pagination "
+            f"(pageInfo/endCursor + --paginate)"
+        )
+
+
+def check_markdown_text(path: str, text: str) -> list[Violation]:
+    """Return over-cap `first:` violations inside `gh api graphql` code blocks."""
+    violations: list[Violation] = []
+    lines = text.splitlines()
+
+    in_block = False
+    block_start = 0  # 0-based index of the first content line of the open block
+    for idx, raw in enumerate(lines):
+        if _FENCE_RE.match(raw):
+            if not in_block:
+                in_block = True
+                block_start = idx + 1
+            else:
+                # Block closed — scan it if it was a GraphQL recipe.
+                block_lines = lines[block_start:idx]
+                violations.extend(_scan_block(path, block_start, block_lines))
+                in_block = False
+    # An unterminated block (no closing fence) still gets scanned to EOF.
+    if in_block:
+        block_lines = lines[block_start:]
+        violations.extend(_scan_block(path, block_start, block_lines))
+
+    return violations
+
+
+def _scan_block(path: str, start_idx: int, block_lines: list[str]) -> list[Violation]:
+    """Scan one fenced block; flag over-cap `first:` only if it is a GraphQL recipe."""
+    block_text = "\n".join(block_lines)
+    if not _GRAPHQL_RE.search(block_text):
+        return []
+    found: list[Violation] = []
+    for offset, line in enumerate(block_lines):
+        for m in _FIRST_RE.finditer(line):
+            value = int(m.group(1))
+            if value > CONNECTION_CAP:
+                # start_idx is 0-based content start; +offset for the line, +1 to 1-base.
+                found.append(Violation(path, start_idx + offset + 1, value))
+    return found
+
+
+def check_file(path: Path) -> list[Violation]:
+    return check_markdown_text(str(path), path.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str]) -> int:
+    paths = argv[1:]
+    if not paths:
+        print(
+            "usage: lint_skill_graphql_pagination.py <file.md> [<file.md> ...]",
+            file=sys.stderr,
+        )
+        return 2
+
+    all_violations: list[Violation] = []
+    for p in paths:
+        path = Path(p)
+        if not path.is_file():
+            print(f"ERROR: not a file: {p}", file=sys.stderr)
+            return 2
+        all_violations.extend(check_file(path))
+
+    if all_violations:
+        print("GraphQL connection over-cap violations (first: > 100, noorinalabs-main#888):")
+        for v in all_violations:
+            print(f"  {v}")
+        print(
+            "\nGraphQL connections cap first: at 100. Page with first: 100 + "
+            "pageInfo { hasNextPage endCursor } + a $endCursor var + gh api graphql "
+            "--paginate, then merge pages with jq -s."
+        )
+        return 1
+
+    print("OK: no GraphQL connection over-cap (first: > 100) found.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.claude/lib/tests/test_lint_skill_graphql_pagination.py
+++ b/.claude/lib/tests/test_lint_skill_graphql_pagination.py
@@ -1,0 +1,148 @@
+"""Tests for lint_skill_graphql_pagination — the GraphQL `first: > 100` guard (#888).
+
+Verifies the lint flags an over-cap `first:` inside a `gh api graphql` code block, treats
+`first: 100` (the legal maximum) and small inner connections as compliant, and ignores a
+`first:` that appears outside a GraphQL recipe block.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from lint_skill_graphql_pagination import (  # noqa: E402
+    check_markdown_text,
+    main,
+)
+
+_GRAPHQL_BLOCK = """### Step 2
+
+```bash
+gh api graphql -f query='
+query {{
+  organization(login: "noorinalabs") {{
+    projectV2(number: 2) {{
+      items(first: {n}) {{
+        nodes {{ id }}
+      }}
+    }}
+  }}
+}}'
+```
+"""
+
+
+class OverCapIsFlagged(unittest.TestCase):
+    def test_first_500_in_graphql_block_flagged(self) -> None:
+        v = check_markdown_text("SKILL.md", _GRAPHQL_BLOCK.format(n=500))
+        self.assertEqual(len(v), 1)
+        self.assertEqual(v[0].value, 500)
+        # Line points at the `items(first: 500)` line inside the fenced block.
+        self.assertEqual(v[0].lineno, 8)
+
+    def test_first_101_is_over_cap(self) -> None:
+        v = check_markdown_text("SKILL.md", _GRAPHQL_BLOCK.format(n=101))
+        self.assertEqual(len(v), 1)
+        self.assertEqual(v[0].value, 101)
+
+    def test_first_1394_flagged(self) -> None:
+        v = check_markdown_text("SKILL.md", _GRAPHQL_BLOCK.format(n=1394))
+        self.assertEqual(len(v), 1)
+
+
+class CompliantIsNotFlagged(unittest.TestCase):
+    def test_first_100_is_the_legal_max(self) -> None:
+        self.assertEqual(check_markdown_text("SKILL.md", _GRAPHQL_BLOCK.format(n=100)), [])
+
+    def test_small_inner_connection_ok(self) -> None:
+        self.assertEqual(check_markdown_text("SKILL.md", _GRAPHQL_BLOCK.format(n=30)), [])
+
+    def test_paginated_block_with_first_100_and_inner_30(self) -> None:
+        md = """```bash
+gh api graphql --paginate -f query='
+query($endCursor: String) {
+  organization(login: "noorinalabs") {
+    projectV2(number: 2) {
+      items(first: 100, after: $endCursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes { fieldValues(first: 30) { nodes { id } } }
+      }
+    }
+  }
+}'
+```
+"""
+        self.assertEqual(check_markdown_text("SKILL.md", md), [])
+
+    def test_first_500_outside_graphql_block_ignored(self) -> None:
+        # A `first: 500` in a non-GraphQL recipe (no `gh api graphql`) is out of scope.
+        md = """```bash
+gh issue list --repo noorinalabs/x --limit 500 --json url
+echo "first: 500 widgets"
+```
+"""
+        self.assertEqual(check_markdown_text("SKILL.md", md), [])
+
+    def test_first_500_in_prose_outside_any_block_ignored(self) -> None:
+        md = "Some prose mentioning items(first: 500) but no code block.\n"
+        self.assertEqual(check_markdown_text("SKILL.md", md), [])
+
+
+class MultipleAndUnterminated(unittest.TestCase):
+    def test_two_over_cap_in_one_block(self) -> None:
+        md = """```bash
+gh api graphql -f query='query { a(first: 200) { b(first: 300) { id } } }'
+```
+"""
+        v = check_markdown_text("SKILL.md", md)
+        self.assertEqual([x.value for x in v], [200, 300])
+
+    def test_unterminated_block_scanned_to_eof(self) -> None:
+        md = "```bash\ngh api graphql -f query='query { a(first: 500) { id } }'\n"
+        v = check_markdown_text("SKILL.md", md)
+        self.assertEqual(len(v), 1)
+        self.assertEqual(v[0].value, 500)
+
+
+class CliExitCodes(unittest.TestCase):
+    def test_usage_error_no_args(self) -> None:
+        self.assertEqual(main(["lint_skill_graphql_pagination.py"]), 2)
+
+    def test_missing_file_errors(self) -> None:
+        self.assertEqual(main(["lint_skill_graphql_pagination.py", "/no/such/file.md"]), 2)
+
+    def test_clean_file_passes(self) -> None:
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as fh:
+            fh.write(_GRAPHQL_BLOCK.format(n=100))
+            name = fh.name
+        try:
+            self.assertEqual(main(["lint_skill_graphql_pagination.py", name]), 0)
+        finally:
+            Path(name).unlink()
+
+    def test_violating_file_returns_1(self) -> None:
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as fh:
+            fh.write(_GRAPHQL_BLOCK.format(n=500))
+            name = fh.name
+        try:
+            self.assertEqual(main(["lint_skill_graphql_pagination.py", name]), 1)
+        finally:
+            Path(name).unlink()
+
+    def test_real_skill_file_is_clean(self) -> None:
+        # The board-audit skill must itself be free of the over-cap after the #888 fix.
+        repo_root = Path(__file__).resolve().parents[3]
+        skill = repo_root / ".claude" / "skills" / "board-audit" / "SKILL.md"
+        if skill.is_file():
+            self.assertEqual(main(["lint_skill_graphql_pagination.py", str(skill)]), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/skills/board-audit/SKILL.md
+++ b/.claude/skills/board-audit/SKILL.md
@@ -48,35 +48,81 @@ Per Hook 15 (`enforce_librarian_consulted`). The board-audit work edits no sourc
 /ontology-librarian board-audit drift orphan project field-sync
 ```
 
-### 1. Fetch all open issues across the 8 org repos
+### 1. Fetch all open issues (with labels) across the 8 org repos
+
+Fetch `url` **and** `labels` in one call per repo. The labels feed Step 4's drift
+detection **in memory** — there is NO per-board-item `gh issue view` later (#888 defect 2).
+Each call is wrapped in a `timeout` and skip-and-warns rather than hanging the whole
+audit on a single stalled `gh` call (#888 defect 3 — the org-wide loop hung at the 2-min
+mark twice, though each repo returns in <0.4 s alone).
 
 ```bash
-REPOS=(noorinalabs-main noorinalabs-isnad-graph noorinalabs-user-service \
-       noorinalabs-deploy noorinalabs-design-system noorinalabs-landing-page \
-       noorinalabs-data-acquisition noorinalabs-isnad-ingest-platform)
+# Literal repo list in the `for` (NOT `for repo in $SCALAR`) — under zsh an unquoted
+# scalar is not word-split, so a "$REPOS"-string would collapse to one bogus iteration
+# (#759). A literal word-list is split correctly in both bash and zsh.
+: > /tmp/issue-labels.tsv      # url \t expected-Wave-option (computed from the wave label)
+: > /tmp/all-issue-urls.txt    # every open issue url across the org
 
-ALL_ISSUES=()
-for repo in "${REPOS[@]}"; do
-  while read -r url; do
-    ALL_ISSUES+=("$url")
-  done < <(gh issue list --repo "noorinalabs/$repo" --state open \
-             --limit 500 --json url --jq '.[].url')
+for repo in noorinalabs-main noorinalabs-isnad-graph noorinalabs-user-service \
+            noorinalabs-deploy noorinalabs-design-system noorinalabs-landing-page \
+            noorinalabs-data-acquisition noorinalabs-isnad-ingest-platform; do
+  # Per-call timeout: one stalled call must not hang the whole audit (#888 defect 3).
+  # `timeout` exits 124 on stall → the `if !` branch warns and `continue`s.
+  if ! timeout 45 gh issue list --repo "noorinalabs/$repo" --state open \
+         --limit 500 --json url,labels > "/tmp/issues-$repo.json" 2>/dev/null; then
+    echo "WARN: gh issue list for $repo stalled/failed — skipping (audit continues)" >&2
+    continue
+  fi
+
+  # url + the highest-numbered wave label, mapped to its expected Wave-field option:
+  #   wave-{X}  -> W{X}      p{N}-wave-{M} -> P{N}W{M}      wave-x -> WX
+  # Ties on multiple wave labels (rare, transitional) resolve to highest-numbered, matching
+  # the issue body's "highest-numbered wins" rule. Issues with no wave label are omitted here.
+  jq -r '.[]
+         | .url as $u
+         | ([.labels[].name
+             | select(test("^wave-[0-9]+$") or test("^p[0-9]+-wave-[0-9]+$") or . == "wave-x")]
+            | sort_by(if . == "wave-x" then -1 else (capture("(?<n>[0-9]+)$").n | tonumber) end)
+            | last) as $lbl
+         | select($lbl != null)
+         | ($lbl
+            | if . == "wave-x" then "WX"
+              elif startswith("wave-") then "W" + ltrimstr("wave-")
+              else (capture("p(?<n>[0-9]+)-wave-(?<m>[0-9]+)") | "P\(.n)W\(.m)")
+              end) as $opt
+         | "\($u)\t\($opt)"' "/tmp/issues-$repo.json" >> /tmp/issue-labels.tsv
+
+  jq -r '.[].url' "/tmp/issues-$repo.json" >> /tmp/all-issue-urls.txt
+  printf '  %s: done\n' "$repo"          # progress flush — unbuffered, per-repo
 done
 
-echo "Open issues across org: ${#ALL_ISSUES[@]}"
+echo "Open issues across org: $(wc -l < /tmp/all-issue-urls.txt | tr -d ' ')"
+echo "Issues carrying a wave label: $(wc -l < /tmp/issue-labels.tsv | tr -d ' ')"
 ```
 
 `--limit 500` is intentional — the default 30 truncates silently per memory `feedback_gh_pr_edit_silent_noop` family. Adjust upward if any single repo crosses 500 open issues (unlikely but capture as an annunaki event if hit).
 
-### 2. Fetch all items on project 2
+### 2. Fetch all items on project 2 (paginated — connections cap at 100)
+
+**`items(first: …)` MUST be ≤ 100.** GitHub's GraphQL API caps every connection's
+`first:` at 100 — `first: 500` errors with *"Requesting 500 records on the connection
+exceeds the `first` limit of 100 records"* and returns **0 nodes**, which downstream
+reads as "every issue is an orphan" (#888 defect 1; project 2 had 1394 items at the
+P7W19 run, so this is not an edge case). Page with `first: 100` + a `$endCursor` cursor
+var + `pageInfo { hasNextPage endCursor }`, let `gh api graphql --paginate` walk the
+pages, then merge them with `jq -s`.
 
 ```bash
-gh api graphql -f query='
-query($org: String!, $project: Int!) {
+# `--paginate` re-runs the query with $endCursor for each page (it keys off
+# `pageInfo.endCursor` — the cursor var MUST be named endCursor). It emits one JSON
+# document per page on stdout; `jq -s` (Step below) slurps them into one array.
+gh api graphql --paginate -f org=noorinalabs -F project=2 -f query='
+query($org: String!, $project: Int!, $endCursor: String) {
   organization(login: $org) {
     projectV2(number: $project) {
       id
-      items(first: 500) {
+      items(first: 100, after: $endCursor) {
+        pageInfo { hasNextPage endCursor }
         nodes {
           id
           content {
@@ -97,10 +143,23 @@ query($org: String!, $project: Int!) {
       }
     }
   }
-}' -f org=noorinalabs -F project=2 > /tmp/board-items.json
+}' > /tmp/board-items-pages.json
+
+# Merge the per-page documents into the single-object shape downstream jq expects:
+# `.data.organization.projectV2.{id,items.nodes[]}`. `jq -s` slurps the page stream
+# into an array; we flatten every page's nodes[] and keep page 0's project id (stable
+# across pages). Works whether there were 1 page or 14.
+jq -s '{ data: { organization: { projectV2: {
+          id: .[0].data.organization.projectV2.id,
+          items: { nodes: [ .[].data.organization.projectV2.items.nodes[] ] }
+        } } } }' /tmp/board-items-pages.json > /tmp/board-items.json
+
+echo "Board items fetched: $(jq '.data.organization.projectV2.items.nodes | length' /tmp/board-items.json)"
 ```
 
-Save raw to `/tmp/` (or `.claude/scratch/`) for downstream parsing.
+Save raw to `/tmp/` (or `.claude/scratch/`) for downstream parsing. A board-item count
+of **0** here is a red flag (the over-cap symptom) — investigate before treating every
+issue as an orphan, never run the apply steps off a zero-item fetch.
 
 ### 3. Detect orphans
 
@@ -108,8 +167,8 @@ Save raw to `/tmp/` (or `.claude/scratch/`) for downstream parsing.
 # Build set of URLs on the board
 BOARD_URLS=$(jq -r '.data.organization.projectV2.items.nodes[] | .content.url // empty' /tmp/board-items.json | sort -u)
 
-# Set of URLs found in repo issue lists
-ISSUE_URLS=$(printf '%s\n' "${ALL_ISSUES[@]}" | sort -u)
+# Set of URLs found in repo issue lists (collected to a file in Step 1)
+ISSUE_URLS=$(sort -u /tmp/all-issue-urls.txt)
 
 # Orphans = issues NOT on the board
 ORPHANS=$(comm -23 <(echo "$ISSUE_URLS") <(echo "$BOARD_URLS"))
@@ -121,11 +180,15 @@ echo "$ORPHANS" | head -20
 
 ### 4. Detect Wave-field drift
 
-For each board item that maps to an issue/PR with a wave label, compute the expected Wave-field option using the grammar above (`wave-{X}` → `W{X}`, legacy `p{N}-wave-{M}` → `P{N}W{M}`, `wave-x` → `WX`). Compare against the actual Wave-field value:
+Drift is computed **entirely in memory** by cross-referencing two maps already on disk —
+no per-board-item `gh issue view` (#888 defect 2; the old loop was ~1394 serial network
+calls). The expected Wave-field option per issue comes from `/tmp/issue-labels.tsv` (built
+in Step 1 from the bulk `--json url,labels` fetch, grammar `wave-{X}` → `W{X}`,
+`p{N}-wave-{M}` → `P{N}W{M}`, `wave-x` → `WX`); the board's actual Wave-field value comes
+from the Step-2 GraphQL response. A single hash-join `awk` matches them by URL.
 
 ```bash
-# For each board item, walk the labels of the linked issue/PR and find the wave label
-# (new `wave-{X}` or grandfathered `p{N}-wave-{M}`).
+# Board side: url \t item_id \t current-Wave-field (from the merged Step-2 response).
 jq -r '.data.organization.projectV2.items.nodes[]
        | select(.content.url != null)
        | "\(.content.url)\t\(.id)\t\(
@@ -135,49 +198,51 @@ jq -r '.data.organization.projectV2.items.nodes[]
              | .name] | first // "(unset)")
          )"' /tmp/board-items.json > /tmp/board-wave-values.tsv
 
-# Cross-join with issue labels.
-# (For each url in the tsv, fetch its labels via gh and compare.)
-#
-# Drift bucketing (see #427 for the regression that motivated the split):
+# In-memory hash join (NO network): first file builds url -> expected-option, second
+# file (board) is streamed and annotated with the expected option (or "(unset)" when the
+# issue carries no wave label / isn't an open issue — e.g. a PR or closed item).
+# NB: the map array is `want`, NOT `exp` — `exp` is awk's built-in exponential fn and
+# using it as an array name is a syntax error.
+awk -F'\t' '
+  NR==FNR { want[$1] = $2; next }                # /tmp/issue-labels.tsv : url -> W{X}
+  { e = ($1 in want) ? want[$1] : "(unset)";
+    print $1 "\t" $3 "\t" e }                     # url \t current_wave \t expected
+' /tmp/issue-labels.tsv /tmp/board-wave-values.tsv > /tmp/board-drift-join.tsv
+
+# Bucket the join rows (see #427 for the regression that motivated the split):
 #   DRIFT      — actionable rows where a mutation will change board state.
-#   NOOP_COUNT — issues with no wave label AND Wave field already (unset).
-#                Functionally `(unset) → (clear)`; the apply step's
-#                clearProjectV2ItemFieldValue is a no-op against a field
-#                already cleared. Counted separately so the operator sees
-#                "audit is clean" even when the no-op equivalence class is
-#                non-empty; MUST stay out of DRIFT so Step 7 doesn't emit
-#                redundant clear mutations and Step 5's gate doesn't
-#                over-report.
+#   NOOP_COUNT — no wave label AND Wave field already (unset). Functionally
+#                `(unset) → (clear)`; the apply step's clearProjectV2ItemFieldValue is a
+#                no-op against an already-cleared field. Counted separately so the operator
+#                sees "audit is clean" even when the no-op equivalence class is non-empty;
+#                MUST stay out of DRIFT so Step 7 doesn't emit redundant clear mutations and
+#                Step 5's gate doesn't over-report.
+# DRIFT rows carry REAL tab separators (`$'\t'`, not the literal backslash-t that a
+# double-quoted "\t" would store) so Step 7's `while IFS=$'\t' read` actually splits them.
 DRIFT=()
 NOOP_COUNT=0
-while IFS=$'\t' read -r url item_id current_wave; do
-  REPO=$(echo "$url" | sed -E 's#https://github.com/[^/]+/([^/]+)/.*#\1#')
-  NUM=$(echo "$url" | sed -E 's#.*/(issues|pull)/##')
-  LABEL=$(gh issue view "$NUM" --repo "noorinalabs/$REPO" --json labels \
-            --jq '.labels[].name' 2>/dev/null \
-          | grep -E '^p[0-9]+-wave-[0-9]+$' | sort -V | tail -1)
-
-  if [ -n "$LABEL" ]; then
-    EXPECTED=$(echo "$LABEL" | sed -E 's#p([0-9]+)-wave-([0-9]+)#P\1W\2#')
-    if [ "$current_wave" != "$EXPECTED" ]; then
-      DRIFT+=("$url\t$current_wave\t$EXPECTED")
+while IFS=$'\t' read -r url current_wave expected; do
+  [ -n "$url" ] || continue
+  if [ "$expected" != "(unset)" ]; then
+    if [ "$current_wave" != "$expected" ]; then
+      DRIFT+=("$url"$'\t'"$current_wave"$'\t'"$expected")
     fi
   elif [ "$current_wave" != "(unset)" ]; then
-    # Labeled with no wave label but Wave field is populated — should clear.
-    DRIFT+=("$url\t$current_wave\t(clear)")
+    # No wave label but Wave field is populated — should clear.
+    DRIFT+=("$url"$'\t'"$current_wave"$'\t'"(clear)")
   else
-    # No wave label AND Wave field already (unset) — already in desired
-    # state. Count for visibility; do NOT add to DRIFT.
+    # No wave label AND Wave field already (unset) — already in desired state.
     NOOP_COUNT=$((NOOP_COUNT + 1))
   fi
-done < /tmp/board-wave-values.tsv
+done < /tmp/board-drift-join.tsv
 
 echo "Actionable Wave-field drift:        ${#DRIFT[@]}"
 echo "No-op equivalents (unset == clear): ${NOOP_COUNT}"
 printf '%s\n' "${DRIFT[@]}" | head -30
 ```
 
-"Multiple wave labels (rare, transitional)" — `sort -V | tail -1` takes the highest-numbered which matches the issue body's "highest-numbered wins" rule.
+"Multiple wave labels (rare, transitional)" — Step 1's `sort_by(... | tonumber) | last`
+takes the highest-numbered, matching the issue body's "highest-numbered wins" rule.
 
 ### 5. Confirmation gate (mandatory)
 
@@ -333,6 +398,36 @@ If read-back actionable drift > 0, raise a warning and link to charter `pull-req
 - Daily cron (issue body Option B) — deferred unless drift recurs after this skill ships.
 - Auto-add via Hook 13 extension — Hook 13 catches in-session creates; extending it to cron-style cross-repo scans is the Option B path, deferred for the same reason.
 - Wave-field option auto-creation — `gh project field-create` requires project-edit scope; one-time owner action.
+
+## Skill-authoring notes — GitHub API access patterns
+
+These are the footguns this skill hit (main#888, surfaced during the P7W19 `/board-audit`
+run). Any skill that queries the GitHub GraphQL or REST APIs over a growing collection
+should heed them:
+
+- **GraphQL connections cap at 100 — always paginate.** Every GraphQL *connection*
+  (`items`, `nodes`, `issues`, …) rejects `first:` > 100 with a hard error and returns
+  zero rows. Use `first: 100` + `pageInfo { hasNextPage endCursor }` + a `$endCursor`
+  query var + `gh api graphql --paginate`, then merge pages with `jq -s`. Never raise
+  `first:` to "fit the dataset" — that is the over-cap regression (Step 2).
+- **Derive in memory; don't loop network calls per row.** If you already have the data in
+  a bulk response (or can get it in one `gh … --json` call per repo), cross-reference it
+  in memory (an `awk`/`jq` hash join) rather than an `O(collection)` per-item `gh view`
+  loop (Step 1 + Step 4).
+- **Wrap each external call in a `timeout` and skip-and-warn.** A single stalled `gh`/HTTP
+  call must not hang a whole multi-repo sweep; bound it and continue (Step 1).
+
+A cheap regression lint for the first item ships at
+[`.claude/lib/lint_skill_graphql_pagination.py`](../../lib/lint_skill_graphql_pagination.py):
+it flags `first: <n≥100>` inside a `gh api graphql` block across `.claude/skills/**/*.md`.
+Run it over the skills tree with:
+
+```bash
+python3 .claude/lib/lint_skill_graphql_pagination.py .claude/skills/**/*.md
+```
+
+Wiring it into pre-commit/CI is a deliberate follow-up (it is not yet a blocking gate); its
+detection logic is covered by `.claude/lib/tests/test_lint_skill_graphql_pagination.py`.
 
 ## Promotion provenance
 


### PR DESCRIPTION
## Summary

Fixes three mechanical GitHub-API defects in `.claude/skills/board-audit/SKILL.md`, surfaced during the P7W19 `/board-audit` run (main#888).

### Defect 1 — GraphQL `first: 500` over-cap (Step 2)
GitHub GraphQL connections cap `first:` at **100**; `first: 500` hard-errors and returns 0 nodes (read as "every issue is an orphan"). Now `first: 100` + `pageInfo { hasNextPage endCursor }` + `$endCursor` + `gh api graphql --paginate`, merged with `jq -s`. Verified the merge shape against a 2-page fixture.

### Defect 2 — per-item `gh issue view` drift scan (Steps 1 + 4)
Was ~1394 serial network calls. Step 1 now fetches `--json url,labels` in bulk (8 calls total) and maps each issue → expected Wave-field option (`wave-{X}`→`W{X}`, `p{N}-wave-{M}`→`P{N}W{M}`, `wave-x`→`WX`). Step 4 cross-references **in memory** via a single `awk` hash join — no per-board-item `gh view`. (Also: DRIFT rows now carry real tabs via `$'\t'` so Step 7's `IFS=$'\t' read` actually splits them — the literal `"\t"` form never would.)

### Defect 3 — org-wide loop hang (Step 1)
Each `gh issue list` is wrapped in `timeout 45` and skip-and-warns rather than hanging the whole audit; per-repo progress is flushed.

### Extras
- **Skill-authoring note** — "GraphQL connections cap at 100; always paginate" + derive-in-memory + bounded-call patterns.
- **Regression lint** — `.claude/lib/lint_skill_graphql_pagination.py` flags `first: > 100` inside `gh api graphql` blocks across `.claude/skills/**/*.md` (`first: 100` is the legal max and is NOT flagged). Covered by `test_lint_skill_graphql_pagination.py` (15 cases). Wiring it into pre-commit/CI is a deliberate follow-up; it runs clean over the skills tree today.

## Acceptance (main#888)
- [x] Step 2 paginates (`first: 100` + `--paginate`).
- [x] Step 4 derives drift from bulk `--json url,labels`, no per-item `gh issue view`.
- [x] Step 1 loop resilient to a single stalled `gh` call.
- [x] Skill-authoring note + (optional) lint.

## Verification
- All recipe transforms exercised with sample fixtures (jq label→option mapping, `jq -s` page merge, `awk` join, Step-4 bucketing + Step-7 tab round-trip under **zsh**).
- `ruff format --check`, `ruff check`, `mypy`, full `pytest` (624 passed), cspell, markdownlint, sync-drift gate — all green locally. Lint runs clean over all skills.

## Reviewers
- Primary: Weronika Zielinska
- Secondary: Lucas Ferreira

TechDebt: none — this PR pays down skill tech-debt (no new debt introduced; CI-wiring of the new lint is the one tracked follow-up, noted in the skill-authoring section).

Closes #888

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NwiLxghxyUaTLc78FWeDVW
