### PR TITLE
Config-driven hook dispatch via framework.config.json (#1018)

### DIFF
--- a/.claude/framework.config.json
+++ b/.claude/framework.config.json
@@ -1,0 +1,63 @@
+{
+  "version": 1,
+  "scm": {
+    "provider": "github",
+    "default_branch": "main",
+    "allow_force": false
+  },
+  "branch": {
+    "feature": "{FirstInitial}.{LastName}/{issue}-{slug}",
+    "integration": "deployments/phase-{phase}/wave-{wave}"
+  },
+  "identity": {
+    "enforce": true,
+    "email_pattern": "parametrization+{First}.{Last}@gmail.com",
+    "roster_source": ".claude/team/roster.json",
+    "allow_emails": [
+      "parametrization@gmail.com"
+    ]
+  },
+  "shell": "zsh",
+  "hooks": {
+    "pre_bash": [
+      "validate_commit_identity",
+      "block_no_verify",
+      "smart_grep_ontology",
+      "block_bare_grep",
+      "block_git_config",
+      "block_gh_pr_review",
+      "block_stale_tmp_message_file",
+      "no_worktree_self_delete",
+      "validate_edit_completion",
+      "auto_set_env_test",
+      "validate_lockfile_paths",
+      "validate_labels",
+      "validate_wave_label_evidence",
+      "validate_review_comment_format",
+      "validate_pr_review",
+      "validate_pr_ci_status",
+      "validate_branch_freshness",
+      "validate_workflow_paths_coverage",
+      "validate_vps_host",
+      "warn_ghcr_image",
+      "warn_zsh_wordsplit",
+      "block_squash_wave_merge"
+    ],
+    "post_bash": [
+      "annunaki_monitor",
+      "warn_pipe_mask_rc",
+      "auto_sync_main",
+      "auto_add_issue_to_board",
+      "post_wave_kickoff_comment",
+      "post_label_change_wave_field_sync"
+    ],
+    "post_file": [
+      "ontology_tracker",
+      "suggest_generic_prompt",
+      "validate_edit_completion"
+    ],
+    "post_notebook": [
+      "validate_edit_completion"
+    ]
+  }
+}

--- a/.claude/hooks/_framework_config.py
+++ b/.claude/hooks/_framework_config.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Shared config loader for framework hooks/libs.
+
+The opinionated values that used to be hard-coded in the dispatchers (which
+hook modules run, in what order) and elsewhere are read through this module
+instead. The config lives at ``<repo>/.claude/framework.config.json``; this
+loader finds it by walking up from the invocation cwd, parses it, and exposes a
+dotted-path getter merged over the schema defaults.
+
+Design contract
+===============
+
+- **Stdlib only.** No PyYAML / pydantic dependency — a hook must run in a
+  freshly-pulled checkout with zero install step. Config is JSON for the same
+  reason (``json`` is stdlib; YAML is not).
+- **Fail-open to defaults.** A missing/unreadable/malformed config never raises
+  and never blocks — :func:`config` returns the defaults so a hook degrades to
+  its documented behaviour rather than crashing the tool call. Because
+  ``_DEFAULTS`` carries the full hook lists, a config-less (or corrupt-config)
+  checkout still dispatches every gate — the fail-open direction is "run the
+  gates", never "silently drop them".
+- **Defaults live here.** Dotted lookups fall back to ``_DEFAULTS`` when the
+  loaded config omits a key. Keep ``_DEFAULTS['hooks']`` in sync with
+  ``.claude/framework.config.json`` — the two are cross-checked by
+  ``tests/test_hook_registration_coverage.py``.
+
+Usage
+=====
+
+    from _framework_config import config
+    cfg = config(input_data)                       # input_data optional
+    if cfg.get("scm.allow_force", False): ...
+    pre = cfg.get("hooks.pre_bash", [])
+
+``config()`` caches per resolved config-file path, so repeated calls within one
+hook invocation are cheap.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+CONFIG_FILENAME = "framework.config.json"
+
+# Runtime shadow of ``.claude/framework.config.json``. Dotted lookups fall back
+# here when the loaded config omits a key, and a config-less checkout runs on
+# these values verbatim. Keep in sync with the committed config file.
+#
+# ``hooks.*`` — the ordered module lists the dispatchers run. A module named
+# here MUST expose the dispatcher contract ``check(input_data) -> dict | None``;
+# the dispatchers skip any module without it, so a non-conforming name is an
+# inert entry that reads as enabled but never runs (issue #698). Hooks that only
+# implement ``main()`` — session_start, session_handoff, validate_wave_context —
+# are registered standalone in ``.claude/settings.json`` instead, and are
+# deliberately absent here.
+#
+# ``pre_bash`` order matters: cheap/local checks first, network-calling checks
+# last. In particular smart_grep_ontology routes a symbol-shaped rg/grep to the
+# structural ontology BEFORE the block_bare_grep backstop (#1017), and
+# block_squash_wave_merge runs LAST because it resolves a PR base via
+# ``gh pr view`` (a network call, cheap-prefiltered on ``--squash``).
+#
+# A supplied ``hooks.*`` list REPLACES the default (see _deep_merge: lists are
+# not merged) so a repo can disable a default hook by omitting it. The cost is
+# that an omission is indistinguishable from an oversight —
+# ``tests/test_hook_registration_coverage.py`` is the safety net that fails when
+# a ``check()``-exposing hook ends up dispatched nowhere.
+_DEFAULTS: dict[str, Any] = {
+    "version": 1,
+    "scm": {"provider": "github", "default_branch": "main", "allow_force": False},
+    "branch": {
+        "feature": "{FirstInitial}.{LastName}/{issue}-{slug}",
+        "integration": "deployments/phase-{phase}/wave-{wave}",
+    },
+    "identity": {
+        "enforce": True,
+        "email_pattern": "parametrization+{First}.{Last}@gmail.com",
+        "roster_source": ".claude/team/roster.json",
+        "allow_emails": ["parametrization@gmail.com"],
+    },
+    "shell": "zsh",
+    "hooks": {
+        "pre_bash": [
+            "validate_commit_identity",
+            "block_no_verify",
+            "smart_grep_ontology",
+            "block_bare_grep",
+            "block_git_config",
+            "block_gh_pr_review",
+            "block_stale_tmp_message_file",
+            "no_worktree_self_delete",
+            "validate_edit_completion",
+            "auto_set_env_test",
+            "validate_lockfile_paths",
+            "validate_labels",
+            "validate_wave_label_evidence",
+            "validate_review_comment_format",
+            "validate_pr_review",
+            "validate_pr_ci_status",
+            "validate_branch_freshness",
+            "validate_workflow_paths_coverage",
+            "validate_vps_host",
+            "warn_ghcr_image",
+            "warn_zsh_wordsplit",
+            "block_squash_wave_merge",
+        ],
+        "post_bash": [
+            "annunaki_monitor",
+            "warn_pipe_mask_rc",
+            "auto_sync_main",
+            "auto_add_issue_to_board",
+            "post_wave_kickoff_comment",
+            "post_label_change_wave_field_sync",
+        ],
+        "post_file": [
+            "ontology_tracker",
+            "suggest_generic_prompt",
+            "validate_edit_completion",
+        ],
+        "post_notebook": [
+            "validate_edit_completion",
+        ],
+    },
+}
+
+# Cache: resolved-config-path -> merged dict. Keyed by path so different repos in
+# one process (rare) don't collide; the None key caches "not found → defaults".
+_CACHE: dict[str | None, dict[str, Any]] = {}
+
+
+def _find_config_file(start: Path) -> Path | None:
+    """Walk up from ``start`` looking for ``.claude/framework.config.json``."""
+    cur = start.resolve()
+    for d in (cur, *cur.parents):
+        candidate = d / ".claude" / CONFIG_FILENAME
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _deep_merge(base: dict[str, Any], over: dict[str, Any]) -> dict[str, Any]:
+    """Return ``base`` deep-merged with ``over`` (over wins; dicts merge recursively).
+
+    Lists are replaced wholesale, not concatenated — so a supplied ``hooks.*``
+    list fully overrides the default, which is how a repo disables a hook.
+    """
+    out = dict(base)
+    for k, v in over.items():
+        if isinstance(v, dict) and isinstance(out.get(k), dict):
+            out[k] = _deep_merge(out[k], v)
+        else:
+            out[k] = v
+    return out
+
+
+def _resolve_start_dir(input_data: dict | None) -> Path:
+    """Best-effort cwd for the tool call."""
+    if input_data:
+        cwd = input_data.get("cwd")
+        if isinstance(cwd, str) and cwd:
+            return Path(cwd)
+    return Path(os.getcwd())
+
+
+class _Config:
+    """Thin wrapper exposing :meth:`get` with dotted-path access over a merged dict."""
+
+    __slots__ = ("_data", "path")
+
+    def __init__(self, data: dict[str, Any], path: Path | None) -> None:
+        self._data = data
+        self.path = path
+
+    def get(self, dotted: str, default: Any = None) -> Any:
+        """Return the value at ``dotted`` (e.g. ``"hooks.pre_bash"``), or ``default``.
+
+        ``default`` is returned only when the key is absent from BOTH the loaded
+        config and ``_DEFAULTS`` — so callers can omit ``default`` for keys that
+        always have a default, and pass one for genuinely-optional keys.
+        """
+        node: Any = self._data
+        for part in dotted.split("."):
+            if isinstance(node, dict) and part in node:
+                node = node[part]
+            else:
+                return default
+        return node
+
+    def as_dict(self) -> dict[str, Any]:
+        return dict(self._data)
+
+
+def config(input_data: dict | None = None, *, start_dir: str | Path | None = None) -> _Config:
+    """Load the framework config merged over defaults. Never raises.
+
+    Resolution order for the config file: explicit ``start_dir`` →
+    ``input_data["cwd"]`` → ``os.getcwd()``, walking up to the filesystem root.
+    If no config file is found (or it is unreadable/invalid JSON), the pure
+    defaults are returned.
+    """
+    start = Path(start_dir) if start_dir else _resolve_start_dir(input_data)
+    path = _find_config_file(start)
+    key = str(path) if path else None
+    if key in _CACHE:
+        return _Config(_CACHE[key], path)
+
+    merged = dict(_DEFAULTS)
+    if path is not None:
+        try:
+            loaded = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(loaded, dict):
+                merged = _deep_merge(_DEFAULTS, loaded)
+        except (OSError, json.JSONDecodeError, ValueError):
+            merged = dict(_DEFAULTS)  # fail-open
+
+    _CACHE[key] = merged
+    return _Config(merged, path)
+
+
+def clear_cache() -> None:
+    """Drop the memoized config (tests that write a config mid-run call this)."""
+    _CACHE.clear()

--- a/.claude/hooks/dispatcher.py
+++ b/.claude/hooks/dispatcher.py
@@ -9,6 +9,15 @@ Each hook module exposes:
     check(input_data: dict) -> dict | None
         Returns None to allow, or a dict with "decision" and "reason"/"systemMessage".
 
+The active module list + order is read from the framework config
+(``hooks.pre_bash`` in ``.claude/framework.config.json``), so enabling,
+disabling, or reordering a check is a config edit rather than a code change.
+The loader fails open to the full default list, so a missing/corrupt config
+still dispatches every gate. Order matters: cheap/local checks first (e.g.
+smart_grep_ontology routes a symbol search before the block_bare_grep backstop,
+#1017), network-calling checks last (block_squash_wave_merge resolves a PR base
+via `gh pr view`).
+
 Exit codes:
   0 — allow (all hooks passed, or aggregated warnings)
   2 — block (first blocking hook wins)
@@ -24,36 +33,7 @@ _HOOKS_DIR = Path(__file__).resolve().parent
 if str(_HOOKS_DIR) not in sys.path:
     sys.path.insert(0, str(_HOOKS_DIR))
 
-# Ordered list of hook modules to run for Bash PreToolUse.
-# Order matters: cheap/fast checks first, network-calling checks last.
-_BASH_HOOKS = [
-    "validate_commit_identity",
-    "block_no_verify",
-    # Route a symbol-shaped rg/grep to the structural ontology BEFORE the
-    # block_bare_grep backstop, so a symbol search is answered inline (#1017).
-    "smart_grep_ontology",
-    "block_bare_grep",
-    "block_git_config",
-    "block_gh_pr_review",
-    "block_stale_tmp_message_file",
-    "no_worktree_self_delete",
-    "validate_edit_completion",
-    "auto_set_env_test",
-    "validate_lockfile_paths",
-    "validate_labels",
-    "validate_wave_label_evidence",
-    "validate_review_comment_format",
-    "validate_pr_review",
-    "validate_pr_ci_status",
-    "validate_branch_freshness",
-    "validate_workflow_paths_coverage",
-    "validate_vps_host",
-    "warn_ghcr_image",
-    "warn_zsh_wordsplit",
-    # Network-calling checks LAST: resolves a PR's base ref via `gh pr view`.
-    # Cheap-prefiltered on `--squash` and fails open on any gh error. P7W19.
-    "block_squash_wave_merge",
-]
+from _framework_config import config  # noqa: E402
 
 
 def main() -> None:
@@ -68,7 +48,7 @@ def main() -> None:
 
     warnings: list[str] = []
 
-    for module_name in _BASH_HOOKS:
+    for module_name in config(input_data).get("hooks.pre_bash", []):
         try:
             mod = importlib.import_module(module_name)
         except ImportError:

--- a/.claude/hooks/post_dispatcher.py
+++ b/.claude/hooks/post_dispatcher.py
@@ -27,7 +27,9 @@ mirroring `dispatcher.py`).
 Input Language:
   Fires on:      PostToolUse Bash | Edit | Write | NotebookEdit
   Matches:       any tool invocation whose `tool_name` is a key in
