### PR TITLE
memory: per-file staleness/size advisory + wave-retro decay sweep (#995)

### DIFF
--- a/.claude/lib/memory_budget.py
+++ b/.claude/lib/memory_budget.py
@@ -98,7 +98,9 @@ from __future__ import annotations
 
 import argparse
 import re
+import subprocess
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import NamedTuple
 
@@ -106,6 +108,26 @@ from typing import NamedTuple
 MAX_INDEX_ENTRIES = 132
 MAX_MEMORY_FILES = 132
 MAX_MEMORY_BYTES = 28_672  # 28 KiB
+
+# --- Advisory staleness/size signal (#995, P9W25) — NOT a gate ---------------
+# The three budgets above are a HARD gate on the corpus *in aggregate* (index
+# count, file count, MEMORY.md bytes). They say nothing about an individual
+# topic file being oversized or long-untouched — the 52KB narrator file is the
+# poster child: uncapped and unflagged. The `--staleness` mode below is the
+# advisory that surfaces those per-file signals for the /wave-retro decay sweep
+# (Step 7.8). It ALWAYS exits 0 — a large or old memory is a candidate for a
+# human consolidate/archive decision, never an auto-block and never an
+# auto-delete (a rare-but-critical memory must survive age alone; mirrors
+# /promotion-audit in reverse).
+#
+# SOFT_FILE_BYTES is anchored to the aggregate byte cap: no single topic file
+# should exceed *half* the entire always-loaded index's own budget. A file that
+# large is worth a "still all pulling its weight?" look.
+SOFT_FILE_BYTES = MAX_MEMORY_BYTES // 2  # 14,336 bytes (14 KiB)
+# STALE_DAYS: a topic file whose last *commit* is older than this is a decay
+# candidate. Edit-recency is a pragmatic proxy — a memory can stay recall-
+# relevant without being edited — which is exactly why this is advisory-only.
+STALE_DAYS = 90
 
 # Files under .claude/memory/ that are NOT counted as topic files: the index
 # itself, and the gitignored per-session handoff (absent in CI — see module
@@ -209,6 +231,116 @@ def evaluate(memory_dir: Path) -> int:
     return 0
 
 
+# --- Advisory staleness/size report (#995) -----------------------------------
+
+
+class FileSignal(NamedTuple):
+    """Per-file size + recency reading for the advisory sweep."""
+
+    name: str
+    size_bytes: int
+    last_commit: datetime | None  # None when git recency is unavailable
+    days_stale: int | None  # None when last_commit is None
+
+    @property
+    def oversized(self) -> bool:
+        return self.size_bytes > SOFT_FILE_BYTES
+
+    @property
+    def stale(self) -> bool:
+        return self.days_stale is not None and self.days_stale > STALE_DAYS
+
+    @property
+    def flagged(self) -> bool:
+        return self.oversized or self.stale
+
+
+def _git_last_commit(path: Path, repo_root: Path) -> datetime | None:
+    """Last-commit datetime (UTC) for `path` via git, or None on any failure.
+
+    Kept behind a tiny helper so the report degrades gracefully outside a git
+    checkout (fresh clone with no history for the file, git absent, non-repo)
+    and so tests can monkeypatch it without invoking git.
+    """
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(repo_root), "log", "-1", "--format=%cI", "--", str(path)],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    stamp = out.stdout.strip()
+    if out.returncode != 0 or not stamp:
+        return None
+    try:
+        return datetime.fromisoformat(stamp).astimezone(timezone.utc)
+    except ValueError:
+        return None
+
+
+def gather_file_signals(memory_dir: Path, now: datetime | None = None) -> list[FileSignal]:
+    """Size + recency for every topic file, sorted largest-first.
+
+    `now` is injectable for deterministic tests; defaults to the current UTC time.
+    Recency is resolved relative to the repo root (parent of `.claude/memory`).
+    """
+    now = now or datetime.now(timezone.utc)
+    # repo_root = <...>/.claude/memory → up two levels. Falls back to memory_dir
+    # itself if the layout is unexpected; git will simply return None there.
+    repo_root = memory_dir.parent.parent if memory_dir.parent.name == ".claude" else memory_dir
+    signals: list[FileSignal] = []
+    for p in sorted(memory_dir.glob("*.md")):
+        if p.name in _NON_TOPIC_FILES:
+            continue
+        last = _git_last_commit(p, repo_root)
+        days = (now - last).days if last is not None else None
+        signals.append(FileSignal(p.name, p.stat().st_size, last, days))
+    signals.sort(key=lambda s: s.size_bytes, reverse=True)
+    return signals
+
+
+def format_staleness_report(signals: list[FileSignal]) -> str:
+    """Render the advisory table: flagged files first, with size + age columns."""
+    flagged = [s for s in signals if s.flagged]
+    lines = [
+        "MEMORY STALENESS/SIZE ADVISORY (non-blocking — /wave-retro decay sweep, #995)",
+        f"  soft per-file ceiling: {SOFT_FILE_BYTES} bytes   stale after: {STALE_DAYS} days",
+        f"  topic files: {len(signals)}   flagged: {len(flagged)} "
+        f"(size and/or age — candidates for a human consolidate/archive decision)",
+        "",
+    ]
+    if not flagged:
+        lines.append("  No files over the size ceiling or staleness threshold. Nothing to sweep.")
+        return "\n".join(lines)
+    for s in flagged:
+        marks = []
+        if s.oversized:
+            marks.append("SIZE")
+        if s.stale:
+            marks.append("STALE")
+        age = f"{s.days_stale}d" if s.days_stale is not None else "age?"
+        lines.append(f"  [{'+'.join(marks):<10}] {s.size_bytes:>6}B  last-touch {age:>6}  {s.name}")
+    lines.append("")
+    lines.append(
+        "  These are ADVISORY: a large or long-untouched memory is a candidate for "
+        "consolidation or a move to .claude/memory/archive/ (a cold tier outside "
+        "the always-loaded index), NEVER an auto-delete. Age is edit-recency, not "
+        "reference-recency — decide per file."
+    )
+    return "\n".join(lines)
+
+
+def evaluate_staleness(memory_dir: Path) -> int:
+    """Print the advisory report. Always returns 0 (non-blocking)."""
+    if not memory_dir.is_dir():
+        raise FileNotFoundError(f"memory directory not found: {memory_dir}")
+    print(format_staleness_report(gather_file_signals(memory_dir)))
+    return 0
+
+
 def main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -221,6 +353,12 @@ def main(argv: list[str]) -> int:
         "--memory-dir",
         help="Path to the memory dir directly (overrides <repo_root>/.claude/memory).",
     )
