### PR TITLE
fix(hooks): parse cd-prefixed gh issue edit in PostToolUse parsers (main#901)

### DIFF
--- a/.claude/hooks/_shell_parse.py
+++ b/.claude/hooks/_shell_parse.py
@@ -253,6 +253,90 @@ def tokenize(cmd: str) -> list[str] | None:
         return None
 
 
+def normalize_command_separators(cmd: str) -> str:
+    """Quote/escape-aware normalization of shell command separators.
+
+    shlex.split treats a NEWLINE as ordinary whitespace and only recognizes
+    `;`/`&&`/`||`/`|` as standalone tokens when they are ALREADY surrounded by
+    whitespace. So two very common orchestrator idioms defeat
+    `iter_command_segments`, which relies on those separators surviving
+    tokenization as their own tokens:
+
+        cd "$(git rev-parse --show-toplevel)"\\n gh issue edit N --add-label ...
+        cd /some/dir; gh issue edit N --add-label ...
+
+    In the first the newline vanishes into whitespace, so `cd`, the command
+    substitution, and `gh` collapse into ONE segment whose first token is
+    `cd` — `find_gh_subcommand` bails and the parser returns empty (issue
+    #901: kickoff-comment + Wave-field-sync PostToolUse hooks silently skip).
+    In the second the `;` sticks to `/some/dir` (`/some/dir;`), so again no
+    separator token is produced.
+
+    This helper rewrites the raw command so shlex WILL emit the separators as
+    standalone tokens:
+      - line-continuation `\\<newline>` -> a single space (a continued command
+        is ONE command, not two — done first so a continuation newline is not
+        misread as a command separator);
+      - an unquoted, unescaped NEWLINE -> ` ; ` (newline is a command
+        terminator in shell, equivalent to `;`);
+      - an unquoted, unescaped `;` / `|` / `&&` / `||` -> the same operator
+        space-padded on both sides.
+
+    Quote/escape awareness is essential: a `|`/`;`/`&&`/newline INSIDE a single
+    or double quoted string (e.g. `--body "x && y"`, a multi-line
+    `--body "line1\\nline2"`) or preceded by a backslash is DATA, not a
+    separator, and is left byte-for-byte untouched. The result is only ever
+    fed back through `tokenize` (which re-applies line-continuation
+    normalization harmlessly), so injecting extra spaces around genuine
+    operators cannot change the parsed argument values.
+    """
+    cmd = _LINE_CONTINUATION_RE.sub(" ", cmd)
+    out: list[str] = []
+    i = 0
+    n = len(cmd)
+    quote: str | None = None  # active quote char: "'" or '"', else None
+    while i < n:
+        c = cmd[i]
+        if quote is not None:
+            out.append(c)
+            # Inside double quotes a backslash escapes the next char; inside
+            # single quotes nothing is special (shell single-quote semantics).
+            if c == "\\" and quote == '"' and i + 1 < n:
+                out.append(cmd[i + 1])
+                i += 2
+                continue
+            if c == quote:
+                quote = None
+            i += 1
+            continue
+        if c in ("'", '"'):
+            quote = c
+            out.append(c)
+            i += 1
+            continue
+        if c == "\\" and i + 1 < n:
+            # Escaped char outside quotes — emit both, do not treat as separator.
+            out.append(c)
+            out.append(cmd[i + 1])
+            i += 2
+            continue
+        if c == "\n":
+            out.append(" ; ")
+            i += 1
+            continue
+        if cmd[i : i + 2] in ("&&", "||"):
+            out.append(" " + cmd[i : i + 2] + " ")
+            i += 2
+            continue
+        if c in (";", "|"):
+            out.append(" " + c + " ")
+            i += 1
+            continue
+        out.append(c)
+        i += 1
+    return "".join(out)
+
+
 def strip_heredocs(cmd: str) -> str:
     """Remove all heredoc bodies. Iterates until no more matches (handles nested)."""
     prev = None

--- a/.claude/hooks/_wave_label_parse.py
+++ b/.claude/hooks/_wave_label_parse.py
@@ -121,6 +121,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _shell_parse import (  # noqa: E402
     find_gh_subcommand,
     iter_command_segments,
+    normalize_command_separators,
     strip_heredocs,
     tokenize,
 )
@@ -373,7 +374,11 @@ def parse_wave_label_changes(command: str) -> list[WaveLabelChange]:
     `gh issue edit 1 ... && gh issue edit 2 ...` shapes which is the
     dominant batch shape.
     """
-    cleaned = strip_heredocs(command)
+    # Strip heredocs FIRST (its regex needs the raw newlines to find the body),
+    # THEN normalize command separators so a leading `cd "$(...)"`-newline or a
+    # non-space-padded `;` prefix still segments the `gh issue edit/create`
+    # invocation into its own command segment (#901).
+    cleaned = normalize_command_separators(strip_heredocs(command))
     tokens = tokenize(cleaned)
     if tokens is None:
         return []
@@ -431,7 +436,11 @@ def parse_wave_label_create(command: str) -> list[WaveLabelCreate]:
     not the command tokens). The caller extracts the number from the
     PostToolUse `tool_response.stdout` URL.
     """
-    cleaned = strip_heredocs(command)
+    # Strip heredocs FIRST (its regex needs the raw newlines to find the body),
+    # THEN normalize command separators so a leading `cd "$(...)"`-newline or a
+    # non-space-padded `;` prefix still segments the `gh issue edit/create`
+    # invocation into its own command segment (#901).
+    cleaned = normalize_command_separators(strip_heredocs(command))
     tokens = tokenize(cleaned)
     if tokens is None:
         return []

--- a/.claude/hooks/tests/test__wave_label_parse.py
+++ b/.claude/hooks/tests/test__wave_label_parse.py
@@ -155,5 +155,124 @@ class ParseChangesAcceptsNewForms(unittest.TestCase):
         self.assertEqual(changes[0].add_label, "p6-wave-16")
 
 
+class CdPrefixedCommand(unittest.TestCase):
+    """#901: a `cd ...`-prefixed `gh issue edit/create` must still parse.
+
+    Before the `normalize_command_separators` fix, a leading `cd` joined to the
+    `gh` invocation by a NEWLINE (shlex eats newlines as whitespace) or by a
+    non-space-padded `;` (`/dir;` sticks together) collapsed `cd` and `gh` into
+    one command segment whose first token was `cd`. `find_gh_subcommand` bailed
+    and the parser returned an empty list — so both PostToolUse hooks
+    (`post_wave_kickoff_comment`, `post_label_change_wave_field_sync`) silently
+    skipped (`skip_parser_returned_empty`). These are the regression cases.
+    """
+
+    # The exact P7W20-kickoff shape from the issue repro: `cd "$(...)"` then a
+    # newline then the label-apply. This is the case that FAILS pre-fix.
+    _NEWLINE_CD = (
+        'cd "$(git rev-parse --show-toplevel)"\n'
+        'gh issue edit 901 --repo noorinalabs/noorinalabs-main --add-label "wave-20"'
+    )
+
+    def test_edit_newline_cd_subst_prefix(self) -> None:
+        changes = p.parse_wave_label_changes(self._NEWLINE_CD)
+        self.assertEqual(len(changes), 1)
+        self.assertEqual(changes[0].issue_number, "901")
+        self.assertEqual(changes[0].add_label, "wave-20")
+        self.assertEqual(changes[0].repo, "noorinalabs-main")
+
+    def test_edit_newline_cd_subst_prefix_singular(self) -> None:
+        change = p.parse_wave_label_change(self._NEWLINE_CD)
+        assert change is not None  # the kickoff-comment hook's entry point
+        self.assertEqual(change.add_label, "wave-20")
+
+    def test_edit_andand_cd_prefix(self) -> None:
+        changes = p.parse_wave_label_changes(
+            'cd "$(git rev-parse --show-toplevel)" && '
+            'gh issue edit 901 --repo noorinalabs/noorinalabs-main --add-label "wave-20"'
+        )
+        self.assertEqual(len(changes), 1)
+        self.assertEqual(changes[0].add_label, "wave-20")
+
+    def test_edit_semicolon_nospace_cd_prefix(self) -> None:
+        """`cd /dir; gh ...` — the `;` is not space-padded, so shlex keeps it
+        attached to `/dir` pre-fix; the normalizer splits it out."""
+        changes = p.parse_wave_label_changes(
+            'cd /some/dir; gh issue edit 5 --add-label "p6-wave-16"'
+        )
+        self.assertEqual(len(changes), 1)
+        self.assertEqual(changes[0].issue_number, "5")
+        self.assertEqual(changes[0].add_label, "p6-wave-16")
+
+    def test_create_newline_cd_prefix(self) -> None:
+        creates = p.parse_wave_label_create(
+            'cd "$(git rev-parse --show-toplevel)"\n'
+            "gh issue create --repo noorinalabs/noorinalabs-main "
+            '--title t --label "wave-20"'
+        )
+        self.assertEqual(len(creates), 1)
+        self.assertEqual(creates[0].add_label, "wave-20")
+        self.assertEqual(creates[0].repo, "noorinalabs-main")
+
+    def test_bare_command_unchanged(self) -> None:
+        """Regression guard: an un-prefixed command still parses identically."""
+        changes = p.parse_wave_label_changes(
+            'gh issue edit 42 --repo noorinalabs/noorinalabs-main --add-label "wave-16"'
+        )
+        self.assertEqual(len(changes), 1)
+        self.assertEqual(changes[0].add_label, "wave-16")
+
+    def test_operators_inside_quoted_arg_not_split(self) -> None:
+        """A `;`/`&&`/`|` INSIDE a quoted `--body` is data, not a separator:
+        the edit still parses and no spurious segment is introduced."""
+        changes = p.parse_wave_label_changes(
+            'cd /repo && gh issue edit 7 --add-label "wave-20" --body "run x && y; then z | w"'
+        )
+        self.assertEqual(len(changes), 1)
+        self.assertEqual(changes[0].issue_number, "7")
+        self.assertEqual(changes[0].add_label, "wave-20")
+
+
+class NormalizeCommandSeparators(unittest.TestCase):
+    """Direct tests for the shared `_shell_parse.normalize_command_separators`.
+
+    Assertions are whitespace-insensitive on purpose: the contract is that
+    after normalization + `tokenize`, the separator survives as its own token
+    so `iter_command_segments` splits correctly (exact space padding is an
+    implementation detail shlex collapses)."""
+
+    def setUp(self) -> None:
+        import _shell_parse as sp  # noqa: PLC0415
+
+        self.sp = sp
+
+    def _segments(self, cmd: str) -> list[list[str]]:
+        normalized = self.sp.normalize_command_separators(cmd)
+        tokens = self.sp.tokenize(normalized)
+        assert tokens is not None
+        return list(self.sp.iter_command_segments(tokens))
+
+    def test_unquoted_newline_becomes_separator(self) -> None:
+        self.assertEqual(self._segments("cmd1 a\ncmd2 b"), [["cmd1", "a"], ["cmd2", "b"]])
+
+    def test_nonspaced_semicolon_becomes_separator(self) -> None:
+        self.assertEqual(self._segments("cd /x; gh"), [["cd", "/x"], ["gh"]])
+
+    def test_andand_and_pipe_split(self) -> None:
+        self.assertEqual(self._segments("cd /x&&gh|jq"), [["cd", "/x"], ["gh"], ["jq"]])
+
+    def test_quoted_newline_preserved_as_single_token(self) -> None:
+        self.assertEqual(self._segments('echo "a\nb"'), [["echo", "a\nb"]])
+
+    def test_quoted_operators_not_split(self) -> None:
+        self.assertEqual(self._segments('echo "a && b; c | d"'), [["echo", "a && b; c | d"]])
+
+    def test_single_quote_operators_not_split(self) -> None:
+        self.assertEqual(self._segments("echo 'a; b'"), [["echo", "a; b"]])
+
+    def test_line_continuation_joined_not_split(self) -> None:
+        self.assertEqual(self._segments("echo a \\\n  b"), [["echo", "a", "b"]])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.claude/hooks/tests/test_validate_wave_label_evidence.py
+++ b/.claude/hooks/tests/test_validate_wave_label_evidence.py
@@ -414,5 +414,72 @@ class LineContinuationTests(unittest.TestCase):
         self.assertEqual(result["decision"], "block")
 
 
+class CdPrefixedCommandTests(unittest.TestCase):
+    """#901 fourth surface: a `cd <dir>`-prefixed `gh issue edit --add-label
+    wave-*` command must NOT bypass the evidence gate.
+
+    Root cause: `_find_issue_command` used the UNFIXED
+    `tokenize(strip_heredocs(command))` path. shlex treats a bare NEWLINE as
+    ordinary whitespace and only emits `;`/`&&` as standalone tokens when they
+    are ALREADY space-padded, so the two dominant orchestrator idioms —
+
+        cd "$(git rev-parse --show-toplevel)"\\n gh issue edit N --add-label ...
+        cd /repo; gh issue edit N --add-label ...            (no space before gh)
+
+    — collapse `cd`, its argument, and `gh` into ONE command segment whose
+    first token is `cd`. `find_gh_subcommand` bails, `_find_issue_command`
+    returns None, and the cited-path evidence gate is SILENTLY skipped
+    (fail-open). Applying `normalize_command_separators` before `tokenize`
+    (matching `_wave_label_parse.py`) restores segmentation so the gate
+    evaluates the command instead of bypassing it.
+
+    Each case cites an all-404 path → the gate must BLOCK (proving it reached
+    verification, i.e. was NOT bypassed). Pre-fix every case returned None
+    (allow/skip).
+    """
+
+    def test_newline_cd_prefixed_edit_does_not_bypass_gate(self):
+        # Canonical #901 repro: `cd "$(...)"`<newline>`gh issue edit ...`.
+        body = "## Summary\nFile at noorinalabs-main/.claude/hooks/gone.py is removed.\n"
+        cmd = (
+            'cd "$(git rev-parse --show-toplevel)"\n'
+            "gh issue edit 100 --repo noorinalabs/noorinalabs-main --add-label 'wave-22'"
+        )
+        fake = _fake_subprocess_factory(main_exists=set(), issue_body=body)
+        with mock.patch.object(hook.subprocess, "run", side_effect=fake):
+            result = hook.check(_bash_input(cmd))
+        assert result is not None, "cd-newline-prefixed edit bypassed the evidence gate (fail-open)"
+        self.assertEqual(result["decision"], "block")
+        self.assertIn("noorinalabs-main/.claude/hooks/gone.py", result["reason"])
+        self.assertIn("wave-22", result["reason"])
+
+    def test_semicolon_cd_prefixed_edit_does_not_bypass_gate(self):
+        # `cd /repo;gh issue edit ...` — the `;` sticks to `/repo` under raw
+        # shlex, so no separator token is produced pre-fix.
+        body = "## Summary\nFile at noorinalabs-main/.claude/hooks/gone.py is removed.\n"
+        cmd = "cd /repo;gh issue edit 100 --repo noorinalabs/noorinalabs-main --add-label 'wave-22'"
+        fake = _fake_subprocess_factory(main_exists=set(), issue_body=body)
+        with mock.patch.object(hook.subprocess, "run", side_effect=fake):
+            result = hook.check(_bash_input(cmd))
+        assert result is not None, "cd-semicolon-prefixed edit bypassed the evidence gate"
+        self.assertEqual(result["decision"], "block")
+        self.assertIn("noorinalabs-main/.claude/hooks/gone.py", result["reason"])
+
+    def test_newline_cd_prefixed_create_does_not_bypass_gate(self):
+        # Create surface of the same shape: `cd <dir>`<newline>`gh issue create`.
+        body = "## Summary\nFile at noorinalabs-main/.claude/hooks/gone.py is removed.\n"
+        cmd = (
+            'cd "$(git rev-parse --show-toplevel)"\n'
+            "gh issue create --repo noorinalabs/noorinalabs-main --title T "
+            f"--body {body!r} --label 'wave-22'"
+        )
+        fake = _fake_subprocess_factory(main_exists=set())
+        with mock.patch.object(hook.subprocess, "run", side_effect=fake):
+            result = hook.check(_bash_input(cmd))
+        assert result is not None, "cd-newline-prefixed create bypassed the evidence gate"
+        self.assertEqual(result["decision"], "block")
+        self.assertIn("noorinalabs-main/.claude/hooks/gone.py", result["reason"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.claude/hooks/validate_wave_label_evidence.py
+++ b/.claude/hooks/validate_wave_label_evidence.py
@@ -65,6 +65,7 @@ from _repo_flag_parse import extract_repo  # noqa: E402
 from _shell_parse import (  # noqa: E402
     find_gh_subcommand,
     iter_command_segments,
+    normalize_command_separators,
     resolve_repo_short_name,
     strip_heredocs,
     tokenize,
@@ -137,8 +138,17 @@ def _find_issue_command(command: str) -> tuple[str, str | None, list[str]] | Non
     and `rest_tokens` is the post-`gh` token tail (e.g.
     `["issue", "create", "--label", ...]`). Returns None when no matching
     segment is present or the command does not tokenize.
+
+    Strip heredocs FIRST (its regex needs the raw newlines to find the body),
+    THEN normalize command separators so a leading `cd "$(...)"`-newline or a
+    non-space-padded `;`/`&&` prefix still segments the `gh issue edit/create`
+    invocation into its own command segment. Without this the evidence gate
+    fails OPEN on a `cd x && gh issue edit N --add-label wave-22` command:
+    `find_gh_subcommand` returns None on the collapsed `cd ... gh ...` segment,
+    `_find_issue_command` returns None, and the cited-path check is skipped
+    (#901 — the fourth surface of the same cd-prefix blind spot).
     """
-    tokens = tokenize(strip_heredocs(command))
+    tokens = tokenize(normalize_command_separators(strip_heredocs(command)))
     if tokens is None:
         return None
     for segment in iter_command_segments(tokens):


### PR DESCRIPTION
## Summary

Fixes **main#901**: the two wave-label PostToolUse hooks —
`post_wave_kickoff_comment` and `post_label_change_wave_field_sync` — silently
skipped (`skip_parser_returned_empty`) whenever the label-apply command was
prefixed with a `cd ...` line, e.g. the P7W20-kickoff shape:

```
cd "$(git rev-parse --show-toplevel)"
gh issue edit 901 --repo noorinalabs/noorinalabs-main --add-label "wave-20"
```

## Root cause

`shlex.split` treats a NEWLINE as ordinary whitespace, and only tokenizes
`;`/`&&`/`||`/`|` as standalone separators when they are already
whitespace-padded. So a newline-joined (or non-space `;`-joined) `cd` + `gh`
collapsed into ONE command segment whose first token was `cd`;
`find_gh_subcommand` requires the segment to start with `gh`, bailed, and the
parser returned an empty list. The label-apply itself succeeded — only the two
automations no-op'd (kickoff comment not posted, Wave field unsynced).

## Fix (shared path, once)

- Add quote/escape-aware `normalize_command_separators()` to `_shell_parse.py`:
  rewrites unquoted newlines to ` ; ` and space-pads unquoted
  `;`/`&&`/`||`/`|` so shlex emits them as separator tokens. Operators and
  newlines **inside** quoted args (e.g. `--body "x && y; z"`, multi-line
  bodies) and backslash-escaped chars are left byte-for-byte untouched.
- `_wave_label_parse.py` applies it (after `strip_heredocs`, before
  `tokenize`) in **both** `parse_wave_label_changes` and
  `parse_wave_label_create` — so all three affected surfaces (kickoff comment,
  EDIT field-sync, CREATE field-sync) are fixed by one shared change.
- The global `tokenize` is deliberately left unchanged (15+ hooks, incl.
  security-critical commit-identity/git-config, depend on it); the fix is
  scoped to the wave-label parser path that #901 traverses.

Un-prefixed commands parse identically to before.

## Tests

New `CdPrefixedCommand` and `NormalizeCommandSeparators` classes in
`test__wave_label_parse.py`. The newline-`cd`-substitution and non-spaced-`;`
cases **fail pre-fix** (verified by neutralizing the normalizer: 4/7 fail) and
pass post-fix. Includes a regression guard for un-prefixed commands and for
operators inside quoted args.

## Verification (local ⇄ CI parity)

- `pytest .claude/hooks/tests/ .claude/lib/tests/` — 2269 passed
- `ruff@0.15.11 format --check` + `ruff@0.15.11 check` — clean
- `mypy --ignore-missing-imports` on changed files — clean
- `pre_commit_ci_sync.py .` — OK (mirror intact)

## Reviewers

- **Wanjiku Mwangi** (peer)
- **Santiago Ferreira** (secondary)

Closes #901