-                 `_REGISTRY` (Bash, Edit, Write, NotebookEdit)
+                 `_MATCHER_CFG_KEY` (Bash, Edit, Write, NotebookEdit); the
+                 ordered module list per matcher comes from the framework
+                 config (hooks.post_bash / post_file / post_notebook)
   Does NOT match: tool invocations whose matcher has no registered modules
   Flag pass-through: stdin JSON is read once and passed verbatim to each
                      registered module's `check()` function
@@ -50,6 +52,7 @@ _HOOKS_DIR = Path(__file__).resolve().parent
 if str(_HOOKS_DIR) not in sys.path:
     sys.path.insert(0, str(_HOOKS_DIR))
 
+from _framework_config import config  # noqa: E402
 from annunaki_log import log_posttooluse_dispatch  # noqa: E402
 
 # Per-check dispatch tracing (#425). When `POST_DISPATCHER_TRACE_ALL=1` is
@@ -62,33 +65,32 @@ from annunaki_log import log_posttooluse_dispatch  # noqa: E402
 # log doesn't drown in no-op entries.
 _TRACE_EVERY = os.environ.get("POST_DISPATCHER_TRACE_ALL", "").lower() in ("1", "true", "yes")
 
-# Edit and Write share the same module set today (every module that runs on
-# Edit also runs on Write). Defining it once keeps the two matcher entries
-# in lock-step.
-_EDIT_WRITE_MODULES = [
-    "ontology_tracker",
-    "suggest_generic_prompt",
-    "validate_edit_completion",
-]
-
-# Matcher → ordered list of hook-module import names.
-# Order matters: cheap/local checks first, network-calling checks last
+# Matcher → the framework-config ``hooks.<event>`` key whose ordered module list
+# runs for that tool. The lists themselves live in ``.claude/framework.config.json``
+# (shadowed by ``_framework_config._DEFAULTS`` for a config-less checkout), so
+# enabling/reordering a hook is a config edit rather than a code change. Order
+# within each list is preserved: cheap/local checks first, network-calling last
 # (mirroring `dispatcher.py`'s ordering convention).
