### PR TITLE
Phase 7 Wave 19 → main (noorinalabs-main)

### DIFF
--- a/.claude/hooks/tests/test_validate_pr_review.py
+++ b/.claude/hooks/tests/test_validate_pr_review.py
@@ -1645,6 +1645,74 @@ class BatchLoopMergeDetectorTests(unittest.TestCase):
             )
         )
 
+    # ---- #894 residual fail-open evasions ----
+
+    def test_894_subshell_wrapped_merge_blocked(self):
+        # Gap 1: a merge wrapped in a `( … )` subshell leaves the arg as `$pr)`.
+        # The pre-#894 terminator lookahead `(?=\s|;|&|\||$)` omitted `)`, so the
+        # merge verb never matched and the loop fail-opened. Now BLOCKED.
+        self.assertTrue(
+            hook.is_variable_pr_merge_in_loop("for pr in 1 2; do (gh pr merge $pr); done")
+        )
+
+    def test_894_subshell_wrapped_quoted_merge_blocked(self):
+        # Gap 1 variant: subshell + quoted var arg.
+        self.assertTrue(
+            hook.is_variable_pr_merge_in_loop('for pr in 1 2; do (gh pr merge "$pr" --merge); done')
+        )
+
+    def test_894_subscripted_array_arg_blocked(self):
+        # Gap 2: a subscripted `"${prs[$i]}"` arg failed the lone-simple-var
+        # unwrap fullmatch and was stripped as opaque prose — the merge arg
+        # vanished and the loop fail-opened. Now BLOCKED.
+        self.assertTrue(
+            hook.is_variable_pr_merge_in_loop('for i in 0 1; do gh pr merge "${prs[$i]}"; done')
+        )
+
+    def test_894_command_substitution_arg_blocked(self):
+        # Gap 2 variant: a command-substitution `"$(cmd)"` arg, likewise stripped
+        # pre-#894. Now BLOCKED.
+        self.assertTrue(
+            hook.is_variable_pr_merge_in_loop(
+                'for i in 0 1; do gh pr merge "$(get_pr)" --merge; done'
+            )
+        )
+
+    def test_894_command_substitution_arg_with_inner_space_blocked(self):
+        # Gap 2 robustness: whitespace INSIDE the `$(…)` expansion must not make
+        # the quoted run look like prose — it is still one shell-word argument.
+        self.assertTrue(
+            hook.is_variable_pr_merge_in_loop('for i in 0 1; do gh pr merge "$(get_pr $i)"; done')
+        )
+
+    def test_894_literal_merge_inside_loop_not_blocked(self):
+        # Over-broadening guard: a bare-integer `gh pr merge 54` INSIDE a loop is
+        # still NOT blocked — the literal parses and the normal gate runs.
+        self.assertFalse(
+            hook.is_variable_pr_merge_in_loop("for n in 1; do gh pr merge 54 --merge; done")
+        )
+
+    def test_894_nonliteral_merge_outside_loop_not_blocked(self):
+        # #886 co-location preserved under the #894 broadening: a one-off
+        # subscripted/compound merge OUTSIDE any loop, co-occurring with an
+        # unrelated `gh run rerun` loop, does NOT fail-open and MUST NOT block.
+        cmd = (
+            'gh pr merge "${prs[0]}" --repo noorinalabs/noorinalabs-deploy --merge\n'
+            "for r in 11 12 13; do "
+            'gh run rerun "$r" --repo noorinalabs/noorinalabs-deploy --failed; done'
+        )
+        self.assertFalse(hook.is_variable_pr_merge_in_loop(cmd))
+
+    def test_894_body_mention_of_compound_merge_not_blocked(self):
+        # The #894 unwrap broadening must not re-open the prose-mention guard:
+        # a `--body "…"` payload mentioning the compound-arg loop shape (it
+        # carries whitespace OUTSIDE the expansion) is still stripped, not matched.
+        self.assertFalse(
+            hook.is_variable_pr_merge_in_loop(
+                'gh pr create --body "for i in 0 1; do gh pr merge ${prs[$i]}; done"'
+            )
+        )
+
 
 class BatchLoopMergeEndToEndTests(unittest.TestCase):
     """#567 end-to-end: check() HARD BLOCKS a batch-loop variable merge, and a
@@ -1667,6 +1735,27 @@ class BatchLoopMergeEndToEndTests(unittest.TestCase):
         self.assertEqual(result.get("decision"), "block")
         self.assertIn("Batch-loop", result["reason"])
         self.assertIn("one pr per call", result["reason"].lower())
+
+    def test_894_subscripted_loop_merge_hard_blocked(self):
+        # #894 end-to-end: a subscripted in-loop merge reaches check() and HARD
+        # BLOCKS. Patch get_pr_data so a pass proves the LOOP guard fired, not
+        # the downstream gate.
+        with mock.patch.object(hook, "get_pr_data", return_value=None):
+            result = hook.check(
+                self._input('for i in 0 1; do gh pr merge "${prs[$i]}" --merge; done')
+            )
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result.get("decision"), "block")
+        self.assertIn("Batch-loop", result["reason"])
+
+    def test_894_subshell_loop_merge_hard_blocked(self):
+        # #894 end-to-end: a subshell-wrapped in-loop merge HARD BLOCKS.
+        with mock.patch.object(hook, "get_pr_data", return_value=None):
+            result = hook.check(self._input("for pr in 1 2; do (gh pr merge $pr); done"))
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result.get("decision"), "block")
 
     def test_loop_var_merge_with_admin_still_overrides(self):
         # --admin is the emergency override and bypasses the loop guard too.
@@ -1717,6 +1806,73 @@ class StripQuotedRunsKeepVarArgsTests(unittest.TestCase):
     def test_single_quoted_run_dropped(self):
         out = hook._strip_quoted_runs_keep_var_args("echo 'for pr in 1; do gh pr merge $pr; done'")
         self.assertNotIn("gh pr merge", out)
+
+    # ---- #894: broadened single-word-expansion unwrap ----
+
+    def test_subscripted_array_arg_unwrapped(self):
+        out = hook._strip_quoted_runs_keep_var_args('gh pr merge "${prs[$i]}" --merge')
+        self.assertIn("${prs[$i]}", out)
+        self.assertNotIn('"', out)
+
+    def test_command_substitution_arg_unwrapped(self):
+        out = hook._strip_quoted_runs_keep_var_args('gh pr merge "$(get_pr)" --merge')
+        self.assertIn("$(get_pr)", out)
+
+    def test_command_substitution_with_inner_space_unwrapped(self):
+        # Whitespace inside the expansion does not make the run prose.
+        out = hook._strip_quoted_runs_keep_var_args('gh pr merge "$(get_pr $i)" --merge')
+        self.assertIn("$(get_pr $i)", out)
+
+    def test_quoted_literal_word_not_unwrapped(self):
+        # A non-expansion single word (e.g. a stray `"done"`) must NOT be
+        # unwrapped — that would inject a spurious loop keyword into the view.
+        out = hook._strip_quoted_runs_keep_var_args('gh pr comment --body "done"')
+        self.assertNotIn("done", out)
+
+    def test_prose_with_expansion_outside_dropped(self):
+        # Whitespace OUTSIDE the expansion ⇒ prose ⇒ dropped wholesale.
+        out = hook._strip_quoted_runs_keep_var_args('--body "merge ${prs[$i]} now"')
+        self.assertNotIn("prs", out)
+
+
+class StripExpansionsTests(unittest.TestCase):
+    """#894 pure-parser: `_strip_expansions` removes balanced ${…}/$(…) groups so
+    `_is_single_expansion_word` can tell a one-word arg from prose."""
+
+    def test_brace_group_removed(self):
+        self.assertEqual(hook._strip_expansions("${prs[$i]}").strip(), "")
+
+    def test_paren_group_with_inner_space_removed(self):
+        self.assertEqual(hook._strip_expansions("$(get_pr $i)").strip(), "")
+
+    def test_nested_paren_group_removed(self):
+        self.assertEqual(hook._strip_expansions("$(a $(b) c)").strip(), "")
+
+    def test_bare_var_left_intact(self):
+        # A bare `$pr` has no internal whitespace to hide, so it is not a group.
+        self.assertEqual(hook._strip_expansions("$pr"), "$pr")
+
+    def test_prose_whitespace_survives(self):
+        self.assertTrue(any(c.isspace() for c in hook._strip_expansions("do merge $pr")))
+
+
+class IsSingleExpansionWordTests(unittest.TestCase):
+    """#894: predicate gating the double-quoted-run unwrap."""
+
+    def test_bare_var_is_word(self):
+        self.assertTrue(hook._is_single_expansion_word("$pr"))
+
+    def test_subscripted_is_word(self):
+        self.assertTrue(hook._is_single_expansion_word("${prs[$i]}"))
+
+    def test_command_sub_with_space_is_word(self):
+        self.assertTrue(hook._is_single_expansion_word("$(get_pr $i)"))
+
+    def test_prose_is_not_word(self):
+        self.assertFalse(hook._is_single_expansion_word("do gh pr merge $pr"))
+
+    def test_literal_word_is_not_word(self):
+        self.assertFalse(hook._is_single_expansion_word("done"))
 
 
 if __name__ == "__main__":

--- a/.claude/hooks/tests/test_validate_pr_review.py
+++ b/.claude/hooks/tests/test_validate_pr_review.py
@@ -1608,6 +1608,43 @@ class BatchLoopMergeDetectorTests(unittest.TestCase):
             hook.is_variable_pr_merge_in_loop('for pr in 1 2; do gh pr view "$pr"; done')
         )
 
