### PR TITLE
ontology: PageRank importance layer — hub-files view in llms.txt (#1002)

### DIFF
--- a/.claude/lib/ontology_gen/generate.py
+++ b/.claude/lib/ontology_gen/generate.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 from .assemble import assemble
 from .cypher_ext import extract_cypher
+from .importance import rank_files
 from .llms import render_llms
 from .model import CodeGraph, FileInfo, serialize_graph
 from .python_ext import extract_python
@@ -128,7 +129,10 @@ def generate(repo_root: Path, out_dir: Path, repo_name: str) -> dict[str, int]:
     out_dir.mkdir(parents=True, exist_ok=True)
     (out_dir / "code-graph.json").write_text(serialize_graph(graph_dict), encoding="utf-8")
 
-    llms_text = render_llms(files, repo_name, node_count, edge_count)
+    # PageRank importance layer (#1002): rank the depended-upon hub files so
+    # llms.txt leads with "what matters most here" before the per-file sections.
+    hub_files = rank_files(graph_dict)
+    llms_text = render_llms(files, repo_name, node_count, edge_count, hub_files=hub_files)
     (out_dir / "llms.txt").write_text(llms_text, encoding="utf-8")
 
     return {"files": len(files), "nodes": node_count, "edges": edge_count}

--- a/.claude/lib/ontology_gen/importance.py
+++ b/.claude/lib/ontology_gen/importance.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""PageRank importance layer over the structural repo-map (main#1002, Move #8).
+
+The structural graph (`code-graph.json`) treats every file equally — an agent
+orienting in a large repo gets no "what matters most here" signal, so its first
+grep can be blind. This module adds the cheap additive win the token-efficiency
+survey (#986) flagged: a **PageRank importance ranking** so `llms.txt` can lead
+with the repo's genuine hub files (the depended-upon core), the way Aider's
+tree-sitter + PageRank repo-map does.
+
+Design
+======
+- **File-level graph.** The node/edge graph is collapsed to a weighted file →
+  file dependency graph: an edge from a node in file A to a node in file B
+  becomes a weighted A→B file edge (weight = number of such cross-file edges).
+  Ranking whole files (not symbols) is what an agent orients on, and collapsing
+  sidesteps the `contains` self-inflation a symbol-level rank would suffer.
+- **Dependency edges only.** `contains` (file→its own symbols) is structural,
+  not a dependency signal, so it is excluded. `imports`, `imports_from`,
+  `calls`, `inherits`, `references` are the candidate dependency edges; self-loops
+  (A→A) are dropped, since a file depending on itself says nothing about
+  cross-file importance. NOTE that `calls`/`inherits` are resolved intra-file only
+  today (see the `DEP_EDGE_TYPES` caveat below), so the *live* signal is the
+  cross-file import/re-export graph; the other two are kept forward-compatibly.
+- **Edge direction = importance flow.** In the graph an edge `src→dst` means
+  "src depends on / references dst" (assemble.py), so standard PageRank
+  accumulates score at the *depended-upon* node — exactly "what everything else
+  needs." A file imported/called/subclassed from many places ranks high.
+- **Pure Python, no new dependency.** Power iteration; ~15K nodes is trivial.
+  Keeps the generator's stdlib-only footprint (no networkx).
+- **Deterministic.** Sorted traversal + fixed damping/tolerance/iteration cap →
+  the same graph always yields the same ranking (the generator's #855 invariant).
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+from .model import GraphDict
+
+# Edges that carry a "depends-on" signal. `contains` is deliberately excluded
+# (a file containing its own symbols is not a dependency). This is the same
+# vocabulary as model.EDGE_TYPES minus `contains`.
+#
+# Caveat (accuracy over aspiration): today only `imports`, `imports_from`, and
+# `references` actually feed the ranking. `calls` and `inherits` are resolved by
+# assemble.py *intra-file only* (same-file name matching), so both endpoints
+# always share a path and `build_file_graph` drops them as self-loops — they
+# contribute ZERO signal at present. They are kept here for forward-compatibility:
+# if cross-file call/inherit resolution is ever added, they light up automatically
+# with no change here. So the live signal is the cross-file *import/re-export*
+# graph; do not read "calls/inherits" as currently influencing hub ranks.
+DEP_EDGE_TYPES = frozenset({"imports", "imports_from", "calls", "inherits", "references"})
+
+_DAMPING = 0.85  # standard PageRank teleport probability
+_MAX_ITERS = 100  # power-iteration cap (converges well before this at 15K nodes)
+_TOL = 1e-9  # L1 convergence threshold across one iteration
+
+
+def build_file_graph(
+    graph: GraphDict,
+) -> tuple[list[str], dict[str, dict[str, int]]]:
+    """Collapse the node/edge graph to a weighted file→file dependency graph.
+
+    Returns ``(files, out_weights)`` where ``files`` is the sorted list of every
+    distinct file path (a node's ``path``) and ``out_weights[a][b]`` is the count
+    of dependency edges from a node in file ``a`` to a node in file ``b`` (a≠b).
+    """
+    id_to_path = {node["id"]: node["path"] for node in graph["nodes"]}
+    files = sorted({node["path"] for node in graph["nodes"]})
+    out_weights: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    for edge in graph["edges"]:
+        if edge["type"] not in DEP_EDGE_TYPES:
+            continue
+        src_path = id_to_path.get(edge["src"])
+        dst_path = id_to_path.get(edge["dst"])
+        if src_path is None or dst_path is None or src_path == dst_path:
+            continue
+        out_weights[src_path][dst_path] += 1
+    return files, {src: dict(dsts) for src, dsts in out_weights.items()}
+
+
+def pagerank(
+    files: list[str],
+    out_weights: dict[str, dict[str, int]],
+    *,
+    damping: float = _DAMPING,
+    max_iters: int = _MAX_ITERS,
+    tol: float = _TOL,
+) -> dict[str, float]:
+    """Weighted PageRank via power iteration. Deterministic; scores sum to ~1.
+
+    Dangling files (no outgoing dependency edges) redistribute their score
+    uniformly across all files, the standard handling that keeps the total mass
+    conserved. Iteration is over ``files`` in the caller's (sorted) order so the
+    floating-point sums are order-stable and the result is reproducible.
+    """
+    n = len(files)
+    if n == 0:
+        return {}
+
+    out_total = {f: sum(out_weights.get(f, {}).values()) for f in files}
+    # Invert to in-links: dst -> [(src, weight), ...], for the per-node update.
+    in_links: dict[str, list[tuple[str, int]]] = defaultdict(list)
+    for src in files:
+        for dst, weight in out_weights.get(src, {}).items():
+            in_links[dst].append((src, weight))
+
+    rank = {f: 1.0 / n for f in files}
+    base = (1.0 - damping) / n
+    for _ in range(max_iters):
+        dangling_mass = sum(rank[f] for f in files if out_total[f] == 0)
+        dangling_share = damping * dangling_mass / n
+        new_rank: dict[str, float] = {}
+        delta = 0.0
+        for f in files:
+            score = base + dangling_share
+            for src, weight in in_links.get(f, []):
+                score += damping * rank[src] * weight / out_total[src]
+            new_rank[f] = score
+            delta += abs(score - rank[f])
+        rank = new_rank
+        if delta < tol:
+            break
+    return rank
+
+
+def rank_files(graph: GraphDict, limit: int = 20) -> list[tuple[str, float]]:
+    """Top-``limit`` files by PageRank importance, most-important first.
+
+    Ties break by path (ascending) so the ranking is fully deterministic. A file
+    with no dependency edges at all still appears (with the teleport-floor score)
+    but ranks below any depended-upon file.
+    """
+    files, out_weights = build_file_graph(graph)
+    scores = pagerank(files, out_weights)
+    ordered = sorted(scores.items(), key=lambda kv: (-kv[1], kv[0]))
+    return ordered[:limit]

--- a/.claude/lib/ontology_gen/llms.py
+++ b/.claude/lib/ontology_gen/llms.py
@@ -72,7 +72,30 @@ def _render_file(file_info: FileInfo) -> list[str]:
     return lines
 
 
-def render_llms(files: list[FileInfo], repo_name: str, node_count: int, edge_count: int) -> str:
+def _render_hub_files(hub_files: list[tuple[str, float]]) -> list[str]:
+    """A ranked 'Hub files' orientation block (PageRank importance, #1002).
+
+    Rendered as ``#``-prefixed metadata right after the header so an agent sees
+    the repo's depended-upon core BEFORE scanning per-file sections — the cheap
+    'what matters most here' signal that keeps the first grep well-aimed. Terse
+    by design (rank, path, score) so it costs ~1 line per file.
+    """
+    lines = [
+        "# Hub files (most depended-upon — PageRank over the cross-file "
+        "import/re-export graph; highest first):"
+    ]
+    for rank, (path, score) in enumerate(hub_files, start=1):
+        lines.append(f"#  {rank:>2}. {path}  ({score:.4f})")
+    return lines
+
+
+def render_llms(
+    files: list[FileInfo],
+    repo_name: str,
+    node_count: int,
+    edge_count: int,
+    hub_files: list[tuple[str, float]] | None = None,
+) -> str:
     ordered = sorted(files, key=lambda f: f.path)
     lang_counts: dict[str, int] = {}
     for f in ordered:
@@ -88,6 +111,8 @@ def render_llms(files: list[FileInfo], repo_name: str, node_count: int, edge_cou
             langs=langs or "none",
         )
     ]
+    if hub_files:
+        out.extend(_render_hub_files(hub_files))
     for file_info in ordered:
         out.append("")
         out.extend(_render_file(file_info))

--- a/.claude/lib/tests/test_ontology_importance.py
+++ b/.claude/lib/tests/test_ontology_importance.py
@@ -1,0 +1,186 @@
+"""Tests for ontology_gen.importance — the PageRank hub-file layer (main#1002).
+
+Covers the file-graph collapse (dependency edges only, contains excluded,
+self-loops dropped, weighted by count), the pure-Python weighted PageRank
+(empty, star, exact 2-node fixed point, dangling-node mass conservation,
+determinism), and rank_files (ordering, deterministic ties, limit).
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from ontology_gen.importance import (  # noqa: E402
+    build_file_graph,
+    pagerank,
+    rank_files,
+)
+from ontology_gen.model import EdgeDict, GraphDict, NodeDict  # noqa: E402
+
+
+def _node(node_id: str, path: str, kind: str = "func") -> NodeDict:
+    return {"id": node_id, "kind": kind, "path": path, "line": 1, "lang": "python"}
+
+
+def _edge(src: str, dst: str, etype: str) -> EdgeDict:
+    return {"src": src, "dst": dst, "type": etype}
+
+
+def _graph(nodes: list[NodeDict], edges: list[EdgeDict]) -> GraphDict:
+    return {"nodes": nodes, "edges": edges}
+
+
+class BuildFileGraphTests(unittest.TestCase):
+    def test_collapses_symbol_edges_to_files_and_weights_by_count(self) -> None:
+        # Two symbols in a.py both call into b.py -> weight 2 on a->b.
+        graph: GraphDict = {
+            "nodes": [
+                _node("a:f", "a.py"),
+                _node("a:g", "a.py"),
+                _node("b:h", "b.py"),
+            ],
+            "edges": [
+                _edge("a:f", "b:h", "calls"),
+                _edge("a:g", "b:h", "calls"),
+            ],
+        }
+        files, out_weights = build_file_graph(graph)
+        self.assertEqual(files, ["a.py", "b.py"])
+        self.assertEqual(out_weights, {"a.py": {"b.py": 2}})
+
+    def test_contains_edges_excluded(self) -> None:
+        # A file 'containing' its own symbol must NOT create a dependency edge.
+        graph: GraphDict = {
+            "nodes": [_node("a", "a.py", "file"), _node("a:f", "a.py")],
+            "edges": [_edge("a", "a:f", "contains")],
+        }
+        _, out_weights = build_file_graph(graph)
+        self.assertEqual(out_weights, {})
+
+    def test_self_loop_dropped(self) -> None:
+        # Intra-file call (both endpoints in a.py) is not a cross-file dependency.
+        graph: GraphDict = {
+            "nodes": [_node("a:f", "a.py"), _node("a:g", "a.py")],
+            "edges": [_edge("a:f", "a:g", "calls")],
+        }
+        _, out_weights = build_file_graph(graph)
+        self.assertEqual(out_weights, {})
+
+    def test_all_dependency_edge_types_counted(self) -> None:
+        graph: GraphDict = {
+            "nodes": [_node("a", "a.py", "file"), _node("b", "b.py", "file")],
+            "edges": [
+                _edge("a", "b", "imports"),
+                _edge("a", "b", "imports_from"),
+                _edge("a", "b", "calls"),
+                _edge("a", "b", "inherits"),
+                _edge("a", "b", "references"),
+            ],
+        }
+        _, out_weights = build_file_graph(graph)
+        self.assertEqual(out_weights["a.py"]["b.py"], 5)
+
+
+class PageRankTests(unittest.TestCase):
+    def test_empty_graph(self) -> None:
+        self.assertEqual(pagerank([], {}), {})
+
+    def test_scores_sum_to_one(self) -> None:
+        files = ["a.py", "b.py", "c.py"]
+        out_weights = {"a.py": {"b.py": 1}, "b.py": {"c.py": 1}}
+        scores = pagerank(files, out_weights)
+        self.assertAlmostEqual(sum(scores.values()), 1.0, places=6)
+
+    def test_star_center_ranks_highest(self) -> None:
+        # a,b,c,d all depend on e -> e is the hub, must rank highest.
+        files = ["a.py", "b.py", "c.py", "d.py", "e.py"]
+        out_weights = {
+            "a.py": {"e.py": 1},
+            "b.py": {"e.py": 1},
+            "c.py": {"e.py": 1},
+            "d.py": {"e.py": 1},
+        }
+        scores = pagerank(files, out_weights)
+        top = max(scores, key=lambda f: scores[f])
+        self.assertEqual(top, "e.py")
+
+    def test_two_node_exact_fixed_point(self) -> None:
+        # A -> B, damping 0.85. Hand-solved fixed point (B is dangling):
+        #   PR[A] = 0.075 + 0.425*PR[B];  PR[B] = 0.075 + 0.425*PR[B] + 0.85*PR[A]
+        #   => PR[A] ~= 0.350877, PR[B] ~= 0.649123.
+        files = ["a.py", "b.py"]
+        out_weights = {"a.py": {"b.py": 1}}
+        scores = pagerank(files, out_weights)
+        self.assertAlmostEqual(scores["a.py"], 0.350877, places=4)
+        self.assertAlmostEqual(scores["b.py"], 0.649123, places=4)
+        self.assertGreater(scores["b.py"], scores["a.py"])
+
+    def test_dangling_node_conserves_mass(self) -> None:
+        # Every node dangling (no edges) -> uniform, still sums to 1.
+        files = ["a.py", "b.py", "c.py"]
+        scores = pagerank(files, {})
+        self.assertAlmostEqual(sum(scores.values()), 1.0, places=6)
+        for f in files:
+            self.assertAlmostEqual(scores[f], 1.0 / 3, places=6)
+
+    def test_deterministic(self) -> None:
+        files = ["a.py", "b.py", "c.py"]
+        out_weights = {"a.py": {"b.py": 2}, "c.py": {"b.py": 1}}
+        self.assertEqual(pagerank(files, out_weights), pagerank(files, out_weights))
+
+    def test_weight_increases_importance(self) -> None:
+        # b is depended on 3x, c once -> b outranks c.
+        files = ["a.py", "b.py", "c.py"]
+        out_weights = {"a.py": {"b.py": 3, "c.py": 1}}
+        scores = pagerank(files, out_weights)
+        self.assertGreater(scores["b.py"], scores["c.py"])
+
+
+class RankFilesTests(unittest.TestCase):
+    def test_hub_ranks_first_and_contains_ignored(self) -> None:
+        graph: GraphDict = {
+            "nodes": [
+                _node("a", "a.py", "file"),
+                _node("b", "b.py", "file"),
+                _node("hub", "hub.py", "file"),
+                _node("hub:f", "hub.py"),
+            ],
+            "edges": [
+                _edge("hub", "hub:f", "contains"),  # ignored
+                _edge("a", "hub", "imports"),
+                _edge("b", "hub", "imports"),
+            ],
+        }
+        ranked = rank_files(graph)
+        self.assertEqual(ranked[0][0], "hub.py")
+
+    def test_limit_respected(self) -> None:
+        nodes = [_node(f"n{i}", f"f{i}.py", "file") for i in range(10)]
+        edges = [_edge("n0", f"n{i}", "imports") for i in range(1, 10)]
+        ranked = rank_files(_graph(nodes, edges), limit=3)
+        self.assertEqual(len(ranked), 3)
+
+    def test_ties_break_by_path(self) -> None:
+        # Two symmetric hubs with identical in-degree -> equal score, path order.
+        graph: GraphDict = {
+            "nodes": [
+                _node("src", "src.py", "file"),
+                _node("z", "z.py", "file"),
+                _node("a", "a.py", "file"),
+            ],
+            "edges": [_edge("src", "z", "imports"), _edge("src", "a", "imports")],
+        }
+        ranked = rank_files(graph)
+        by_path = {p: s for p, s in ranked}
+        self.assertAlmostEqual(by_path["a.py"], by_path["z.py"], places=9)
+        # a.py before z.py on the tie.
+        order = [p for p, _ in ranked]
+        self.assertLess(order.index("a.py"), order.index("z.py"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1002. Token/context-efficiency **Move #8** (tracker #986).

## Gap
`ontology_gen` builds the structural repo-map (`code-graph.json`, ~14.8K nodes / 23K edges) rendered to the agent-facing `llms.txt` — but every file section is equal, so an agent orienting in a large repo has **no "what matters most here" signal** and its first grep can be blind. This is the single clearest *additive* win the survey flagged (Aider's tree-sitter+PageRank repo-map is the best compression-per-token reviewed).

## Change (additive; output is the gitignored build product)
- **`ontology_gen/importance.py`** — pure-Python (no networkx dependency) **weighted PageRank** via power iteration over the dependency edges (`imports`, `imports_from`, `calls`, `inherits`, `references`; `contains` excluded), collapsed to a **file-level** graph (cross-file edges only, self-loops dropped). Edge `src→dst` = "src depends on dst" (assemble.py), so score accumulates at the depended-upon core. Deterministic (sorted traversal, fixed damping/tol/iter-cap — the #855 invariant).
- **`llms.py` + `generate.py`** — a ranked **"Hub files (most depended-upon)"** block at the top of `llms.txt`, so the agent sees the core before scanning sections. ~1 line/file, negligible tokens. Backward-compatible optional param; `aggregate.py` inherits it (calls `generate()` per repo).

## Verification
- **14 new tests** including an **exact hand-solved 2-node PageRank fixed point** (0.3509 / 0.6491) — verifies the instrument, not just that it runs — plus star-hub, mass-conservation, determinism, `contains`-exclusion, self-loop-drop, tie-by-path. **63 existing ontology tests still green.** ruff + mypy clean.
- **Demo on `noorinalabs-isnad-graph` (313 files)** ranks the genuine core first:
  `useAuth.ts`, `src/config.py`, `src/utils/logging.py`, `frontend/src/types/api.ts`, `src/utils/neo4j_client.py`, `src/api/auth.py|deps.py|middleware.py`, shared API clients. These are exactly the depended-upon hubs.

## Non-goals
Output (`llms.txt`) is the gitignored structural build product (main#939) — no committed churn. Applies to all repos via the generator; "prototype on isnad-graph" is the validation, not a scope limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