-_REGISTRY: dict[str, list[str]] = {
-    "Bash": [
-        "annunaki_monitor",  # local: regex over stdout/stderr, JSONL append
-        "warn_pipe_mask_rc",  # local: flag rc-masking `git push|tail`/`gh pr merge|head` (#838)
-        "auto_sync_main",  # local: ff local main after a push/merge to origin/main (#713)
-        "auto_add_issue_to_board",  # network: runs `gh project item-add`
-        "post_wave_kickoff_comment",  # network: gh fetch + post comment
-        "post_label_change_wave_field_sync",  # network: GraphQL updateProjectV2ItemFieldValue
-    ],
-    "Edit": _EDIT_WRITE_MODULES,
-    "Write": _EDIT_WRITE_MODULES,
-    "NotebookEdit": [
-        "validate_edit_completion",  # PostToolUse sentinel write only
-    ],
+#
+# Edit and Write share ``hooks.post_file`` (every module that runs on Edit also
+# runs on Write). NotebookEdit keeps its own ``hooks.post_notebook`` list — it
+# runs ONLY the PostToolUse sentinel write (validate_edit_completion), NOT the
+# ontology/suggest modules — so it must not collapse into post_file.
+_MATCHER_CFG_KEY: dict[str, str] = {
+    "Bash": "hooks.post_bash",
+    "Edit": "hooks.post_file",
+    "Write": "hooks.post_file",
+    "NotebookEdit": "hooks.post_notebook",
 }
+
+
+def _modules_for(tool_name: str, input_data: dict | None = None) -> list[str]:
+    """Resolve the ordered hook-module list for ``tool_name`` from the framework
+    config. Returns ``[]`` for a tool with no registered matcher."""
+    cfg_key = _MATCHER_CFG_KEY.get(tool_name)
+    if cfg_key is None:
+        return []
+    return list(config(input_data).get(cfg_key, []))
 
 
 def main() -> None:
@@ -98,7 +100,7 @@ def main() -> None:
         sys.exit(0)
 
     tool_name = input_data.get("tool_name", "")
-    modules = _REGISTRY.get(tool_name)
+    modules = _modules_for(tool_name, input_data)
     if not modules:
         sys.exit(0)
 

--- a/.claude/hooks/tests/test_hook_registration_coverage.py
+++ b/.claude/hooks/tests/test_hook_registration_coverage.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""Registration-coverage guards for the hook dispatchers — issue #698.
+
+A hook only runs if it is reachable one of exactly two ways:
+
+  * **dispatched** — named in a ``hooks.*`` list in the *resolved* framework
+    config, and exposing the dispatcher contract ``check(input_data)``; or
+  * **standalone** — registered as its own ``command`` entry in
+    ``.claude/settings.json``, invoked as a subprocess (``main()``).
+
+Two silent failure modes live in the gap between those:
+
+  1. A ``check()``-exposing hook reachable *neither* way. Because a supplied
+     ``hooks.*`` list REPLACES the default rather than merging (see
+     ``_framework_config._deep_merge``), a module dropped from
+     ``framework.config.json`` silently stops running even though its ``check()``
+     is still on disk.
+  2. A module *named* in a ``hooks.*`` list that exposes no ``check()``. The
+     dispatchers ``getattr(mod, "check", None)`` and skip on ``None``, so the
+     entry reads as enabled and never runs.
+
+Replacement semantics are deliberate — omitting a default is how a repo disables
+a hook — so these tests are the safety net that makes an *accidental* omission
+loud. Hermetic: modules are parsed with ``ast``, never imported, so no hook side
+effect (network, git, ontology I/O) can run here.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+HOOKS_DIR = Path(__file__).resolve().parents[1]
+CLAUDE_DIR = HOOKS_DIR.parent
+SETTINGS = CLAUDE_DIR / "settings.json"
+
+_CFG_PATH = HOOKS_DIR / "_framework_config.py"
+_spec = importlib.util.spec_from_file_location("_framework_config", _CFG_PATH)
+assert _spec is not None and _spec.loader is not None
+_framework_config = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_framework_config)
+
+# The dispatchers themselves, plus ``_``-prefixed shared libs, are infrastructure
+# rather than hooks: they are never listed in a ``hooks.*`` list.
+DISPATCHERS = {"dispatcher", "post_dispatcher"}
+
+# Hooks that intentionally expose ``check()`` while being reachable neither way.
+# Empty by design: adding a name here must be a deliberate, reviewed decision
+# with a rationale, not the silent default that #698 was.
+INTENTIONALLY_UNREGISTERED: set[str] = set()
+
+# Every ``hooks.<event>`` list the dispatchers read. ``dispatcher.py`` reads
+# ``pre_bash``; ``post_dispatcher.py`` reads ``post_bash`` (Bash), ``post_file``
+# (Edit/Write) and ``post_notebook`` (NotebookEdit).
+HOOK_LIST_KEYS = ("pre_bash", "post_bash", "post_file", "post_notebook")
+
+# A shell tail that swallows a non-zero exit and reports success. Appended to a
+# hook ``command`` it converts *"this gate could not run"* (a missing script
+# exits 2, which PreToolUse reads as BLOCK) into *"this gate silently allows"* —
+# fail-open. Forbidden for IN-TREE registrations; see #828 / #830 / #697 / #698.
+#
+# The guard flags a ``||``- or ``;``-sequenced tail whose right-hand side is
+# anything OTHER than a non-zero ``exit`` — because any such RHS can exit 0 and
+# thereby swallow the block. A genuine re-raise (``|| exit 1``, ``; exit 2``) is
+# deliberately allowed, as is a bare trailing separator with no RHS.
+#   * ``(?:\|\||;)``           — a ``||`` or ``;`` sequencer, then optional space,
+#   * ``(?=\S)``               — with a non-empty RHS (skip a bare trailing sep),
+#   * ``(?!exit\s+0*[1-9]\d*)`` — that is NOT ``exit <non-zero>``.
+_FAIL_OPEN_GUARD = re.compile(r"(?:\|\||;)\s*(?=\S)(?!exit\s+0*[1-9]\d*)")
+
+
+def _exposes_check(path: Path) -> bool:
+    """True if the module defines a top-level ``check`` function. Parse, not import."""
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    return any(
+        isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == "check"
+        for node in tree.body
+    )
+
+
+def _hook_modules() -> dict[str, Path]:
+    """Every candidate hook module: ``.claude/hooks/*.py`` minus libs + dispatchers."""
+    return {
+        p.stem: p
+        for p in sorted(HOOKS_DIR.glob("*.py"))
+        if not p.stem.startswith("_") and p.stem not in DISPATCHERS
+    }
+
+
+def _resolved_config():
+    """The live merged config, exactly as a dispatcher resolves it at runtime."""
+    _framework_config.clear_cache()
+    return _framework_config.config(start_dir=CLAUDE_DIR)
+
+
+def _dispatched_modules(cfg) -> dict[str, str]:
+    """module -> the ``hooks.<event>`` key that dispatches it."""
+    out: dict[str, str] = {}
+    for key in HOOK_LIST_KEYS:
+        for name in cfg.get(f"hooks.{key}", []) or []:
+            out.setdefault(name, key)
+    return out
+
+
+def _standalone_modules() -> set[str]:
+    """Modules invoked by their own ``command`` entry in settings.json."""
+    settings = json.loads(SETTINGS.read_text(encoding="utf-8"))
+    found: set[str] = set()
+    for matchers in settings.get("hooks", {}).values():
+        for matcher in matchers:
+            for hook in matcher.get("hooks", []):
+                command = hook.get("command", "")
+                for stem in _hook_modules():
+                    if f"/{stem}.py" in command:
+                        found.add(stem)
+    return found
+
+
+def test_every_check_exposing_hook_is_reachable() -> None:
+    """A hook implementing ``check()`` must be dispatched or standalone-registered.
+
+    This is the guard that would have caught a hook silently dropped from the
+    ``hooks.*`` lists (#698).
+    """
+    cfg = _resolved_config()
+    dispatched = set(_dispatched_modules(cfg))
+    standalone = _standalone_modules()
+
+    orphans = sorted(
+        name
+        for name, path in _hook_modules().items()
+        if _exposes_check(path)
+        and name not in dispatched
+        and name not in standalone
+        and name not in INTENTIONALLY_UNREGISTERED
+    )
+
+    assert not orphans, (
+        "Hook module(s) expose check() but are never executed — dead code:\n"
+        + "".join(f"  - {name}\n" for name in orphans)
+        + f"\nA supplied hooks.* list in {SETTINGS.parent.name}/framework.config.json "
+        "REPLACES the default list in _framework_config._DEFAULTS, so a module "
+        "omitted there is silently dropped.\n"
+        "Remedy — pick one:\n"
+        "  (a) dispatch it: add the module to the appropriate hooks.<event> list "
+        "in .claude/framework.config.json (and keep _DEFAULTS in sync); or\n"
+        "  (b) register it standalone: add a command entry running "
+        "<module>.py to .claude/settings.json.\n"
+        "If it is genuinely meant to run nowhere, delete it — or add it to "
+        "INTENTIONALLY_UNREGISTERED in this file with a written rationale."
+    )
+
+
+def test_every_dispatched_module_exposes_check() -> None:
+    """A module named in a resolved ``hooks.*`` list must implement ``check()``.
+
+    The dispatchers skip a module without one, so the entry reads as enabled and
+    never runs — the inverse of the orphan above (#698).
+    """
+    cfg = _resolved_config()
+    modules = _hook_modules()
+    inert: list[str] = []
+
+    for name, key in _dispatched_modules(cfg).items():
+        path = modules.get(name)
+        if path is None or not _exposes_check(path):
+            missing = "no such module" if path is None else "no check()"
+            inert.append(f"  - {name} (hooks.{key}: {missing})\n")
+
+    assert not inert, (
+        "Config lists module(s) the dispatcher cannot run — inert entries:\n"
+        + "".join(inert)
+        + "\nEvery dispatched module must define a top-level "
+        "check(input_data) -> dict | None.\n"
+        "Remedy — pick one:\n"
+        "  (a) give the module a check() so the dispatcher runs it; or\n"
+        "  (b) drop it from the hooks.<event> list — if it is standalone-registered "
+        "in .claude/settings.json it already runs, and the list entry is a lie."
+    )
+
+
+def test_defaults_hook_lists_expose_check() -> None:
+    """``_DEFAULTS`` is the template a config-less repo runs on — hold it to the
+    same contract, so a fresh checkout does not inherit inert entries."""
+    modules = _hook_modules()
+    defaults = _framework_config._DEFAULTS["hooks"]
+    inert = sorted(
+        f"{key}:{name}"
+        for key, names in defaults.items()
+        for name in names
+        if name not in modules or not _exposes_check(modules[name])
+    )
+    assert not inert, (
+        "_framework_config._DEFAULTS names module(s) without a check() — they "
+        f"would never run in a repo with no framework.config.json: {inert}"
+    )
+
+
+def test_config_file_matches_defaults() -> None:
+    """The committed ``framework.config.json`` hooks and ``_DEFAULTS['hooks']``
+    must agree.
+
+    The two are meant to be a mirror (the JSON is the live source of truth; the
+    Python defaults are its config-less shadow). A drift between them means a
+    fresh checkout runs a different gate set than a configured one — exactly the
+    silent divergence this suite exists to forbid.
+    """
+    cfg_file = json.loads((CLAUDE_DIR / "framework.config.json").read_text(encoding="utf-8"))
+    assert cfg_file.get("hooks") == _framework_config._DEFAULTS["hooks"], (
+        "framework.config.json 'hooks' and _framework_config._DEFAULTS['hooks'] "
+        "have drifted. Keep them in sync — the JSON is the source of truth; "
+        "_DEFAULTS is the fallback a config-less checkout runs on."
+    )
+
+
+def test_block_squash_wave_merge_is_dispatched_last() -> None:
+    """The squash guard is wired, and ordered after the local-only checks.
+
+    It resolves a PR base via ``gh pr view``, so it must not gate cheap checks
+    behind a network call. Pinning the position keeps the dispatcher's documented
+    "cheap/local first, network-calling last" ordering honest.
+    """
+    pre_bash = _resolved_config().get("hooks.pre_bash", [])
+    assert "block_squash_wave_merge" in pre_bash, (
+        "block_squash_wave_merge must be dispatched — it is the only enforcement "
+        "of --merge over --squash for integration-branch merges (#698)."
+    )
+    assert pre_bash[-1] == "block_squash_wave_merge", (
+        "block_squash_wave_merge issues a `gh pr view` call and must run last in "
+        f"hooks.pre_bash; found order: {pre_bash}"
+    )
+
+
+def test_smart_grep_ontology_precedes_block_bare_grep() -> None:
+    """smart_grep_ontology must run before the block_bare_grep backstop (#1017).
+
+    A symbol-shaped rg/grep is answered inline by the ontology router; if the
+    bare-grep block ran first it would reject the command before the router got
+    a chance, defeating the point.
+    """
+    pre_bash = _resolved_config().get("hooks.pre_bash", [])
+    assert "smart_grep_ontology" in pre_bash and "block_bare_grep" in pre_bash
+    assert pre_bash.index("smart_grep_ontology") < pre_bash.index("block_bare_grep"), (
+        "smart_grep_ontology must precede block_bare_grep in hooks.pre_bash; "
+        f"found order: {pre_bash}"
+    )
+
+
+def _settings_commands() -> list[tuple[str, str]]:
+    """(event, command) for every hook command registered in settings.json."""
+    settings = json.loads(SETTINGS.read_text(encoding="utf-8"))
+    out: list[tuple[str, str]] = []
+    for event, matchers in settings.get("hooks", {}).items():
+        for matcher in matchers:
+            for hook in matcher.get("hooks", []):
+                out.append((event, hook.get("command", "")))
+    return out
+
+
+def test_no_intree_registration_fails_open() -> None:
+    """No `.claude/settings.json` hook command may swallow a run failure.
+
+    Every command in the *tracked* ``settings.json`` is an **in-tree**
+    registration — it invokes ``$CLAUDE_PROJECT_DIR/.claude/hooks/<script>.py``,
+    which lives in the same commit as this entry and cannot decouple from it.
+    Any ``||``- or ``;``-sequenced tail whose RHS is not a non-zero ``exit``
+    would convert a hand-deleted script's loud BLOCK (exit 2) into a silent
+    ALLOW — the fail-open footgun #828 was filed to forbid, #830 to document,
+    and #851 to broaden this guard against.
+    """
+    offenders = [
+        f"  - {event}: {command}\n"
+        for event, command in _settings_commands()
+        if _FAIL_OPEN_GUARD.search(command)
+    ]
+
+    assert not offenders, (
+        "In-tree hook registration(s) in .claude/settings.json fail OPEN:\n"
+        + "".join(offenders)
+        + "\nAn in-tree hook and its settings.json registration are tracked in "
+        "the same commit and cannot decouple, so a `||`/`;`-sequenced tail whose "
+        "RHS is not a non-zero `exit` (e.g. `|| exit 0`, `|| true`, `; exit 0`, "
+        "`|| echo x`) only turns a hand-deleted script's loud BLOCK into a silent "
+        "ALLOW (fail-open — #697/#698). Drop the guard: a security gate that "
+        "cannot run must fail closed."
+    )
+
+
+# --- Direct bite-tests on _FAIL_OPEN_GUARD (#851) ------------------------------
+# The consumer test above exercises the guard only through the live settings.json,
+# which today has zero offenders — so it stays green no matter how broad OR narrow
+# the regex is. These pin the guard's BOUND directly.
+
+# The in-tree registration form every tracked settings.json command takes.
+_REGISTRATION = 'python3 "$CLAUDE_PROJECT_DIR"/.claude/hooks/some_gate.py'
+
+# Tails that convert a missing-script BLOCK (exit 2) into a silent ALLOW — the
+# guard MUST flag each.
+_SWALLOW_TAILS = [
+    "|| exit 0",
+    "|| true",
+    "|| :",
+    "; exit 0",
+    "|| echo skip",
+    "|| printf skip",
+    "|| cat",
+    "|| exit 000",
+    "|| exit 00",
+]
+
+# Tails (or their absence) that CANNOT swallow a block: a genuine fail-CLOSED
+# re-raise (non-zero ``exit``), a bare command, or a bare trailing separator.
+_SAFE_TAILS = [
+    "",  # the bare registration, no tail
+    "|| exit 1",
+    "; exit 2",
+    "|| exit 010",
+    "|| exit 42",
+    ";",  # bare trailing separator
+]
+
+
+@pytest.mark.parametrize("tail", _SWALLOW_TAILS)
+def test_fail_open_guard_flags_swallow_tails(tail: str) -> None:
+    """Every block-swallowing tail must be caught by ``_FAIL_OPEN_GUARD``."""
+    command = f"{_REGISTRATION} {tail}"
+    assert _FAIL_OPEN_GUARD.search(command), (
+        f"_FAIL_OPEN_GUARD failed to flag a fail-open tail: {tail!r} — its RHS can "
+        "exit 0 and swallow the missing-script BLOCK. A narrowing re-opens #851."
+    )
+
+
+@pytest.mark.parametrize("tail", _SAFE_TAILS)
+def test_fail_open_guard_allows_safe_tails(tail: str) -> None:
+    """A fail-CLOSED re-raise, a bare command, or a bare separator must NOT flag."""
+    command = f"{_REGISTRATION} {tail}".rstrip()
+    assert not _FAIL_OPEN_GUARD.search(command), (
+        f"_FAIL_OPEN_GUARD false-flagged a legitimate registration tail: {tail!r}. "
+        "A non-zero `exit` fails CLOSED and a bare separator exits with the LHS "
+        "status — neither swallows a block."
+    )

