### PR TITLE
memory: Hook 4's verdict field is RequestOrReplied, never Verdict

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -73,7 +73,7 @@
 - [Verify PostToolUse firing before trusting hook](feedback_verify_posttooluse_firing.md) — at session start, fire one disposable Bash failure to verify annunaki_monitor logs it.
 - [Pre-spawn verify file existence at HEAD](feedback_pre_spawn_verify_file_exists.md) — per-file claims in briefs need git cat-file -e origin/<branch>:<path>, not ls/working-tree.
 - [Reviewer must not branch-switch parent](feedback_reviewer_no_branch_switch.md) — reviewers read PR code via gh api contents?ref=<sha>; MUST NOT git checkout in parent.
-- [Verdict count must match Hook 4 regex](feedback_verdict_count_hook_regex.md) — pre-spawn verdict counts must accept BOTH Requestor: bare AND **Requestor:** bold forms.
+- [Verdict count must match Hook 4 regex](feedback_verdict_count_hook_regex.md) — field is RequestOrReplied:, NEVER Verdict:, after the LAST sole --- line; hooks fail open. main#932.
 - [Requestor must be space-form roster name](feedback_requestor_roster_name_form.md) — Hook4 roster-validates Requestor; dotted First.Last counts as non-roster → 0/2 block; dictate exact name in briefs, fix by REST PATCH. da PR#269.
 - [Safety direction > UX friction](feedback_safety_direction_over_ux_friction.md) — when a hook can't auto-fix cleanly, HARD BLOCK with diagnostic, never allow_with_log. PR#494.
 - [Investigate before implement on unevidenced brief](feedback_investigate_before_implement.md) — brief asserts problem w/o evidence → origin-audit BEFORE Edit/Write. ds#81.

--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -29,7 +29,7 @@
 - [Wave planning from project board](feedback_wave_planning_from_board.md) — Project 2 is authoritative backlog; labels are post-scoping tags. 37% drift 2026-04-23.
 - [Enforcement hierarchy](feedback_enforcement_hierarchy.md) — prefer hook > skill > charter; charter rules without enforcement decay.
 - [Spawn-brief Requestor field](feedback_spawn_brief_requestor.md) — reviewer-spawn briefs name reviewer as Requestor, PR author as Requestee. PR#349.
