### PR TITLE
lifecycle: session-hygiene guidance — /clear at wave boundaries (#991)

### DIFF
--- a/.claude/team/lifecycle.md
+++ b/.claude/team/lifecycle.md
@@ -134,6 +134,14 @@ flowchart LR
 
 A `Stop` hook auto-writes a handoff to project memory after every response (throttled to 5 min). The next `/session-start` Step 2 reads whichever handoff is freshest. Manual `/handoff` adds conversational context (decisions, discussion) that the automatic hook cannot infer.
 
+### Session hygiene — `/clear` at wave boundaries, `/compact` mid-task
+
+Long multi-wave sessions degrade quality, not just cost: research finds marathon sessions (many unrelated tasks queued in one continuous session) underperform single-task-scoped sessions by **16–29 percentage points**, and Anthropic's own guidance is that *over-compacting within one session* is a more common failure than *under-clearing between* unrelated tasks (token-efficiency audit #986, Part 7). Two built-in CLI commands, two distinct jobs — they are **not** lifecycle skills, so they have no table row above; the discipline is:
+
+- **`/compact`** (summarize-and-continue) — use *inside* one still-relevant task, at natural checkpoints. Rule of thumb: proactively compact around ~70% context capacity, before a step that will consume a lot of tokens. Critical facts belong in files (`.claude/memory/`, `cross-repo-status.json`), never only in the conversation, so a compaction can never drop them.
+- **`/clear`** (full wipe) — use when switching to *unrelated* work. **A wave boundary is an unrelated-task boundary:** once `/wave-retro` closes a wave (and `session_handoff.md` is written), prefer `/clear` before taking on the next wave's execution rather than compacting the closed wave's context forward. The handoff mechanism (`/handoff` + the automatic `Stop`-hook `session_handoff.md`) exists precisely to carry state across the clear — the next `/session-start` Step 2 reloads it.
+- **Scope a session to one wave / one coherent task.** Design for die-and-resume from the `session_handoff.md` checkpoint, not from a replayed transcript; run `/handoff` before the clear so conversational context (decisions, in-flight caveats) survives the boundary. This is discipline over the mechanisms already in place — no new tooling.
+
 ---
 
 ## Cross-references


### PR DESCRIPTION
Closes #991. Part of #986 (token-efficiency tracker), move #3.

## What
Adds a **§ Session hygiene — `/clear` at wave boundaries, `/compact` mid-task** to `.claude/team/lifecycle.md` § Session Lifecycle. Doc-only; no code.

## The guidance
- **`/compact`** (summarize+continue) — inside one still-relevant task, at ~70% context, before a token-heavy step. Critical facts live in files, never only in conversation.
- **`/clear`** (full wipe) — when switching to *unrelated* work. **A wave boundary is an unrelated-task boundary**: clear after `/wave-retro` closes a wave rather than compacting it forward — `/handoff` + `session_handoff.md` carry state across the clear (next `/session-start` Step 2 reloads it).
- **Scope a session to one wave / coherent task**; `/handoff` before the clear. Discipline over existing mechanisms, no new tooling.

Basis: report Part 7 — marathon sessions underperform single-task-scoped by 16–29pt; over-compacting-within is a more common failure than under-clearing-between (Anthropic context-engineering guidance).

## Placement note
`/clear` and `/compact` are built-in CLI commands, not lifecycle *skills*, so they're prose in § Session Lifecycle, not rows in the skill tables (which the § Maintenance rule governs).

## Gate note (non-blocking, pre-existing)
A local `cspell` run flags `upserts` at **line 16 — pre-existing content, not in this diff**. `.claude/team/lifecycle.md` is **out of the cspell `files` scope** (the regex covers `.claude/team/charter/**`, not `.claude/team/*.md`), which is why it survives on main. My added prose has zero unknown words. Flagging the scope gap (non-charter `.claude/team/*.md` aren't spell-checked) as a possible tracker follow-up — not fixing it here (out of scope, not my change).

markdown-lint clean; no new links (lychee-safe).

## Reviewers
Requested: Aino Virtanen (Standards & Quality Lead), Santiago Ferreira (Release Coordinator).