--- a/.claude/hooks/tests/test_post_dispatcher.py
+++ b/.claude/hooks/tests/test_post_dispatcher.py
@@ -47,12 +47,12 @@ def _run_dispatcher(input_data: dict) -> tuple[int, str]:
 
 
 class RegistryCompletenessTests(unittest.TestCase):
-    """Every PostToolUse entry in settings.json must be in _REGISTRY."""
+    """Every PostToolUse entry in settings.json must resolve to modules via config."""
 
     def test_settings_post_tool_use_entries_all_registered(self):
-        """If settings.json registered foo.py for matcher M, _REGISTRY[M] must
-        list 'foo' (or the entry must already be `post_dispatcher.py`, the
-        consolidation entry).
+        """If settings.json registered foo.py for matcher M, the config module
+        list for M must include 'foo' (or the entry must already be
+        `post_dispatcher.py`, the consolidation entry).
         """
         settings_path = _REPO_ROOT / ".claude" / "settings.json"
         with open(settings_path, encoding="utf-8") as f:
@@ -75,9 +75,9 @@ class RegistryCompletenessTests(unittest.TestCase):
             if all(m == "post_dispatcher" for m in registered):
                 self.assertIn(
                     matcher,
-                    pd._REGISTRY,
+                    pd._MATCHER_CFG_KEY,
                     f"settings.json registers post_dispatcher for matcher "
-                    f"{matcher!r} but _REGISTRY has no entry for it",
+                    f"{matcher!r} but _MATCHER_CFG_KEY has no entry for it",
                 )
                 continue
             for module in registered:
@@ -85,30 +85,32 @@ class RegistryCompletenessTests(unittest.TestCase):
                     continue
                 self.assertIn(
                     module,
-                    pd._REGISTRY.get(matcher, []),
+                    pd._modules_for(matcher),
                     f"settings.json registers {module!r} for matcher "
-                    f"{matcher!r} but _REGISTRY[{matcher!r}] does not include it",
+                    f"{matcher!r} but the config module list for it "
+                    "does not include it",
                 )
 
     def test_registry_modules_all_importable(self):
-        """Every module in _REGISTRY must be importable from .claude/hooks/."""
+        """Every config-dispatched module must be importable from .claude/hooks/."""
         import importlib
 
-        for matcher, modules in pd._REGISTRY.items():
-            for module_name in modules:
+        for matcher in pd._MATCHER_CFG_KEY:
+            for module_name in pd._modules_for(matcher):
                 try:
                     importlib.import_module(module_name)
                 except ImportError as e:
                     self.fail(
-                        f"_REGISTRY[{matcher!r}] lists {module_name!r} but it failed to import: {e}"
+                        f"config lists {module_name!r} for matcher {matcher!r} "
+                        f"but it failed to import: {e}"
                     )
 
     def test_registry_modules_expose_check(self):
-        """Every module in _REGISTRY must expose a `check(input_data)` function."""
+        """Every config-dispatched module must expose a `check(input_data)` function."""
         import importlib
 
-        for matcher, modules in pd._REGISTRY.items():
-            for module_name in modules:
+        for matcher in pd._MATCHER_CFG_KEY:
+            for module_name in pd._modules_for(matcher):
                 mod = importlib.import_module(module_name)
                 self.assertTrue(
                     callable(getattr(mod, "check", None)),
@@ -117,7 +119,7 @@ class RegistryCompletenessTests(unittest.TestCase):
 
     def test_edit_write_share_module_list(self):
         """Edit and Write should reference the same module sequence today."""
-        self.assertEqual(pd._REGISTRY["Edit"], pd._REGISTRY["Write"])
+        self.assertEqual(pd._modules_for("Edit"), pd._modules_for("Write"))
 
 
 class DispatchPerMatcherTests(unittest.TestCase):
@@ -134,7 +136,7 @@ class DispatchPerMatcherTests(unittest.TestCase):
             input_data.update(extra_input)
 
         mocks: list[mock.MagicMock] = []
-        modules = pd._REGISTRY[matcher]
+        modules = pd._modules_for(matcher)
 
         # Patch each module's `check` so we can assert call counts without
         # exercising real side effects.
@@ -566,10 +568,10 @@ class DispatchTraceTests(unittest.TestCase):
             "tool_input": {"command": "echo trace-all"},
             "tool_response": {"stdout": "", "stderr": "", "exitCode": 0},
         }
-        # Derive the expected module set from the registry itself so this test
-        # does not rot when the registry grows (it gained
+        # Derive the expected module set from the config itself so this test
+        # does not rot when the list grows (it gained
         # post_label_change_wave_field_sync via #445 after wave-10 authored it).
-        bash_modules = list(post_dispatcher._REGISTRY["Bash"])
+        bash_modules = post_dispatcher._modules_for("Bash")
         with mock.patch.dict("os.environ", {"POST_DISPATCHER_TRACE_ALL": "1"}):
             importlib.reload(post_dispatcher)
             try:

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/dispatcher.py",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/dispatcher.py",
             "timeout": 30
           }
         ]
@@ -16,12 +16,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_wave_context.py",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/validate_wave_context.py",
             "timeout": 10
           },
           {
             "type": "command",
-            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/enforce_ontology_context.py",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/enforce_ontology_context.py",
             "timeout": 10
           }
         ]
@@ -31,12 +31,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/block_shutdown_without_retro.py",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/block_shutdown_without_retro.py",
             "timeout": 10
           },
           {
             "type": "command",
-            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_edit_completion.py",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/validate_edit_completion.py",
             "timeout": 10
           }
         ]
@@ -46,7 +46,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_wave_audit.py",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/validate_wave_audit.py",
             "timeout": 30
           }
         ]
@@ -56,12 +56,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/enforce_librarian_consulted.py",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/enforce_librarian_consulted.py",
             "timeout": 10
           },
           {
             "type": "command",
-            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_edit_completion.py",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/validate_edit_completion.py",
             "timeout": 10
           }
         ]
@@ -71,12 +71,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/enforce_librarian_consulted.py",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/enforce_librarian_consulted.py",
             "timeout": 10
           },
           {
             "type": "command",
-            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_edit_completion.py",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/validate_edit_completion.py",
             "timeout": 10
           }
         ]
@@ -86,12 +86,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/enforce_librarian_consulted.py",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/enforce_librarian_consulted.py",
             "timeout": 10
           },
           {
             "type": "command",
-            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/validate_edit_completion.py",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/validate_edit_completion.py",
             "timeout": 10
           }
         ]
@@ -103,7 +103,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/post_dispatcher.py",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/post_dispatcher.py",
             "timeout": 90
           }
         ]
@@ -113,7 +113,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/post_dispatcher.py",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/post_dispatcher.py",
             "timeout": 30
           }
         ]
@@ -123,7 +123,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/post_dispatcher.py",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/post_dispatcher.py",
             "timeout": 30
           }
         ]
@@ -133,7 +133,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/post_dispatcher.py",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/post_dispatcher.py",
             "timeout": 30
           }
         ]
@@ -145,7 +145,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/session_start.py",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/session_start.py",
             "timeout": 10
           }
         ]
@@ -155,7 +155,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/session_start.py",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/session_start.py",
             "timeout": 10
           }
         ]
@@ -167,7 +167,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 /home/parameterization/code/noorinalabs-main/.claude/hooks/session_handoff.py",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/session_handoff.py",
             "timeout": 30
           }
         ]


### PR DESCRIPTION
## Summary

Introduces a **config-driven** hook-dispatch layer so noorina's hook lists stop being hardcoded in Python, and converts `settings.json` absolute machine paths to `$CLAUDE_PROJECT_DIR`.

- **New `.claude/framework.config.json`** (mirrors botfarm's shape): `scm` / `branch` / `identity` / `shell` + the four ordered hook lists `hooks.{pre_bash, post_bash, post_file, post_notebook}`.
- **New `.claude/hooks/_framework_config.py`** — loader ported from botfarm: walk-up discovery, stdlib-only, fail-open to `_DEFAULTS`. Because `_DEFAULTS` carries the full hook lists, a missing/corrupt config still dispatches **every** gate (fail-open = "run the gates", never "silently drop them").
- **`dispatcher.py`** reads `config(input_data).get("hooks.pre_bash", [])`; **`post_dispatcher.py`** maps each matcher to a config key via `_MATCHER_CFG_KEY`.
- **`settings.json`**: 19 absolute `python3 /home/.../.claude/hooks/...` paths → `python3 "$CLAUDE_PROJECT_DIR"/.claude/hooks/...`. noorina's **single-dispatcher consolidation is kept** (one dispatcher entry per phase — not split into per-hook subprocess entries).

## How order / behavior is preserved

The config lists are **byte-identical** to the removed `_BASH_HOOKS` / `_REGISTRY`:

- `pre_bash` keeps the #1017 ordering (`smart_grep_ontology` before the `block_bare_grep` backstop) and `block_squash_wave_merge` **last** (network `gh pr view`).
- `post_bash` = old `_REGISTRY["Bash"]`; `post_file` = old `_EDIT_WRITE_MODULES` (Edit **and** Write); `post_notebook` = old `_REGISTRY["NotebookEdit"]` — kept **separate** so NotebookEdit still runs only `validate_edit_completion` and does **not** collapse into `post_file` (which would newly pull in `ontology_tracker` / `suggest_generic_prompt`).
- All of `post_dispatcher`'s in-process logic (annunaki dispatch-trace, `EMIT_DISPATCH_SUMMARY`, timing, `command_excerpt`) is untouched.

Verified at runtime through the real dispatchers: `block_no_verify` / commit-identity and `block_bare_grep` still block (exit 2); a benign command allows (exit 0); the four post matcher lists resolve to exactly the old sets.

## Registration-coverage test

`tests/test_hook_registration_coverage.py` (ported from botfarm, adapted to noorina's four keys): a `check()`-exposing hook dispatched **nowhere** fails; a dispatched module **without** `check()` fails; the committed config and `_DEFAULTS['hooks']` are cross-checked for drift; the #1017 and squash-last orderings are pinned; the `_FAIL_OPEN_GUARD` bite-tests forbid a swallowing tail in any in-tree `settings.json` registration. `test_post_dispatcher.py` updated to derive expectations from `post_dispatcher._modules_for(...)` instead of the removed `_REGISTRY`.

## Tests

- Full hooks suite: **1854 passed** (baseline 1832 + 22 new).
- `ruff format` + `ruff check`: clean. `mypy .claude/hooks/ .claude/lib/`: clean.
- Pre-push gate (mypy + pytest + budgets): all passed.

## ⚠️ Stacking

**Stacked on #1017 — retarget to `main` after #1017 merges.** Base branch is `A.Virtanen/1017-smart-grep-ontology`; this PR's own diff is only the config/dispatch changes.

Closes #1018

🤖 Generated with [Claude Code](https://claude.com/claude-code)
