### PR TITLE
ci(lint): wire lint_skill_graphql_pagination into pre-commit + CI (#893)

### DIFF
--- a/.claude/lib/pre_commit_ci_sync.py
+++ b/.claude/lib/pre_commit_ci_sync.py
@@ -47,7 +47,7 @@ kind tokens so they compare:
 
     ruff-lint, ruff-format, mypy, pytest, eslint, typescript, prettier,
     terraform-fmt, gitleaks, actionlint, astro-check, pip-audit, build,
-    cspell, dockerfile-base-pin, fixture-realism
+    cspell, dockerfile-base-pin, fixture-realism, skill-graphql-pagination
 
 Unknown tools are ignored (neither side gates on a kind we can't classify),
 which keeps the gate conservative — it never fails on something it doesn't
@@ -168,6 +168,19 @@ _KIND_PATTERNS: dict[str, tuple[str, ...]] = {
     # line) and the hook id / job name.
     "dockerfile-base-pin": ("check_dockerfile_base_pin", "dockerfile-base-pin"),
     "fixture-realism": ("check_fixture_realism", "fixture-realism"),
+    # `skill-graphql-pagination` is the skill-markdown GraphQL over-cap lint
+    # (`.claude/lib/lint_skill_graphql_pagination.py`, #888/#892 → wired by #893):
+    # it flags any `first: > 100` inside a `gh api graphql` block in
+    # `.claude/skills/**/*.md` (the over-cap footgun that made `/board-audit` read
+    # every issue as an orphan). Same contract as the two charter-prose→code gates
+    # above — a CI run of the lint with no pre-commit hook is harmful drift (#684),
+    # not a silently-ignored unknown, so classifying it makes the drift gate
+    # actively DEMAND the local⇄CI mirror. Patterns match the script basename
+    # (present on both sides' invoke line) and the hook id / job name.
+    "skill-graphql-pagination": (
+        "lint_skill_graphql_pagination",
+        "skill-graphql-pagination",
+    ),
 }
 
 

--- a/.claude/lib/tests/test_pre_commit_ci_sync.py
+++ b/.claude/lib/tests/test_pre_commit_ci_sync.py
@@ -486,6 +486,66 @@ repos:
         self.assertNotIn("fixture-realism", harmful)
 
 
+class SkillGraphqlPaginationKind(unittest.TestCase):
+    """#888/#893: the skill-markdown GraphQL over-cap lint must be a classified kind
+    so the sync-drift gate DEMANDS a pre-commit mirror of the CI lint job (an
+    un-mirrored gate lets a `first: > 100` over-cap reintroduce the silent
+    zero-row read that made `/board-audit` treat every issue as an orphan)."""
+
+    def test_ci_skill_graphql_pagination_run_step_classified(self) -> None:
+        wf = """
+jobs:
+  skill-graphql-pagination:
+    steps:
+      - run: python3 .claude/lib/lint_skill_graphql_pagination.py $files
+"""
+        self.assertIn("skill-graphql-pagination", kinds_from_ci(wf))
+
+    def test_precommit_skill_graphql_pagination_hook_classified(self) -> None:
+        cfg = """
+repos:
+  - repo: local
+    hooks:
+      - id: skill-graphql-pagination
+        name: skill-graphql-pagination
+        entry: python3 .claude/lib/lint_skill_graphql_pagination.py
+"""
+        self.assertIn("skill-graphql-pagination", kinds_from_precommit(cfg))
+
+    def test_ci_skill_graphql_pagination_without_precommit_is_harmful_drift(self) -> None:
+        wf = """
+jobs:
+  skill-graphql-pagination:
+    steps:
+      - run: python3 .claude/lib/lint_skill_graphql_pagination.py $files
+"""
+        cfg = """
+repos:
+  - repo: local
+    hooks:
+      - id: ruff
+"""
+        harmful, _ = compute_drift(kinds_from_precommit(cfg), kinds_from_ci(wf))
+        self.assertIn("skill-graphql-pagination", harmful)
+
+    def test_ci_skill_graphql_pagination_with_precommit_mirror_no_drift(self) -> None:
+        wf = """
+jobs:
+  skill-graphql-pagination:
+    steps:
+      - run: python3 .claude/lib/lint_skill_graphql_pagination.py $files
+"""
+        cfg = """
+repos:
+  - repo: local
+    hooks:
+      - id: skill-graphql-pagination
+        entry: python3 .claude/lib/lint_skill_graphql_pagination.py
+"""
+        harmful, _ = compute_drift(kinds_from_precommit(cfg), kinds_from_ci(wf))
+        self.assertNotIn("skill-graphql-pagination", harmful)
+
+
 class BuildKindTightening(unittest.TestCase):
     """#576: runtime `docker build` / `docker buildx` steps are image-MOVING,
     not a build-QUALITY gate a local pre-commit hook can mirror — they must
@@ -734,6 +794,10 @@ _OLD_KIND_PATTERNS = {
     "mermaid": ("mermaid", "check-mermaid"),
     "dockerfile-base-pin": ("check_dockerfile_base_pin", "dockerfile-base-pin"),
     "fixture-realism": ("check_fixture_realism", "fixture-realism"),
+    "skill-graphql-pagination": (
+        "lint_skill_graphql_pagination",
+        "skill-graphql-pagination",
+    ),
 }
 _OLD_RUN_BLOCK_OPEN_RE = re.compile(r"^(?P<indent>\s*)-?\s*run:\s*[|>][+\-0-9]*\s*$")
 
@@ -828,6 +892,7 @@ _EXPECTED_KINDS = {
             "pytest",
             "ruff-format",
             "ruff-lint",
+            "skill-graphql-pagination",
         },
         "ci": {
             "actionlint",
@@ -843,6 +908,7 @@ _EXPECTED_KINDS = {
             "pytest",
             "ruff-format",
             "ruff-lint",
+            "skill-graphql-pagination",
         },
     },
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,31 @@ jobs:
           # shellcheck disable=SC2086  # word-splitting is intended (one path per arg)
           python3 .claude/lib/check_fixture_realism.py $files
 
+  skill-graphql-pagination:
+    name: GraphQL pagination over-cap lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      # Skill-markdown GraphQL over-cap guard (#888/#892, wired by #893). Flags any
+      # `first: > 100` inside a `gh api graphql` block in a skill markdown file —
+      # GitHub caps connection `first:` at 100, and the silent zero-row read made
+      # `/board-audit` treat every issue as an orphan. Mirrors the
+      # `skill-graphql-pagination` pre-commit hook (the sync-drift gate classifies
+      # the kind, so this mirror is mandatory). The lint self-scopes to
+      # gh-api-graphql blocks, so a `first:` in prose is ignored.
+      - name: "Lint skill markdown for GraphQL first: > 100 over-cap"
+        run: |
+          files=$(find .claude/skills -name '*.md' -print)
+          if [ -z "$files" ]; then
+            echo "No skill markdown files found — pagination lint is a no-op here."
+            exit 0
+          fi
+          # shellcheck disable=SC2086  # word-splitting is intended (one path per arg)
+          python3 .claude/lib/lint_skill_graphql_pagination.py $files
+
   precommit-ci-sync:
     name: Pre-commit ⇄ CI sync-drift gate
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -116,6 +116,23 @@ repos:
         files: (^|/)(fixtures|test_data|testdata)/.*\.(json|jsonl|txt|csv|tsv|ndjson|py)$
         exclude: ^\.claude/worktrees/
         pass_filenames: true
+      # skill-graphql-pagination mirrors the `GraphQL pagination over-cap lint` CI
+      # job in ci.yml (the sync-drift gate classifies the `skill-graphql-pagination`
+      # kind — #888/#893 — so a CI-enforced lint not mirrored here turns the gate
+      # red, same contract as the two prose gates above). Flags any `first: > 100`
+      # inside a `gh api graphql` block in a skill markdown file — the over-cap
+      # footgun that made `/board-audit` read every issue as an orphan (#888). The
+      # lint self-scopes to `gh api graphql` blocks, so a `first:` in prose or a
+      # non-GraphQL recipe is ignored. Commit-stage (cheap static scan); `files:`
+      # restricts candidates to the skills tree, `pass_filenames` hands the changed
+      # *.md to the lint (whose CLI takes file args, like the prose gates above).
+      - id: skill-graphql-pagination
+        name: skill-graphql-pagination
+        entry: python3 .claude/lib/lint_skill_graphql_pagination.py
+        language: system
+        files: ^\.claude/skills/.*\.md$
+        exclude: ^\.claude/worktrees/
+        pass_filenames: true
 
   # Heavier checks run at pre-push (mirror CI's mypy + pytest jobs). Running as
   # `local`/`system` hooks so we use the system tools and don't drift from


### PR DESCRIPTION
## What

Wires the GraphQL connection over-cap lint (`.claude/lib/lint_skill_graphql_pagination.py`, added by #892 / #888) into **both** local pre-commit and CI, so a future skill author cannot reintroduce the `first: > 100` footgun that made `/board-audit` read every issue as an orphan.

## Where the lint is wired

- **`.pre-commit-config.yaml`** — new commit-stage `skill-graphql-pagination` local hook over `^\.claude/skills/.*\.md$` (excludes worktrees), `pass_filenames: true`. Modeled on the `dockerfile-base-pin` / `fixture-realism` prose gates.
- **`.github/workflows/ci.yml`** — new `skill-graphql-pagination` job ("GraphQL pagination over-cap lint") that finds every `.claude/skills/**/*.md` and runs the lint, mirroring the pre-commit hook.
- **`.claude/lib/pre_commit_ci_sync.py`** — classifies the new `skill-graphql-pagination` kind in `_KIND_PATTERNS` so the sync-drift gate **DEMANDS** the local⇄CI mirror (closes the unclassified-kind blind spot per `feedback_local_ci_parity_no_force` / #684) — the lint is mirrored, not a silent gap.
- **tests** — new `SkillGraphqlPaginationKind` mirror-test class (classify-both-sides + harmful-drift + no-drift-with-mirror), lock-step `_OLD_KIND_PATTERNS` entry, and the documented parent `_EXPECTED_KINDS` snapshot updated (precommit + ci).

## Verification

- `python3 .claude/lib/pre_commit_ci_sync.py .` → `OK: pre-commit config mirrors all CI-enforced checks.` (rc 0) — parity confirmed, new kind classified.
- Lint **catches** a regression: a temp skill md with `first: 500` in a `gh api graphql` block exits 1 with the over-cap diagnostic.
- `board-audit/SKILL.md` (the only in-scope skill, already fixed at #892) passes (rc 0).
- New `skill-graphql-pagination` pre-commit hook fires and passes via `pre-commit run skill-graphql-pagination --all-files`.
- Full local hook set green: `pre-commit run --all-files` (commit stage) and `--hook-stage pre-push` (mypy, pytest, pytest-skills, memory/headcount budget, doc-freshness, office-drift, mermaid-render) all Passed. Sync-gate + lint test suites: 78 passed.

## Reviewers

- **Lucas Ferreira** (primary)
- **Nurul Hakim** (secondary — author of the lint, #892)

## Tech debt

None introduced. This PR retires the deferred-wiring tech debt tracked by #893 itself; the lint goes from manually-runnable to a blocking local⇄CI gate.

Closes #893

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NwiLxghxyUaTLc78FWeDVW
