### PR TITLE
fix(hook-4): validate_pr_review blocks subshell-wrapped & compound-arg in-loop variable merges (closes #894)

### DIFF
--- a/.claude/hooks/tests/test_validate_pr_review.py
+++ b/.claude/hooks/tests/test_validate_pr_review.py
@@ -1645,6 +1645,74 @@ class BatchLoopMergeDetectorTests(unittest.TestCase):
             )
         )
 
+    # ---- #894 residual fail-open evasions ----
+
+    def test_894_subshell_wrapped_merge_blocked(self):
+        # Gap 1: a merge wrapped in a `( … )` subshell leaves the arg as `$pr)`.
+        # The pre-#894 terminator lookahead `(?=\s|;|&|\||$)` omitted `)`, so the
+        # merge verb never matched and the loop fail-opened. Now BLOCKED.
+        self.assertTrue(
+            hook.is_variable_pr_merge_in_loop("for pr in 1 2; do (gh pr merge $pr); done")
+        )
+
+    def test_894_subshell_wrapped_quoted_merge_blocked(self):
+        # Gap 1 variant: subshell + quoted var arg.
+        self.assertTrue(
+            hook.is_variable_pr_merge_in_loop('for pr in 1 2; do (gh pr merge "$pr" --merge); done')
+        )
+
+    def test_894_subscripted_array_arg_blocked(self):
+        # Gap 2: a subscripted `"${prs[$i]}"` arg failed the lone-simple-var
+        # unwrap fullmatch and was stripped as opaque prose — the merge arg
+        # vanished and the loop fail-opened. Now BLOCKED.
+        self.assertTrue(
+            hook.is_variable_pr_merge_in_loop('for i in 0 1; do gh pr merge "${prs[$i]}"; done')
+        )
+
+    def test_894_command_substitution_arg_blocked(self):
+        # Gap 2 variant: a command-substitution `"$(cmd)"` arg, likewise stripped
+        # pre-#894. Now BLOCKED.
+        self.assertTrue(
+            hook.is_variable_pr_merge_in_loop(
+                'for i in 0 1; do gh pr merge "$(get_pr)" --merge; done'
+            )
+        )
+
+    def test_894_command_substitution_arg_with_inner_space_blocked(self):
+        # Gap 2 robustness: whitespace INSIDE the `$(…)` expansion must not make
+        # the quoted run look like prose — it is still one shell-word argument.
+        self.assertTrue(
+            hook.is_variable_pr_merge_in_loop('for i in 0 1; do gh pr merge "$(get_pr $i)"; done')
+        )
+
+    def test_894_literal_merge_inside_loop_not_blocked(self):
+        # Over-broadening guard: a bare-integer `gh pr merge 54` INSIDE a loop is
+        # still NOT blocked — the literal parses and the normal gate runs.
+        self.assertFalse(
+            hook.is_variable_pr_merge_in_loop("for n in 1; do gh pr merge 54 --merge; done")
+        )
+
+    def test_894_nonliteral_merge_outside_loop_not_blocked(self):
+        # #886 co-location preserved under the #894 broadening: a one-off
+        # subscripted/compound merge OUTSIDE any loop, co-occurring with an
+        # unrelated `gh run rerun` loop, does NOT fail-open and MUST NOT block.
+        cmd = (
+            'gh pr merge "${prs[0]}" --repo noorinalabs/noorinalabs-deploy --merge\n'
+            "for r in 11 12 13; do "
+            'gh run rerun "$r" --repo noorinalabs/noorinalabs-deploy --failed; done'
+        )
+        self.assertFalse(hook.is_variable_pr_merge_in_loop(cmd))
+
+    def test_894_body_mention_of_compound_merge_not_blocked(self):
+        # The #894 unwrap broadening must not re-open the prose-mention guard:
+        # a `--body "…"` payload mentioning the compound-arg loop shape (it
+        # carries whitespace OUTSIDE the expansion) is still stripped, not matched.
+        self.assertFalse(
+            hook.is_variable_pr_merge_in_loop(
+                'gh pr create --body "for i in 0 1; do gh pr merge ${prs[$i]}; done"'
+            )
+        )
+
 
 class BatchLoopMergeEndToEndTests(unittest.TestCase):
     """#567 end-to-end: check() HARD BLOCKS a batch-loop variable merge, and a
@@ -1667,6 +1735,27 @@ class BatchLoopMergeEndToEndTests(unittest.TestCase):
         self.assertEqual(result.get("decision"), "block")
         self.assertIn("Batch-loop", result["reason"])
         self.assertIn("one pr per call", result["reason"].lower())
+
+    def test_894_subscripted_loop_merge_hard_blocked(self):
+        # #894 end-to-end: a subscripted in-loop merge reaches check() and HARD
+        # BLOCKS. Patch get_pr_data so a pass proves the LOOP guard fired, not
+        # the downstream gate.
+        with mock.patch.object(hook, "get_pr_data", return_value=None):
+            result = hook.check(
+                self._input('for i in 0 1; do gh pr merge "${prs[$i]}" --merge; done')
+            )
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result.get("decision"), "block")
+        self.assertIn("Batch-loop", result["reason"])
+
+    def test_894_subshell_loop_merge_hard_blocked(self):
+        # #894 end-to-end: a subshell-wrapped in-loop merge HARD BLOCKS.
+        with mock.patch.object(hook, "get_pr_data", return_value=None):
+            result = hook.check(self._input("for pr in 1 2; do (gh pr merge $pr); done"))
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result.get("decision"), "block")
 
     def test_loop_var_merge_with_admin_still_overrides(self):
         # --admin is the emergency override and bypasses the loop guard too.
@@ -1717,6 +1806,73 @@ class StripQuotedRunsKeepVarArgsTests(unittest.TestCase):
     def test_single_quoted_run_dropped(self):
         out = hook._strip_quoted_runs_keep_var_args("echo 'for pr in 1; do gh pr merge $pr; done'")
         self.assertNotIn("gh pr merge", out)
+
+    # ---- #894: broadened single-word-expansion unwrap ----
+
+    def test_subscripted_array_arg_unwrapped(self):
+        out = hook._strip_quoted_runs_keep_var_args('gh pr merge "${prs[$i]}" --merge')
+        self.assertIn("${prs[$i]}", out)
+        self.assertNotIn('"', out)
+
+    def test_command_substitution_arg_unwrapped(self):
+        out = hook._strip_quoted_runs_keep_var_args('gh pr merge "$(get_pr)" --merge')
+        self.assertIn("$(get_pr)", out)
+
+    def test_command_substitution_with_inner_space_unwrapped(self):
+        # Whitespace inside the expansion does not make the run prose.
+        out = hook._strip_quoted_runs_keep_var_args('gh pr merge "$(get_pr $i)" --merge')
+        self.assertIn("$(get_pr $i)", out)
+
+    def test_quoted_literal_word_not_unwrapped(self):
+        # A non-expansion single word (e.g. a stray `"done"`) must NOT be
+        # unwrapped — that would inject a spurious loop keyword into the view.
+        out = hook._strip_quoted_runs_keep_var_args('gh pr comment --body "done"')
+        self.assertNotIn("done", out)
+
+    def test_prose_with_expansion_outside_dropped(self):
+        # Whitespace OUTSIDE the expansion ⇒ prose ⇒ dropped wholesale.
+        out = hook._strip_quoted_runs_keep_var_args('--body "merge ${prs[$i]} now"')
+        self.assertNotIn("prs", out)
+
+
+class StripExpansionsTests(unittest.TestCase):
+    """#894 pure-parser: `_strip_expansions` removes balanced ${…}/$(…) groups so
+    `_is_single_expansion_word` can tell a one-word arg from prose."""
+
+    def test_brace_group_removed(self):
+        self.assertEqual(hook._strip_expansions("${prs[$i]}").strip(), "")
+
+    def test_paren_group_with_inner_space_removed(self):
+        self.assertEqual(hook._strip_expansions("$(get_pr $i)").strip(), "")
+
+    def test_nested_paren_group_removed(self):
+        self.assertEqual(hook._strip_expansions("$(a $(b) c)").strip(), "")
+
+    def test_bare_var_left_intact(self):
+        # A bare `$pr` has no internal whitespace to hide, so it is not a group.
+        self.assertEqual(hook._strip_expansions("$pr"), "$pr")
+
+    def test_prose_whitespace_survives(self):
+        self.assertTrue(any(c.isspace() for c in hook._strip_expansions("do merge $pr")))
+
+
+class IsSingleExpansionWordTests(unittest.TestCase):
+    """#894: predicate gating the double-quoted-run unwrap."""
+
+    def test_bare_var_is_word(self):
+        self.assertTrue(hook._is_single_expansion_word("$pr"))
+
+    def test_subscripted_is_word(self):
+        self.assertTrue(hook._is_single_expansion_word("${prs[$i]}"))
+
+    def test_command_sub_with_space_is_word(self):
+        self.assertTrue(hook._is_single_expansion_word("$(get_pr $i)"))
+
+    def test_prose_is_not_word(self):
+        self.assertFalse(hook._is_single_expansion_word("do gh pr merge $pr"))
+
+    def test_literal_word_is_not_word(self):
+        self.assertFalse(hook._is_single_expansion_word("done"))
 
 
 if __name__ == "__main__":

