### PR TITLE
session-start: read compact status digest, not the whole 212KB file (#987)

### DIFF
--- a/.claude/lib/tests/test_wave_status.py
+++ b/.claude/lib/tests/test_wave_status.py
@@ -270,5 +270,102 @@ class Write(unittest.TestCase):
             self.assertEqual(data["wave_4_repos_in_scope"], _REPOS)
 
 
+class Digest(unittest.TestCase):
+    """`digest` projects the status file to the current-wave/phase slice (#987)."""
+
+    def _status(self, **overrides: object) -> dict:
+        data: dict = {
+            # lifecycle pointers
+            "current_phase": 9,
+            "current_wave": "wave-25",
+            "next_wave": "wave-26",
+            "last_completed_wave": "wave-24",
+            "global_wave_seq": 25,
+            "wave_active": False,
+            "last_updated": "2026-07-19T00:00:00Z",
+            "open_prs_total": 0,
+            # current + next wave keys (kept)
+            "wave_25_scope": {"theme": "current"},
+            "wave_25_meta_issue": "noorinalabs-main#980",
+            "wave_26_meta_issue": "noorinalabs-main#983",
+            # current phase key (kept)
+            "phase_9_status": "ACTIVE",
+            # HISTORICAL — must be dropped
+            "wave_24_scope": {"theme": "old"},
+            "wave_2_active": False,
+            "phase_3_status": "COMPLETE",
+            # blockers: live one kept, resolved audit key dropped
+            "owner_decision_gated": ["deploy#999 — needs an owner call"],
+            "owner_decision_gated_resolved_2026_04_29": ["main#211 — RESOLVED"],
+        }
+        data.update(overrides)
+        return data
+
+    def _digest(self, data: dict) -> dict:
+        with TemporaryDirectory() as td:
+            status = Path(td) / "cross-repo-status.json"
+            status.write_text(json.dumps(data))
+            return wave_status.build_digest(status)
+
+    def test_keeps_pointers_current_and_next_wave_and_phase(self) -> None:
+        d = self._digest(self._status())
+        for key in wave_status._DIGEST_POINTER_KEYS:
+            self.assertIn(key, d)
+        self.assertIn("wave_25_scope", d)
+        self.assertIn("wave_25_meta_issue", d)
+        self.assertIn("wave_26_meta_issue", d)
+        self.assertIn("phase_9_status", d)
+
+    def test_drops_historical_wave_and_phase_keys(self) -> None:
+        d = self._digest(self._status())
+        self.assertNotIn("wave_24_scope", d)
+        # wave_2_active must NOT be swept in by the wave_25 prefix — the trailing
+        # underscore in `wave_2_` vs `wave_25_` is the guard.
+        self.assertNotIn("wave_2_active", d)
+        self.assertNotIn("phase_3_status", d)
+
+    def test_live_blocker_kept_resolved_audit_key_dropped(self) -> None:
+        d = self._digest(self._status())
+        self.assertIn("owner_decision_gated", d)
+        self.assertNotIn("owner_decision_gated_resolved_2026_04_29", d)
+
+    def test_empty_live_blocker_is_omitted(self) -> None:
+        d = self._digest(self._status(owner_decision_gated=[]))
+        self.assertNotIn("owner_decision_gated", d)
+
+    def test_is_a_large_reduction(self) -> None:
+        data = self._status()
+        # pad with a lot of historical noise the digest must shed
+        for w in range(1, 24):
+            data[f"wave_{w}_scope"] = {"junk": "x" * 500}
+        d = self._digest(data)
+        full = len(json.dumps(data))
+        proj = len(json.dumps(d))
+        self.assertLess(proj, full // 4)
+
+    def test_malformed_current_wave_degrades_gracefully(self) -> None:
+        # No wave pointers at all → still emit pointers-that-exist + phase + blocker
+        # without raising; wave-scoped keys simply drop out.
+        d = self._digest(self._status(current_wave=None, next_wave=None))
+        self.assertIn("current_phase", d)
+        self.assertIn("phase_9_status", d)
+        self.assertIn("owner_decision_gated", d)
+        self.assertNotIn("wave_25_scope", d)
+
+    def test_cli_prints_valid_json(self) -> None:
+        with TemporaryDirectory() as td:
+            status = Path(td) / "cross-repo-status.json"
+            status.write_text(json.dumps(self._status()))
+            import io
+            from contextlib import redirect_stdout
+
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = wave_status.main(["digest", "--status", str(status)])
+            self.assertEqual(rc, 0)
+            parsed = json.loads(buf.getvalue())
+            self.assertEqual(parsed["current_wave"], "wave-25")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.claude/lib/wave_status.py
+++ b/.claude/lib/wave_status.py
@@ -29,6 +29,7 @@ Design contract:
                      count mismatch.
 
 CLI:
+  wave_status.py digest              [--status PATH]  # current-wave/phase slice (#987)
   wave_status.py repos       <P> <M> [--status PATH]
   wave_status.py merged-prs  <P> <M> [--status PATH]
   wave_status.py counters    <P> <M> [--write] [--expect N] [--status PATH]
@@ -232,6 +233,99 @@ def _write_counters(wave: str, counters: dict[str, int], status_path: Path) -> i
     )
 
 
+# Lifecycle pointer keys always surfaced in the session-start digest — the small
+# fixed set /session-start Step 5 reports (active phase/wave, staleness, in-flight
+# counts). Everything else in the digest is derived by wave/phase scoping below.
+_DIGEST_POINTER_KEYS = (
+    "current_phase",
+    "current_wave",
+    "next_wave",
+    "last_completed_wave",
+    "global_wave_seq",
+    "wave_active",
+    "last_updated",
+    "open_prs_total",
+)
+
+
+def _wave_ordinal(value: object) -> str | None:
+    """Extract the numeric wave ordinal from a ``wave-<N>`` pointer.
+
+    Returns the ordinal as a string (used to build the ``wave_<N>_`` key prefix)
+    or None when the pointer is absent/malformed — the digest degrades to
+    pointers+phase+blockers rather than raising, matching the non-fatal stance of
+    the session-start Step blocks that call it.
+    """
+    if not isinstance(value, str):
+        return None
+    tail = value.rsplit("-", 1)[-1]
+    return tail if tail.isdigit() else None
+
+
+def build_digest(status_path: Path) -> dict:
+    """Project cross-repo-status.json down to the current-wave/phase slice.
+
+    The full file is a flat dict of ~500 keys accreted across every wave (>200KB,
+    ~53K tokens); ``cat``-ing it whole into context each session was the single
+    biggest guaranteed per-session token cost (#987). Step 5 only needs the
+    lifecycle pointers plus the keys scoped to the *current* wave, the *next*
+    wave, and the *current* phase, plus any open owner-decision blockers. This
+    returns exactly that as an ordered, valid-JSON-serialisable dict — no
+    historical wave/phase keys. Nothing is written; it is a pure read.
+    """
+    data = _load_status(status_path)
+
+    digest: dict = {}
+    for key in _DIGEST_POINTER_KEYS:
+        if key in data:
+            digest[key] = data[key]
+
+    # Wave-scoped keys for the current + next wave. The trailing underscore in the
+    # prefix is load-bearing: ``wave_2_`` must not match ``wave_25_`` keys.
+    wave_prefixes = [
+        f"wave_{ordinal}_"
+        for ordinal in (
+            _wave_ordinal(data.get("current_wave")),
+            _wave_ordinal(data.get("next_wave")),
+        )
+        if ordinal is not None
+    ]
+
+    # Phase-scoped keys for the current phase (``phase_9_`` won't match
+    # ``phase_2_wave_9_work`` — again the trailing underscore disambiguates).
+    phase = data.get("current_phase")
+    phase_prefix = f"phase_{phase}_" if phase is not None else None
+
+    scoped: dict = {}
+    blockers: dict = {}
+    for key, value in data.items():
+        if key in _DIGEST_POINTER_KEYS:
+            continue
+        if key.startswith("owner_decision_gated"):
+            # Only surface unresolved blockers (a non-empty list / truthy value);
+            # the ``owner_decision_gated_resolved_*`` audit keys are history, not
+            # live state, so they stay out of the digest even when non-empty.
+            if value and "resolved" not in key:
+                blockers[key] = value
+            continue
+        if any(key.startswith(p) for p in wave_prefixes):
+            scoped[key] = value
+            continue
+        if phase_prefix is not None and key.startswith(phase_prefix):
+            scoped[key] = value
+
+    for key in sorted(scoped):
+        digest[key] = scoped[key]
+    for key in sorted(blockers):
+        digest[key] = blockers[key]
+    return digest
+
+
+def _cmd_digest(args: argparse.Namespace) -> int:
+    print(json.dumps(build_digest(args.status), indent=2))
+    return 0
+
+
 def _cmd_repos(args: argparse.Namespace) -> int:
     for repo in read_repos(args.wave, args.status):
         print(repo)
@@ -274,6 +368,18 @@ def _build_parser() -> argparse.ArgumentParser:
             default=_DEFAULT_STATUS,
             help="path to cross-repo-status.json (default: repo-root copy)",
         )