+    def test_886_gh_run_rerun_loop_not_blocked(self):
+        # #886 regression — the EXACT non-merge shape that false-blocked at the
+        # P7W18 wrapup: a `gh run rerun "$ds_run" --failed` staleness recheck
+        # inside a for-loop. No `gh pr merge` anywhere → must not match.
+        self.assertFalse(
+            hook.is_variable_pr_merge_in_loop(
+                "for ds_run in $(gh run list --repo noorinalabs/noorinalabs-deploy "
+                '--json databaseId --jq ".[].databaseId"); do '
+                'gh run rerun "$ds_run" --repo noorinalabs/noorinalabs-deploy --failed; done'
+            )
+        )
+
+    def test_886_nonloop_merge_with_unrelated_rerun_loop_not_blocked(self):
+        # #886 regression (the actual false-positive mechanism): a multi-line
+        # block pairing a NON-loop variable merge with a SEPARATE, unrelated
+        # `gh run rerun` staleness loop. The merge is not inside the loop body,
+        # so the gate does not fail-open and the guard must NOT fire. Before the
+        # #886 narrowing this returned True (merge-var pattern + loop keywords
+        # matched independently anywhere in the command).
+        cmd = (
+            'gh pr merge "$PR" --repo noorinalabs/noorinalabs-deploy --merge\n'
+            'echo "wave merged"\n'
+            "for ds_run in 11 12 13; do "
+            'gh run rerun "$ds_run" --repo noorinalabs/noorinalabs-deploy --failed; done'
+        )
+        self.assertFalse(hook.is_variable_pr_merge_in_loop(cmd))
+
+    def test_886_batch_loop_merge_still_blocked(self):
+        # #886 must NOT weaken the real protection: a `gh pr merge "$pr"` that is
+        # genuinely INSIDE the loop body (the fail-open evasion class from
+        # `feedback_batch_loop_merge_evades`) is still detected.
+        self.assertTrue(
+            hook.is_variable_pr_merge_in_loop(
+                'for pr in 48 49 50; do gh pr merge "$pr" --repo o/r --merge; done'
+            )
+        )
+
 
 class BatchLoopMergeEndToEndTests(unittest.TestCase):
     """#567 end-to-end: check() HARD BLOCKS a batch-loop variable merge, and a

--- a/.claude/hooks/validate_pr_review.py
+++ b/.claude/hooks/validate_pr_review.py
@@ -19,18 +19,20 @@ Input Language:
                the PR in the repo the user named, not the cwd-resolved repo.
     --admin  → short-circuits (emergency override — allows merge).
 
-  Batch-loop guard (#567, narrowed #886): a `gh pr merge <shell-var>` located
-  INSIDE a for/while/until loop body (e.g.
+  Batch-loop guard (#567, narrowed #886, broadened #894): a `gh pr merge` with
+  a NON-LITERAL PR argument located INSIDE a for/while/until loop body (e.g.
   `for pr in 48 49; do gh pr merge "$pr" …; done`) is HARD BLOCKED. The
-  literal-PR parse cannot resolve a loop variable, so the gate would fail-open
-  and merge every iteration unverified (observed P3W11 + P3W13). The operator is
-  told to run one literal merge per call so each PR is gate-checked. The merge
-  must sit between a `do` and its matching `done` to trip the guard — an
-  unrelated loop in the same block (e.g. a `gh run rerun "$r" --failed`
-  staleness recheck) alongside a non-loop variable merge does NOT (#886).
-  `--admin` still overrides; a literal `gh pr merge 54` is unaffected.
-  Conservative DECIDE-tier shape (no conditional-allow) per
-  `feedback_safety_direction_over_ux_friction`.
+  literal-PR parse cannot resolve a non-integer argument, so the gate would
+  fail-open and merge every iteration unverified (observed P3W11 + P3W13). The
+  operator is told to run one literal merge per call so each PR is gate-checked.
+  The merge must sit between a `do` and its matching `done` to trip the guard —
+  an unrelated loop in the same block (e.g. a `gh run rerun "$r" --failed`
+  staleness recheck) alongside a non-loop variable merge does NOT (#886). #894
+  extended the matched argument forms from `$pr`/`${pr}` to ANY non-literal
+  argument — also `${prs[$i]}`, `$(get_pr)`, and a subshell-wrapped
+  `(gh pr merge $pr)` — closing two residual fail-open evasions. `--admin` still
+  overrides; a literal `gh pr merge 54` is unaffected. Conservative DECIDE-tier
+  shape (no conditional-allow) per `feedback_safety_direction_over_ux_friction`.
 
 Charter-format review comments (canonical per `pull-requests.md` § Comment-Based Reviews,
 resolves #233):
@@ -144,14 +146,33 @@ def extract_pr_number(command: str) -> str | None:
     return None
 
 
-# A `gh pr merge` whose PR-number argument is a shell variable rather than a
-# literal: `$pr` or `${pr}` (the surrounding double-quotes of a `"$pr"` arg are
-# normalized away by `_strip_quoted_runs_keep_var_args` before this matches).
-# The lookahead lets the arg end at whitespace, a shell terminator, or EOS.
-_GH_MERGE_VAR_PR = re.compile(
-    r"\bgh\s+pr\s+merge\s+"  # the merge verb
-    r"\$\{?[A-Za-z_][A-Za-z0-9_]*\}?"  # $pr | ${pr}
-    r"(?=\s|;|&|\||$)"  # arg ends at whitespace, a shell terminator, or EOS
+# A `gh pr merge` whose positional PR argument is NON-LITERAL — i.e. anything
+# other than a bare integer PR number (the only form the literal-PR gate can
+# resolve) or an absent positional (flags-only / current-branch merge). This
+# deliberately matches on the FIRST character of the argument rather than on a
+# fully-shaped `$var` token, so it is agnostic to how the argument is spelled or
+# terminated. That single change closes two residual fail-open evasions of the
+# old `$var`-only matcher (#894):
+#
+#   1. Subshell-wrapped merge — `(gh pr merge $pr)`. The old terminator lookahead
+#      `(?=\s|;|&|\||$)` did not admit the `)` that ends the arg, so `$pr)` never
+#      matched. Matching the leading `$` needs no terminator, so the `)` (and the
+#      `}` of a `{ …; }` brace group, which already ends at `;` anyway) require no
+#      special-casing.
+#   2. Subscripted / compound / command-substitution arg — `"${prs[$i]}"`,
+#      `"$(get_pr)"`. These survive quote-normalization now that
+#      `_strip_quoted_runs_keep_var_args` unwraps any single-word expansion
+#      (not only a lone `$pr`), and their leading `$` matches here.
+#
+# `(?![-\d])` keeps the two LITERAL/absent forms allowed: a flag (`--merge`,
+# leading `-`) means no positional arg (current-branch merge, out of scope for
+# #567), and a leading digit is the bare integer the gate resolves. The class
+# `[^\s;&|()]` requires a real argument character — a bare terminator left behind
+# by a stripped quoted run (`gh pr merge ;`) is NOT treated as an argument.
+_GH_MERGE_NONLITERAL_ARG = re.compile(
+    r"\bgh\s+pr\s+merge\s+"  # the merge verb + separating whitespace
+    r"(?![-\d])"  # NOT a flag and NOT a bare-integer literal PR number
+    r"[^\s;&|()]"  # a present, non-terminator positional argument character
 )
 
 # `do` / `done` loop keywords as standalone tokens (delimited by start-of-string,
@@ -187,21 +208,78 @@ def _loop_body_spans(view: str) -> list[tuple[int, int]]:
     return spans
 
 
+def _strip_expansions(text: str) -> str:
+    """Return `text` with balanced `${…}` and `$(…)` expansion groups removed.
+
+    Used by `_is_single_expansion_word` to decide whether a double-quoted run is
+    a single shell WORD argument: a run like `"$(get_pr $i)"` or `"${prs[$i]}"`
+    is one argument even though it contains whitespace INSIDE the expansion,
+    whereas a prose run like `"do gh pr merge $pr"` carries whitespace OUTSIDE
+    any expansion. Nested groups are paired with a depth counter over the group's
+    own `(`/`)` or `{`/`}`. A bare `$pr` (no brace/paren) is left intact — it has
+    no internal whitespace to hide, so the surrounding-whitespace test handles it.
+    """
+    out: list[str] = []
+    i = 0
+    n = len(text)
+    while i < n:
+        if text[i] == "$" and i + 1 < n and text[i + 1] in "({":
+            opener = text[i + 1]
+            closer = ")" if opener == "(" else "}"
+            depth = 0
+            j = i + 1
+            while j < n:
+                if text[j] == opener:
+                    depth += 1
+                elif text[j] == closer:
+                    depth -= 1
+                    if depth == 0:
+                        j += 1
+                        break
+                j += 1
+            i = j  # skip the whole (possibly unbalanced) expansion group
+            continue
+        out.append(text[i])
+        i += 1
+    return "".join(out)
+
+
+def _is_single_expansion_word(text: str) -> bool:
+    """True if `text` is a single shell-word argument carrying an expansion.
+
+    `text` qualifies when it (a) contains a `$` expansion and (b) has no
+    whitespace OUTSIDE any `${…}`/`$(…)` group. This admits the real merge-arg
+    forms a loop can carry — `$pr`, `${pr}`, `${prs[$i]}`, `$(get_pr)`,
+    `$(get_pr $i)` — while rejecting a `--body "for … do gh pr merge $pr; done"`
+    prose payload (whitespace outside the expansion) and a quoted literal word
+    like `"done"` (no `$`, so it is not unwrapped into a stray loop keyword).
+    """
+    if "$" not in text:
+        return False
+    return not any(ch.isspace() for ch in _strip_expansions(text))
+
+
 def _strip_quoted_runs_keep_var_args(command: str) -> str:
-    """Return `command` with quoted regions removed, EXCEPT a quoted region
-    that is exactly a single variable reference (`"$pr"` / `"${pr}"`), which
-    is unwrapped to its bare `$pr` / `${pr}` form.
+    """Return `command` with quoted regions removed, EXCEPT a double-quoted
+    region that is a single-word expansion argument (`"$pr"`, `"${pr}"`,
+    `"${prs[$i]}"`, `"$(get_pr)"`), which is unwrapped to its bare inner form.
 
     Why: the loop-merge detector must (a) NOT see a `gh pr merge $pr` that
     lives inside a `--body "..."` payload (quoted argument data — strip it),
     yet (b) STILL see the real arg in `gh pr merge "$pr"` where only the
-    variable itself is quoted (unwrap it). Shell semantics agree: double
-    quotes around a lone variable are removed and the variable remains the
+    argument itself is quoted (unwrap it). Shell semantics agree: double
+    quotes around a single expansion word are removed and the word remains the
     program's argument, whereas a quoted run of prose is one opaque arg.
 
+    The unwrap predicate is `_is_single_expansion_word` (#894): the earlier
+    matcher only unwrapped a LONE simple variable (`\\$\\{?name\\}?`), so a
+    subscripted / compound / command-substitution arg failed that fullmatch and
+    was stripped as opaque prose — making the real merge arg vanish and the
+    guard fail-open. Keying on "single expansion word" keeps every such arg.
+
     Single-quoted runs are always opaque data (no expansion) and are removed
-    wholesale. Double-quoted runs are unwrapped to the inner text ONLY when
-    the inner text is a lone variable reference; otherwise removed.
+    wholesale. Double-quoted runs are unwrapped only when the inner text is a
+    single expansion word; otherwise removed.
     """
     out: list[str] = []
     i = 0
@@ -220,8 +298,8 @@ def _strip_quoted_runs_keep_var_args(command: str) -> str:
             if j == -1:
                 break  # unbalanced
             inner = command[i + 1 : j]
-            # Keep a lone-variable double-quoted arg as the bare variable.
-            if re.fullmatch(r"\$\{?[A-Za-z_][A-Za-z0-9_]*\}?", inner):
+            # Keep a single-word expansion double-quoted arg as its bare form.
+            if _is_single_expansion_word(inner):
                 out.append(inner)
             i = j + 1
             continue
@@ -231,45 +309,44 @@ def _strip_quoted_runs_keep_var_args(command: str) -> str:
 
 
 def is_variable_pr_merge_in_loop(command: str) -> bool:
-    """True if `command` runs `gh pr merge <shell-var>` inside a for/while/until
-    loop — the batch-loop merge shape that fail-opens the 2-reviewer gate
-    (#567, memory `feedback_batch_loop_merge_evades_pr_review_hook`).
+    """True if `command` runs a `gh pr merge` with a NON-LITERAL PR argument
+    inside a for/while/until loop — the batch-loop merge shape that fail-opens
+    the 2-reviewer gate (#567/#886/#894, memory `feedback_batch_loop_merge_evades`).
 
     The gate parses a LITERAL PR number from `gh pr merge <N>` to fetch that
-    PR's reviews. When the PR number is a loop variable (`$pr`), the literal
-    parse returns None, `get_pr_data(None)` resolves the cwd branch's PR (or
-    nothing), and the merge fail-opens — the gate is silently disabled for
-    every iteration. Both observed instances (P3W11 wave→main 4-merge loop,
-    P3W13 ingest 6-PR loop) merged with the gate effectively off.
+    PR's reviews. When the argument is not a bare integer (`$pr`, `${pr}`,
+    `${prs[$i]}`, `$(get_pr)`, or a subshell-wrapped `(gh pr merge $pr)`), the
+    literal parse returns None, `get_pr_data(None)` resolves the cwd branch's PR
+    (or nothing), and the merge fail-opens — the gate is silently disabled for
+    every iteration. Both originally-observed instances (P3W11 wave→main 4-merge
+    loop, P3W13 ingest 6-PR loop) merged with the gate effectively off.
 
     Conservative DECIDE-tier design (per #567 + `feedback_safety_direction_
-    over_ux_friction`): we HARD BLOCK the variable-PR-in-loop shape outright.
+    over_ux_friction`): we HARD BLOCK the non-literal-PR-in-loop shape outright.
     We do NOT attempt to enumerate loop values and gate-verify each — that is
-    the explicitly-deferred conditional-allow path. A literal
-    `gh pr merge 54` is untouched (its PR number parses, the gate runs).
+    the explicitly-deferred conditional-allow path. A literal `gh pr merge 54`
+    is untouched (its PR number parses, the gate runs).
 
