### PR TITLE
Add smart_grep_ontology PreToolUse hook (#1017)

### DIFF
--- a/.claude/hooks/dispatcher.py
+++ b/.claude/hooks/dispatcher.py
@@ -29,6 +29,9 @@ if str(_HOOKS_DIR) not in sys.path:
 _BASH_HOOKS = [
     "validate_commit_identity",
     "block_no_verify",
+    # Route a symbol-shaped rg/grep to the structural ontology BEFORE the
+    # block_bare_grep backstop, so a symbol search is answered inline (#1017).
+    "smart_grep_ontology",
     "block_bare_grep",
     "block_git_config",
     "block_gh_pr_review",

--- a/.claude/hooks/smart_grep_ontology.py
+++ b/.claude/hooks/smart_grep_ontology.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: route a symbol-shaped `rg`/`grep` to the structural ontology.
+
+Problem (#1017, ported from botfarm #886): a brute-force `rg some_func` (or the
+`grep` block_bare_grep already discourages) re-discovers structure the generated
+ontology (`ontology/structural/code-graph.json`) already holds — every symbol's
+definition site, plus its callers/callees as graph edges — and pays for it in
+tokens (the search dumps every matching line across the tree; the agent then
+re-reads whole files to get the surrounding context anyway).
+
+What this hook does: when the Bash command is an `rg`/`grep`/`egrep`/`fgrep`
+invocation searching for a single bare-identifier pattern (or a dotted
+`Class.method` qualname) that the graph actually indexes, it BLOCKS the raw
+search and returns the answer inline instead — definition site(s) plus a few
+call-site pointers, all as `path:line`, straight from `code-graph.json` (the
+fixed node/edge contract `ontology_gen.model` documents, not a re-derived
+index). The agent reads exactly those lines instead of searching the tree.
+
+Relationship to `block_bare_grep`: this hook runs BEFORE that backstop in the
+dispatcher, so a symbol-shaped `grep`/`rg` is answered from the ontology first.
+Everything block_bare_grep still owns is untouched: a free-text `grep` falls
+through to its "use `rg`" message, and a free-text `rg` is allowed as before.
+
+Escape hatch — `# --graph-tried`: a free-text search (a log message, an error
+string, a regex with metacharacters) has nothing for the graph to match, so it
+is never intercepted in the first place. For the narrower case — the pattern
+IS a real symbol name but the ontology answer is stale, incomplete, or the
+agent has already used it and genuinely needs the raw search (e.g. to see every
+call site, not just the first few) — append a trailing shell comment to the
+SAME command: `rg foo_bar . # --graph-tried`. `#` opens a real shell comment
+there (preceded by whitespace), so the shell runs the search UNCHANGED; this
+hook independently tokenizes the same string (shlex does not strip `#`) and
+recognizes the literal `#` `--graph-tried` token pair as the bypass. A quoted
+occurrence of the same text (`rg "--graph-tried" .`) collapses to one data
+token under `tokenize()` and does NOT match — only the unquoted, comment-
+position marker counts (Rule 2). (For a `grep` invocation the marker bypasses
+THIS hook, but block_bare_grep still applies — pair it with `rg`, or with
+`NOORINA_ALLOW_GREP=1` if a raw `grep` is truly needed.)
+
+Context-guard convention (charter/hooks.md):
+- Rule 1 — N/A: this hook only inspects/blocks a command; it never mutates git.
+- Rule 2 — command-text matching goes through the shared `_shell_parse` helpers
+  (`strip_heredocs` + `tokenize` + `iter_command_segments`), never a raw regex
+  over the untouched command. An `rg`/`grep` mention inside a heredoc body or a
+  quoted argument collapses to a single data token and is not matched as a
+  command-position invocation.
+
+Fail-safe posture: a tokenization failure, a missing/unparseable ontology graph,
+or zero graph matches ALL allow (return None) — this hook only ever prevents a
+search it can genuinely answer better; it never blocks a query the ontology has
+nothing for.
+
+Exit codes:
+  0 — allow (not a Bash call, not rg/grep, escape hatch present, pattern isn't
+      a bare identifier, ontology missing/unparseable, or no graph match)
+  2 — block (a symbol the graph indexes was found; the answer is inline)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _shell_parse import (  # noqa: E402
+    iter_command_segments,
+    strip_heredocs,
+    tokenize,
+    walk_flag_values,
+)
+from annunaki_log import log_pretooluse_block  # noqa: E402
+
+# Repo root, resolved module-relative exactly like ontology_tracker.py: the hook
+# lives at ``<repo>/.claude/hooks/smart_grep_ontology.py``, so three parents up
+# is the repo root that owns ``ontology/structural/code-graph.json``. This is
+# the worktree root in production (the structural layer is generated per-tree),
+# and is monkeypatched in tests to point at a synthetic ontology.
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+# The grep family plus ripgrep — matched on basename, so `/usr/bin/grep` and a
+# wrapper-prefixed `sudo grep` both resolve. `rg` is noorina's standard text
+# search (block_bare_grep steers `grep` to it); a symbol-shaped `rg` is exactly
+# what this hook answers from the ontology.
+_GREP_BINARIES = frozenset({"grep", "egrep", "fgrep", "rg"})
+
+# Common exec wrappers peeled to find the effective command word, mirroring
+# block_bare_grep. We over-peel a wrapper's value tokens rather than track them
+# per-wrapper: mis-peeling only ever makes us fail OPEN (return None), and a
+# genuinely bare grep we miss is still caught by block_bare_grep downstream.
+_WRAPPERS = frozenset(
+    {"sudo", "env", "time", "command", "nice", "nohup", "stdbuf", "ionice", "xargs", "watch"}
+)
+
+_ENV_ASSIGN_RE = re.compile(r"^[A-Za-z_]\w*=")
+
+# Flags (grep + ripgrep, short and long form) that consume a SEPARATE following
+# token as their value. Getting this list right matters: a value like the "3"
+# in `-A 3` must never be mistaken for the search pattern. `-e`/`--regexp` is
+# handled separately (its value IS the pattern, not something to skip past).
+_VALUE_FLAGS = frozenset(
+    {
+        "-A",
+        "-B",
+        "-C",
+        "-m",
+        "-f",
+        "--file",
+        "-g",
+        "--glob",
+        "-t",
+        "--type",
+        "-T",
+        "--type-not",
+        "--include",
+        "--exclude",
+        "--after-context",
+        "--before-context",
+        "--context",
+        "--max-count",
+        "--max-columns",
+        "--max-columns-preview",
+        "-M",
+        "--threads",
+        "-j",
+    }
+)
+
+# A bare identifier or a dotted qualname (`Class.method`) — the only shapes the
+# graph indexes as a symbol id. Anything else (spaces, quotes, regex
+# metacharacters) is free text the graph was never going to answer, so it is
+# never even looked up.
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*$")
+
+# Skip a pattern this short even if it parses as an identifier — a 1-2 char
+# token ("id", "ok") is too generic to be worth an ontology round-trip and
+# would surface a wall of unrelated hits.
+_MIN_PATTERN_LEN = 3
+
+# Cap how many definition sites the answer lists, and how many call sites per
+# definition — keeps the block message a scan, not a second search dump.
+_MAX_MATCHES = 8
+_MAX_CALLERS = 5
+
+
+def _ontology_dir() -> Path:
+    return REPO_ROOT / "ontology"
+
+
+def _grep_tail(segment: list[str]) -> list[str] | None:
+    """The tokens AFTER an `rg`/`grep`-family binary in a command segment, or None.
+
+    Peels leading one-shot env-assignments (`FOO=bar rg ...`) and known exec
+    wrappers with their flags (`sudo grep`, `env X=1 rg`), then returns the tail
+    when the effective command's basename is a grep-family binary. Wrapper value
+    tokens are over-peeled (see `_WRAPPERS`) — safe because a miss fails open.
+    """
+    i = 0
+    n = len(segment)
+    while i < n and _ENV_ASSIGN_RE.match(segment[i]):
+        i += 1
+    while i < n and os.path.basename(segment[i]) in _WRAPPERS:
+        i += 1
+        while i < n and (segment[i].startswith("-") or _ENV_ASSIGN_RE.match(segment[i])):
+            i += 1
+    if i < n and os.path.basename(segment[i]) in _GREP_BINARIES:
+        return segment[i + 1 :]
+    return None
+
+
+def _find_grep_segment(tokens: list[str]) -> list[str] | None:
+    """The grep/rg-family invocation's tail tokens (binary + prefix stripped)."""
+    for segment in iter_command_segments(tokens):
+        tail = _grep_tail(segment)
+        if tail is not None:
+            return tail
+    return None
+
+
+def _has_escape_hatch(tokens: list[str]) -> bool:
+    """True iff a literal, unquoted `# --graph-tried` token pair is present.
+
+    Both are separate shlex tokens only when unquoted (a quoted copy collapses
+    to one data token — see module docstring), so this cannot be tripped by a
+    search pattern that merely contains the same text.
+    """
+    return any(
+        tokens[i] == "#" and tokens[i + 1] == "--graph-tried" for i in range(len(tokens) - 1)
+    )
+
+
+def _extract_pattern(rest: list[str]) -> str | None:
+    """The search pattern from a grep/rg tail (binary already dropped), or None.
+
+    `-e`/`--regexp`'s value wins when present; otherwise the first token that
+    isn't a flag or a flag's value.
+    """
+    explicit = walk_flag_values(rest, {"-e", "--regexp"})
+    if explicit:
+        return explicit[0]
+    i = 0
+    n = len(rest)
+    while i < n:
+        tok = rest[i]
+        if tok in _VALUE_FLAGS:
+            i += 2
+            continue
+        if tok.startswith("-"):
+            i += 1
+            continue
+        return tok
+    return None
+
+
+def _looks_like_symbol(pattern: str) -> bool:
+    return bool(_IDENTIFIER_RE.match(pattern)) and len(pattern.replace(".", "")) >= _MIN_PATTERN_LEN
+
+
+def _load_graph() -> dict | None:
+    path = _ontology_dir() / "structural" / "code-graph.json"
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _dirty_files() -> set[str]:
+    """Paths whose ``last_tracked`` checksum has drifted from ``last_resolved`` —
+    same staleness signal `/ontology-librarian` reports. Empty on any read error
+    (advisory only; never blocks the hook itself)."""
+    path = _ontology_dir() / "checksums.json"
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return set()
+    files = data.get("files", {}) if isinstance(data, dict) else {}
+    return {
+        f
+        for f, v in files.items()
+        if isinstance(v, dict) and v.get("last_tracked") != v.get("last_resolved")
+    }
+
+
+def _lookup_symbol(graph: dict, pattern: str) -> list[dict]:
+    """Nodes whose qualname (the part of the id after ``::``) IS ``pattern``, or
+    whose last dotted component is — so a bare method search (``get``) also
+    surfaces ``_Config.get``, and an exact qualname search (``_Config.get``)
+    matches only that. File/module nodes (no ``::``) are never returned — a
+    bare filename is a `find` job, not a symbol lookup."""
+    matches = []
+    for node in graph.get("nodes", []):
+        node_id = node.get("id", "")
+        if "::" not in node_id:
+            continue
+        symbol = node_id.split("::", 1)[1]
+        if symbol == pattern or symbol.rsplit(".", 1)[-1] == pattern:
+            matches.append(node)
+    return matches
+
+
+def _callers(graph: dict, node_id: str, nodes_by_id: dict[str, dict]) -> list[str]:
+    """Up to `_MAX_CALLERS` ``path:line`` pointers for edges that call `node_id`."""
+    out: list[str] = []
+    for edge in graph.get("edges", []):
+        if edge.get("type") != "calls" or edge.get("dst") != node_id:
+            continue
+        src = nodes_by_id.get(edge.get("src", ""))
+        if src is not None:
+            out.append(f"{src['path']}:{src['line']}")
+        if len(out) >= _MAX_CALLERS:
+            break
+    return out
+
+
+def _build_answer(pattern: str, matches: list[dict], graph: dict) -> str:
+    nodes_by_id = {n["id"]: n for n in graph.get("nodes", []) if "id" in n}
+    dirty = _dirty_files()
+    shown = matches[:_MAX_MATCHES]
+
+    lines = [
+        f"ONTOLOGY HIT for `{pattern}` — routed to the structural ontology instead "
+        f"of a brute-force search ({len(matches)} definition site(s)):",
+        "",
+    ]
+    for node in shown:
+        node_id = node["id"]
+        stale = (
+            "  [STALE: source changed since ontology was last resolved]"
+            if node.get("path") in dirty
+            else ""
+        )
+        lines.append(f"  - {node.get('kind')} {node_id} -> {node['path']}:{node['line']}{stale}")
+        callers = _callers(graph, node_id, nodes_by_id)
+        if callers:
+            lines.append(f"      called from: {', '.join(callers)}")
+    if len(matches) > _MAX_MATCHES:
+        lines.append(
+            f"  ... and {len(matches) - _MAX_MATCHES} more match(es) — refine the "
+            "query (e.g. the full `Class.method` qualname) if you need a different one."
+        )
+
+    lines += [
+        "",
+        "Read the file(s) at the line(s) above directly instead of searching the tree.",
+        "Escape hatch: if this is stale/insufficient or you need the raw search for "
+        "another reason, append ` # --graph-tried` to the SAME command (use `rg`, not "
+        "`grep` — block_bare_grep still applies) — the shell treats it as a comment "
+        "and runs the search unchanged.",
+    ]
+    return "\n".join(lines)
+
+
+def check(input_data: dict) -> dict | None:
+    """Dispatcher-compatible entry point. None to allow, dict to block."""
+    if input_data.get("tool_name", "") != "Bash":
+        return None
+
+    command = input_data.get("tool_input", {}).get("command", "")
+    if not isinstance(command, str) or not command:
+        return None
+
+    tokens = tokenize(strip_heredocs(command))
+    if tokens is None:
+        return None  # unparseable → fail open (not a security gate)
+
+    if _has_escape_hatch(tokens):
+        return None
+
+    grep_tail = _find_grep_segment(tokens)
+    if grep_tail is None:
+        return None
+
+    pattern = _extract_pattern(grep_tail)
+    if pattern is None or not _looks_like_symbol(pattern):
+        return None
+
+    graph = _load_graph()
+    if graph is None:
+        return None
+
+    matches = _lookup_symbol(graph, pattern)
+    if not matches:
+        return None
+
+    reason = _build_answer(pattern, matches, graph)
+    log_pretooluse_block("smart_grep_ontology", command, reason)
+    return {"decision": "block", "reason": reason}
+
+
+def main() -> None:
+    try:
+        input_data = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        sys.exit(0)
+
+    result = check(input_data)
+    if result and result.get("decision") == "block":
+        print(json.dumps(result))
+        sys.exit(2)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/tests/test_smart_grep_ontology.py
+++ b/.claude/hooks/tests/test_smart_grep_ontology.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""Unit tests for smart_grep_ontology.py — issue #1017 (ported from botfarm #886).
+
+The hook blocks an `rg`/`grep` call searching for a bare-identifier (or dotted
+`Class.method`) pattern the structural ontology (`code-graph.json`) already
+indexes, and returns the definition site(s) + call sites inline instead of
+letting the brute-force search run. Coverage:
+
+  _find_grep_segment / _extract_pattern — locating the grep-family invocation
+    and its search pattern past value-taking flags (`-A 3`, `-e PATTERN`),
+    a wrapper prefix (`sudo grep`), and `rg`. `_find_grep_segment` returns the
+    tail AFTER the binary (noorina has no `strip_command_prefix`; the tail feeds
+    `_extract_pattern` directly).
+  _has_escape_hatch — the `# --graph-tried` bypass is unquoted-token-position
+    only; a quoted copy of the same text (search DATA, not a shell comment)
+    never trips it.
+  check() — blocks + answers for a known func/class/method (with call sites
+    and a truncation note past `_MAX_MATCHES`); allows a non-Bash tool, a
+    non-grep command, a free-text/regex pattern, an unknown symbol, a missing
+    ontology graph, the escape hatch, and an `rg` mention hidden inside a
+    heredoc body; flags a STALE source file.
+  THE BITE — neutering `_lookup_symbol` (the actual graph query) turns the
+    baseline block into an allow, proving the block is produced by the
+    ontology lookup and not some other path.
+
+Hermetic: the ontology is a small synthetic `code-graph.json`/`checksums.json`
+written under `tmp_path` and resolved by monkeypatching `mod.REPO_ROOT`; nothing
+reads the real repo's ontology and `log_pretooluse_block` is stubbed out.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+HOOKS_DIR = Path(__file__).resolve().parents[1]
+if str(HOOKS_DIR) not in sys.path:
+    sys.path.insert(0, str(HOOKS_DIR))
+
+import smart_grep_ontology as mod  # noqa: E402
+
+_GRAPH = {
+    "nodes": [
+        {
+            "id": "pkg/mod.py",
+            "kind": "module",
+            "path": "pkg/mod.py",
+            "line": 1,
+            "lang": "python",
+        },
+        {
+            "id": "pkg/mod.py::foo_bar",
+            "kind": "func",
+            "path": "pkg/mod.py",
+            "line": 10,
+            "lang": "python",
+        },
+        {
+            "id": "pkg/mod.py::Widget",
+            "kind": "class",
+            "path": "pkg/mod.py",
+            "line": 20,
+            "lang": "python",
+        },
+        {
+            "id": "pkg/mod.py::Widget.get",
+            "kind": "method",
+            "path": "pkg/mod.py",
+            "line": 25,
+            "lang": "python",
+        },
+        {
+            "id": "pkg/caller.py::do_thing",
+            "kind": "func",
+            "path": "pkg/caller.py",
+            "line": 5,
+            "lang": "python",
+        },
+    ],
+    "edges": [
+        {
+            "src": "pkg/caller.py::do_thing",
+            "dst": "pkg/mod.py::foo_bar",
+            "type": "calls",
+        },
+    ],
+}
+
+
+def _write_ontology(root: Path) -> None:
+    structural = root / "ontology" / "structural"
+    structural.mkdir(parents=True)
+    (structural / "code-graph.json").write_text(json.dumps(_GRAPH), encoding="utf-8")
+    checksums = {
+        "files": {
+            "pkg/mod.py": {"last_tracked": "aaa", "last_resolved": "aaa"},
+            "pkg/caller.py": {"last_tracked": "bbb", "last_resolved": "bbb"},
+        }
+    }
+    (root / "ontology" / "checksums.json").write_text(json.dumps(checksums), encoding="utf-8")
+
+
+@pytest.fixture
+def repo(tmp_path, monkeypatch):
+    """A repo root with a synthetic ontology. Returns a factory building
+    `input_data` for a Bash command; `mod.REPO_ROOT` is pinned to `tmp_path`."""
+    monkeypatch.setattr(mod, "log_pretooluse_block", lambda *a, **k: None)
+    monkeypatch.setattr(mod, "REPO_ROOT", tmp_path)
+    _write_ontology(tmp_path)
+
+    def _build(command: str) -> dict:
+        return {
+            "tool_name": "Bash",
+            "cwd": str(tmp_path),
+            "tool_input": {"command": command},
+        }
+
+    return _build
+
+
+def _mark_dirty(tmp_path: Path) -> None:
+    checksums = json.loads((tmp_path / "ontology" / "checksums.json").read_text())
+    checksums["files"]["pkg/mod.py"]["last_tracked"] = "changed"
+    (tmp_path / "ontology" / "checksums.json").write_text(json.dumps(checksums), encoding="utf-8")
+
+
+def _tok(command: str) -> list[str]:
+    """`tokenize`, asserting a parse (it is `list[str] | None`) for the callers
+    below that pass the result straight into a `list[str]`-typed helper."""
+    tokens = mod.tokenize(command)
+    assert tokens is not None
+    return tokens
+
+
+# ---------------------------------------------------------------- _extract_pattern
+
+
+def test_extract_pattern_plain() -> None:
+    assert mod._extract_pattern(["-rn", "foo_bar", "."]) == "foo_bar"
+
+
+def test_extract_pattern_skips_value_flag() -> None:
+    """`-A 3` must not leave `3` mistaken for the pattern."""
+    assert mod._extract_pattern(["-A", "3", "-rn", "foo_bar", "."]) == "foo_bar"
+
+
+def test_extract_pattern_dash_e() -> None:
+    assert mod._extract_pattern(["-rn", "-e", "foo_bar", "."]) == "foo_bar"
+
+
+def test_extract_pattern_none_when_only_flags() -> None:
+    assert mod._extract_pattern(["-rn", "-l"]) is None
+
+
+# ---------------------------------------------------------------- _find_grep_segment
+#
+# Returns the tail AFTER the grep-family binary (noorina lacks
+# strip_command_prefix — the binary is peeled by _grep_tail itself).
+
+
+def test_find_grep_segment_plain() -> None:
+    tokens = _tok("grep -rn foo_bar .")
+    assert mod._find_grep_segment(tokens) == ["-rn", "foo_bar", "."]
+
+
+def test_find_grep_segment_ripgrep() -> None:
+    tokens = _tok('rg "foo_bar" .')
+    assert mod._find_grep_segment(tokens) == ["foo_bar", "."]
+
+
+def test_find_grep_segment_wrapper_prefix() -> None:
+    tokens = _tok("sudo grep -rn foo_bar .")
+    assert mod._find_grep_segment(tokens) == ["-rn", "foo_bar", "."]
+
+
+def test_find_grep_segment_none_for_other_commands() -> None:
+    tokens = _tok("ls -la .")
+    assert mod._find_grep_segment(tokens) is None
+
+
+# ---------------------------------------------------------------- _has_escape_hatch
+
+
+def test_escape_hatch_present() -> None:
+    tokens = _tok('rg "foo_bar" . # --graph-tried')
+    assert mod._has_escape_hatch(tokens) is True
+
+
+def test_escape_hatch_absent() -> None:
+    tokens = _tok("rg foo_bar .")
+    assert mod._has_escape_hatch(tokens) is False
+
+
+def test_escape_hatch_not_tripped_by_quoted_data() -> None:
+    """A quoted `--graph-tried` search pattern is DATA, not a shell comment — it
+    collapses to one token under `tokenize()`, so it must never be read as the
+    bypass marker (Rule 2: quote-awareness, no false-match on the search's data)."""
+    tokens = _tok('rg "# --graph-tried" file.py')
+    assert mod._has_escape_hatch(tokens) is False
+
+
+# ---------------------------------------------------------------- check(): allowing
+
+
+def test_allows_non_bash_tool(repo) -> None:
+    data = repo("rg foo_bar .")
+    data["tool_name"] = "Read"
+    assert mod.check(data) is None
+
+
+def test_allows_non_grep_command(repo) -> None:
+    assert mod.check(repo("ls -la .")) is None
+
+
+def test_allows_free_text_pattern(repo) -> None:
+    """A pattern with spaces / regex metacharacters is not a symbol shape — the
+    graph was never going to answer it, so it's never even looked up."""
+    assert mod.check(repo('rg "does not exist yet" .')) is None
+
+
+def test_allows_regex_pattern(repo) -> None:
+    assert mod.check(repo('rg "foo.*bar" .')) is None
+
+
+def test_allows_unknown_symbol(repo) -> None:
+    assert mod.check(repo("rg totally_unknown_symbol_xyz .")) is None
+
+
+def test_allows_when_escape_hatch_present(repo) -> None:
+    """Same command as the blocking test below, plus the bypass marker."""
+    assert mod.check(repo("rg foo_bar . # --graph-tried")) is None
+
+
+def test_allows_grep_mentioned_inside_heredoc(repo) -> None:
+    command = "cat <<'EOF' > note.txt\nrg foo_bar .\nEOF\n"
+    assert mod.check(repo(command)) is None
+
+
+def test_allows_when_ontology_missing(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(mod, "log_pretooluse_block", lambda *a, **k: None)
+    monkeypatch.setattr(mod, "REPO_ROOT", tmp_path)  # no ontology written
+    data = {
+        "tool_name": "Bash",
+        "cwd": str(tmp_path),
+        "tool_input": {"command": "rg foo_bar ."},
+    }
+    assert mod.check(data) is None
+
+
+# ---------------------------------------------------------------- check(): blocking
+
+
+def test_blocks_and_answers_known_function(repo) -> None:
+    result = mod.check(repo("rg foo_bar ."))
+    assert result is not None
+    assert result["decision"] == "block"
+    assert "pkg/mod.py:10" in result["reason"]
+    assert "called from: pkg/caller.py:5" in result["reason"]
+    assert "--graph-tried" in result["reason"]
+
+
+def test_blocks_bare_grep_symbol_too(repo) -> None:
+    """A symbol-shaped `grep` is answered here BEFORE block_bare_grep sees it."""
+    result = mod.check(repo("grep -rn foo_bar ."))
+    assert result is not None and result["decision"] == "block"
+    assert "pkg/mod.py:10" in result["reason"]
+
+
+def test_bare_method_name_matches_dotted_qualname(repo) -> None:
+    result = mod.check(repo("rg get ."))
+    assert result is not None
+    assert "pkg/mod.py::Widget.get" in result["reason"]
+    assert "pkg/mod.py:25" in result["reason"]
+
+
+def test_exact_qualname_pattern_matches_only_that(repo) -> None:
+    result = mod.check(repo('rg -e "Widget.get" .'))
+    assert result is not None
+    assert "Widget.get" in result["reason"]
+    assert "foo_bar" not in result["reason"]
+
+
+def test_class_name_match(repo) -> None:
+    result = mod.check(repo("rg Widget ."))
+    assert result is not None
+    assert "pkg/mod.py::Widget " in result["reason"] or "pkg/mod.py::Widget\n" in result["reason"]
+
+
+def test_ripgrep_invocation_blocks_too(repo) -> None:
+    result = mod.check(repo('rg "foo_bar" .'))
+    assert result is not None and result["decision"] == "block"
+
+
+def test_stale_source_is_flagged(repo, tmp_path) -> None:
+    _mark_dirty(tmp_path)
+    result = mod.check(repo("rg foo_bar ."))
+    assert result is not None
+    assert "STALE" in result["reason"]
+
+
+def test_truncates_past_max_matches(repo, tmp_path) -> None:
+    graph = json.loads((tmp_path / "ontology" / "structural" / "code-graph.json").read_text())
+    for i in range(mod._MAX_MATCHES + 1):
+        graph["nodes"].append(
+            {
+                "id": f"pkg/extra{i}.py::shared_name",
+                "kind": "func",
+                "path": f"pkg/extra{i}.py",
+                "line": 1,
+                "lang": "python",
+            }
+        )
+    (tmp_path / "ontology" / "structural" / "code-graph.json").write_text(
+        json.dumps(graph), encoding="utf-8"
+    )
+    result = mod.check(repo("rg shared_name ."))
+    assert result is not None
+    assert "more match(es)" in result["reason"]
+
+
+# ---------------------------------------------------------------- THE BITE
+
+
+def test_the_guard_bites(repo, monkeypatch) -> None:
+    """Mutation proof: with the graph query neutered, the same command that
+    blocked at baseline now allows — the block is produced BY the ontology
+    lookup, not incidentally by some other path (memory: gate-must-be-shown-to-bite)."""
+    live = mod.check(repo("rg foo_bar ."))
+    assert live is not None and live["decision"] == "block"  # baseline: bites
+
+    monkeypatch.setattr(mod, "_lookup_symbol", lambda graph, pattern: [])
+    neutered = mod.check(repo("rg foo_bar ."))
+    assert neutered is None  # neutered: the block is gone -> the fires-test reds


### PR DESCRIPTION
## Summary

Ports botfarm's `smart_grep_ontology` PreToolUse hook into noorina (#1017).

When a Bash command is a **symbol-shaped** `rg`/`grep` search — a bare identifier or a dotted `Class.method` qualname that the structural ontology already indexes — the hook blocks the brute-force search and instead returns, inline, the definition site(s) plus up to five caller `path:line` pointers straight from `ontology/structural/code-graph.json`. The agent reads exactly those lines rather than paying tokens for a full match dump and then re-reading whole files for context.

## Dispatcher placement

Registered in `_BASH_HOOKS` **before** `block_bare_grep`, which stays as the backstop:

- symbol-shaped `rg`/`grep` → answered from the ontology here first;
- free-text `grep` → falls through to `block_bare_grep`'s "use `rg`" message;
- free-text `rg` → allowed, unchanged.

## noorina adaptations

The graph schema is otherwise identical to botfarm's (`nodes`: id/kind/path/line; `edges`: src/dst/type=`calls`), so the lookup/answer logic ports verbatim. Changes:

- **Path resolution**: ontology dir comes from a module-relative `REPO_ROOT` (three parents up), matching `ontology_tracker.py`, instead of botfarm's `framework.config` helper — noorina has no `_framework_config`.
- **Logging**: uses `annunaki_log.log_pretooluse_block` (noorina's logger).
- **Wrapper peeling**: noorina's `_shell_parse` has no `strip_command_prefix`, so a local `_grep_tail` peels env-assignments/exec-wrappers to find the grep-family binary and returns the tail; mis-peels fail **open** (the search is still caught by `block_bare_grep` downstream).

Fail-open posture preserved: a missing/unparseable graph or zero matches all allow. Escape hatch ` # --graph-tried` runs the raw search unchanged (pair with `rg`, since `block_bare_grep` still applies to `grep`).

## Testing

- Ported the unit test — 28 cases including the mutation "bite" (neutering `_lookup_symbol` turns the baseline block into an allow).
- `ruff format` + `ruff check`: clean.
- `mypy .claude/hooks/ .claude/lib/ --ignore-missing-imports`: clean.
- Full `.claude/hooks/tests/` + `.claude/lib/tests/`: 2563 passed.
- Live end-to-end through `dispatcher.py` against the real generated graph: a symbol-shaped `rg` blocks with the ontology answer; free-text and the escape hatch pass.

Closes #1017

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QdvQ7Aa4P8DGnKXS2rgobE
