### PR TITLE
memory: shared $CLAUDE_JOB_DIR/tmp + $$ unstable across Bash calls

### DIFF
--- a/.claude/memory/feedback_parallel_reviewer_tmp.md
+++ b/.claude/memory/feedback_parallel_reviewer_tmp.md
@@ -13,3 +13,27 @@ When two reviewer-class agents are spawned in parallel on the same PR and the br
 - ALWAYS read-back the posted comment immediately after `gh pr comment` and verify the `Requestor:` line matches YOUR identity, not the other reviewer's. The 4-literal-string verification in the brief catches this if you check the literals BEFORE assuming success.
 - Recovery: if you discover post-hoc that you posted the wrong body, edit in place via `gh api -X PATCH .../issues/comments/<id> --input <json>` where the JSON is built with `python3 -c "import json; print(json.dumps({'body': open('file').read()}))"`. Do NOT post a new comment — the hook counts the most recent verdict per author and a corrected new comment leaves the bad one behind.
 - Charter follow-up worth proposing in retro: brief template should specify per-reviewer filename, OR validate_pr_review hook should warn on identical bodies across distinct GitHub-identity authors as a likely collision signal.
+
+## The shared scratch path is `$CLAUDE_JOB_DIR/tmp`, and it is shared by EVERY agent in the job (2026-07-10)
+
+The `/tmp/review.md` case above is one instance of a broader fact: **`$CLAUDE_JOB_DIR/tmp` is a single directory shared by every agent spawned in the same job**, not per-agent. During a large parallel review session it held 1806 entries and 123 directories authored by six different agents.
+
+Two agents building mutation harnesses each `git archive`'d a repo into a scratch subdir, and one `rm -rf`'d a *shared parent* to rebuild — deleting the other's export. **Each would have read the other's vanished export as their own setup failing.** For mutation work this is the worst kind of collision: a harness whose export silently disappeared and a mutant that never applied produce the *same* green (or the same spurious red).
+
+**How to apply:**
+- Name every scratch path `<agent>_<pr#>_<unique>` and **never `rm -rf` a shared parent** — only paths you created under your own uniquely-named subtree.
+- After `git archive <sha>` into a scratch dir, **assert the export is the tree you asked for** before trusting it: `git hash-object -- "$ABS/path"` must equal `git rev-parse <sha>:path`. A mid-run overwrite by another agent shows up here.
+- The structural generator derives the repo name from the output directory **basename**, so keep the basename (`noorinalabs-data-acquisition`) and make the *parent* unique: `$CLAUDE_JOB_DIR/tmp/<agent>_<pr#>_<n>/noorinalabs-data-acquisition`.
+
+### `$$` is NOT stable across Bash tool calls — do not use it for a cross-call unique dir
+
+Each Bash tool invocation is a **fresh shell**, so `$$` (the shell PID) is a *different value on every call*. Confirmed:
+
+```
+call 1:  echo $$   ->  3471437
+call 2:  echo $$   ->  3471547     # different shell, different PID
+```
+
+So `mkdir dir_$$` in one call and `cd dir_$$` in the next land in **different directories**. It is stable only *within* a single call/block. The failure it produces is a silent-zero-family instrument lie: a "does my export still exist / does the blob differ?" probe run in call 2 against `dir_$$` checks a path nobody wrote, and returns a false "missing / differs." (Surfaced by a reviewer whose blob-identity check reported a spurious mismatch against a directory the previous call never created.)
+
+**How to apply:** for a scratch dir that must persist across Bash calls, use a fixed literal chosen once (`<agent>_<pr#>_1`), or a name derived from something stable across calls (the PR sha, the agent name) — never `$$`. Reserve `$$` for create-and-use-in-the-same-block. Sibling of [[feedback_silent_zero_is_not_a_measurement]]: the instrument pointed at a path that never existed and reported its absence as data.


### PR DESCRIPTION
## What

Extends `feedback_parallel_reviewer_tmp.md` with two scratch-hygiene facts confirmed during the P8W24 parallel-review session. Two files changed → one; 24 insertions; memory-only, linter-excluded.

## Why

The existing memory covers reviewer `/tmp/review.md` collisions. Tonight surfaced the broader mechanism and a second, sharper hazard:

1. **`$CLAUDE_JOB_DIR/tmp` is shared by every agent in a job** (observed: 1806 entries / 123 dirs / 6 agents). Two agents `rm -rf`'d a shared parent and destroyed each other's mutation-harness exports — and each would have read the vanished export as its *own* setup failing. For mutation work a vanished export and a mutant that never applied produce the same green.

2. **`$$` is not stable across Bash tool calls.** Each call is a fresh shell → different PID. Empirically confirmed: `echo $$` returned `3471437` then `3471547` on two consecutive calls. A scratch dir made as `dir_$$` in one call and referenced in the next lands in a different directory, and a blob-identity probe then reports a false "missing / differs" against a path nobody wrote — a silent-zero-family instrument lie.

## Verification

Both facts were **run, not asserted**, before recording. The `$$` values above are from this session's own Bash calls; the shared-tmp entry count is a live `ls | wc -l`.

## Reviewers

Two-fact memory addition; review is a quick correctness check. `$$` claim is reproducible with two `echo $$` calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BmCDgMue9jRtYqqUxvbDN1