+    parser.add_argument(
+        "--staleness",
+        action="store_true",
+        help="Advisory only: print the per-file size/staleness sweep (always exits 0) "
+        "instead of the hard budget gate. Used by the /wave-retro decay sweep (#995).",
+    )
     args = parser.parse_args(argv[1:])
 
     memory_dir = (
@@ -230,6 +368,8 @@ def main(argv: list[str]) -> int:
     )
 
     try:
+        if args.staleness:
+            return evaluate_staleness(memory_dir)
         return evaluate(memory_dir)
     except FileNotFoundError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)

--- a/.claude/lib/tests/test_memory_budget.py
+++ b/.claude/lib/tests/test_memory_budget.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import sys
 import unittest
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -25,9 +26,13 @@ from memory_budget import (  # noqa: E402
     MAX_INDEX_ENTRIES,
     MAX_MEMORY_BYTES,
     MAX_MEMORY_FILES,
+    SOFT_FILE_BYTES,
+    STALE_DAYS,
     count_index_entries,
     count_memory_files,
     evaluate,
+    format_staleness_report,
+    gather_file_signals,
     gather_metrics,
     main,
 )
@@ -176,6 +181,107 @@ class RealCorpusWithinBudgetTests(unittest.TestCase):
         if not (memory_dir / "MEMORY.md").is_file():
             self.skipTest("parent memory corpus not present in this checkout")
         self.assertEqual(evaluate(memory_dir), 0)