+
+    p_digest = sub.add_parser(
+        "digest",
+        help="emit a compact current-wave/phase projection of the status file (session-start)",
+    )
+    p_digest.add_argument(
+        "--status",
+        type=Path,
+        default=_DEFAULT_STATUS,
+        help="path to cross-repo-status.json (default: repo-root copy)",
+    )
+    p_digest.set_defaults(func=_cmd_digest)
 
     p_repos = sub.add_parser("repos", help="emit wave_{M}_repos_in_scope one per line")
     _add_pm(p_repos)

--- a/.claude/skills/session-start/SKILL.md
+++ b/.claude/skills/session-start/SKILL.md
@@ -202,11 +202,23 @@ Read the current project state:
 # parent of --git-common-dir resolves the org root even from a worktree.
 REPO_ROOT="$(cd "$(git rev-parse --git-common-dir 2>/dev/null)/.." 2>/dev/null && pwd)"
 [ -f "$REPO_ROOT/cross-repo-status.json" ] || REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
-cat "$REPO_ROOT/cross-repo-status.json"
+# Read a COMPACT current-wave/phase projection, NOT the whole file. The status
+# file is a flat dict of ~500 keys accreted over every wave (>200KB / ~53K
+# tokens); `cat`-ing it whole was the single biggest guaranteed per-session token
+# cost (#987 — bigger than CLAUDE.md + MEMORY.md + this skill combined). The
+# digest keeps the lifecycle pointers + current/next-wave + current-phase keys +
+# open blockers (a few KB — ~96% smaller), dropping 24 waves of history. Falls back to `cat` only if
+# the helper is missing, matching the non-fatal stance of the other Step blocks.
+if [ -f "$REPO_ROOT/.claude/lib/wave_status.py" ]; then
+  python3 "$REPO_ROOT/.claude/lib/wave_status.py" digest --status "$REPO_ROOT/cross-repo-status.json" \
+    || cat "$REPO_ROOT/cross-repo-status.json"
+else
+  cat "$REPO_ROOT/cross-repo-status.json"
+fi
 gh issue list --repo noorinalabs/noorinalabs-main --state open --limit 10 --json number,title,labels
 ```
 
-Report: active wave/phase, staleness of `cross-repo-status.json`, open issue count and blockers, open PRs across repos. On unexpected board-vs-issue gaps (wave-labeled issues missing from project 2, or Wave-field out of sync with the canonical `wave-{X}` / grandfathered `p{N}-wave-{M}` labels, #810), invoke `/board-audit` (labels are canonical, the Wave field is a derived projection — main#199).
+Report: active wave/phase, staleness of `cross-repo-status.json` (from `last_updated`), open issue count and blockers, open PRs across repos. The Step-5 read is now the compact `wave_status.py digest` projection (#987), not the full file — if you need a historical wave's keys, read `cross-repo-status.json` directly. On unexpected board-vs-issue gaps (wave-labeled issues missing from project 2, or Wave-field out of sync with the canonical `wave-{X}` / grandfathered `p{N}-wave-{M}` labels, #810), invoke `/board-audit` (labels are canonical, the Wave field is a derived projection — main#199).
 
 ### Step 5a — Red default-branch workflow verdict (scheduled sweep, #962)
 


### PR DESCRIPTION
Closes #987. Part of #986 (token-efficiency tracker), move #1 — highest leverage / lowest risk.

## Problem
`/session-start` Step 5 ran `cat "$REPO_ROOT/cross-repo-status.json"` (`SKILL.md:205`), dumping the **entire 212,703-byte** status file into context **every session** (~53K tokens — larger than `CLAUDE.md` + `MEMORY.md` + the session-start skill body **combined**). The file is a flat dict of ~500 keys accreted over 25 waves; `wave_17_scope` alone is 62,813 B. Step 5 only reports active wave/phase, staleness, and blockers — it needs the current-wave/phase slice, not 24 waves of history.

## Fix
- New `digest` subcommand on `.claude/lib/wave_status.py` (build-before-you-build — it already loads the file and is test-covered) projecting the status file to: lifecycle pointers + current-wave + next-wave + current-phase keys + live `owner_decision_gated` blockers. Drops all historical wave/phase keys and the resolved-* audit keys. Pure read, no writes.
- Step 5 now calls `wave_status.py digest`, with a `cat` fallback only if the helper is absent (non-fatal stance of the other Step blocks).

## Measured (against the live file)
| | bytes | ~tokens |
|---|---:|---:|
| before (`cat`) | 212,703 | ~53,175 |
| after (`digest`) | 8,091 | ~2,022 |
| **reduction** | | **~96%** |

Output is valid JSON; verified no `wave_1..24_*` / `phase_1..8_*` keys leak.

## Tests / gates
- 7 new unit tests (pointers kept; current+next-wave + current-phase kept; historical + resolved-audit keys dropped; the `wave_2_`/`wave_25_` prefix guard; graceful degradation on missing `current_wave`; CLI JSON path). Full lib suite **694 passed**.
- ruff format+lint clean (0.15.11), mypy clean, sync-gate OK, cspell clean on the changed skill.

## Reviewers
@ requested: Wanjiku Mwangi (TPM), Santiago Ferreira (Release Coordinator).