-    Detection, evaluated on a quote-normalized view of the command (quoted
-    prose stripped, a lone `"$pr"` arg unwrapped — see
-    `_strip_quoted_runs_keep_var_args`) so a `--body "... for … do gh pr
-    merge $pr … done"` payload that merely MENTIONS the shape is not matched:
-    a `gh pr merge` whose PR-number arg is a shell variable
-    (`$pr` / `${pr}` / `"$pr"` / `"${pr}"`) that is located INSIDE a loop body
-    (the text between a `do` keyword and its matching `done`).
+    Mechanic (#894 broadening). Detection runs on a quote-normalized view of the
+    command (quoted prose stripped, a single-word expansion arg such as `"$pr"`
+    or `"${prs[$i]}"` unwrapped — see `_strip_quoted_runs_keep_var_args`) so a
+    `--body "... for … do gh pr merge $pr … done"` payload that merely MENTIONS
+    the shape is not matched. On that view, `_GH_MERGE_NONLITERAL_ARG` matches a
+    `gh pr merge` whose first positional-argument character is non-literal (not a
+    flag, not a bare integer). Matching the argument's leading character rather
+    than a fully-shaped `$var` token closes the two residual #886 evasions:
+      - subshell `(gh pr merge $pr)` — old terminator lookahead omitted `)`;
+      - compound `${prs[$i]}` / `$(get_pr)` — old unwrap dropped it as prose.
 
-    Co-location matters (#886). The earlier form required only that a
-    variable-PR merge AND loop keywords each appear SOMEWHERE in the command,
-    independently. That over-matched any multi-line block that happened to pair
-    an unrelated loop with a non-loop variable merge — e.g. a `/wave-wrapup`
-    block doing a single `gh pr merge "$PR"` AND, separately, a staleness
-    recheck loop `for r in …; do gh run rerun "$r" --failed; done`. The merge
-    was not in the loop, so the gate did not fail-open, yet the guard blocked.
-    Requiring the merge to sit inside a `do … done` body fires on the real
-    batch-loop shape (`for pr in …; do gh pr merge "$pr"; done`) while leaving
-    unrelated loops (and one-off variable merges outside any loop — out of
-    scope for #567) alone.
+    Co-location is preserved (#886). The match must sit INSIDE a `do … done`
+    loop body. A one-off `gh pr merge "$PR"` OUTSIDE any loop, co-occurring with
+    an unrelated `for r in …; do gh run rerun "$r" --failed; done`, does NOT
+    fail-open (the merge resolves its own PR) and so MUST NOT block — the
+    co-location requirement leaves it alone, while the real batch-loop shape
+    (`for pr in …; do gh pr merge "$pr"; done`) still trips.
     """
     view = _strip_quoted_runs_keep_var_args(command)
-    merge_matches = list(_GH_MERGE_VAR_PR.finditer(view))
+    merge_matches = list(_GH_MERGE_NONLITERAL_ARG.finditer(view))
     if not merge_matches:
         return False
     spans = _loop_body_spans(view)

--- a/.claude/hooks/validate_pr_review.py
+++ b/.claude/hooks/validate_pr_review.py
@@ -19,13 +19,17 @@ Input Language:
                the PR in the repo the user named, not the cwd-resolved repo.
     --admin  → short-circuits (emergency override — allows merge).
 
-  Batch-loop guard (#567): a `gh pr merge <shell-var>` inside a
-  for/while/until loop (e.g. `for pr in 48 49; do gh pr merge "$pr" …; done`)
-  is HARD BLOCKED. The literal-PR parse cannot resolve a loop variable, so the
-  gate would fail-open and merge every iteration unverified (observed P3W11 +
-  P3W13). The operator is told to run one literal merge per call so each PR is
-  gate-checked. `--admin` still overrides; a literal `gh pr merge 54` is
-  unaffected. Conservative DECIDE-tier shape (no conditional-allow) per
+  Batch-loop guard (#567, narrowed #886): a `gh pr merge <shell-var>` located
+  INSIDE a for/while/until loop body (e.g.
+  `for pr in 48 49; do gh pr merge "$pr" …; done`) is HARD BLOCKED. The
+  literal-PR parse cannot resolve a loop variable, so the gate would fail-open
+  and merge every iteration unverified (observed P3W11 + P3W13). The operator is
+  told to run one literal merge per call so each PR is gate-checked. The merge
+  must sit between a `do` and its matching `done` to trip the guard — an
+  unrelated loop in the same block (e.g. a `gh run rerun "$r" --failed`
+  staleness recheck) alongside a non-loop variable merge does NOT (#886).
+  `--admin` still overrides; a literal `gh pr merge 54` is unaffected.
+  Conservative DECIDE-tier shape (no conditional-allow) per
   `feedback_safety_direction_over_ux_friction`.
 
 Charter-format review comments (canonical per `pull-requests.md` § Comment-Based Reviews,
@@ -150,11 +154,37 @@ _GH_MERGE_VAR_PR = re.compile(
     r"(?=\s|;|&|\||$)"  # arg ends at whitespace, a shell terminator, or EOS
 )
 
-# A shell loop construct: a `for`/`while`/`until` opener token paired with a
-# `do` body keyword. Requiring BOTH (not just `for`) keeps the detector
-# conservative — a bare `for` in a flag value won't trip it on its own.
-_LOOP_OPENER = re.compile(r"\b(?:for|while|until)\b")
-_LOOP_BODY = re.compile(r"(?:^|[\s;])do(?:[\s;]|$)")
+# `do` / `done` loop keywords as standalone tokens (delimited by start-of-string,
+# whitespace, or `;`). `do`/`done` are loop-only keywords in shell, so every
+# balanced `do … done` pair delimits a loop BODY. The alternation lists `done`
+# first so the longer keyword wins (otherwise `do` would match the `do` prefix
+# of `done`). The keyword span is captured via the lookahead so the surrounding
+# delimiters are not consumed and adjacent tokens are not swallowed (#886).
+_LOOP_DO_DONE = re.compile(r"(?:^|[\s;])(done|do)(?=[\s;]|$)")
+
+
+def _loop_body_spans(view: str) -> list[tuple[int, int]]:
+    """Return the (start, end) character spans of each shell loop BODY in `view`.
+
+    A loop body is the text between a `do` keyword and its matching `done`.
+    `do`/`done` are loop-only keywords in shell, so every balanced `do … done`
+    pair delimits one body; nested loops are paired via a stack (each `done`
+    closes the most recent unmatched `do`). Unbalanced tokens are ignored.
+
+    `view` is expected to be the quote-normalized command produced by
+    `_strip_quoted_runs_keep_var_args`, so `do`/`done` mentioned inside a quoted
+    `--body "…"` payload have already been stripped and do not create spans.
+    """
+    spans: list[tuple[int, int]] = []
+    do_stack: list[int] = []  # end-offsets of open `do` keywords (body starts here)
+    for m in _LOOP_DO_DONE.finditer(view):
+        keyword = m.group(1)
+        if keyword == "do":
+            do_stack.append(m.end(1))
+        elif do_stack:  # `done` — close the most recent `do`
+            body_start = do_stack.pop()
+            spans.append((body_start, m.start(1)))
+    return spans
 
 
 def _strip_quoted_runs_keep_var_args(command: str) -> str:
@@ -218,21 +248,38 @@ def is_variable_pr_merge_in_loop(command: str) -> bool:
     the explicitly-deferred conditional-allow path. A literal
     `gh pr merge 54` is untouched (its PR number parses, the gate runs).
 
-    Detection requires BOTH, evaluated on a quote-normalized view of the
-    command (quoted prose stripped, a lone `"$pr"` arg unwrapped — see
+    Detection, evaluated on a quote-normalized view of the command (quoted
+    prose stripped, a lone `"$pr"` arg unwrapped — see
     `_strip_quoted_runs_keep_var_args`) so a `--body "... for … do gh pr
     merge $pr … done"` payload that merely MENTIONS the shape is not matched:
-      1. a `gh pr merge` whose PR-number arg is a shell variable
-         (`$pr` / `${pr}` / `"$pr"` / `"${pr}"`), AND
-      2. a loop construct (`for`/`while`/`until` opener + a `do` body keyword).
-    Requiring the loop keyword pair avoids blocking a one-off
-    `gh pr merge "$PR"` typed outside any loop (out of scope for #567, and
-    rare) — only the batch-loop shape the gate actually fail-opens on.
+    a `gh pr merge` whose PR-number arg is a shell variable
+    (`$pr` / `${pr}` / `"$pr"` / `"${pr}"`) that is located INSIDE a loop body
+    (the text between a `do` keyword and its matching `done`).
+
+    Co-location matters (#886). The earlier form required only that a
+    variable-PR merge AND loop keywords each appear SOMEWHERE in the command,
+    independently. That over-matched any multi-line block that happened to pair
+    an unrelated loop with a non-loop variable merge — e.g. a `/wave-wrapup`
+    block doing a single `gh pr merge "$PR"` AND, separately, a staleness
+    recheck loop `for r in …; do gh run rerun "$r" --failed; done`. The merge
+    was not in the loop, so the gate did not fail-open, yet the guard blocked.
+    Requiring the merge to sit inside a `do … done` body fires on the real
+    batch-loop shape (`for pr in …; do gh pr merge "$pr"; done`) while leaving
+    unrelated loops (and one-off variable merges outside any loop — out of
+    scope for #567) alone.
     """
     view = _strip_quoted_runs_keep_var_args(command)
-    if not _GH_MERGE_VAR_PR.search(view):
+    merge_matches = list(_GH_MERGE_VAR_PR.finditer(view))
+    if not merge_matches:
         return False
-    return bool(_LOOP_OPENER.search(view) and _LOOP_BODY.search(view))
+    spans = _loop_body_spans(view)
+    if not spans:
+        return False
+    return any(
+        body_start <= mm.start() < body_end
+        for mm in merge_matches
+        for (body_start, body_end) in spans
+    )
 
 
 def get_pr_data(pr_number: str | None, repo: str | None = None) -> dict | None:

--- a/.claude/lib/lint_skill_graphql_pagination.py
+++ b/.claude/lib/lint_skill_graphql_pagination.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Lint skill markdown for the GraphQL `first: > 100` over-cap footgun.
+
+GitHub's GraphQL API caps every *connection* `first:` at **100** — a query that asks
+for more (e.g. `items(first: 500)`) errors with *"Requesting 500 records on the
+connection exceeds the `first` limit of 100 records"* and returns **zero** rows. In
+`/board-audit` (noorinalabs-main#888) that silent zero read as "every issue is an
+orphan". The fix is always cursor pagination (`first: 100` + `pageInfo`/`$endCursor` +
+`--paginate`); this lint is the cheap regression guard the issue asked for.
+
+What it flags
+=============
+Inside any fenced code block that contains a `gh api graphql` invocation, any
+`first: <n>` whose integer value is **strictly greater than 100**. `first: 100` is the
+legal maximum and is NOT flagged; `first: 30` (e.g. a small inner `fieldValues`
+connection) is fine. Restricting to `gh api graphql` blocks avoids flagging an unrelated
+`first:` that happens to appear in prose or a non-GraphQL recipe.
+
+Today only `.claude/skills/board-audit/SKILL.md` is in scope; the lint exists so a future
+skill author can't reintroduce the over-cap.
+
+CLI
+===
+    python3 .claude/lib/lint_skill_graphql_pagination.py <file.md> [<file.md> ...]
+
+Glob over the skills tree (zsh recursive glob; bash needs `shopt -s globstar`):
+
+    python3 .claude/lib/lint_skill_graphql_pagination.py .claude/skills/**/*.md
+
+Exit codes:
+    0 — no over-cap `first:` found in any file
+    1 — at least one violation (each printed as `path:line: first: <n> — <why>`)
+    2 — usage / file-not-found error
+
+Same CLI/exit-code shape as `.claude/lib/check_dockerfile_base_pin.py` so it wires
+identically into pre-commit + CI when promoted to a blocking gate (a #888 follow-up).
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# A fenced code block opens/closes on a line that is only a ``` (optionally with an info
+# string like ```bash). We track open/close to scope the scan to code, not prose.
+_FENCE_RE = re.compile(r"^\s*```")
+# `gh api graphql` anywhere in the block marks it as a GraphQL recipe.
+_GRAPHQL_RE = re.compile(r"\bgh\s+api\s+graphql\b")
+# `first:` followed by an integer literal — capture the number to compare numerically.
+_FIRST_RE = re.compile(r"\bfirst:\s*(\d+)")
+
+CONNECTION_CAP = 100
+
+
+class Violation:
+    """One over-cap `first:` occurrence."""
+
+    def __init__(self, path: str, lineno: int, value: int) -> None:
+        self.path = path
+        self.lineno = lineno
+        self.value = value
+
+    def __str__(self) -> str:
+        return (
+            f"{self.path}:{self.lineno}: first: {self.value} — exceeds the GraphQL "
+            f"connection cap of {CONNECTION_CAP}; use first: 100 + cursor pagination "
+            f"(pageInfo/endCursor + --paginate)"
+        )
+
+
+def check_markdown_text(path: str, text: str) -> list[Violation]:
+    """Return over-cap `first:` violations inside `gh api graphql` code blocks."""
+    violations: list[Violation] = []
+    lines = text.splitlines()
+
+    in_block = False
+    block_start = 0  # 0-based index of the first content line of the open block
+    for idx, raw in enumerate(lines):
+        if _FENCE_RE.match(raw):
+            if not in_block:
+                in_block = True
+                block_start = idx + 1
+            else:
+                # Block closed — scan it if it was a GraphQL recipe.
+                block_lines = lines[block_start:idx]
+                violations.extend(_scan_block(path, block_start, block_lines))
+                in_block = False
+    # An unterminated block (no closing fence) still gets scanned to EOF.
+    if in_block:
+        block_lines = lines[block_start:]
+        violations.extend(_scan_block(path, block_start, block_lines))
+
+    return violations
+
+
+def _scan_block(path: str, start_idx: int, block_lines: list[str]) -> list[Violation]:
+    """Scan one fenced block; flag over-cap `first:` only if it is a GraphQL recipe."""
+    block_text = "\n".join(block_lines)
+    if not _GRAPHQL_RE.search(block_text):
+        return []
+    found: list[Violation] = []
+    for offset, line in enumerate(block_lines):
+        for m in _FIRST_RE.finditer(line):
+            value = int(m.group(1))
+            if value > CONNECTION_CAP:
+                # start_idx is 0-based content start; +offset for the line, +1 to 1-base.
+                found.append(Violation(path, start_idx + offset + 1, value))
+    return found
+
+
+def check_file(path: Path) -> list[Violation]:
+    return check_markdown_text(str(path), path.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str]) -> int:
+    paths = argv[1:]
+    if not paths:
+        print(
+            "usage: lint_skill_graphql_pagination.py <file.md> [<file.md> ...]",
+            file=sys.stderr,
+        )
+        return 2
+
+    all_violations: list[Violation] = []
+    for p in paths:
+        path = Path(p)
+        if not path.is_file():
+            print(f"ERROR: not a file: {p}", file=sys.stderr)
+            return 2
+        all_violations.extend(check_file(path))
+
+    if all_violations:
+        print("GraphQL connection over-cap violations (first: > 100, noorinalabs-main#888):")
+        for v in all_violations:
+            print(f"  {v}")
+        print(
+            "\nGraphQL connections cap first: at 100. Page with first: 100 + "
+            "pageInfo { hasNextPage endCursor } + a $endCursor var + gh api graphql "
+            "--paginate, then merge pages with jq -s."
+        )
+        return 1
+
+    print("OK: no GraphQL connection over-cap (first: > 100) found.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.claude/lib/ontology_gen/typescript_ext.py
+++ b/.claude/lib/ontology_gen/typescript_ext.py
@@ -74,13 +74,43 @@ def _line_of(text: str, pos: int) -> int:
     return text.count("\n", 0, pos) + 1
 
 
+def _split_top_level_commas(raw: str) -> list[str]:
+    """Split ``raw`` on commas that sit at bracket-nesting depth 0.
+
+    Commas nested inside ``<>`` / ``()`` / ``[]`` / ``{}`` are NOT split points, so a
+    base list like ``Bar<Map<K, V>>, Baz`` splits into ``["Bar<Map<K, V>>", "Baz"]``
+    rather than naively at the inner ``, `` (#887). Empty / whitespace-only segments
+    are dropped. Shared by both the ``extends``/``implements`` base-list parser and the
+    parameter splitter so neither re-implements the depth tracking.
+    """
+    parts: list[str] = []
+    depth = 0
+    current = ""
+    for ch in raw:
+        if ch in "([{<":
+            depth += 1
+        elif ch in ")]}>":
+            depth = max(0, depth - 1)
+        if ch == "," and depth == 0:
+            if current.strip():
+                parts.append(current)
+            current = ""
+        else:
+            current += ch
+    if current.strip():
+        parts.append(current)
+    return parts
+
+
 def _parse_extends_bases(raw: str) -> list[str]:
     """Return base names from a raw ``extends A, B<T>`` clause (drops generics).
 
-    Splits on top-level commas and strips generic type-parameters so ``Foo<T>`` → ``Foo``.
+    Splits on top-level commas (depth-aware, so a comma inside a nested generic such as
+    ``Map<K, V>`` does not split — #887) and strips generic type-parameters so
+    ``Foo<T>`` → ``Foo``.
     """
     bases: list[str] = []
-    for part in raw.split(","):
+    for part in _split_top_level_commas(raw):
         name = part.strip().split("<")[0].strip()
         if name and re.match(r"^[A-Za-z_$][\w$]*$", name):
             bases.append(name)
@@ -88,27 +118,8 @@ def _parse_extends_bases(raw: str) -> list[str]:
 
 
 def _split_params(raw: str) -> list[str]:
-    raw = raw.strip()
-    if not raw:
-        return []
-    params: list[str] = []
-    depth = 0
-    current = ""
-    # Split on top-level commas only (object/array/generic destructuring may nest).
-    for ch in raw:
-        if ch in "([{<":
-            depth += 1
-        elif ch in ")]}>":
-            depth -= 1
-        if ch == "," and depth == 0:
-            params.append(current)
-            current = ""
-        else:
-            current += ch
-    if current.strip():
-        params.append(current)
     out: list[str] = []
-    for part in params:
+    for part in _split_top_level_commas(raw):
         # Keep just the parameter name (drop type annotations / defaults).
         name = part.strip().split(":")[0].split("=")[0].strip()
         name = name.lstrip(".")  # rest params ...args

--- a/.claude/lib/pre_commit_ci_sync.py
+++ b/.claude/lib/pre_commit_ci_sync.py
@@ -47,7 +47,7 @@ kind tokens so they compare:
 
     ruff-lint, ruff-format, mypy, pytest, eslint, typescript, prettier,
     terraform-fmt, gitleaks, actionlint, astro-check, pip-audit, build,
-    cspell, dockerfile-base-pin, fixture-realism
+    cspell, dockerfile-base-pin, fixture-realism, skill-graphql-pagination
 
 Unknown tools are ignored (neither side gates on a kind we can't classify),
 which keeps the gate conservative — it never fails on something it doesn't
@@ -168,6 +168,19 @@ _KIND_PATTERNS: dict[str, tuple[str, ...]] = {
     # line) and the hook id / job name.
     "dockerfile-base-pin": ("check_dockerfile_base_pin", "dockerfile-base-pin"),
     "fixture-realism": ("check_fixture_realism", "fixture-realism"),
+    # `skill-graphql-pagination` is the skill-markdown GraphQL over-cap lint
+    # (`.claude/lib/lint_skill_graphql_pagination.py`, #888/#892 → wired by #893):
+    # it flags any `first: > 100` inside a `gh api graphql` block in
+    # `.claude/skills/**/*.md` (the over-cap footgun that made `/board-audit` read
+    # every issue as an orphan). Same contract as the two charter-prose→code gates
+    # above — a CI run of the lint with no pre-commit hook is harmful drift (#684),
+    # not a silently-ignored unknown, so classifying it makes the drift gate
+    # actively DEMAND the local⇄CI mirror. Patterns match the script basename
+    # (present on both sides' invoke line) and the hook id / job name.
+    "skill-graphql-pagination": (
+        "lint_skill_graphql_pagination",
+        "skill-graphql-pagination",
+    ),
 }
 
 

--- a/.claude/lib/tests/test_lint_skill_graphql_pagination.py
+++ b/.claude/lib/tests/test_lint_skill_graphql_pagination.py
@@ -1,0 +1,148 @@
+"""Tests for lint_skill_graphql_pagination — the GraphQL `first: > 100` guard (#888).
+
+Verifies the lint flags an over-cap `first:` inside a `gh api graphql` code block, treats
+`first: 100` (the legal maximum) and small inner connections as compliant, and ignores a
+`first:` that appears outside a GraphQL recipe block.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from lint_skill_graphql_pagination import (  # noqa: E402
+    check_markdown_text,
+    main,
+)
+
+_GRAPHQL_BLOCK = """### Step 2
+
+```bash
+gh api graphql -f query='
+query {{
+  organization(login: "noorinalabs") {{
+    projectV2(number: 2) {{
+      items(first: {n}) {{
+        nodes {{ id }}
+      }}
+    }}
+  }}
+}}'
+```
+"""
+
+
+class OverCapIsFlagged(unittest.TestCase):
+    def test_first_500_in_graphql_block_flagged(self) -> None:
+        v = check_markdown_text("SKILL.md", _GRAPHQL_BLOCK.format(n=500))
+        self.assertEqual(len(v), 1)
+        self.assertEqual(v[0].value, 500)
+        # Line points at the `items(first: 500)` line inside the fenced block.
+        self.assertEqual(v[0].lineno, 8)
+
+    def test_first_101_is_over_cap(self) -> None:
+        v = check_markdown_text("SKILL.md", _GRAPHQL_BLOCK.format(n=101))
+        self.assertEqual(len(v), 1)
+        self.assertEqual(v[0].value, 101)
+
+    def test_first_1394_flagged(self) -> None:
+        v = check_markdown_text("SKILL.md", _GRAPHQL_BLOCK.format(n=1394))
+        self.assertEqual(len(v), 1)
+
+
+class CompliantIsNotFlagged(unittest.TestCase):
+    def test_first_100_is_the_legal_max(self) -> None:
+        self.assertEqual(check_markdown_text("SKILL.md", _GRAPHQL_BLOCK.format(n=100)), [])
+
+    def test_small_inner_connection_ok(self) -> None:
+        self.assertEqual(check_markdown_text("SKILL.md", _GRAPHQL_BLOCK.format(n=30)), [])
+
+    def test_paginated_block_with_first_100_and_inner_30(self) -> None:
+        md = """```bash
+gh api graphql --paginate -f query='
+query($endCursor: String) {
+  organization(login: "noorinalabs") {
+    projectV2(number: 2) {
+      items(first: 100, after: $endCursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes { fieldValues(first: 30) { nodes { id } } }
+      }
+    }
+  }
+}'
+```
+"""
+        self.assertEqual(check_markdown_text("SKILL.md", md), [])
+
+    def test_first_500_outside_graphql_block_ignored(self) -> None:
+        # A `first: 500` in a non-GraphQL recipe (no `gh api graphql`) is out of scope.
+        md = """```bash
+gh issue list --repo noorinalabs/x --limit 500 --json url
+echo "first: 500 widgets"
+```
+"""
+        self.assertEqual(check_markdown_text("SKILL.md", md), [])
+
+    def test_first_500_in_prose_outside_any_block_ignored(self) -> None:
+        md = "Some prose mentioning items(first: 500) but no code block.\n"
+        self.assertEqual(check_markdown_text("SKILL.md", md), [])
+
+
+class MultipleAndUnterminated(unittest.TestCase):
+    def test_two_over_cap_in_one_block(self) -> None:
+        md = """```bash
+gh api graphql -f query='query { a(first: 200) { b(first: 300) { id } } }'
+```
+"""
+        v = check_markdown_text("SKILL.md", md)
+        self.assertEqual([x.value for x in v], [200, 300])
+
+    def test_unterminated_block_scanned_to_eof(self) -> None:
+        md = "```bash\ngh api graphql -f query='query { a(first: 500) { id } }'\n"
+        v = check_markdown_text("SKILL.md", md)
+        self.assertEqual(len(v), 1)
+        self.assertEqual(v[0].value, 500)
+
+
+class CliExitCodes(unittest.TestCase):
+    def test_usage_error_no_args(self) -> None:
+        self.assertEqual(main(["lint_skill_graphql_pagination.py"]), 2)
+
+    def test_missing_file_errors(self) -> None:
+        self.assertEqual(main(["lint_skill_graphql_pagination.py", "/no/such/file.md"]), 2)
+
+    def test_clean_file_passes(self) -> None:
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as fh:
+            fh.write(_GRAPHQL_BLOCK.format(n=100))
+            name = fh.name
+        try:
+            self.assertEqual(main(["lint_skill_graphql_pagination.py", name]), 0)
+        finally:
+            Path(name).unlink()
+
+    def test_violating_file_returns_1(self) -> None:
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as fh:
+            fh.write(_GRAPHQL_BLOCK.format(n=500))
+            name = fh.name
+        try:
+            self.assertEqual(main(["lint_skill_graphql_pagination.py", name]), 1)
+        finally:
+            Path(name).unlink()
+
+    def test_real_skill_file_is_clean(self) -> None:
+        # The board-audit skill must itself be free of the over-cap after the #888 fix.
+        repo_root = Path(__file__).resolve().parents[3]
+        skill = repo_root / ".claude" / "skills" / "board-audit" / "SKILL.md"
+        if skill.is_file():
+            self.assertEqual(main(["lint_skill_graphql_pagination.py", str(skill)]), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/lib/tests/test_ontology_gen.py
+++ b/.claude/lib/tests/test_ontology_gen.py
@@ -30,7 +30,11 @@ from ontology_gen.model import (  # noqa: E402
     serialize_graph,
 )
 from ontology_gen.python_ext import extract_python  # noqa: E402
-from ontology_gen.typescript_ext import extract_typescript  # noqa: E402
+from ontology_gen.typescript_ext import (  # noqa: E402
+    _parse_extends_bases,
+    _split_top_level_commas,
+    extract_typescript,
+)
 
 
 class TestModel(unittest.TestCase):
@@ -299,6 +303,55 @@ type MaybeNull<T> = T | null;
         by_name = {s.qualname: s for s in iter_symbols(py_info.symbols)}
         self.assertEqual(by_name["Foo"].kind, "class")
         self.assertEqual(by_name["Foo.bar"].kind, "method")
+
+
+class TestExtendsBaseSplitter(unittest.TestCase):
+    """Depth-aware top-level-comma splitting of ``extends``/``implements`` lists (#887)."""
+
+    def test_nested_generic_not_split(self) -> None:
+        # The inner ``, `` of ``Map<K, V>`` must NOT be a split point.
+        self.assertEqual(_parse_extends_bases("Bar<Map<K, V>>, Baz"), ["Bar", "Baz"])
+
+    def test_two_generics_each_with_args(self) -> None:
+        self.assertEqual(_parse_extends_bases("Foo<A, B>, Bar<C>"), ["Foo", "Bar"])
+
+    def test_paren_and_bracket_nesting(self) -> None:
+        # Commas inside ``()`` and ``[]`` are likewise depth-protected.
+        self.assertEqual(
+            _parse_extends_bases("Foo<[A, B]>, Bar<(C, D)>, Baz"),
+            ["Foo", "Bar", "Baz"],
+        )
+
+    def test_deeply_nested_generic(self) -> None:
+        self.assertEqual(
+            _parse_extends_bases("A<B<C, D<E, F>>>, G"),
+            ["A", "G"],
+        )
+
+    def test_plain_list_unchanged(self) -> None:
+        self.assertEqual(_parse_extends_bases("Alpha, Beta, Gamma"), ["Alpha", "Beta", "Gamma"])
+
+    def test_single_base(self) -> None:
+        self.assertEqual(_parse_extends_bases("OnlyBase"), ["OnlyBase"])
+
+    def test_empty_clause(self) -> None:
+        self.assertEqual(_parse_extends_bases(""), [])
+        self.assertEqual(_parse_extends_bases("   "), [])
+
+    def test_splitter_keeps_nested_segment_intact(self) -> None:
+        # The low-level splitter returns the whole nested segment as one part.
+        self.assertEqual(
+            _split_top_level_commas("Bar<Map<K, V>>, Baz"),
+            ["Bar<Map<K, V>>", " Baz"],
+        )
+
+    def test_interface_with_nested_generic_base(self) -> None:
+        # End-to-end through the extractor: a real interface declaration.
+        src = "export interface Repo extends Bar<Map<K, V>>, Baz {\n  x: number;\n}\n"
+        info = extract_typescript("src/repo.ts", src)
+        by_name = {s.name: s for s in info.symbols}
+        self.assertIn("Repo", by_name)
+        self.assertEqual(by_name["Repo"].bases, ["Bar", "Baz"])
 
 
 class TestCypherExtractor(unittest.TestCase):

--- a/.claude/lib/tests/test_pre_commit_ci_sync.py
+++ b/.claude/lib/tests/test_pre_commit_ci_sync.py
@@ -486,6 +486,66 @@ repos:
         self.assertNotIn("fixture-realism", harmful)
 
 
+class SkillGraphqlPaginationKind(unittest.TestCase):
+    """#888/#893: the skill-markdown GraphQL over-cap lint must be a classified kind
+    so the sync-drift gate DEMANDS a pre-commit mirror of the CI lint job (an
+    un-mirrored gate lets a `first: > 100` over-cap reintroduce the silent
+    zero-row read that made `/board-audit` treat every issue as an orphan)."""
+
+    def test_ci_skill_graphql_pagination_run_step_classified(self) -> None:
+        wf = """
+jobs:
+  skill-graphql-pagination:
+    steps:
+      - run: python3 .claude/lib/lint_skill_graphql_pagination.py $files
+"""
+        self.assertIn("skill-graphql-pagination", kinds_from_ci(wf))
+
+    def test_precommit_skill_graphql_pagination_hook_classified(self) -> None:
+        cfg = """
+repos:
+  - repo: local
+    hooks:
+      - id: skill-graphql-pagination
+        name: skill-graphql-pagination
+        entry: python3 .claude/lib/lint_skill_graphql_pagination.py
+"""
+        self.assertIn("skill-graphql-pagination", kinds_from_precommit(cfg))
+
+    def test_ci_skill_graphql_pagination_without_precommit_is_harmful_drift(self) -> None:
+        wf = """
+jobs:
+  skill-graphql-pagination:
+    steps:
+      - run: python3 .claude/lib/lint_skill_graphql_pagination.py $files
+"""
+        cfg = """
+repos:
+  - repo: local
+    hooks:
+      - id: ruff
+"""
+        harmful, _ = compute_drift(kinds_from_precommit(cfg), kinds_from_ci(wf))
+        self.assertIn("skill-graphql-pagination", harmful)
+
+    def test_ci_skill_graphql_pagination_with_precommit_mirror_no_drift(self) -> None:
+        wf = """
+jobs:
+  skill-graphql-pagination:
+    steps:
+      - run: python3 .claude/lib/lint_skill_graphql_pagination.py $files
+"""
+        cfg = """
+repos:
+  - repo: local
+    hooks:
+      - id: skill-graphql-pagination
+        entry: python3 .claude/lib/lint_skill_graphql_pagination.py
+"""
+        harmful, _ = compute_drift(kinds_from_precommit(cfg), kinds_from_ci(wf))
+        self.assertNotIn("skill-graphql-pagination", harmful)
+
+
 class BuildKindTightening(unittest.TestCase):
     """#576: runtime `docker build` / `docker buildx` steps are image-MOVING,
     not a build-QUALITY gate a local pre-commit hook can mirror — they must
@@ -734,6 +794,10 @@ _OLD_KIND_PATTERNS = {
     "mermaid": ("mermaid", "check-mermaid"),
     "dockerfile-base-pin": ("check_dockerfile_base_pin", "dockerfile-base-pin"),
     "fixture-realism": ("check_fixture_realism", "fixture-realism"),
+    "skill-graphql-pagination": (
+        "lint_skill_graphql_pagination",
+        "skill-graphql-pagination",
+    ),
 }
 _OLD_RUN_BLOCK_OPEN_RE = re.compile(r"^(?P<indent>\s*)-?\s*run:\s*[|>][+\-0-9]*\s*$")
 
@@ -828,6 +892,7 @@ _EXPECTED_KINDS = {
             "pytest",
             "ruff-format",
             "ruff-lint",
+            "skill-graphql-pagination",
         },
         "ci": {
             "actionlint",
@@ -843,6 +908,7 @@ _EXPECTED_KINDS = {
             "pytest",
             "ruff-format",
             "ruff-lint",
+            "skill-graphql-pagination",
         },
     },
 }

--- a/.claude/lib/tests/test_wave_seq.py
+++ b/.claude/lib/tests/test_wave_seq.py
@@ -135,6 +135,89 @@ class TestNoCrossPhaseCollision(unittest.TestCase):
         self.assertEqual(status["wave_17_phase_ordinal"], 2)
 
 
+class TestRetroReservationAwareness(unittest.TestCase):
+    """Regression for main#885: ``/wave-retro`` Step 9 reserves the next id by
+    writing ``wave_{N}_meta_issue`` WITHOUT bumping ``global_wave_seq`` (it stays
+    N-1). The subsequent ``/wave-scope`` ``allocate`` must claim N — NOT skip to
+    N+1 as it did in the P7 W18→W19 transition (allocated 20 instead of 19)."""
+
+    def _post_retro_reservation(self) -> dict:
+        """Status exactly as /wave-retro Step 9 leaves it: P7W18 committed
+        (global_wave_seq=18, wave_18 stamped phase 7 ordinal 1), and wave_19
+        reserved via its meta_issue key ONLY — counter NOT advanced, no phase
+        stamp on 19 yet (mirrors the upsert the retro skill actually performs)."""
+        return {
+            "current_phase": 7,
+            "current_wave": "wave-18",
+            "global_wave_seq": 18,
+            "wave_18_phase": 7,
+            "wave_18_phase_ordinal": 1,
+            "wave_18_scope": {"phase": 7, "theme": "P7W1"},
+            # Retro Step 9 reservation: meta_issue key, counter still 18.
+            "wave_19_meta_issue": "noorinalabs-main#882",
+        }
+
+    def test_reserved_wave_detects_pending_reservation(self) -> None:
+        self.assertEqual(wave_seq.reserved_wave(self._post_retro_reservation()), 19)
+
+    def test_reserved_wave_none_without_meta_issue_key(self) -> None:
+        status = self._post_retro_reservation()
+        del status["wave_19_meta_issue"]
+        self.assertIsNone(wave_seq.reserved_wave(status))
+
+    def test_reserved_wave_none_when_counter_absent(self) -> None:
+        # No committed counter → cannot distinguish reserved from committed;
+        # fall back to the seed-safe monotonic path.
+        status = self._post_retro_reservation()
+        del status["global_wave_seq"]
+        self.assertIsNone(wave_seq.reserved_wave(status))
+
+    def test_allocation_target_returns_reserved_id(self) -> None:
+        # The headline bug: bare next_global_wave skips to 20; the
+        # reservation-aware target claims the reserved 19.
+        status = self._post_retro_reservation()
+        self.assertEqual(wave_seq.next_global_wave(status), 20)  # the old (wrong) value
+        self.assertEqual(wave_seq.allocation_target(status), 19)
+
+    def test_allocation_target_falls_through_when_no_reservation(self) -> None:
+        # Normal mid-wave state (no pending meta_issue at counter+1) is unchanged.
+        status = _grandfathered_p6_status()
+        self.assertEqual(wave_seq.allocation_target(status), wave_seq.next_global_wave(status))
+
+    def test_peek_returns_reserved_id_not_skip(self) -> None:
+        with TemporaryDirectory() as d:
+            path = Path(d) / "cross-repo-status.json"
+            path.write_text(json.dumps(self._post_retro_reservation(), indent=2) + "\n")
+            import io
+            from contextlib import redirect_stdout
+
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = wave_seq.main(["peek", str(path)])
+            self.assertEqual(rc, 0)
+            self.assertEqual(buf.getvalue().strip(), "19")
+
+    def test_allocate_write_claims_reserved_id_and_advances_counter(self) -> None:
+        with TemporaryDirectory() as d:
+            path = Path(d) / "cross-repo-status.json"
+            path.write_text(json.dumps(self._post_retro_reservation(), indent=2) + "\n")
+
+            rc = wave_seq.main(["allocate", str(path), "--phase", "7", "--write"])
+            self.assertEqual(rc, 0)
+
+            after = json.loads(path.read_text())
+            # Counter advances to the RESERVED id (19), not past it (20).
+            self.assertEqual(after["global_wave_seq"], 19)
+            self.assertEqual(after["wave_19_phase"], 7)
+            # P7 already has wave 18 (ordinal 1); the reserved 19 is ordinal 2.
+            self.assertEqual(after["wave_19_phase_ordinal"], 2)
+            # No wave_20_* keys were ever created.
+            self.assertNotIn("wave_20_phase", after)
+            self.assertNotIn("wave_20_phase_ordinal", after)
+            # The reservation key is preserved.
+            self.assertEqual(after["wave_19_meta_issue"], "noorinalabs-main#882")
+
+
 class TestAllocateWritesPreserveShape(unittest.TestCase):
     """End-to-end --write goes through upsert_status_keys, so the compact-inline
     file shape is preserved and the result is valid JSON."""

--- a/.claude/lib/wave_seq.py
+++ b/.claude/lib/wave_seq.py
@@ -36,12 +36,28 @@ collide with any historical ``wave_1``..``wave_9``. Prior-phase graveyard keys
 are preserved (git history + the phase docs hold them; they are inert because no
 future wave is ever numbered ≤ 15).
 
+Reservation-awareness (main#885)
+--------------------------------
+``/wave-retro`` Step 9 *reserves* the next wave id by writing a
+``wave_{N}_meta_issue`` key **without** bumping ``global_wave_seq`` (the counter
+stays at N-1). A naive ``next = current_seq + 1`` then SKIPS the reserved id,
+because ``seed_value()`` counts the reserved ``wave_{N}_*`` key as an
+already-allocated id (so ``max(global_wave_seq=N-1, seed=N) + 1 = N+1`` — the
+P7 W18→W19 transition allocated 20 instead of 19). The allocator is therefore
+**reservation-aware**: if the id one above the *committed* counter
+(``global_wave_seq + 1``) already carries a ``wave_{N}_meta_issue`` reservation,
+``allocate``/``peek`` claim THAT id rather than incrementing past it. This makes
+the tool correct regardless of caller ordering — the keyspace and
+``global_wave_seq`` can never disagree by construction.
+
 CLI:
   wave_seq.py peek     <status_path>
       Print the next global wave id that WOULD be allocated (no write).
+      Honours a pending retro reservation (see Reservation-awareness above).
   wave_seq.py allocate <status_path> --phase P [--write]
-      Allocate the next global wave id for phase P. ``--write`` persists the
-      incremented ``global_wave_seq`` AND stamps ``wave_{X}_phase`` +
+      Allocate the next global wave id for phase P (a pending retro reservation
+      if one exists, else the monotonic next). ``--write`` persists the
+      ``global_wave_seq`` advance AND stamps ``wave_{X}_phase`` +
       ``wave_{X}_phase_ordinal`` (auto-computed: 1 + waves already in phase P).
       Without ``--write`` it is a dry-run that only prints the id + ordinal.
 """
@@ -108,6 +124,42 @@ def next_global_wave(status: dict) -> int:
     return current_seq(status) + 1
 
 
+def reserved_wave(status: dict) -> int | None:
+    """A wave id reserved by ``/wave-retro`` Step 9 but not yet committed (#885).
+
+    The retro reserves the next id by writing a ``wave_{N}_meta_issue`` key while
+    leaving the **committed** counter (``global_wave_seq``) at N-1 — the id is
+    claimed in the keyspace before the counter advances. That makes ``seed_value``
+    treat N as already-allocated, so a naive ``next_global_wave`` would SKIP it
+    (``+1`` past it). Detect the pending reservation as: the id one above the
+    *explicit committed counter* whose ``wave_{N}_meta_issue`` key already exists.
+
+    Only the explicit ``global_wave_seq`` is consulted (NOT the seed-inflated
+    ``current_seq``) — using the seed would re-introduce the skip this guards
+    against. Returns ``None`` when there is no committed counter (migration: fall
+    back to the seed-safe monotonic next) or no reservation at ``committed + 1``.
+    """
+    committed = status.get("global_wave_seq")
+    if not isinstance(committed, int):
+        return None
+    candidate = committed + 1
+    if f"wave_{candidate}_meta_issue" in status:
+        return candidate
+    return None
+
+
+def allocation_target(status: dict) -> int:
+    """The id ``allocate``/``peek`` will claim.
+
+    A pending retro reservation (``reserved_wave``) if one exists — so the tool
+    is correct regardless of caller ordering — else the monotonic
+    ``next_global_wave``. This is the single source of truth that keeps the
+    keyspace and ``global_wave_seq`` from disagreeing (#885).
+    """
+    reserved = reserved_wave(status)
+    return reserved if reserved is not None else next_global_wave(status)
+
+
 def phase_of(status: dict, wave: int) -> int | None:
     """The phase a recorded global wave belongs to, or None if unstamped.
 
@@ -139,13 +191,13 @@ def _load(status_path: Path) -> dict:
 
 def _cmd_peek(args: argparse.Namespace) -> int:
     status = _load(args.status)
-    print(next_global_wave(status))
+    print(allocation_target(status))
     return 0
 
 
 def _cmd_allocate(args: argparse.Namespace) -> int:
     status = _load(args.status)
-    wave_id = next_global_wave(status)
+    wave_id = allocation_target(status)
     ordinal = phase_ordinal(status, args.phase)
 
     print(f"global wave id: {wave_id}")

--- a/.claude/skills/board-audit/SKILL.md
+++ b/.claude/skills/board-audit/SKILL.md
@@ -48,35 +48,81 @@ Per Hook 15 (`enforce_librarian_consulted`). The board-audit work edits no sourc
 /ontology-librarian board-audit drift orphan project field-sync
 ```
 
-### 1. Fetch all open issues across the 8 org repos
+### 1. Fetch all open issues (with labels) across the 8 org repos
+
+Fetch `url` **and** `labels` in one call per repo. The labels feed Step 4's drift
+detection **in memory** — there is NO per-board-item `gh issue view` later (#888 defect 2).
+Each call is wrapped in a `timeout` and skip-and-warns rather than hanging the whole
+audit on a single stalled `gh` call (#888 defect 3 — the org-wide loop hung at the 2-min
+mark twice, though each repo returns in <0.4 s alone).
 
 ```bash
-REPOS=(noorinalabs-main noorinalabs-isnad-graph noorinalabs-user-service \
-       noorinalabs-deploy noorinalabs-design-system noorinalabs-landing-page \
-       noorinalabs-data-acquisition noorinalabs-isnad-ingest-platform)
+# Literal repo list in the `for` (NOT `for repo in $SCALAR`) — under zsh an unquoted
+# scalar is not word-split, so a "$REPOS"-string would collapse to one bogus iteration
+# (#759). A literal word-list is split correctly in both bash and zsh.
+: > /tmp/issue-labels.tsv      # url \t expected-Wave-option (computed from the wave label)
+: > /tmp/all-issue-urls.txt    # every open issue url across the org
 
-ALL_ISSUES=()
-for repo in "${REPOS[@]}"; do
-  while read -r url; do
-    ALL_ISSUES+=("$url")
-  done < <(gh issue list --repo "noorinalabs/$repo" --state open \
-             --limit 500 --json url --jq '.[].url')
+for repo in noorinalabs-main noorinalabs-isnad-graph noorinalabs-user-service \
+            noorinalabs-deploy noorinalabs-design-system noorinalabs-landing-page \
+            noorinalabs-data-acquisition noorinalabs-isnad-ingest-platform; do
+  # Per-call timeout: one stalled call must not hang the whole audit (#888 defect 3).
+  # `timeout` exits 124 on stall → the `if !` branch warns and `continue`s.
+  if ! timeout 45 gh issue list --repo "noorinalabs/$repo" --state open \
+         --limit 500 --json url,labels > "/tmp/issues-$repo.json" 2>/dev/null; then
+    echo "WARN: gh issue list for $repo stalled/failed — skipping (audit continues)" >&2
+    continue
+  fi
+
+  # url + the highest-numbered wave label, mapped to its expected Wave-field option:
+  #   wave-{X}  -> W{X}      p{N}-wave-{M} -> P{N}W{M}      wave-x -> WX
+  # Ties on multiple wave labels (rare, transitional) resolve to highest-numbered, matching
+  # the issue body's "highest-numbered wins" rule. Issues with no wave label are omitted here.
+  jq -r '.[]
+         | .url as $u
+         | ([.labels[].name
+             | select(test("^wave-[0-9]+$") or test("^p[0-9]+-wave-[0-9]+$") or . == "wave-x")]
+            | sort_by(if . == "wave-x" then -1 else (capture("(?<n>[0-9]+)$").n | tonumber) end)
+            | last) as $lbl
+         | select($lbl != null)
+         | ($lbl
+            | if . == "wave-x" then "WX"
+              elif startswith("wave-") then "W" + ltrimstr("wave-")
+              else (capture("p(?<n>[0-9]+)-wave-(?<m>[0-9]+)") | "P\(.n)W\(.m)")
+              end) as $opt
+         | "\($u)\t\($opt)"' "/tmp/issues-$repo.json" >> /tmp/issue-labels.tsv
+
+  jq -r '.[].url' "/tmp/issues-$repo.json" >> /tmp/all-issue-urls.txt
+  printf '  %s: done\n' "$repo"          # progress flush — unbuffered, per-repo
 done
 
-echo "Open issues across org: ${#ALL_ISSUES[@]}"
+echo "Open issues across org: $(wc -l < /tmp/all-issue-urls.txt | tr -d ' ')"
+echo "Issues carrying a wave label: $(wc -l < /tmp/issue-labels.tsv | tr -d ' ')"
 ```
 
 `--limit 500` is intentional — the default 30 truncates silently per memory `feedback_gh_pr_edit_silent_noop` family. Adjust upward if any single repo crosses 500 open issues (unlikely but capture as an annunaki event if hit).
 
-### 2. Fetch all items on project 2
+### 2. Fetch all items on project 2 (paginated — connections cap at 100)
+
+**`items(first: …)` MUST be ≤ 100.** GitHub's GraphQL API caps every connection's
+`first:` at 100 — `first: 500` errors with *"Requesting 500 records on the connection
+exceeds the `first` limit of 100 records"* and returns **0 nodes**, which downstream
+reads as "every issue is an orphan" (#888 defect 1; project 2 had 1394 items at the
+P7W19 run, so this is not an edge case). Page with `first: 100` + a `$endCursor` cursor
+var + `pageInfo { hasNextPage endCursor }`, let `gh api graphql --paginate` walk the
+pages, then merge them with `jq -s`.
 
 ```bash
-gh api graphql -f query='
-query($org: String!, $project: Int!) {
+# `--paginate` re-runs the query with $endCursor for each page (it keys off
+# `pageInfo.endCursor` — the cursor var MUST be named endCursor). It emits one JSON
+# document per page on stdout; `jq -s` (Step below) slurps them into one array.
+gh api graphql --paginate -f org=noorinalabs -F project=2 -f query='
+query($org: String!, $project: Int!, $endCursor: String) {
   organization(login: $org) {
     projectV2(number: $project) {
       id
-      items(first: 500) {
+      items(first: 100, after: $endCursor) {
+        pageInfo { hasNextPage endCursor }
         nodes {
           id
           content {
@@ -97,10 +143,23 @@ query($org: String!, $project: Int!) {
       }
     }
   }
-}' -f org=noorinalabs -F project=2 > /tmp/board-items.json
+}' > /tmp/board-items-pages.json
+
+# Merge the per-page documents into the single-object shape downstream jq expects:
+# `.data.organization.projectV2.{id,items.nodes[]}`. `jq -s` slurps the page stream
+# into an array; we flatten every page's nodes[] and keep page 0's project id (stable
+# across pages). Works whether there were 1 page or 14.
+jq -s '{ data: { organization: { projectV2: {
+          id: .[0].data.organization.projectV2.id,
+          items: { nodes: [ .[].data.organization.projectV2.items.nodes[] ] }
+        } } } }' /tmp/board-items-pages.json > /tmp/board-items.json
+
+echo "Board items fetched: $(jq '.data.organization.projectV2.items.nodes | length' /tmp/board-items.json)"
 ```
 
-Save raw to `/tmp/` (or `.claude/scratch/`) for downstream parsing.
+Save raw to `/tmp/` (or `.claude/scratch/`) for downstream parsing. A board-item count
+of **0** here is a red flag (the over-cap symptom) — investigate before treating every
+issue as an orphan, never run the apply steps off a zero-item fetch.
 
 ### 3. Detect orphans
 
@@ -108,8 +167,8 @@ Save raw to `/tmp/` (or `.claude/scratch/`) for downstream parsing.
 # Build set of URLs on the board
 BOARD_URLS=$(jq -r '.data.organization.projectV2.items.nodes[] | .content.url // empty' /tmp/board-items.json | sort -u)
 
-# Set of URLs found in repo issue lists
-ISSUE_URLS=$(printf '%s\n' "${ALL_ISSUES[@]}" | sort -u)
+# Set of URLs found in repo issue lists (collected to a file in Step 1)
+ISSUE_URLS=$(sort -u /tmp/all-issue-urls.txt)
 
 # Orphans = issues NOT on the board
 ORPHANS=$(comm -23 <(echo "$ISSUE_URLS") <(echo "$BOARD_URLS"))
@@ -121,11 +180,15 @@ echo "$ORPHANS" | head -20
 
 ### 4. Detect Wave-field drift
 
-For each board item that maps to an issue/PR with a wave label, compute the expected Wave-field option using the grammar above (`wave-{X}` → `W{X}`, legacy `p{N}-wave-{M}` → `P{N}W{M}`, `wave-x` → `WX`). Compare against the actual Wave-field value:
+Drift is computed **entirely in memory** by cross-referencing two maps already on disk —
+no per-board-item `gh issue view` (#888 defect 2; the old loop was ~1394 serial network
+calls). The expected Wave-field option per issue comes from `/tmp/issue-labels.tsv` (built
+in Step 1 from the bulk `--json url,labels` fetch, grammar `wave-{X}` → `W{X}`,
+`p{N}-wave-{M}` → `P{N}W{M}`, `wave-x` → `WX`); the board's actual Wave-field value comes
+from the Step-2 GraphQL response. A single hash-join `awk` matches them by URL.
 
 ```bash
-# For each board item, walk the labels of the linked issue/PR and find the wave label
-# (new `wave-{X}` or grandfathered `p{N}-wave-{M}`).
+# Board side: url \t item_id \t current-Wave-field (from the merged Step-2 response).
 jq -r '.data.organization.projectV2.items.nodes[]
        | select(.content.url != null)
        | "\(.content.url)\t\(.id)\t\(
@@ -135,49 +198,51 @@ jq -r '.data.organization.projectV2.items.nodes[]
              | .name] | first // "(unset)")
          )"' /tmp/board-items.json > /tmp/board-wave-values.tsv
 
-# Cross-join with issue labels.
-# (For each url in the tsv, fetch its labels via gh and compare.)
-#
-# Drift bucketing (see #427 for the regression that motivated the split):
+# In-memory hash join (NO network): first file builds url -> expected-option, second
+# file (board) is streamed and annotated with the expected option (or "(unset)" when the
+# issue carries no wave label / isn't an open issue — e.g. a PR or closed item).
+# NB: the map array is `want`, NOT `exp` — `exp` is awk's built-in exponential fn and
+# using it as an array name is a syntax error.
+awk -F'\t' '
+  NR==FNR { want[$1] = $2; next }                # /tmp/issue-labels.tsv : url -> W{X}
+  { e = ($1 in want) ? want[$1] : "(unset)";
+    print $1 "\t" $3 "\t" e }                     # url \t current_wave \t expected
+' /tmp/issue-labels.tsv /tmp/board-wave-values.tsv > /tmp/board-drift-join.tsv
+
+# Bucket the join rows (see #427 for the regression that motivated the split):
 #   DRIFT      — actionable rows where a mutation will change board state.
-#   NOOP_COUNT — issues with no wave label AND Wave field already (unset).
-#                Functionally `(unset) → (clear)`; the apply step's
-#                clearProjectV2ItemFieldValue is a no-op against a field
-#                already cleared. Counted separately so the operator sees
-#                "audit is clean" even when the no-op equivalence class is
-#                non-empty; MUST stay out of DRIFT so Step 7 doesn't emit
-#                redundant clear mutations and Step 5's gate doesn't
-#                over-report.
+#   NOOP_COUNT — no wave label AND Wave field already (unset). Functionally
+#                `(unset) → (clear)`; the apply step's clearProjectV2ItemFieldValue is a
+#                no-op against an already-cleared field. Counted separately so the operator
+#                sees "audit is clean" even when the no-op equivalence class is non-empty;
+#                MUST stay out of DRIFT so Step 7 doesn't emit redundant clear mutations and
+#                Step 5's gate doesn't over-report.
+# DRIFT rows carry REAL tab separators (`$'\t'`, not the literal backslash-t that a
+# double-quoted "\t" would store) so Step 7's `while IFS=$'\t' read` actually splits them.
 DRIFT=()
 NOOP_COUNT=0
-while IFS=$'\t' read -r url item_id current_wave; do
-  REPO=$(echo "$url" | sed -E 's#https://github.com/[^/]+/([^/]+)/.*#\1#')
-  NUM=$(echo "$url" | sed -E 's#.*/(issues|pull)/##')
-  LABEL=$(gh issue view "$NUM" --repo "noorinalabs/$REPO" --json labels \
-            --jq '.labels[].name' 2>/dev/null \
-          | grep -E '^p[0-9]+-wave-[0-9]+$' | sort -V | tail -1)
-
-  if [ -n "$LABEL" ]; then
-    EXPECTED=$(echo "$LABEL" | sed -E 's#p([0-9]+)-wave-([0-9]+)#P\1W\2#')
-    if [ "$current_wave" != "$EXPECTED" ]; then
-      DRIFT+=("$url\t$current_wave\t$EXPECTED")
+while IFS=$'\t' read -r url current_wave expected; do
+  [ -n "$url" ] || continue
+  if [ "$expected" != "(unset)" ]; then
+    if [ "$current_wave" != "$expected" ]; then
+      DRIFT+=("$url"$'\t'"$current_wave"$'\t'"$expected")
     fi
   elif [ "$current_wave" != "(unset)" ]; then
-    # Labeled with no wave label but Wave field is populated — should clear.
-    DRIFT+=("$url\t$current_wave\t(clear)")
+    # No wave label but Wave field is populated — should clear.
+    DRIFT+=("$url"$'\t'"$current_wave"$'\t'"(clear)")
   else
-    # No wave label AND Wave field already (unset) — already in desired
-    # state. Count for visibility; do NOT add to DRIFT.
+    # No wave label AND Wave field already (unset) — already in desired state.
     NOOP_COUNT=$((NOOP_COUNT + 1))
   fi
-done < /tmp/board-wave-values.tsv
+done < /tmp/board-drift-join.tsv
 
 echo "Actionable Wave-field drift:        ${#DRIFT[@]}"
 echo "No-op equivalents (unset == clear): ${NOOP_COUNT}"
 printf '%s\n' "${DRIFT[@]}" | head -30
 ```
 
-"Multiple wave labels (rare, transitional)" — `sort -V | tail -1` takes the highest-numbered which matches the issue body's "highest-numbered wins" rule.
+"Multiple wave labels (rare, transitional)" — Step 1's `sort_by(... | tonumber) | last`
+takes the highest-numbered, matching the issue body's "highest-numbered wins" rule.
 
 ### 5. Confirmation gate (mandatory)
 
@@ -333,6 +398,36 @@ If read-back actionable drift > 0, raise a warning and link to charter `pull-req
 - Daily cron (issue body Option B) — deferred unless drift recurs after this skill ships.
 - Auto-add via Hook 13 extension — Hook 13 catches in-session creates; extending it to cron-style cross-repo scans is the Option B path, deferred for the same reason.
 - Wave-field option auto-creation — `gh project field-create` requires project-edit scope; one-time owner action.
+
+## Skill-authoring notes — GitHub API access patterns
+
+These are the footguns this skill hit (main#888, surfaced during the P7W19 `/board-audit`
+run). Any skill that queries the GitHub GraphQL or REST APIs over a growing collection
+should heed them:
+
+- **GraphQL connections cap at 100 — always paginate.** Every GraphQL *connection*
+  (`items`, `nodes`, `issues`, …) rejects `first:` > 100 with a hard error and returns
+  zero rows. Use `first: 100` + `pageInfo { hasNextPage endCursor }` + a `$endCursor`
+  query var + `gh api graphql --paginate`, then merge pages with `jq -s`. Never raise
+  `first:` to "fit the dataset" — that is the over-cap regression (Step 2).
+- **Derive in memory; don't loop network calls per row.** If you already have the data in
+  a bulk response (or can get it in one `gh … --json` call per repo), cross-reference it
+  in memory (an `awk`/`jq` hash join) rather than an `O(collection)` per-item `gh view`
+  loop (Step 1 + Step 4).
+- **Wrap each external call in a `timeout` and skip-and-warn.** A single stalled `gh`/HTTP
+  call must not hang a whole multi-repo sweep; bound it and continue (Step 1).
+
+A cheap regression lint for the first item ships at
+[`.claude/lib/lint_skill_graphql_pagination.py`](../../lib/lint_skill_graphql_pagination.py):
+it flags `first: <n≥100>` inside a `gh api graphql` block across `.claude/skills/**/*.md`.
+Run it over the skills tree with:
+
+```bash
+python3 .claude/lib/lint_skill_graphql_pagination.py .claude/skills/**/*.md
+```
+
+Wiring it into pre-commit/CI is a deliberate follow-up (it is not yet a blocking gate); its
+detection logic is covered by `.claude/lib/tests/test_lint_skill_graphql_pagination.py`.
 
 ## Promotion provenance
 

--- a/.claude/skills/wave-retro/SKILL.md
+++ b/.claude/skills/wave-retro/SKILL.md
@@ -332,6 +332,12 @@ MD
     --body "$STUB_BODY")
   NEW_NUM=$(echo "$NEW_URL" | grep -oE '[0-9]+$')
   gh project item-add 2 --owner noorinalabs --url "$NEW_URL" 2>/dev/null || true
+  # NOTE (main#885): this reserves the id via the meta_issue key only and does
+  # NOT bump global_wave_seq (the counter advances at /wave-scope `allocate
+  # --write`). That split is SAFE because `wave_seq.py` is reservation-aware:
+  # `allocate`/`peek` detect this `wave_${NEXT_WAVE}_meta_issue` reservation at
+  # `global_wave_seq + 1` and claim THAT id instead of skipping past it. Do not
+  # "fix" this by adding a counter bump here — that would double-advance.
   python3 "$REPO_ROOT/.claude/lib/upsert_status_keys.py" "$REPO_ROOT/cross-repo-status.json" \
     "wave_${NEXT_WAVE}_meta_issue=\"noorinalabs-main#$NEW_NUM\""
   echo "AUTO-DRAFTED next-wave meta-issue stub: $NEW_URL"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,31 @@ jobs:
           # shellcheck disable=SC2086  # word-splitting is intended (one path per arg)
           python3 .claude/lib/check_fixture_realism.py $files
 
+  skill-graphql-pagination:
+    name: GraphQL pagination over-cap lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      # Skill-markdown GraphQL over-cap guard (#888/#892, wired by #893). Flags any
+      # `first: > 100` inside a `gh api graphql` block in a skill markdown file —
+      # GitHub caps connection `first:` at 100, and the silent zero-row read made
+      # `/board-audit` treat every issue as an orphan. Mirrors the
+      # `skill-graphql-pagination` pre-commit hook (the sync-drift gate classifies
+      # the kind, so this mirror is mandatory). The lint self-scopes to
+      # gh-api-graphql blocks, so a `first:` in prose is ignored.
+      - name: "Lint skill markdown for GraphQL first: > 100 over-cap"
+        run: |
+          files=$(find .claude/skills -name '*.md' -print)
+          if [ -z "$files" ]; then
+            echo "No skill markdown files found — pagination lint is a no-op here."
+            exit 0
+          fi
+          # shellcheck disable=SC2086  # word-splitting is intended (one path per arg)
+          python3 .claude/lib/lint_skill_graphql_pagination.py $files
+
   precommit-ci-sync:
     name: Pre-commit ⇄ CI sync-drift gate
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -116,6 +116,23 @@ repos:
         files: (^|/)(fixtures|test_data|testdata)/.*\.(json|jsonl|txt|csv|tsv|ndjson|py)$
         exclude: ^\.claude/worktrees/
         pass_filenames: true
+      # skill-graphql-pagination mirrors the `GraphQL pagination over-cap lint` CI
+      # job in ci.yml (the sync-drift gate classifies the `skill-graphql-pagination`
+      # kind — #888/#893 — so a CI-enforced lint not mirrored here turns the gate
+      # red, same contract as the two prose gates above). Flags any `first: > 100`
+      # inside a `gh api graphql` block in a skill markdown file — the over-cap
+      # footgun that made `/board-audit` read every issue as an orphan (#888). The
+      # lint self-scopes to `gh api graphql` blocks, so a `first:` in prose or a
+      # non-GraphQL recipe is ignored. Commit-stage (cheap static scan); `files:`
+      # restricts candidates to the skills tree, `pass_filenames` hands the changed
+      # *.md to the lint (whose CLI takes file args, like the prose gates above).
+      - id: skill-graphql-pagination
+        name: skill-graphql-pagination
+        entry: python3 .claude/lib/lint_skill_graphql_pagination.py
+        language: system
+        files: ^\.claude/skills/.*\.md$
+        exclude: ^\.claude/worktrees/
+        pass_filenames: true
 
   # Heavier checks run at pre-push (mirror CI's mypy + pytest jobs). Running as
   # `local`/`system` hooks so we use the system tools and don't drift from


### PR DESCRIPTION
## Phase 7 Wave 19 → main (noorinalabs-main)

Integration of the W19 framework / tech-debt wave branch into `main`. All 6 constituent PRs were reviewed by 2 distinct roster reviewers on green CI and squash-merged into the wave branch:

- #890 — main#885 `wave_seq.reserved_wave()` (keys off committed seq, not seed-inflated)
- #891 — main#886 `validate_pr_review` loop-guard co-location (`_loop_body_spans`)
- #889 — main#887 `ontology_gen` TypeScript extractor depth-aware comma split
- #892 — main#888 `/board-audit` GraphQL pagination + `lint_skill_graphql_pagination`
- #895 — main#893 wire the pagination lint into pre-commit + CI (sync-drift aware)
- #896 — main#894 loop-guard residual evasions (subshell + compound/subscripted args)

No new issue-closing here (per-issue PRs already closed their issues on wave-branch merge). Wave branch retained on merge.