-- [Hook 4 prose false-match](feedback_hook4_regex_prose_false_match.md) — NEVER reproduce literal Field:Value shape in review prose; Hook4 first-match grabs it as the verdict.
+- [Prose false-match is the FORMAT hook](feedback_hook4_regex_prose_false_match.md) — never write literal Field:Value in prose; blocker is validate_review_comment_format, not Hook4 (#511).
 - [SSH topology](reference_ssh_topology.md) — mental model, key-to-user mapping, owner pitfalls; verify w/ whoami each session.
 - [Verify diagnosis before delegating](feedback_verify_diagnosis_before_delegating.md) — run git log -- <path> before spawning a fix agent; API state ≠ ground truth. #162.
 - [Check accepted ADRs before spawn](feedback_check_accepted_adr_before_spawn.md) — an issue may propose what an accepted ADR rejected; that's an owner call, not implementer work.

--- a/.claude/memory/feedback_hook4_regex_prose_false_match.md
+++ b/.claude/memory/feedback_hook4_regex_prose_false_match.md
@@ -29,4 +29,14 @@ Only the ACTUAL trailer at the bottom of the comment should contain the literal 
 
 **The charter-promotion candidate this file used to propose has SHIPPED.** "Require the structured-fields block as the LAST lines of the comment, or scan bottom-up" is `#511`, live in `validate_pr_review` as `_trailer_block_substring` + last-match-wins + `_strip_code_regions`. The open half is `validate_review_comment_format`'s unanchored whole-body `re.search`, tracked in main#932/#934.
 
-**Standing lesson, larger than this file:** a memory that records a defect *and proposes its fix* becomes false the day the fix lands, and it will not tell you. Nothing in a memory file observes the code it describes. **When you land a fix, grep the memory corpus for the defect and amend it in the same PR** — otherwise the memory outlives the bug and starts teaching a mechanism that no longer exists. This file taught one for roughly two months. Sibling: [[feedback_dep_resolution_invalidates]].
+**Standing lesson, larger than this file** (sharpened by Oyunbileg Batbayar, 2026-07-09): a memory that records a defect *and proposes its fix* has **pre-declared the condition under which it becomes false.** Nothing in a memory file observes the code it describes, so the day the proposal lands, the memory silently starts teaching a mechanism that no longer exists. This file taught one for roughly two months.
+
+"Grep the corpus whenever you land a fix" is the general rule and it is weak, because nobody remembers to run it. The strong, cheap special case:
+
+> **Any memory whose body proposes a remedy must name the artifact that will falsify it** — the issue, the PR, the hook — so the grep has a key, and so the person landing that artifact can find the memory from the fix rather than the other way round.
+
+Had this file's closing paragraph read *"falsified by whatever ships the bottom-up scan"*, #511 would have been searchable from here on the day it merged. Sibling: [[feedback_dep_resolution_invalidates]].
+
+**The fail-closed direction, which nobody had written down** (Oyunbileg, verified at main#934's head `1ba68da4`): `validate_review_comment_format`'s captured group is not discarded — it flows to `_extract_lastname` and into the Requestor/Requestee swap heuristic, which ends in `decision: block`. So the *same* unscoped `re.search` can **block a correctly-formed verdict** (when the prose's final token is the PR author's surname) and **pass a genuinely swapped one** (when it isn't). One line, two opposite failures, and which one fires depends on the reviewer's sentence.
+
+Note the trap inside the trap: `_extract_lastname` returns the **final token**, so prose ending in a full stop yields `''` and blocks nothing. **A repro whose sentence ends in a period cannot go red** — an inert fixture inside the demonstration of a hook bug. Tracked in main#932.

--- a/.claude/memory/feedback_hook4_regex_prose_false_match.md
+++ b/.claude/memory/feedback_hook4_regex_prose_false_match.md
@@ -1,17 +1,23 @@
 ---
 name: feedback_hook4_regex_prose_false_match
-description: "Avoid literal `Field: Value` strings in review-comment prose — Hook 4's first-match regex grabs them as the verdict's structured-field, mis-classifying the verdict"
+description: "Avoid literal `Field: Value` strings in review-comment prose. The hook that bites is `validate_review_comment_format` (unanchored whole-body FIRST-match `re.search`), NOT Hook 4 — Hook 4 was scoped by #511 to the trailer block with last-match-wins. The rule is right; the mechanism in this file's title is wrong."
 metadata: 
   node_type: memory
   type: feedback
   originSessionId: 02cdc334-fbe1-4680-8b6b-975c55fd3a44
 ---
 
-In review-comment prose, NEVER reproduce the literal `Requestor: <name>` / `Requestee: <name>` / `RequestOrReplied: <value>` / `TechDebt: <value>` pattern, even inside an inline-code span or describing an absence. Hook 4's first-match regex scans the comment top-to-bottom and grabs the FIRST occurrence as the verdict's structured field, regardless of surrounding context.
+In review-comment prose, NEVER reproduce the literal `Requestor: <name>` / `Requestee: <name>` / `RequestOrReplied: <value>` / `TechDebt: <value>` pattern. **The rule stands. The mechanism this file's title gives for it is wrong, and was corrected 2026-07-09 (main#933 review, Wanjiku Mwangi).**
 
-**Why:** Hook 4 (validate_pr_review.py in the noorinalabs-main repo) parses verdict-comment structured fields with a first-match regex. When prose contains the literal `Requestor:` (e.g., "the PR body lacks the `Requestor: / Requestee: / RequestOrReplied: New / TechDebt: none` trailer"), the regex captures everything from `Requestor:` to the next newline as the Requestor field value — yielding `Requestor="/ Requestee: / RequestOrReplied: New / TechDebt: none"` instead of the intended `Requestor: Lucas Ferreira` from the trailer. The hook then mis-classifies the verdict's author, the 2-reviewer-approved gate doesn't register the approval, and merge blocks until the comment is PATCHed.
+## Which hook actually bites (verified against source, 2026-07-09)
 
-**Past incidents:** P3W11 PR #337 (my review) — orchestrator had to PATCH the comment to break the regex match. Same pattern bit Wanjiku on PR #509 earlier the same day. Both went to the orchestrator's manual fix-up cycle.
+**Not Hook 4.** `validate_pr_review._extract_charter_field` was scoped by **#511**: it calls `_strip_code_regions` (blanking fenced *and* inline code), then `_trailer_block_substring` (keeping only text after the **last** sole `---` line), then matches **last-match-wins** within that scope. Its own docstring names the incidents below as the patterns #511 fixed. **When a sole `---` exists, Hook 4 cannot see prose above it at all.** It remains prose-sensitive only for the shape appearing *inside* the trailer, and in the legacy no-separator fallback.
+
+**`validate_review_comment_format` is the one that bites.** Its probe is a bare `re.search(r"\*{0,2}Requestor:\*{0,2}\s*(.+)", body)` over the **whole body** — first match, no `^`, no `MULTILINE`, no code-stripping, no trailer narrowing. A sentence four screens above your trailer is what blocks the `gh pr comment`.
+
+**Two hooks, opposite scoping disciplines, one rule.** Writing the rule down against the forgiving hook is how it nearly became superstition: the orchestrator repeated *"Hook 4 first-matches your prose"* to four reviewers on 2026-07-09, each of whom could have read `validate_pr_review.py` and found it false. **A rule with a false mechanism gets applied in the wrong place, or dropped as folklore the first time someone checks.**
+
+**Past incidents (all PRE-#511, all against the then-unscoped Hook 4):** P3W11 PR #337 — orchestrator had to PATCH the comment to break the regex match. Same pattern bit Wanjiku on PR #509 earlier the same day. This file's own closing paragraph proposed the fix — *"require the structured-fields block as the LAST lines of the comment, or scan bottom-up"* — and **#511 shipped exactly that.** The memory was never updated. **The proposal landing is what made the memory wrong**, and nothing in the file could tell you so.
 
 **How to apply:** In any text I author that may be parsed by Hook 4 (PR review comments, PR bodies, PR descriptions, follow-up comments), describe the structured-field block in non-literal form:
 
@@ -21,4 +27,6 @@ In review-comment prose, NEVER reproduce the literal `Requestor: <name>` / `Requ
 
 Only the ACTUAL trailer at the bottom of the comment should contain the literal `Field: Value` form. If I need to quote the exact form for a teammate, do it in plain English description or wrap each field name without the colon (e.g., backtick the field name alone: ``the `Requestor` line``). Related: [[feedback_techdebt_literal_line_not_section]] (TechDebt placement); [[feedback_validate_pr_review_approved]] (RequestOrReplied value); [[feedback_spawn_brief_requestor]] (Requestor field assignment).
 
-**Charter-promotion candidate:** the parallel incident with Wanjiku on #509 confirms this is a recurring shape, not a one-off. A hook-level fix (require structured-fields block as the LAST lines of the comment, or scan bottom-up, or require all four adjacent lines as a group) would prevent the whole class. Worth a follow-up issue on the noorinalabs-main hooks if not already filed — orchestrator may have it under their task #34.
+**The charter-promotion candidate this file used to propose has SHIPPED.** "Require the structured-fields block as the LAST lines of the comment, or scan bottom-up" is `#511`, live in `validate_pr_review` as `_trailer_block_substring` + last-match-wins + `_strip_code_regions`. The open half is `validate_review_comment_format`'s unanchored whole-body `re.search`, tracked in main#932/#934.
+
+**Standing lesson, larger than this file:** a memory that records a defect *and proposes its fix* becomes false the day the fix lands, and it will not tell you. Nothing in a memory file observes the code it describes. **When you land a fix, grep the memory corpus for the defect and amend it in the same PR** — otherwise the memory outlives the bug and starts teaching a mechanism that no longer exists. This file taught one for roughly two months. Sibling: [[feedback_dep_resolution_invalidates]].

--- a/.claude/memory/feedback_verdict_count_hook_regex.md
+++ b/.claude/memory/feedback_verdict_count_hook_regex.md
@@ -1,6 +1,6 @@
 ---
 name: feedback_verdict_count_hook_regex
-description: "Orchestrator pre-spawn verdict-count queries must match Hook 4's actual parser regex (accepts `**Requestor:**` bold-markdown AND bare `Requestor:`) — a brittle jq `startswith(\"Requestor:\")` misses bold-form verdicts and triggers stale-state respawns"
+description: "The verdict field Hook 4 parses is `RequestOrReplied:`, never `Verdict:`, and it must sit after the LAST sole `---` line in the body. Orchestrator verdict-count queries must match the hook's real regex (bold `**Requestor:**` and bare both parse) — and the hooks fail OPEN on every near-miss, so a wrong field name costs zero reviews silently"
 metadata: 
   node_type: memory
   type: feedback
@@ -8,6 +8,21 @@ metadata:
 ---
 
 When auditing PR verdict comments to decide whether to spawn a second reviewer, the orchestrator MUST count verdicts using the **same regex Hook 4 (`validate_pr_review.py`) actually uses**, not a brittle prefix-string match.
+
+## The field is `RequestOrReplied:`. It is never `Verdict:`. (2026-07-09, main#932)
+
+Charter `pull-requests.md:14` names the field, and `_extract_charter_field` reads exactly that name. **`Verdict:` is not a field any hook knows.** A comment reading `Verdict: Approved` contributes **zero** to the two-reviewer threshold.
+
+Two placement rules are as load-bearing as the name:
+
+- `_trailer_block_substring` returns only the text **after the LAST line that is a sole `---`**. Correctly-spelled fields sitting *above* a later separator are invisible. Put the trailer block last.
+- `_strip_code_regions` blanks fenced and inline code before matching, and `_extract_charter_field` is **last-match-wins** within the trailer. Never reproduce the `Field: Value` shape in review prose.
+
+**The regression (2026-07-09, wave 24):** orchestrator spawn briefs dictated `Verdict:`. The whole team complied. **Nine `Approved` comments across five PRs parsed as nothing.** main#930 blocked as `0/2 required peer reviews` with three approvals sitting on it. PRs merged 07-06 used the correct field, so the drift was one session old and invisible for its whole life. Repaired by REST-PATCHing a canonical trailer onto each comment (append after a `---`, remove nothing) and re-verifying with `validate_pr_review.check_comment_reviews` **imported from the hook module**, not a hand-rolled regex — the same mistake one level up would have "confirmed" the fix.
+
+**Why it was silent, which is the real defect:** `validate_review_comment_format.py` sees `Requestor:` + `Requestee:` present and `RequestOrReplied:` absent and **returns None — allow**. Its `is_comment_command` matches only `gh pr comment`, so REST-posted verdicts (the GraphQL-rate-limit fallback) never reach it at all; and `extract_comment_body` reads only `--body`/heredoc, so even a matched `gh api … --input body.json` yields an empty body and fails open a second time. Three fail-open paths, no signal to the reviewer, no signal to the orchestrator, and the shortfall surfaces hours later at merge time **attributed to the reviewers**. Fix tracked in main#932.
+
+This is the measurement family one level up: not a probe that cannot return nonzero, but **a review that cannot be counted, which is indistinguishable from no review at all.** See [[feedback_silent_zero_is_not_a_measurement]].
 
 Hook 4's `_extract_charter_field` regex (per `.claude/hooks/validate_pr_review.py:254-268`):
 

--- a/.claude/memory/feedback_verdict_count_hook_regex.md
+++ b/.claude/memory/feedback_verdict_count_hook_regex.md
@@ -11,23 +11,31 @@ When auditing PR verdict comments to decide whether to spawn a second reviewer, 
 
 ## The field is `RequestOrReplied:`. It is never `Verdict:`. (2026-07-09, main#932)
 
-Charter `pull-requests.md:14` names the field, and `_extract_charter_field` reads exactly that name. **`Verdict:` is not a field any hook knows.** A comment reading `Verdict: Approved` contributes **zero** to the two-reviewer threshold.
+Charter `pull-requests.md` names the field, and **`check_comment_reviews` asks `_extract_charter_field` for `RequestOrReplied` — nothing else does.** `_extract_charter_field` itself reads *whatever name you pass it*: the name is a parameter, `re.escape(field_name)`. So `_extract_charter_field("Verdict", body)` happily returns `'Approved'` and tells you nothing. **The binding to the charter field lives at the call site, not in the helper** — which matters because the natural way to "confirm" a repaired near-miss comment is to call the helper with whatever label the comment carries, and it will answer.
+
+**`Verdict:` is not a field any hook asks for.** A comment reading `Verdict: Approved` contributes **zero** to the two-reviewer threshold.
 
 Two placement rules are as load-bearing as the name:
 
 - `_trailer_block_substring` returns only the text **after the LAST line that is a sole `---`**. Correctly-spelled fields sitting *above* a later separator are invisible. Put the trailer block last.
-- `_strip_code_regions` blanks fenced and inline code before matching, and `_extract_charter_field` is **last-match-wins** within the trailer. Never reproduce the `Field: Value` shape in review prose.
+- `_strip_code_regions` blanks fenced and inline code before matching, and `_extract_charter_field` is **last-match-wins** within the trailer.
+
+**Never reproduce the `Field: Value` shape in review prose — but know which hook bites.** The *counting* hook (`validate_pr_review`) cannot see prose above the trailer at all: when a sole `---` exists, everything before it is sliced away, and within the trailer it is last-match-wins. It is prose-sensitive only for a shape appearing *inside* the trailer, or in the legacy no-separator fallback. The hook that actually blocks you for a sentence written four screens above the trailer is **`validate_review_comment_format`**, whose `Requestor` probe is an unanchored, unscoped, whole-body `re.search` — **first** match, no `^`, no `MULTILINE`, no trailer narrowing. Two hooks, opposite scoping disciplines. See [[feedback_hook4_regex_prose_false_match]], whose title names the wrong one.
 
 **The regression (2026-07-09, wave 24):** orchestrator spawn briefs dictated `Verdict:`. The whole team complied. **Nine `Approved` comments across five PRs parsed as nothing.** main#930 blocked as `0/2 required peer reviews` with three approvals sitting on it. PRs merged 07-06 used the correct field, so the drift was one session old and invisible for its whole life. Repaired by REST-PATCHing a canonical trailer onto each comment (append after a `---`, remove nothing) and re-verifying with `validate_pr_review.check_comment_reviews` **imported from the hook module**, not a hand-rolled regex — the same mistake one level up would have "confirmed" the fix.
 
-**Why it was silent, which is the real defect:** `validate_review_comment_format.py` sees `Requestor:` + `Requestee:` present and `RequestOrReplied:` absent and **returns None — allow**. Its `is_comment_command` matches only `gh pr comment`, so REST-posted verdicts (the GraphQL-rate-limit fallback) never reach it at all; and `extract_comment_body` reads only `--body`/heredoc, so even a matched `gh api … --input body.json` yields an empty body and fails open a second time. Three fail-open paths, no signal to the reviewer, no signal to the orchestrator, and the shortfall surfaces hours later at merge time **attributed to the reviewers**. Fix tracked in main#932.
+**Why it was silent, which is the real defect:** `validate_review_comment_format.py` sees `Requestor:` + `Requestee:` present and `RequestOrReplied:` absent and **returns None — allow**. Its `is_comment_command` matches only `gh pr comment`, so REST-posted verdicts (the GraphQL-rate-limit fallback) never reach it at all; and `extract_comment_body` does not read `--body-file` — **the form charter `agents.md` mandates**, and the one used ~438 times across `.claude/` — nor a quoted `-F body=@"…"`, nor any `$VAR` in a path, so a matched command yields an empty body and fails open again.
+
+**Do not quote a count of these paths.** It was "three" when written; reviewing main#934 turned up `--body-file`, quoted `@path`, and unexpanded `$VAR`; the corpus replay then turned up two more (the segment splitter never split on newlines; `URL=$(gh api -X POST …)` was swallowed by the env-prefix stripper). **A count restated in a second artifact drifts from the artifact that owns it.** Say "several, enumerated in main#932/#934" and let those issues own the number.
+
+No signal to the reviewer, no signal to the orchestrator, and the shortfall surfaces hours later at merge time **attributed to the reviewers**.
 
 This is the measurement family one level up: not a probe that cannot return nonzero, but **a review that cannot be counted, which is indistinguishable from no review at all.** See [[feedback_silent_zero_is_not_a_measurement]].
 
-Hook 4's `_extract_charter_field` regex (per `.claude/hooks/validate_pr_review.py:254-268`):
+Hook 4's `_extract_charter_field` regex (cite the **symbol**, never a line range — the range in the first draft of this memory pointed at `:254-268`, which is a shell-word scanner; the function had moved to `:604` before the memory was even reviewed. **The rot is the argument.**):
 
 ```python
-r"\*{0,2}" + field_name + r":\*{0,2}"
+rf"\*{{0,2}}{re.escape(field_name)}:\*{{0,2}}\s*(.+)"
 ```
 
 That accepts BOTH:
@@ -41,17 +49,37 @@ A jq query like `select(.body | startswith("Requestor:"))` matches only the bare
 
 P3W11 instance (2026-05-18 ~01:00Z): Wanjiku had posted Approved on PR #459 at 04:12:50Z (prior session) using `**Requestor:** Wanjiku Mwangi` bold-markdown. My orchestrator jq query skipped it. Re-spawned a Wanjiku review task; she refreshed at origin, surfaced the stale state, did NOT post a duplicate. Clean recovery thanks to her `feedback_stale_inbox_manager` + `feedback_refresh_before_status_claim` discipline — but the round-trip was avoidable at the orchestrator side.
 
+## The `jq` remedy this memory used to prescribe was wrong, in the unsafe direction (corrected 2026-07-09, main#933 review)
+
+The first draft's step 1 was a hand-rolled `jq` count. **Aino Virtanen ran it and it fails two independent ways**, both found by executing it rather than reading it:
+
+- **`jq`'s `^` is string-anchored, not line-anchored** (`jq`'s `m` flag is dotall, not multiline). Against a comment shaped the way *this very memory mandates* — prose first, trailer last after a sole `---` — it returns **0** where the hook module returns **1**. It only ever appeared to work because the trailers it was tested on happened to sit at the top of the body.
+- **It never filters on the verdict value at all.** It counts distinct authors of any comment carrying a `Requestor` line — requests, replies and blocking verdicts alike. On one `ChangesRequested` plus one `Reply`, with **zero** approvals, it prints **`2`**.
+
+It also skips all three of the hook's scoping steps: no code-region stripping, no trailer-block narrowing, no `Approved`-only filter.
+
+**The direction of the error is what makes this a rule and not a nit.** The memory's stated failure mode was over-spawning a redundant reviewer — a five-minute round trip. The remedy's actual failure mode is **over-counting**: read "2", conclude the gate is clear, skip the second reviewer, merge with fewer reviews than the charter requires *believing you have them*. On 2026-07-09 the orchestrator held exactly that belief about main#933 and main#936; both carried **zero** review comments, and only Hook 4's refusal at merge time surfaced it.
+
+**The memory contained its own correct answer and declined to use it.** Its own regression paragraph records that the repair was verified by importing `check_comment_reviews` **from the hook module**, "not a hand-rolled regex — the same mistake one level up would have confirmed the fix." Step 1 *was* that hand-rolled regex.
+
 **How to apply:**
 
-1. When counting verdicts, use a regex that matches Hook 4's acceptance:
-   ```bash
-   gh api repos/.../issues/<N>/comments \
-     --jq '[.[] | select(.body | test("^\\*{0,2}Requestor:\\*{0,2}\\s")) | (.body | capture("^\\*{0,2}Requestor:\\*{0,2}\\s+(?<r>[^\\n]+)") | .r)] | unique | length'
+1. **Count by importing the hook, never by re-implementing it.** It is the only count that cannot drift from what the hook does, because it *is* what the hook does:
+   ```python
+   import sys; sys.path.insert(0, ".claude/hooks")
+   from validate_pr_review import _extract_charter_field, _is_approved
+   approvers = {
+       r for c in comments
+       if (r := _extract_charter_field("Requestor", c["body"]))
+       and _is_approved(_extract_charter_field("RequestOrReplied", c["body"]) or "")
+   }
    ```
-   This counts distinct Requestor names regardless of bold/bare formatting.
+   Any `jq`/`grep` reimplementation must reproduce code-stripping, trailer-narrowing, last-match-wins **and** the `Approved`-only filter. Four chances to be silently wrong. Do not take them.
 
-2. Or, even simpler: read each "Requestor:"-bearing comment fully and let the reviewer logic itself decide — don't try to pre-filter.
+2. Or, even simpler: read each `Requestor`-bearing comment fully and let the reviewer logic itself decide — don't try to pre-filter.
 
-3. Pre-spawn checklist for reviewer tasks: BEFORE composing the brief, run the Hook 4-equivalent count. If already at 2-of-2 Approved (distinct Requestors), skip the spawn — the gate is clear.
+3. Pre-spawn checklist for reviewer tasks: BEFORE composing the brief, run the hook-imported count. If already at 2-of-2 Approved (distinct Requestors), skip the spawn — the gate is clear. **A count you cannot trace to the hook is not evidence the gate is clear.**
+
+4. **An approval that predates the head is not an approval.** The hook counts *comments*, not shas — it will happily count a verdict written against code that no longer exists. Freshness is the orchestrator's job, and no hook does it for you.
 
 Sibling rule to [[feedback_refresh_before_status_claim]] (which is the reviewer-side discipline). This is the orchestrator-side mirror.


### PR DESCRIPTION
Amends `feedback_verdict_count_hook_regex` to record the field name Hook 4 actually parses, and rewrites its **MEMORY.md index line**, which is the layer that was teaching the wrong thing.

## What happened

Spawn briefs this session dictated `Verdict: Approved`. The charter field (`pull-requests.md:14`) and `validate_pr_review.py::_extract_charter_field` both read **`RequestOrReplied:`**. `Verdict:` is not a field any hook knows.

**Nine `Approved` verdicts across five PRs parsed as zero.** main#930 blocked at `0/2 required peer reviews` with three approvals sitting on it. main#921/#924 (merged 07-06) used the correct field, so the drift was one session old and invisible for its entire life.

Counted with `validate_pr_review.check_comment_reviews` imported from the hook module — not a hand-rolled regex. Repeating the original mistake one level up would have "confirmed" the fix.

## Why the index line changed too

The old index line taught only the bold-vs-bare `Requestor:` distinction. It was silent on the verdict field name, and the always-loaded index is precisely where a wrong form propagates into briefs. A correction that lives only in a file body does not reach the layer that caused the error — the same failure this corpus already recorded once, in `feedback_generic_prompt_hook_advisory_decay`.

MEMORY.md: **24,561 / 24,576 bytes**, 120/120 entries, 119/120 files. In-file amendment, no new entry. `memory-budget (pre-push)` passes.

## Scope

Memory only. The hook fix — three fail-open paths, including the `--input` body-extraction gap Aino found that I had missed — is main#932, authored separately by the Standards & Quality Lead.

## Merge order

**Merge after main#930.** Both touch `MEMORY.md`; the lines are disjoint and should merge cleanly, but #930 is the older branch and rebasing this one is the cheaper direction. See `feedback_parallel_panels_shared_file`.

Part of #932
