### PR TITLE
fix(#1012): validate_matrix_names — H1 slim-card name fallback

### DIFF
--- a/.claude/skills/wave-scope/tests/test_validate_matrix_names.py
+++ b/.claude/skills/wave-scope/tests/test_validate_matrix_names.py
@@ -52,6 +52,64 @@ def _build_fake_org_dir(tmp: Path) -> Path:
     return tmp
 
 
+def _write_slim_roster_card(roster_dir: Path, role_slug: str, name: str) -> None:
+    """Mimic the NEW slim card shape (#1010): H1 `# <Name> — <Role>`, no
+    `**Name:**` field. Verbatim to the shipped template so the fixture can't
+    pass while the real cards fail (feedback_fixture_makes_guard_assertion_inert).
+    """
+    roster_dir.mkdir(parents=True, exist_ok=True)
+    (roster_dir / f"{role_slug}.md").write_text(
+        f"# {name} — Engineer\n\n"
+        "- **Level:** Senior · **Status:** Active\n"
+        f"- **Git:** {name} <parametrization+{name.replace(' ', '.')}@gmail.com>\n\n"
+        "**Style:** Terse.\n"
+    )
+
+
+class SlimCardFormatTests(unittest.TestCase):
+    """#1010: slim H1 cards (no `**Name:**` field) must still resolve.
+
+    Regression guard — the pre-#1010 parser only matched `**Name:**` and
+    silently extracted ZERO names from a slimmed roster dir, fail-closing
+    every name in that repo's matrix slot.
+    """
+
+    def test_slim_parent_and_child_names_resolve(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = Path(tmpdir)
+            _write_slim_roster_card(
+                org / ".claude" / "team" / "roster", "sql_aino", "Aino Virtanen"
+            )
+            # Hyphenated child name — the `\\s+[—–-]\\s+` separator must NOT
+            # split "Jun-Seo Park" at its internal hyphen.
+            _write_slim_roster_card(
+                org / "noorinalabs-isnad-graph" / ".claude" / "team" / "roster",
+                "tl_junseo",
+                "Jun-Seo Park",
+            )
+            matrix = {
+                "noorinalabs-isnad-graph": {
+                    "implementer": "Jun-Seo Park",
+                    "reviewer": "Aino Virtanen",  # parent-org-level, slim card
+                }
+            }
+            report = validate(matrix, org)
+            for f in report["noorinalabs-isnad-graph"]:
+                self.assertTrue(f["resolved"], f"{f['declared']} should resolve")
+
+    def test_mixed_format_roster_dir_resolves_both(self):
+        """A roster dir mid-transition (one slim card + one old card) resolves both."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = Path(tmpdir)
+            roster = org / ".claude" / "team" / "roster"
+            _write_slim_roster_card(roster, "sql_aino", "Aino Virtanen")
+            _write_roster_card(roster, "pd_nadia", "Nadia Khoury")  # old format
+            matrix = {"noorinalabs-main": {"a": "Aino Virtanen", "b": "Nadia Khoury"}}
+            report = validate(matrix, org)
+            for f in report["noorinalabs-main"]:
+                self.assertTrue(f["resolved"], f"{f['declared']} should resolve")
+
+
 class HappyPathTests(unittest.TestCase):
     """All declared names resolve to canonical roster entries."""
 

--- a/.claude/skills/wave-scope/validate_matrix_names.py
+++ b/.claude/skills/wave-scope/validate_matrix_names.py
@@ -74,17 +74,30 @@ def _find_org_dir() -> Path:
 
 
 def _load_roster_names(roster_dir: Path) -> set[str]:
-    """Parse `**Name:** Foo Bar` lines from every .md file in roster_dir."""
+    """Parse member names from every .md card in roster_dir.
+
+    Handles BOTH roster card templates (union of matches, so a mixed-format
+    roster dir mid-transition resolves every card, #1010):
+
+      OLD (verbose): ``- **Name:** Foo Bar``
+      NEW (slim):    ``# Foo Bar — Role`` (H1, em/en/hyphen separator)
+
+    The H1 separator regex requires whitespace on BOTH sides of the dash
+    (``\\s+[—–-]\\s+``) so a genuinely hyphenated name (``Jun-Seo Park``,
+    ``Vega-Cruz``) is never split at its internal hyphen — same guard the
+    sibling parsers use (roster_consistency_check.py, validate_pr_review.py).
+    """
     names: set[str] = set()
     if not roster_dir.is_dir():
         return names
     name_re = re.compile(r"\*\*Name:\*\*\s+(.+?)\s*$", re.MULTILINE)
+    h1_re = re.compile(r"^#\s+(.+?)\s+[—–-]\s+.+$", re.MULTILINE)
     for md_file in roster_dir.glob("*.md"):
         try:
             text = md_file.read_text()
         except OSError:
             continue
-        for match in name_re.finditer(text):
+        for match in list(name_re.finditer(text)) + list(h1_re.finditer(text)):
             name = match.group(1).strip()
             # Trim role/status parentheticals (`Foo Bar (Tech Lead)`).
             name = re.sub(r"\s*\(.*?\)\s*$", "", name)


### PR DESCRIPTION
Closes #1012.

## Regression fixed
#1011 slimmed the 9 parent persona cards (dropped `**Name:**` for the `# <Name> — <Role>` H1). `/wave-scope`'s `_load_roster_names` only matched `**Name:**`, so post-#1011 it extracted **0 names** from the parent roster → every parent implementer/reviewer name in a wave-scope matrix fail-closed as "not in roster". Fixture-based tests stayed green while the real cards broke (the fixture-masks-production pattern).

## Change
- `validate_matrix_names.py::_load_roster_names` — union the old `**Name:**` match with an H1 match using the same whitespace-guarded `\s+[—–-]\s+` separator the sibling parsers (`roster_consistency_check.py`, `validate_pr_review.py`) use, so hyphenated names (`Jun-Seo Park`, `Vega-Cruz`) are never split at an internal hyphen.
- `test_validate_matrix_names.py` — `SlimCardFormatTests`: slim parent+child resolution (incl. a hyphenated name) + mixed-format roster dir, built from the verbatim shipped slim card shape.

## Verification
- Pre-fix: `_load_roster_names('.claude/team/roster')` → 0 names. Post-fix → 9 (slim parent); old-format child rosters (e.g. user-service → 4) still resolve.
- `pytest test_validate_matrix_names.py` 13 passed; ruff check + format clean.

Also unblocks the #1010 child-repo fan-out — `validate_matrix_names` reads child rosters, so it must handle slim cards before children are trimmed.

Reviewers: 2 per charter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5nRsC9woWMwQRdqAfLYYF