+
+
+class StalenessAdvisoryTests(unittest.TestCase):
+    """The advisory --staleness sweep (#995): per-file size + recency signal.
+
+    It is NON-BLOCKING (always exits 0) and must NEVER change the hard gate. The
+    git recency helper is monkeypatched so tests don't depend on a git checkout.
+    """
+
+    NOW = datetime(2026, 7, 19, tzinfo=timezone.utc)
+
+    def _make_memory_dir(self, root: Path) -> Path:
+        memory_dir = root / ".claude" / "memory"
+        memory_dir.mkdir(parents=True)
+        (memory_dir / "MEMORY.md").write_text("- [A](a.md) — x\n", encoding="utf-8")
+        return memory_dir
+
+    def _patch_recency(self, mapping: dict[str, datetime | None]) -> None:
+        """Force _git_last_commit to return a per-file datetime from `mapping`."""
+
+        def fake(path: Path, repo_root: Path) -> datetime | None:
+            return mapping.get(path.name)
+
+        self._orig = memory_budget._git_last_commit
+        memory_budget._git_last_commit = fake  # type: ignore[assignment]
+        self.addCleanup(lambda: setattr(memory_budget, "_git_last_commit", self._orig))
+
+    def test_oversized_file_flagged_size_stale_not(self) -> None:
+        with TemporaryDirectory() as d:
+            memory_dir = self._make_memory_dir(Path(d))
+            (memory_dir / "big.md").write_text("x" * (SOFT_FILE_BYTES + 1), encoding="utf-8")
+            (memory_dir / "small.md").write_text("x" * 100, encoding="utf-8")
+            self._patch_recency({"big.md": self.NOW, "small.md": self.NOW})
+            signals = {s.name: s for s in gather_file_signals(memory_dir, now=self.NOW)}
+            self.assertTrue(signals["big.md"].oversized)
+            self.assertFalse(signals["big.md"].stale)
+            self.assertTrue(signals["big.md"].flagged)
+            self.assertFalse(signals["small.md"].flagged)
+
+    def test_stale_file_flagged_by_age(self) -> None:
+        with TemporaryDirectory() as d:
+            memory_dir = self._make_memory_dir(Path(d))
+            (memory_dir / "old.md").write_text("x" * 50, encoding="utf-8")
+            old = self.NOW - timedelta(days=STALE_DAYS + 5)
+            self._patch_recency({"old.md": old})
+            signal = gather_file_signals(memory_dir, now=self.NOW)[0]
+            self.assertEqual(signal.name, "old.md")
+            self.assertFalse(signal.oversized)
+            self.assertTrue(signal.stale)
+            self.assertEqual(signal.days_stale, STALE_DAYS + 5)
+
+    def test_recency_unavailable_is_not_stale(self) -> None:
+        # git returns None (fresh clone / no history) -> days_stale None, never
+        # flagged as stale on a missing signal.
+        with TemporaryDirectory() as d:
+            memory_dir = self._make_memory_dir(Path(d))
+            (memory_dir / "x.md").write_text("x" * 50, encoding="utf-8")
+            self._patch_recency({"x.md": None})
+            signal = gather_file_signals(memory_dir, now=self.NOW)[0]
+            self.assertIsNone(signal.days_stale)
+            self.assertFalse(signal.stale)
+
+    def test_signals_sorted_largest_first(self) -> None:
+        with TemporaryDirectory() as d:
+            memory_dir = self._make_memory_dir(Path(d))
+            (memory_dir / "mid.md").write_text("x" * 300, encoding="utf-8")
+            (memory_dir / "big.md").write_text("x" * 900, encoding="utf-8")
+            (memory_dir / "tiny.md").write_text("x" * 10, encoding="utf-8")
+            self._patch_recency({"mid.md": self.NOW, "big.md": self.NOW, "tiny.md": self.NOW})
+            names = [s.name for s in gather_file_signals(memory_dir, now=self.NOW)]
+            self.assertEqual(names, ["big.md", "mid.md", "tiny.md"])
+
+    def test_non_topic_files_excluded_from_signals(self) -> None:
+        with TemporaryDirectory() as d:
+            memory_dir = self._make_memory_dir(Path(d))
+            (memory_dir / "session_handoff.md").write_text("h\n", encoding="utf-8")
+            (memory_dir / "topic.md").write_text("t\n", encoding="utf-8")
+            self._patch_recency({"topic.md": self.NOW})
+            names = {s.name for s in gather_file_signals(memory_dir, now=self.NOW)}
+            self.assertEqual(names, {"topic.md"})  # MEMORY.md + handoff excluded
+
+    def test_cli_staleness_is_non_blocking_even_when_flagged(self) -> None:
+        # A flagged (oversized) file must NOT make the advisory exit non-zero —
+        # the hard gate blocks, the advisory only surfaces.
+        with TemporaryDirectory() as d:
+            memory_dir = self._make_memory_dir(Path(d))
+            (memory_dir / "big.md").write_text("x" * (SOFT_FILE_BYTES + 1), encoding="utf-8")
+            self.assertEqual(main(["memory_budget.py", d, "--staleness"]), 0)
+
+    def test_report_reports_nothing_to_sweep_when_clean(self) -> None:
+        with TemporaryDirectory() as d:
+            memory_dir = self._make_memory_dir(Path(d))
+            (memory_dir / "ok.md").write_text("x" * 50, encoding="utf-8")
+            self._patch_recency({"ok.md": self.NOW})
+            report = format_staleness_report(gather_file_signals(memory_dir, now=self.NOW))
+            self.assertIn("Nothing to sweep", report)
+
+    def test_soft_ceiling_is_half_the_byte_cap(self) -> None:
+        # The single source of truth: the per-file soft ceiling is derived from
+        # the aggregate byte cap, not an independent magic number.
+        self.assertEqual(SOFT_FILE_BYTES, MAX_MEMORY_BYTES // 2)
 
 
 if __name__ == "__main__":

--- a/.claude/skills/wave-retro/SKILL.md
+++ b/.claude/skills/wave-retro/SKILL.md
@@ -257,6 +257,27 @@ fi
 
 P3W8 surfaced the gap (2026-05-10): user explicitly noted "these should be a part of the wave-retro for next time." This step is that next time.
 
+### 7.8. Memory decay & size sweep (added P9W25 #995)
+
+The memory-budget gate (`.claude/lib/memory_budget.py`) hard-blocks on the corpus **in aggregate** (index-entry count, file count, `MEMORY.md` bytes) but is blind to an individual topic file being oversized or long-untouched. This step runs the **advisory** per-file sweep — the reverse of `/promotion-audit` (which surfaces memories ready to graduate *up*; this surfaces memories ready to consolidate or move *down* to a cold tier):
+
+```bash
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+# Pass $REPO_ROOT as the positional arg (not the argparse cwd default) so the
+# sweep reads <REPO_ROOT>/.claude/memory even under cwd-drift (worktree / child
+# dir) — matching the hard-gate call sites in .pre-commit-config.yaml and CI,
+# which pass an explicit path. #997.
+python3 "$REPO_ROOT/.claude/lib/memory_budget.py" "$REPO_ROOT" --staleness || true
+```
+
+The report flags files over the soft per-file ceiling (half the `MEMORY.md` byte cap) and files whose last commit is older than `STALE_DAYS`. It is **non-blocking** (always exits 0) and **never auto-deletes** — a flagged file is a candidate for a human decision:
+
+- **Consolidate** — fold a bloated changelog-style file's still-live facts into a tighter form (the `/wave-retro` memory-curation judgment), trimming completed blow-by-blow detail.
+- **Archive** — move a genuinely-historical memory to `.claude/memory/archive/` (a cold tier: outside the top-level `*.md` glob the budget counts, and with **no `MEMORY.md` pointer**, so it is git-tracked and grep-able but *not* always-loaded). Recall it on demand; promote back if it turns live again.
+- **Keep** — age is *edit*-recency, not *reference*-recency; a rarely-edited but frequently-recalled memory (e.g. a stable convention) is correctly kept. Decide per file.
+
+Surface the flagged list in the retro summary (Step 8) alongside the promotion-audit results; act on clear-cut cases in the same pass, carry ambiguous ones forward.
+
 ### 8. Present full retro summary to the user
 
 **Output the complete retro summary directly in the conversation.** Do not just write to files — the user must see the retro without having to open `feedback_log.md`. Include:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,8 @@ Project memory is **version-controlled at `.claude/memory/`**, NOT the user-spac
 **Recording a memory (overrides the default auto-memory tool):** create/edit `.claude/memory/<kebab-slug>.md` with the standard frontmatter (`name`, `description`, `metadata.type` = `user` | `feedback` | `project` | `reference`), add a one-line `MEMORY.md` pointer (`- [Title](file.md) — hook`), and **commit it**. Link related memories with `[[other-slug]]`. Never write to the user-space auto-memory path. Update an existing file covering the same fact instead of duplicating; delete memories that prove wrong.
 
 > `.claude/memory/**` is excluded from the markdown/cspell/lychee linters (dense note prose with names, SHAs, `[[wikilinks]]`, Arabic). `session_handoff.md` is gitignored (per-session, machine-local). Each child repo commits its own `.claude/memory/` + `@import` in its own CLAUDE.md — repos do not import across directories.
+>
+> **Cold-archive tier (`.claude/memory/archive/`):** a genuinely-historical memory can be moved here — it stays git-tracked and grep-able but is **not** always-loaded (no `MEMORY.md` pointer) and is **not** counted by the budget gate (which globs the top-level `*.md` only). The `/wave-retro` decay sweep (`memory_budget.py --staleness`, Step 7.8) surfaces size/age candidates; archiving is a human decision, never automatic.
 
 ## Ontology
 


### PR DESCRIPTION
Closes #995. Token/context-efficiency **Move #5** (tracker #986).

## What
`memory_budget.py` hard-gates the corpus **in aggregate** (index-entry count, file count, `MEMORY.md` bytes) but is blind to a single topic file being oversized or long-untouched. The 52KB `project_narrator_chokepoints_enrich.md` is uncapped and unflagged.

This adds an **advisory** signal + a wave-retro sweep — the reverse of `/promotion-audit`.

## Changes
- **`memory_budget.py --staleness`** — a new mode that lists each topic file's size + last-commit age, flagging files over a soft per-file ceiling and files older than `STALE_DAYS`. **Always exits 0** (non-blocking; the hard 3-dimension gate is unchanged) and **never auto-deletes**.
  - `SOFT_FILE_BYTES = MAX_MEMORY_BYTES // 2` (14,336 B) — single-sourced from the aggregate byte cap, not a magic number. Rationale: no single topic file should exceed half the entire always-loaded index's own budget.
  - `STALE_DAYS = 90`. Recency is git last-commit; degrades gracefully to "age?" (never flags stale) outside a checkout.
- **`/wave-retro` Step 7.8** — runs the sweep, surfaces size/age candidates for a human consolidate / archive / keep decision.
- **`.claude/memory/archive/` cold tier** documented in `CLAUDE.md`: git-tracked + grep-able but not always-loaded (no `MEMORY.md` pointer) and outside the budget glob.
- **8 new tests** (21 total): size-flag, age-flag, missing-recency-not-stale, sort-order, non-topic exclusion, CLI non-blocking-when-flagged, nothing-to-sweep, soft-ceiling-derivation.

## Reliability guard (deliberate non-goal)
The narrator file is **flagged but retained**, NOT cold-archived here: its (trimmed) index line still records **Phase-9 re-cutover pending (#978, owner-gated)** + open non-blockers (ig#1185, da#446, da#443), so it has forward-relevance for the upcoming re-run. It becomes the sweep's top archive candidate once #978 closes. Age is a *candidate* signal, never an auto-delete.

## Verification
Local full gate green: ruff format + lint, mypy, **21/21 pytest**, sync-gate, cspell, markdownlint. Live sweep flags exactly the 3 genuine size outliers (narrator 52K, fixture 21K, sweep 15K), 0 stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