--- a/.claude/hooks/validate_pr_review.py
+++ b/.claude/hooks/validate_pr_review.py
@@ -19,18 +19,20 @@ Input Language:
                the PR in the repo the user named, not the cwd-resolved repo.
     --admin  → short-circuits (emergency override — allows merge).
 
-  Batch-loop guard (#567, narrowed #886): a `gh pr merge <shell-var>` located
-  INSIDE a for/while/until loop body (e.g.
+  Batch-loop guard (#567, narrowed #886, broadened #894): a `gh pr merge` with
+  a NON-LITERAL PR argument located INSIDE a for/while/until loop body (e.g.
   `for pr in 48 49; do gh pr merge "$pr" …; done`) is HARD BLOCKED. The
-  literal-PR parse cannot resolve a loop variable, so the gate would fail-open
-  and merge every iteration unverified (observed P3W11 + P3W13). The operator is
-  told to run one literal merge per call so each PR is gate-checked. The merge
-  must sit between a `do` and its matching `done` to trip the guard — an
-  unrelated loop in the same block (e.g. a `gh run rerun "$r" --failed`
-  staleness recheck) alongside a non-loop variable merge does NOT (#886).
-  `--admin` still overrides; a literal `gh pr merge 54` is unaffected.
-  Conservative DECIDE-tier shape (no conditional-allow) per
-  `feedback_safety_direction_over_ux_friction`.
+  literal-PR parse cannot resolve a non-integer argument, so the gate would
+  fail-open and merge every iteration unverified (observed P3W11 + P3W13). The
+  operator is told to run one literal merge per call so each PR is gate-checked.
+  The merge must sit between a `do` and its matching `done` to trip the guard —
+  an unrelated loop in the same block (e.g. a `gh run rerun "$r" --failed`
+  staleness recheck) alongside a non-loop variable merge does NOT (#886). #894
+  extended the matched argument forms from `$pr`/`${pr}` to ANY non-literal
+  argument — also `${prs[$i]}`, `$(get_pr)`, and a subshell-wrapped
+  `(gh pr merge $pr)` — closing two residual fail-open evasions. `--admin` still
+  overrides; a literal `gh pr merge 54` is unaffected. Conservative DECIDE-tier
+  shape (no conditional-allow) per `feedback_safety_direction_over_ux_friction`.
 
 Charter-format review comments (canonical per `pull-requests.md` § Comment-Based Reviews,
 resolves #233):
@@ -144,14 +146,33 @@ def extract_pr_number(command: str) -> str | None:
     return None
 
 
-# A `gh pr merge` whose PR-number argument is a shell variable rather than a
-# literal: `$pr` or `${pr}` (the surrounding double-quotes of a `"$pr"` arg are
-# normalized away by `_strip_quoted_runs_keep_var_args` before this matches).
-# The lookahead lets the arg end at whitespace, a shell terminator, or EOS.
-_GH_MERGE_VAR_PR = re.compile(
-    r"\bgh\s+pr\s+merge\s+"  # the merge verb
-    r"\$\{?[A-Za-z_][A-Za-z0-9_]*\}?"  # $pr | ${pr}
-    r"(?=\s|;|&|\||$)"  # arg ends at whitespace, a shell terminator, or EOS
+# A `gh pr merge` whose positional PR argument is NON-LITERAL — i.e. anything
+# other than a bare integer PR number (the only form the literal-PR gate can
+# resolve) or an absent positional (flags-only / current-branch merge). This
+# deliberately matches on the FIRST character of the argument rather than on a
+# fully-shaped `$var` token, so it is agnostic to how the argument is spelled or
+# terminated. That single change closes two residual fail-open evasions of the
+# old `$var`-only matcher (#894):
+#
+#   1. Subshell-wrapped merge — `(gh pr merge $pr)`. The old terminator lookahead
+#      `(?=\s|;|&|\||$)` did not admit the `)` that ends the arg, so `$pr)` never
+#      matched. Matching the leading `$` needs no terminator, so the `)` (and the
+#      `}` of a `{ …; }` brace group, which already ends at `;` anyway) require no
+#      special-casing.
+#   2. Subscripted / compound / command-substitution arg — `"${prs[$i]}"`,
+#      `"$(get_pr)"`. These survive quote-normalization now that
+#      `_strip_quoted_runs_keep_var_args` unwraps any single-word expansion
+#      (not only a lone `$pr`), and their leading `$` matches here.
+#
+# `(?![-\d])` keeps the two LITERAL/absent forms allowed: a flag (`--merge`,
+# leading `-`) means no positional arg (current-branch merge, out of scope for
+# #567), and a leading digit is the bare integer the gate resolves. The class
+# `[^\s;&|()]` requires a real argument character — a bare terminator left behind
+# by a stripped quoted run (`gh pr merge ;`) is NOT treated as an argument.
+_GH_MERGE_NONLITERAL_ARG = re.compile(
+    r"\bgh\s+pr\s+merge\s+"  # the merge verb + separating whitespace
+    r"(?![-\d])"  # NOT a flag and NOT a bare-integer literal PR number
+    r"[^\s;&|()]"  # a present, non-terminator positional argument character
 )
 
 # `do` / `done` loop keywords as standalone tokens (delimited by start-of-string,
@@ -187,21 +208,78 @@ def _loop_body_spans(view: str) -> list[tuple[int, int]]:
     return spans
 
 
+def _strip_expansions(text: str) -> str:
+    """Return `text` with balanced `${…}` and `$(…)` expansion groups removed.
+
+    Used by `_is_single_expansion_word` to decide whether a double-quoted run is
+    a single shell WORD argument: a run like `"$(get_pr $i)"` or `"${prs[$i]}"`
+    is one argument even though it contains whitespace INSIDE the expansion,
+    whereas a prose run like `"do gh pr merge $pr"` carries whitespace OUTSIDE
+    any expansion. Nested groups are paired with a depth counter over the group's
+    own `(`/`)` or `{`/`}`. A bare `$pr` (no brace/paren) is left intact — it has
+    no internal whitespace to hide, so the surrounding-whitespace test handles it.
+    """
+    out: list[str] = []
+    i = 0
+    n = len(text)
+    while i < n:
+        if text[i] == "$" and i + 1 < n and text[i + 1] in "({":
+            opener = text[i + 1]
+            closer = ")" if opener == "(" else "}"
+            depth = 0
+            j = i + 1
+            while j < n:
+                if text[j] == opener:
+                    depth += 1
+                elif text[j] == closer:
+                    depth -= 1
+                    if depth == 0:
+                        j += 1
+                        break
+                j += 1
+            i = j  # skip the whole (possibly unbalanced) expansion group
+            continue
+        out.append(text[i])
+        i += 1
+    return "".join(out)
+
+
+def _is_single_expansion_word(text: str) -> bool:
+    """True if `text` is a single shell-word argument carrying an expansion.
+
+    `text` qualifies when it (a) contains a `$` expansion and (b) has no
+    whitespace OUTSIDE any `${…}`/`$(…)` group. This admits the real merge-arg
+    forms a loop can carry — `$pr`, `${pr}`, `${prs[$i]}`, `$(get_pr)`,
+    `$(get_pr $i)` — while rejecting a `--body "for … do gh pr merge $pr; done"`
+    prose payload (whitespace outside the expansion) and a quoted literal word
+    like `"done"` (no `$`, so it is not unwrapped into a stray loop keyword).
+    """
+    if "$" not in text:
+        return False
+    return not any(ch.isspace() for ch in _strip_expansions(text))
+
+
 def _strip_quoted_runs_keep_var_args(command: str) -> str:
-    """Return `command` with quoted regions removed, EXCEPT a quoted region
-    that is exactly a single variable reference (`"$pr"` / `"${pr}"`), which
-    is unwrapped to its bare `$pr` / `${pr}` form.
+    """Return `command` with quoted regions removed, EXCEPT a double-quoted
+    region that is a single-word expansion argument (`"$pr"`, `"${pr}"`,
+    `"${prs[$i]}"`, `"$(get_pr)"`), which is unwrapped to its bare inner form.
 
     Why: the loop-merge detector must (a) NOT see a `gh pr merge $pr` that
     lives inside a `--body "..."` payload (quoted argument data — strip it),
     yet (b) STILL see the real arg in `gh pr merge "$pr"` where only the
-    variable itself is quoted (unwrap it). Shell semantics agree: double
-    quotes around a lone variable are removed and the variable remains the
+    argument itself is quoted (unwrap it). Shell semantics agree: double
+    quotes around a single expansion word are removed and the word remains the
     program's argument, whereas a quoted run of prose is one opaque arg.
 
+    The unwrap predicate is `_is_single_expansion_word` (#894): the earlier
+    matcher only unwrapped a LONE simple variable (`\\$\\{?name\\}?`), so a
+    subscripted / compound / command-substitution arg failed that fullmatch and
+    was stripped as opaque prose — making the real merge arg vanish and the
+    guard fail-open. Keying on "single expansion word" keeps every such arg.
+
     Single-quoted runs are always opaque data (no expansion) and are removed
-    wholesale. Double-quoted runs are unwrapped to the inner text ONLY when
-    the inner text is a lone variable reference; otherwise removed.
+    wholesale. Double-quoted runs are unwrapped only when the inner text is a
+    single expansion word; otherwise removed.
     """
     out: list[str] = []
     i = 0
@@ -220,8 +298,8 @@ def _strip_quoted_runs_keep_var_args(command: str) -> str:
             if j == -1:
                 break  # unbalanced
             inner = command[i + 1 : j]
-            # Keep a lone-variable double-quoted arg as the bare variable.
-            if re.fullmatch(r"\$\{?[A-Za-z_][A-Za-z0-9_]*\}?", inner):
+            # Keep a single-word expansion double-quoted arg as its bare form.
+            if _is_single_expansion_word(inner):
                 out.append(inner)
             i = j + 1
             continue
@@ -231,45 +309,44 @@ def _strip_quoted_runs_keep_var_args(command: str) -> str:
 
 
 def is_variable_pr_merge_in_loop(command: str) -> bool:
-    """True if `command` runs `gh pr merge <shell-var>` inside a for/while/until
-    loop — the batch-loop merge shape that fail-opens the 2-reviewer gate
-    (#567, memory `feedback_batch_loop_merge_evades_pr_review_hook`).
+    """True if `command` runs a `gh pr merge` with a NON-LITERAL PR argument
+    inside a for/while/until loop — the batch-loop merge shape that fail-opens
+    the 2-reviewer gate (#567/#886/#894, memory `feedback_batch_loop_merge_evades`).
 
     The gate parses a LITERAL PR number from `gh pr merge <N>` to fetch that
-    PR's reviews. When the PR number is a loop variable (`$pr`), the literal
-    parse returns None, `get_pr_data(None)` resolves the cwd branch's PR (or
-    nothing), and the merge fail-opens — the gate is silently disabled for
-    every iteration. Both observed instances (P3W11 wave→main 4-merge loop,
-    P3W13 ingest 6-PR loop) merged with the gate effectively off.
+    PR's reviews. When the argument is not a bare integer (`$pr`, `${pr}`,
+    `${prs[$i]}`, `$(get_pr)`, or a subshell-wrapped `(gh pr merge $pr)`), the
+    literal parse returns None, `get_pr_data(None)` resolves the cwd branch's PR
+    (or nothing), and the merge fail-opens — the gate is silently disabled for
+    every iteration. Both originally-observed instances (P3W11 wave→main 4-merge
+    loop, P3W13 ingest 6-PR loop) merged with the gate effectively off.
 
     Conservative DECIDE-tier design (per #567 + `feedback_safety_direction_
-    over_ux_friction`): we HARD BLOCK the variable-PR-in-loop shape outright.
+    over_ux_friction`): we HARD BLOCK the non-literal-PR-in-loop shape outright.
     We do NOT attempt to enumerate loop values and gate-verify each — that is
-    the explicitly-deferred conditional-allow path. A literal
-    `gh pr merge 54` is untouched (its PR number parses, the gate runs).
+    the explicitly-deferred conditional-allow path. A literal `gh pr merge 54`
+    is untouched (its PR number parses, the gate runs).
 
-    Detection, evaluated on a quote-normalized view of the command (quoted
-    prose stripped, a lone `"$pr"` arg unwrapped — see
-    `_strip_quoted_runs_keep_var_args`) so a `--body "... for … do gh pr
-    merge $pr … done"` payload that merely MENTIONS the shape is not matched:
-    a `gh pr merge` whose PR-number arg is a shell variable
-    (`$pr` / `${pr}` / `"$pr"` / `"${pr}"`) that is located INSIDE a loop body
-    (the text between a `do` keyword and its matching `done`).
+    Mechanic (#894 broadening). Detection runs on a quote-normalized view of the
+    command (quoted prose stripped, a single-word expansion arg such as `"$pr"`
+    or `"${prs[$i]}"` unwrapped — see `_strip_quoted_runs_keep_var_args`) so a
+    `--body "... for … do gh pr merge $pr … done"` payload that merely MENTIONS
+    the shape is not matched. On that view, `_GH_MERGE_NONLITERAL_ARG` matches a
+    `gh pr merge` whose first positional-argument character is non-literal (not a
+    flag, not a bare integer). Matching the argument's leading character rather
+    than a fully-shaped `$var` token closes the two residual #886 evasions:
+      - subshell `(gh pr merge $pr)` — old terminator lookahead omitted `)`;
+      - compound `${prs[$i]}` / `$(get_pr)` — old unwrap dropped it as prose.
 
-    Co-location matters (#886). The earlier form required only that a
-    variable-PR merge AND loop keywords each appear SOMEWHERE in the command,
-    independently. That over-matched any multi-line block that happened to pair
-    an unrelated loop with a non-loop variable merge — e.g. a `/wave-wrapup`
-    block doing a single `gh pr merge "$PR"` AND, separately, a staleness
-    recheck loop `for r in …; do gh run rerun "$r" --failed; done`. The merge
-    was not in the loop, so the gate did not fail-open, yet the guard blocked.
-    Requiring the merge to sit inside a `do … done` body fires on the real
-    batch-loop shape (`for pr in …; do gh pr merge "$pr"; done`) while leaving
-    unrelated loops (and one-off variable merges outside any loop — out of
-    scope for #567) alone.
+    Co-location is preserved (#886). The match must sit INSIDE a `do … done`
+    loop body. A one-off `gh pr merge "$PR"` OUTSIDE any loop, co-occurring with
+    an unrelated `for r in …; do gh run rerun "$r" --failed; done`, does NOT
+    fail-open (the merge resolves its own PR) and so MUST NOT block — the
+    co-location requirement leaves it alone, while the real batch-loop shape
+    (`for pr in …; do gh pr merge "$pr"; done`) still trips.
     """
     view = _strip_quoted_runs_keep_var_args(command)
-    merge_matches = list(_GH_MERGE_VAR_PR.finditer(view))
+    merge_matches = list(_GH_MERGE_NONLITERAL_ARG.finditer(view))
     if not merge_matches:
         return False
     spans = _loop_body_spans(view)


### PR DESCRIPTION
## Summary

Closes the two residual fail-open evasions left in the batch-loop merge guard (`is_variable_pr_merge_in_loop`) after #886 narrowed it to require `do…done` co-location. Both let a `gh pr merge` inside a loop body slip past the matcher, silently disabling the 2-reviewer gate for every iteration.

## Ontology Context

This change is in the **org hook tier** — `.claude/hooks/validate_pr_review.py`, the PreToolUse Bash guard that enforces the 2-reviewer merge gate (Hook 4). Hooks are the durable enforcement tier (`feedback_enforcement_hierarchy`: hook > skill > charter), so a fail-open here is a real bypass of charter review policy. The guard's lineage: #567 introduced the batch-loop block; #886/#891 added the `_LOOP_DO_DONE` + `_loop_body_spans()` co-location refactor (merge must sit inside a loop body) to stop false-blocking unrelated loops. This PR closes the two fail-open gaps that narrowing left open, keeping the conservative HARD-BLOCK shape (`feedback_safety_direction_over_ux_friction`).

## The two evasions

**Gap 1 — subshell-wrapped merge**
```sh
for pr in 1 2; do (gh pr merge $pr); done
```
After quote-normalization the merge argument reads `$pr)`. The old `_GH_MERGE_VAR_PR` matched a full `$var` token terminated by `(?=\s|;|&|\||$)` — that lookahead does not admit the `)` that ends the arg inside a subshell, so the merge verb never matched and the loop fail-opened.

**Gap 2 — subscripted / compound / command-substitution arg**
```sh
for i in 0 1; do gh pr merge "${prs[$i]}"; done    # also "$(get_pr)"
```
`_strip_quoted_runs_keep_var_args` only unwrapped a double-quoted run that fullmatched a LONE simple variable (`$pr` / `${pr}`). A subscripted/compound/command-substitution arg fails that fullmatch, so the whole quoted run was stripped as opaque prose — the real merge argument disappeared and the guard fail-opened.

## Mechanic chosen (and why)

The issue's recommended defensive direction: **inside a loop body, flag any `gh pr merge` whose positional argument is NON-LITERAL** — i.e. not a bare integer and not absent-by-design. This catches `$pr`, `${pr}`, `${prs[$i]}`, `$(cmd)`, and the subshell case in one stroke, while a literal `gh pr merge 54` (PR number parses → gate runs) stays allowed.

- `_GH_MERGE_VAR_PR` → **`_GH_MERGE_NONLITERAL_ARG`**: matches on the FIRST character of the argument rather than a fully-shaped `$var` token. `(?![-\d])` keeps the two literal/absent forms allowed — a leading `-` is a flag (current-branch merge, out of scope for #567) and a leading digit is the bare integer the gate resolves. `[^\s;&|()]` requires a real argument character, so a bare terminator left behind by a stripped quoted run (`gh pr merge ;`) is not mistaken for an argument. Because we match the leading character, there is **no terminator lookahead** — so neither `)` (Gap 1) nor `}` needs special-casing. (A `{ …; }` brace group already ends the arg at `;`, which is why `}` was unnecessary.)
- **`_strip_quoted_runs_keep_var_args`** unwrap predicate broadened to **`_is_single_expansion_word`**: a double-quoted run is unwrapped when it is one shell WORD carrying a `$` expansion with no whitespace OUTSIDE any `${…}`/`$(…)` group. A new `_strip_expansions` helper removes balanced (and nested) expansion groups so internal whitespace like `$(get_pr $i)` does not make the run look like prose. This keeps the real compound args while a `--body "for … do gh pr merge $pr; done"` prose payload (whitespace outside any expansion) is still dropped, and a quoted literal word such as `"done"` (no `$`) is not unwrapped into a stray loop keyword.

## Co-location preserved (#886 regression guard)

The #886 narrowing made a one-off `gh pr merge "$PR"` OUTSIDE any loop — co-occurring with an unrelated `for r in …; do gh run rerun "$r" --failed; done` — NOT block. That property is preserved: the broadened argument match still only fires when the match offset falls inside a `do … done` body span. A non-literal merge has to be INSIDE the loop body to trip. Re-asserted by test.

## Tests added

- subshell-wrapped in-loop variable merge → BLOCKED (was fail-open)
- subscripted `${prs[$i]}` in-loop merge → BLOCKED
- command-substitution `"$(cmd)"` in-loop merge → BLOCKED (plus an inner-whitespace `$(get_pr $i)` robustness case)
- literal `gh pr merge 54` inside a loop → NOT blocked (over-broadening guard)
- the existing #886 unrelated-loop + one-off-merge case → STILL not blocked, re-asserted under the broadened matcher
- end-to-end `check()` HARD-BLOCK tests for the subshell and subscripted shapes
- pure-parser coverage for the new `_strip_expansions` and `_is_single_expansion_word` helpers

## Local ⇄ CI parity evidence

- `ruff@0.15.11 format --check` + `ruff@0.15.11 check` over `.claude/hooks/` — clean
- `mypy --ignore-missing-imports` over both changed files — clean
- full hooks pytest suite — 1593 passed
- `pre_commit_ci_sync.py` drift gate — OK
- pre-commit + pre-push hooks ran green on commit and push (no `--no-verify`)

## Reviewers

This PR is set up for two reviewers — a security/fail-open-safety lens and a parser/regex-correctness lens. The change is verifiable directly against `.claude/hooks/validate_pr_review.py` at this PR's head and the added tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NwiLxghxyUaTLc78FWeDVW
