### PR TITLE
Add deterministic wave-lifecycle facade over cross-repo state (foundation, #1019)

### DIFF
--- a/.claude/lib/lifecycle.py
+++ b/.claude/lib/lifecycle.py
@@ -1,0 +1,480 @@
+#!/usr/bin/env python3
+"""Deterministic wave-lifecycle facade over noorina's cross-repo state (main#1019).
+
+A single, deterministic entry point that drives one iteration ("wave") through
+its phases:
+
+    allocate → start → scope → kickoff → (work) → wrapup → retro
+
+**Org-scale adaptation.** Unlike botfarm's single-repo ``lifecycle.py`` (which
+owns a private ``.claude/state.json``), noorina is ORG-SCALE / CROSS-REPO: wave
+state lives in the repo-root ``cross-repo-status.json`` and is already driven by
+three deterministic modules —
+
+  * :mod:`wave_seq`          — the monotonic wave-id allocator (``allocate`` /
+                               ``peek``; ``global_wave_seq`` + phase stamps).
+  * :mod:`wave_merge_model`  — one-merge-model-per-wave (``get`` / ``set``) plus
+                               the mid-wave reachability classifier.
+  * :mod:`wave_status`       — in-scope repos, the merged-PR set, the three wave
+                               counters, and the session-start digest.
+
+This module does **not** introduce a competing state file or re-implement any of
+that. It is a THIN WRAPPER: for the transitions that already have deterministic
+code it *delegates* to the owning module (so the keyspace and the counter can
+never disagree), and for the transitions that until now lived only in the
+``/wave-*`` skill prose — ``start`` / ``scope`` pointers / the ``kickoff``
+timestamp / the ``wrapup`` pointers / ``retro`` — it performs the write through
+the SAME ``upsert_status_keys`` helper every other tool uses, so the file's
+compact-inline shape is preserved and the rewrite is JSON-validated before AND
+after (main#332/#456).
+
+Write ownership is respected, not duplicated:
+
+  * ``wave_{W}_phase`` / ``wave_{W}_phase_ordinal`` / ``global_wave_seq`` — owned
+    by :mod:`wave_seq` (``allocate`` delegates to it).
+  * ``wave_{W}_merge_model`` — validated by :mod:`wave_merge_model` (its enum is
+    the single validator; ``kickoff`` reuses it).
+  * ``wave_{W}_final_pr_count`` / ``wave_{W}_changes_requested_cycles`` /
+    ``wave_{W}_top_concentration_pct`` — owned by :mod:`wave_status` (``counters
+    --write``). ``wrapup`` here writes only the lifecycle POINTERS
+    (``active`` / ``completed_at`` / ``last_completed_wave``); it never writes a
+    counter, matching the lifecycle-doc "Owner of writes" contract (wrapup is the
+    authoritative counter writer *via* ``wave_status.py``, retro only verifies).
+
+The genuinely-new deterministic writes this facade adds (previously prose-only in
+``/wave-start`` / ``/wave-scope`` / ``/wave-kickoff`` / ``/wave-wrapup`` /
+``/wave-retro``):
+
+  * ``start``   → ``current_wave``, ``wave_{W}_active=true``, ``wave_{W}_started_at``
+  * ``scope``   → ``wave_{W}_repos_in_scope``, ``wave_{W}_scope_reconciled_at`` (+
+                  optional ``wave_{W}_phase``)
+  * ``kickoff`` → ``wave_{W}_kicked_off_at``, ``wave_{W}_active=true``,
+                  ``current_wave`` (+ optional validated ``wave_{W}_merge_model``)
+  * ``wrapup``  → ``wave_{W}_active=false``, ``wave_{W}_completed_at``,
+                  ``last_completed_wave``
+  * ``retro``   → ``wave_{W}_retro_completed_at`` (the key ``/wave-kickoff`` Step
+                  0a reads to gate the next wave)
+
+Wave ids are GLOBAL monotonic ids (``wave_25``), not per-phase ordinals — phase
+is a derived display attribute (see :mod:`wave_seq`). ``--status`` defaults to the
+repo-root ``cross-repo-status.json``, resolved from this file's location exactly
+like the three modules above so it is correct from any cwd or worktree.
+
+Stdlib only. The transition writers are I/O-thin (one ``upsert`` call each);
+delegations forward to the owning module's ``main``.
+
+CLI::
+
+  lifecycle.py wave peek                 [--status PATH]
+  lifecycle.py wave allocate --phase P   [--write] [--status PATH]
+  lifecycle.py wave start    <W>         [--at TS] [--status PATH]
+  lifecycle.py wave scope    <W> --repos a,b,c [--phase P] [--at TS] [--status PATH]
+  lifecycle.py wave kickoff  <W>         [--merge-model M] [--at TS] [--status PATH]
+  lifecycle.py wave wrapup   <W>         [--at TS] [--status PATH]
+  lifecycle.py wave retro    <W>         [--at TS] [--status PATH]
+  lifecycle.py merge-model get <W>       [--status PATH]           # → wave_merge_model
+  lifecycle.py merge-model set <P> <W> <model> [--status PATH]     # → wave_merge_model
+  lifecycle.py reachability  <P> <W>     [--json] [--status PATH]  # → wave_merge_model
+  lifecycle.py counters      <P> <W>     [--write] [--expect N] [--status PATH]  # → wave_status
+  lifecycle.py state show                [--status PATH]
+  lifecycle.py state digest              [--status PATH]           # → wave_status
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# The deterministic modules this facade wraps all live alongside it in
+# .claude/lib/. Put the lib dir on sys.path so the sibling imports resolve when
+# lifecycle.py is imported as a module (run-as-script already has sys.path[0] =
+# this dir; the tests add it explicitly). This mirrors the lib->lib import
+# bridge wave_seq / wave_status use for upsert_status_keys.
+_LIB_DIR = Path(__file__).resolve().parent
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+import upsert_status_keys  # noqa: E402
+import wave_merge_model  # noqa: E402
+import wave_seq  # noqa: E402
+import wave_status  # noqa: E402
+
+# Repo root = two parents above .claude/lib/ (lib -> .claude -> root). Same
+# anchor as wave_seq / wave_merge_model / wave_status so the default status path
+# is correct from any cwd or worktree with no `git rev-parse` subprocess.
+_REPO_ROOT = _LIB_DIR.parents[1]
+_DEFAULT_STATUS = _REPO_ROOT / "cross-repo-status.json"
+
+
+# ============================================================================
+# Shared helpers
+# ============================================================================
+
+
+def _now_iso(at: str | None = None) -> str:
+    """An ISO-8601 UTC timestamp; ``at`` overrides for deterministic tests.
+
+    Matches the ``...Z`` shape every existing key in cross-repo-status.json uses
+    (e.g. ``wave_25_kicked_off_at``).
+    """
+    if at:
+        return at
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _wave_label(wave: str) -> str:
+    """The ``current_wave`` / ``last_completed_wave`` pointer form (``wave-25``)."""
+    return f"wave-{wave}"
+
+
+def _persist(status_path: Path, pairs: dict[str, object]) -> int:
+    """Upsert ``pairs`` (key → python value) into the status file.
+
+    Delegates to :func:`upsert_status_keys.main` — the SAME helper wave_seq /
+    wave_merge_model / wave_status write through — so the file's compact-inline
+    shape is preserved and the rewrite is JSON-validated before AND after
+    (main#332/#456). Each value is rendered as a self-contained JSON literal.
+    A no-op returning 0 when ``pairs`` is empty.
+    """
+    if not pairs:
+        return 0
+    argv = ["lifecycle", str(status_path)]
+    for key, value in pairs.items():
+        argv.append(f"{key}={json.dumps(value)}")
+    return upsert_status_keys.main(argv)
+
+
+def _load_status(status_path: Path) -> dict:
+    return json.loads(status_path.read_text())
+
+
+# ============================================================================
+# Lifecycle transitions
+# ============================================================================
+
+
+def peek(status_path: Path) -> int:
+    """The next wave id ``allocate`` would claim (delegates to wave_seq).
+
+    Reservation-aware — a ``wave_{N}_meta_issue`` reserved ahead of the committed
+    counter is claimed, not skipped (see :func:`wave_seq.allocation_target`).
+    """
+    return wave_seq.allocation_target(_load_status(status_path))
+
+
+def allocate(status_path: Path, phase: int, *, write: bool = False) -> int:
+    """Allocate the next global wave id for ``phase`` (delegates to wave_seq).
+
+    ``wave_seq`` is the authoritative allocator: with ``write`` it advances
+    ``global_wave_seq`` and stamps ``wave_{W}_phase`` + ``wave_{W}_phase_ordinal``.
+    This wrapper never re-implements the monotonic / reservation-aware math.
+    """
+    argv = ["allocate", str(status_path), "--phase", str(phase)]
+    if write:
+        argv.append("--write")
+    return wave_seq.main(argv)
+
+
+def start(status_path: Path, wave: str, *, at: str | None = None) -> int:
+    """Mark a wave active and point ``current_wave`` at it.
+
+    Deterministic form of ``/wave-start``'s active-state stamping. Writes
+    ``current_wave``, ``wave_{W}_active=true``, ``wave_{W}_started_at``.
+    """
+    return _persist(
+        status_path,
+        {
+            "current_wave": _wave_label(wave),
+            f"wave_{wave}_active": True,
+            f"wave_{wave}_started_at": _now_iso(at),
+        },
+    )
+
+
+def scope(
+    status_path: Path,
+    wave: str,
+    repos: list[str],
+    *,
+    phase: int | None = None,
+    at: str | None = None,
+) -> int:
+    """Record the wave's in-scope repo list + a scope-reconciled timestamp.
+
+    Writes the two keys ``wave_status.read_repos`` / the kickoff pre-flight read
+    (``wave_{W}_repos_in_scope``, ``wave_{W}_scope_reconciled_at``) plus, when
+    given, the display phase stamp ``wave_{W}_phase``. The richer
+    ``wave_{W}_scope`` block (theme/shape) and the meta-issue reservation stay
+    owned by the ``/wave-scope`` skill — this facade only writes the deterministic
+    machine-readable subset.
+    """
+    pairs: dict[str, object] = {
+        f"wave_{wave}_repos_in_scope": repos,
+        f"wave_{wave}_scope_reconciled_at": _now_iso(at),
+    }
+    if phase is not None:
+        pairs[f"wave_{wave}_phase"] = phase
+    return _persist(status_path, pairs)
+
+
+def kickoff(
+    status_path: Path,
+    wave: str,
+    *,
+    merge_model: str | None = None,
+    at: str | None = None,
+) -> int:
+    """Record kickoff: timestamp, active+pointer, and (optionally) merge model.
+
+    Writes ``wave_{W}_kicked_off_at`` (the #423 cross-window filter boundary
+    wave_status reads), re-points ``current_wave``, and re-affirms
+    ``wave_{W}_active``. When ``merge_model`` is given it is validated through
+    :func:`wave_merge_model.validate_merge_model` (the single enum validator) and
+    written as ``wave_{W}_merge_model`` in the same atomic upsert.
+    """
+    pairs: dict[str, object] = {
+        "current_wave": _wave_label(wave),
+        f"wave_{wave}_active": True,
+        f"wave_{wave}_kicked_off_at": _now_iso(at),
+    }
+    if merge_model is not None:
+        wave_merge_model.validate_merge_model(merge_model)
+        pairs[f"wave_{wave}_merge_model"] = merge_model
+    return _persist(status_path, pairs)
+
+
+def wrapup(status_path: Path, wave: str, *, at: str | None = None) -> int:
+    """Close a wave's lifecycle pointers.
+
+    Writes ``wave_{W}_active=false``, ``wave_{W}_completed_at`` and advances
+    ``last_completed_wave``. It deliberately writes NO counter: the three
+    counters are owned by ``wave_status.py counters --write`` (the lifecycle-doc
+    "Owner of writes" contract — ``/wave-wrapup`` is the authoritative counter
+    writer *via* wave_status, ``/wave-retro`` only verifies). Run
+    ``lifecycle.py counters {P} {W} --write`` (or ``wave_status.py`` directly)
+    for the counter write.
+    """
+    return _persist(
+        status_path,
+        {
+            f"wave_{wave}_active": False,
+            f"wave_{wave}_completed_at": _now_iso(at),
+            "last_completed_wave": _wave_label(wave),
+        },
+    )
+
+
+def retro(status_path: Path, wave: str, *, at: str | None = None) -> int:
+    """Stamp the wave's retro-complete pointer.
+
+    Writes ``wave_{W}_retro_completed_at`` — the key ``/wave-kickoff`` Step 0a
+    reads to gate the NEXT wave (the next kickoff's ``scope_reconciled_at`` must
+    post-date this). Trust-matrix / feedback-log writes remain owned by the
+    ``/wave-retro`` skill (they are narrative, not lifecycle pointers).
+    """
+    return _persist(
+        status_path,
+        {f"wave_{wave}_retro_completed_at": _now_iso(at)},
+    )
+
+
+# ============================================================================
+# CLI
+# ============================================================================
+
+
+def _cmd_wave_peek(args: argparse.Namespace) -> int:
+    print(peek(args.status))
+    return 0
+
+
+def _cmd_wave_allocate(args: argparse.Namespace) -> int:
+    return allocate(args.status, args.phase, write=args.write)
+
+
+def _cmd_wave_start(args: argparse.Namespace) -> int:
+    return start(args.status, args.wave, at=args.at)
+
+
+def _cmd_wave_scope(args: argparse.Namespace) -> int:
+    repos = [r.strip() for r in args.repos.split(",") if r.strip()]
+    return scope(args.status, args.wave, repos, phase=args.phase, at=args.at)
+
+
+def _cmd_wave_kickoff(args: argparse.Namespace) -> int:
+    return kickoff(args.status, args.wave, merge_model=args.merge_model, at=args.at)
+
+
+def _cmd_wave_wrapup(args: argparse.Namespace) -> int:
+    return wrapup(args.status, args.wave, at=args.at)
+
+
+def _cmd_wave_retro(args: argparse.Namespace) -> int:
+    return retro(args.status, args.wave, at=args.at)
+
+
+# --- Delegations to the owning modules (thin passthroughs) ------------------
+
+
+def _cmd_merge_model_get(args: argparse.Namespace) -> int:
+    return wave_merge_model.main(["model", args.phase, args.wave, "--status", str(args.status)])
+
+
+def _cmd_merge_model_set(args: argparse.Namespace) -> int:
+    return wave_merge_model.main(
+        ["set", args.phase, args.wave, args.model, "--status", str(args.status)]
+    )
+
+
+def _cmd_reachability(args: argparse.Namespace) -> int:
+    argv = ["reachability", args.phase, args.wave, "--status", str(args.status)]
+    if args.json:
+        argv.append("--json")
+    return wave_merge_model.main(argv)
+
+
+def _cmd_counters(args: argparse.Namespace) -> int:
+    argv = ["counters", args.phase, args.wave, "--status", str(args.status)]
+    if args.write:
+        argv.append("--write")
+    if args.expect is not None:
+        argv.extend(["--expect", str(args.expect)])
+    return wave_status.main(argv)
+
+
+def _cmd_state_show(args: argparse.Namespace) -> int:
+    print(json.dumps(_load_status(args.status), indent=2))
+    return 0
+
+
+def _cmd_state_digest(args: argparse.Namespace) -> int:
+    return wave_status.main(["digest", "--status", str(args.status)])
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    top = parser.add_subparsers(dest="group", required=True)
+
+    def _status_opt(p: argparse.ArgumentParser) -> None:
+        p.add_argument(
+            "--status",
+            type=Path,
+            default=_DEFAULT_STATUS,
+            help="path to cross-repo-status.json (default: repo-root copy)",
+        )
+
+    # wave ...
+    wave = top.add_parser("wave", help="wave allocator + lifecycle transitions")
+    wsub = wave.add_subparsers(dest="command", required=True)
+
+    p = wsub.add_parser("peek", help="print the next wave id (no write; → wave_seq)")
+    _status_opt(p)
+    p.set_defaults(func=_cmd_wave_peek)
+
+    p = wsub.add_parser("allocate", help="allocate the next wave id for a phase (→ wave_seq)")
+    p.add_argument("--phase", type=int, required=True)
+    p.add_argument("--write", action="store_true", help="persist global_wave_seq + phase stamps")
+    _status_opt(p)
+    p.set_defaults(func=_cmd_wave_allocate)
+
+    p = wsub.add_parser("start", help="mark a wave active + point current_wave at it")
+    p.add_argument("wave")
+    p.add_argument("--at", default=None, help="ISO timestamp override (deterministic)")
+    _status_opt(p)
+    p.set_defaults(func=_cmd_wave_start)
+
+    p = wsub.add_parser("scope", help="record repos_in_scope + scope_reconciled_at (+phase)")
+    p.add_argument("wave")
+    p.add_argument("--repos", required=True, help="comma-separated repo list")
+    p.add_argument("--phase", type=int, default=None)
+    p.add_argument("--at", default=None)
+    _status_opt(p)
+    p.set_defaults(func=_cmd_wave_scope)
+
+    p = wsub.add_parser("kickoff", help="record kicked_off_at (+ optional validated merge model)")
+    p.add_argument("wave")
+    p.add_argument(
+        "--merge-model",
+        dest="merge_model",
+        default=None,
+        choices=wave_merge_model.MERGE_MODELS,
+    )
+    p.add_argument("--at", default=None)
+    _status_opt(p)
+    p.set_defaults(func=_cmd_wave_kickoff)
+
+    p = wsub.add_parser("wrapup", help="close a wave's lifecycle pointers (counters → wave_status)")
+    p.add_argument("wave")
+    p.add_argument("--at", default=None)
+    _status_opt(p)
+    p.set_defaults(func=_cmd_wave_wrapup)
+
+    p = wsub.add_parser("retro", help="stamp wave_{W}_retro_completed_at")
+    p.add_argument("wave")
+    p.add_argument("--at", default=None)
+    _status_opt(p)
+    p.set_defaults(func=_cmd_wave_retro)
+
+    # merge-model ... (delegates to wave_merge_model)
+    mm = top.add_parser("merge-model", help="per-wave merge model get/set (→ wave_merge_model)")
+    msub = mm.add_subparsers(dest="command", required=True)
+    p = msub.add_parser("get", help="print the declared merge model")
+    p.add_argument("phase", help="phase number (P)")
+    p.add_argument("wave", help="wave number (W)")
+    _status_opt(p)
+    p.set_defaults(func=_cmd_merge_model_get)
+    p = msub.add_parser("set", help="record the merge model")
+    p.add_argument("phase", help="phase number (P)")
+    p.add_argument("wave", help="wave number (W)")
+    p.add_argument("model", choices=wave_merge_model.MERGE_MODELS)
+    _status_opt(p)
+    p.set_defaults(func=_cmd_merge_model_set)
+
+    # reachability ... (delegates to wave_merge_model)
+    p = top.add_parser("reachability", help="mid-wave reachability check (→ wave_merge_model)")
+    p.add_argument("phase", help="phase number (P)")
+    p.add_argument("wave", help="wave number (W)")
+    p.add_argument("--json", action="store_true", help="emit results as JSON")
+    _status_opt(p)
+    p.set_defaults(func=_cmd_reachability)
+
+    # counters ... (delegates to wave_status — the authoritative counter writer)
+    p = top.add_parser(
+        "counters", help="compute (and optionally write) wave counters (→ wave_status)"
+    )
+    p.add_argument("phase", help="phase number (P)")
+    p.add_argument("wave", help="wave number (W)")
+    p.add_argument("--write", action="store_true", help="upsert the three canonical counter keys")
+    p.add_argument("--expect", type=int, default=None, help="loud-fail if final_pr_count != N")
+    _status_opt(p)
+    p.set_defaults(func=_cmd_counters)
+
+    # state ...
+    st = top.add_parser("state", help="inspect the status file")
+    ssub = st.add_subparsers(dest="command", required=True)
+    p = ssub.add_parser("show", help="dump the full status file")
+    _status_opt(p)
+    p.set_defaults(func=_cmd_state_show)
+    p = ssub.add_parser("digest", help="emit the current-wave/phase digest (→ wave_status)")
+    _status_opt(p)
+    p.set_defaults(func=_cmd_state_digest)
+
+    return parser
+
+
+def main(argv: list[str]) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        return int(args.func(args))
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.claude/lib/tests/test_lifecycle.py
+++ b/.claude/lib/tests/test_lifecycle.py
@@ -1,0 +1,252 @@
+"""Tests for lifecycle.py — the deterministic wave-lifecycle facade (main#1019).
+
+The facade is a THIN WRAPPER over noorina's existing cross-repo state: it writes
+through the shared ``upsert_status_keys`` helper (so the file's compact-inline
+shape and JSON validity are preserved) and delegates the transitions that already
+have deterministic modules (``allocate`` → wave_seq, ``merge-model`` /
+``reachability`` → wave_merge_model, ``counters`` → wave_status).
+
+These tests exercise the genuinely-new transition writes end-to-end against a
+real (temp) status file — no network, no mocks for the write path — plus the key
+invariants the facade must hold:
+
+  * every write round-trips through the file as valid JSON (upsert contract);
+  * the file's compact-inline shape survives (no whole-file reflow);
+  * ownership boundaries hold — ``wrapup`` writes NO counter; ``kickoff`` with a
+    bad merge model raises before writing anything;
+  * the read-only delegations forward to the owning module.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+# Helper lives at .claude/lib/lifecycle.py; this test is at
+# .claude/lib/tests/test_*.py. parent.parent reaches the lib root.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import lifecycle  # noqa: E402
+import wave_merge_model  # noqa: E402
+
+
+def _seed_status() -> dict:
+    """A minimal but realistic mid-lifecycle status file.
+
+    Global-wave numbering (main#804): the committed counter is 25 (wave 25 is
+    scoped/kicked-off), and wave 26's meta-issue is reserved one above the
+    committed counter (the /wave-retro Step 9 reservation) so the allocator's
+    reservation-awareness is exercised through the facade.
+    """
+    return {
+        "current_phase": 9,
+        "current_wave": "wave-25",
+        "last_completed_wave": "wave-24",
+        "global_wave_seq": 25,
+        "wave_24_phase": 8,
+        "wave_24_active": False,
+        "wave_24_completed_at": "2026-07-05T00:00:00Z",
+        "wave_25_phase": 9,
+        "wave_25_phase_ordinal": 1,
+        "wave_25_active": True,
+        "wave_25_repos_in_scope": ["noorinalabs-data-acquisition"],
+        "wave_25_kicked_off_at": "2026-07-18T21:11:08Z",
+        "wave_25_merge_model": "wave-branch",
+        "wave_26_meta_issue": "noorinalabs-main#983",
+    }
+
+
+class _StatusFileTest(unittest.TestCase):
+    """Base: write the seed dict to a temp file in the compact-inline shape."""
+
+    def setUp(self) -> None:
+        self._tmp = TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.path = Path(self._tmp.name) / "cross-repo-status.json"
+        # json.dumps(indent=2) yields the `{\n  "k": v,\n}` shape upsert extends.
+        self.path.write_text(json.dumps(_seed_status(), indent=2) + "\n")
+
+    def _reload(self) -> dict:
+        return json.loads(self.path.read_text())
+
+
+class TestStart(_StatusFileTest):
+    def test_start_stamps_active_and_pointer(self) -> None:
+        rc = lifecycle.start(self.path, "27", at="2026-07-19T10:00:00Z")
+        self.assertEqual(rc, 0)
+        data = self._reload()
+        self.assertEqual(data["current_wave"], "wave-27")
+        self.assertIs(data["wave_27_active"], True)
+        self.assertEqual(data["wave_27_started_at"], "2026-07-19T10:00:00Z")
+
+    def test_start_leaves_file_valid_and_other_keys_intact(self) -> None:
+        lifecycle.start(self.path, "27", at="2026-07-19T10:00:00Z")
+        data = self._reload()
+        # Untouched keys survive the targeted upsert.
+        self.assertEqual(data["wave_25_repos_in_scope"], ["noorinalabs-data-acquisition"])
+        self.assertEqual(data["global_wave_seq"], 25)
+
+
+class TestScope(_StatusFileTest):
+    def test_scope_writes_repos_and_reconciled_at(self) -> None:
+        rc = lifecycle.scope(
+            self.path,
+            "27",
+            ["noorinalabs-isnad-graph", "noorinalabs-user-service"],
+            phase=9,
+            at="2026-07-19T11:00:00Z",
+        )
+        self.assertEqual(rc, 0)
+        data = self._reload()
+        self.assertEqual(
+            data["wave_27_repos_in_scope"],
+            ["noorinalabs-isnad-graph", "noorinalabs-user-service"],
+        )
+        self.assertEqual(data["wave_27_scope_reconciled_at"], "2026-07-19T11:00:00Z")
+        self.assertEqual(data["wave_27_phase"], 9)
+
+    def test_scope_phase_optional(self) -> None:
+        lifecycle.scope(self.path, "27", ["noorinalabs-landing-page"], at="2026-07-19T11:00:00Z")
+        data = self._reload()
+        self.assertNotIn("wave_27_phase", data)
+        self.assertEqual(data["wave_27_repos_in_scope"], ["noorinalabs-landing-page"])
+
+    def test_scoped_repos_readable_by_wave_status(self) -> None:
+        # The facade's scope write must satisfy wave_status.read_repos — the
+        # cross-module contract kickoff/wrapup depend on.
+        import wave_status
+
+        lifecycle.scope(self.path, "27", ["repo-a", "repo-b"], at="2026-07-19T11:00:00Z")
+        self.assertEqual(wave_status.read_repos("27", self.path), ["repo-a", "repo-b"])
+
+
+class TestKickoff(_StatusFileTest):
+    def test_kickoff_stamps_timestamp_pointer_and_merge_model(self) -> None:
+        rc = lifecycle.kickoff(
+            self.path, "27", merge_model="wave-branch", at="2026-07-19T12:00:00Z"
+        )
+        self.assertEqual(rc, 0)
+        data = self._reload()
+        self.assertEqual(data["wave_27_kicked_off_at"], "2026-07-19T12:00:00Z")
+        self.assertEqual(data["current_wave"], "wave-27")
+        self.assertIs(data["wave_27_active"], True)
+        self.assertEqual(data["wave_27_merge_model"], "wave-branch")
+
+    def test_kickoff_merge_model_optional(self) -> None:
+        lifecycle.kickoff(self.path, "27", at="2026-07-19T12:00:00Z")
+        data = self._reload()
+        self.assertNotIn("wave_27_merge_model", data)
+
+    def test_kickoff_rejects_bad_merge_model_without_writing(self) -> None:
+        before = self.path.read_text()
+        with self.assertRaises(ValueError):
+            lifecycle.kickoff(self.path, "27", merge_model="squash-and-pray")
+        # Validation happens before the upsert, so nothing was written.
+        self.assertEqual(self.path.read_text(), before)
+
+    def test_kickoff_merge_model_readable_by_owning_module(self) -> None:
+        lifecycle.kickoff(self.path, "27", merge_model="direct-to-main", at="2026-07-19T12:00:00Z")
+        self.assertEqual(wave_merge_model.read_merge_model("27", self.path), "direct-to-main")
+
+
+class TestWrapup(_StatusFileTest):
+    def test_wrapup_closes_pointers(self) -> None:
+        rc = lifecycle.wrapup(self.path, "25", at="2026-07-19T13:00:00Z")
+        self.assertEqual(rc, 0)
+        data = self._reload()
+        self.assertIs(data["wave_25_active"], False)
+        self.assertEqual(data["wave_25_completed_at"], "2026-07-19T13:00:00Z")
+        self.assertEqual(data["last_completed_wave"], "wave-25")
+
+    def test_wrapup_writes_no_counter(self) -> None:
+        # Counter ownership stays with wave_status.py; wrapup must not write one.
+        lifecycle.wrapup(self.path, "25", at="2026-07-19T13:00:00Z")
+        data = self._reload()
+        for counter in (
+            "wave_25_final_pr_count",
+            "wave_25_changes_requested_cycles",
+            "wave_25_top_concentration_pct",
+        ):
+            self.assertNotIn(counter, data)
+
+
+class TestRetro(_StatusFileTest):
+    def test_retro_stamps_completed_at(self) -> None:
+        rc = lifecycle.retro(self.path, "25", at="2026-07-19T14:00:00Z")
+        self.assertEqual(rc, 0)
+        self.assertEqual(self._reload()["wave_25_retro_completed_at"], "2026-07-19T14:00:00Z")
+
+
+class TestPeekAndAllocateDelegation(_StatusFileTest):
+    def test_peek_honours_reservation(self) -> None:
+        # committed counter 24 + reserved wave_26_meta_issue → peek claims 26.
+        self.assertEqual(lifecycle.peek(self.path), 26)
+
+    def test_allocate_dry_run_does_not_write(self) -> None:
+        before = self.path.read_text()
+        rc = lifecycle.allocate(self.path, 9, write=False)
+        self.assertEqual(rc, 0)
+        self.assertEqual(self.path.read_text(), before)
+
+    def test_allocate_write_persists_via_wave_seq(self) -> None:
+        rc = lifecycle.allocate(self.path, 9, write=True)
+        self.assertEqual(rc, 0)
+        data = self._reload()
+        # The reserved id 26 is claimed and its phase stamps written by wave_seq.
+        self.assertEqual(data["global_wave_seq"], 26)
+        self.assertEqual(data["wave_26_phase"], 9)
+        self.assertIn("wave_26_phase_ordinal", data)
+
+
+class TestFileShapePreserved(_StatusFileTest):
+    def test_compact_inline_shape_not_reflowed(self) -> None:
+        # A representative multi-transition sequence, then assert the file is
+        # still line-oriented compact-inline (one top-level key per line) — the
+        # whole reason the facade routes through upsert_status_keys.
+        lifecycle.start(self.path, "27", at="2026-07-19T10:00:00Z")
+        lifecycle.scope(self.path, "27", ["repo-a"], phase=9, at="2026-07-19T11:00:00Z")
+        lifecycle.kickoff(self.path, "27", merge_model="wave-branch", at="2026-07-19T12:00:00Z")
+        text = self.path.read_text()
+        # Still valid JSON.
+        json.loads(text)
+        # The newly written keys are each a single physical line (compact-inline),
+        # not pretty-expanded across lines.
+        for key in ("wave_27_active", "wave_27_repos_in_scope", "wave_27_kicked_off_at"):
+            matches = [ln for ln in text.splitlines() if f'"{key}":' in ln]
+            self.assertEqual(len(matches), 1, f"{key} should be exactly one line")
+
+    def test_idempotent_re_write(self) -> None:
+        # Re-running a transition with the same timestamp is a no-op on content.
+        lifecycle.start(self.path, "27", at="2026-07-19T10:00:00Z")
+        once = self.path.read_text()
+        lifecycle.start(self.path, "27", at="2026-07-19T10:00:00Z")
+        self.assertEqual(self.path.read_text(), once)
+
+
+class TestCliSmoke(_StatusFileTest):
+    def test_cli_wave_start(self) -> None:
+        rc = lifecycle.main(
+            ["wave", "start", "27", "--at", "2026-07-19T10:00:00Z", "--status", str(self.path)]
+        )
+        self.assertEqual(rc, 0)
+        self.assertEqual(self._reload()["current_wave"], "wave-27")
+
+    def test_cli_wave_peek(self) -> None:
+        rc = lifecycle.main(["wave", "peek", "--status", str(self.path)])
+        self.assertEqual(rc, 0)
+
+    def test_cli_merge_model_get_delegates(self) -> None:
+        # wave 25's model is recorded in the seed; the delegation must surface it.
+        rc = lifecycle.main(["merge-model", "get", "9", "25", "--status", str(self.path)])
+        self.assertEqual(rc, 0)
+
+    def test_cli_state_show(self) -> None:
+        rc = lifecycle.main(["state", "show", "--status", str(self.path)])
+        self.assertEqual(rc, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/skills/wave-lifecycle/SKILL.md
+++ b/.claude/skills/wave-lifecycle/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: wave-lifecycle
+description: Deterministic wave-lifecycle core for noorina's cross-repo state — the single entry point over lifecycle.py that drives allocate → start → scope → kickoff → wrapup → retro, delegating to the owning modules (wave_seq / wave_merge_model / wave_status).
+---
+
+# wave-lifecycle
+
+Drive one iteration ("wave") of cross-repo team work through its lifecycle:
+
+    allocate → start → scope → kickoff → (work) → wrapup → retro
+
+This skill is **deterministic-first**: every state mutation goes through
+`.claude/lib/lifecycle.py`, a thin facade over noorina's **existing** cross-repo
+state. Prompts only fill in the decisions a human must make (the wave theme, the
+in-scope repo list, the merge model). Everything else is mechanical.
+
+## Org-scale reality — this is NOT botfarm's single-repo lifecycle
+
+botfarm's `lifecycle.py` owns a private single-repo `.claude/state.json`. **noorina
+is org-scale / cross-repo**: wave state lives in the repo-root
+`cross-repo-status.json` (a flat dict of ~400 keys accreted across every wave,
+read on demand via `wave_status.py digest`, #987), and it was already driven by
+three deterministic modules:
+
+| Concern | Owning module | Keys it owns |
+|---------|---------------|--------------|
+| Wave-id allocation (monotonic, reservation-aware) | `wave_seq.py` | `global_wave_seq`, `wave_{W}_phase`, `wave_{W}_phase_ordinal` |
+| One-merge-model-per-wave + mid-wave reachability | `wave_merge_model.py` | `wave_{W}_merge_model` |
+| In-scope repos, merged-PR set, wave counters, digest | `wave_status.py` | `wave_{W}_final_pr_count`, `wave_{W}_changes_requested_cycles`, `wave_{W}_top_concentration_pct` |
+
+`lifecycle.py` does **not** introduce a competing state file and does **not**
+re-implement any of that. It is a **facade** that:
+
+- **delegates** the transitions that already have deterministic code — `allocate`
+  → `wave_seq`, `merge-model` / `reachability` → `wave_merge_model`, `counters` →
+  `wave_status` (so the keyspace and the counter can never disagree); and
+- **adds deterministic writes** for the transitions that until now lived only in
+  the `/wave-*` skill prose — the `start` / `scope` / `kickoff` timestamp / `wrapup`
+  / `retro` lifecycle **pointers** — routing every write through the same
+  `upsert_status_keys` helper the modules above use, so the file's compact-inline
+  shape is preserved and each rewrite is JSON-validated before AND after
+  (main#332/#456).
+
+**Wave ids are GLOBAL monotonic ids** (`wave_25`), not per-phase ordinals — phase
+is a derived display attribute (`wave_seq.py`, main#804). `--status` defaults to
+the repo-root `cross-repo-status.json`, resolved from the file's own location so
+it is correct from any cwd or worktree.
+
+## Relationship to the existing `wave-*` skills (additive, for now)
+
+This PR is **additive foundation only** (main#1019, the epic). The 10 existing
+`wave-*` / `phase-*` skills and the wave hooks are **unchanged** — nothing is
+deleted or demoted here. In follow-up PRs (see the epic sequence) the
+state-transition prose in `/wave-start`, `/wave-kickoff`, `/wave-wrapup` and
+`/wave-retro` will be progressively **demoted to thin references** that call
+`lifecycle.py` for the mechanical writes, keeping only the genuinely human-
+decision and cross-repo-orchestration prose (branch creation across repos, issue
+labelling, reviewer slates, PR merge sequencing). The canonical order,
+preconditions and state effects remain documented in
+[`.claude/team/lifecycle.md`](../../team/lifecycle.md) — that doc stays
+authoritative for the ordering; this skill is the deterministic execution layer.
+
+## Preconditions
+
+- Run from anywhere in the repo; `lifecycle.py` resolves `cross-repo-status.json`
+  from its own path.
+- `cross-repo-status.json` is on `main`. When the orchestrator writes it while
+  parked on `main`, the established recipe is the `gh api PUT /contents` commit
+  under the TPM (Wanjiku) identity (`/wave-kickoff` Step 1a) — `lifecycle.py`
+  writes the LOCAL file (exactly as `wave_seq`/`wave_merge_model`/`wave_status`
+  already do); committing that change to `main` follows the same PUT-contents path
+  the skills use today.
+
+## Steps
+
+### 1. Allocate the wave id (monotonic, never reused) — delegates to `wave_seq`
+
+```bash
+python3 .claude/lib/lifecycle.py wave peek                        # next id (no write)
+python3 .claude/lib/lifecycle.py wave allocate --phase {P} --write
+```
+
+`allocate --write` advances `global_wave_seq` and stamps `wave_{W}_phase` +
+`wave_{W}_phase_ordinal` (the "Phase P, Wave N" display). Reservation-aware: an id
+reserved ahead of the counter (a `wave_{N}_meta_issue` written by `/wave-retro`
+Step 9) is claimed, not skipped.
+
+### 2. Start the wave
+
+```bash
+python3 .claude/lib/lifecycle.py wave start {W}
+```
+
+Sets `current_wave`, `wave_{W}_active=true`, `wave_{W}_started_at`.
+
+### 3. Scope it (owner decision: which repos)
+
+Decide the in-scope repo subset for this wave, then record it:
+
+```bash
+python3 .claude/lib/lifecycle.py wave scope {W} \
+    --repos noorinalabs-isnad-graph,noorinalabs-user-service --phase {P}
+```
+
+Writes `wave_{W}_repos_in_scope` + `wave_{W}_scope_reconciled_at` (+ the display
+`wave_{W}_phase`). The richer `wave_{W}_scope` block (theme/shape) and the
+meta-issue reservation stay owned by `/wave-scope` — this facade writes only the
+machine-readable subset that the kickoff pre-flight and `wave_status` read.
+
+### 4. Kick off (owner decision: merge model) — merge model validated by `wave_merge_model`
+
+A wave uses exactly ONE merge model for its whole life — `wave-branch` (per-issue
+PRs base on `deployments/phase-{P}/wave-{W}`; one wave→main PR at wrapup) or
+`direct-to-main` (every PR bases on `main`). Mixing strands work (main#801).
+
+```bash
+python3 .claude/lib/lifecycle.py wave kickoff {W} --merge-model wave-branch
+```
+
+Records `wave_{W}_kicked_off_at` (the #423 cross-window filter boundary), re-points
+`current_wave`, and writes the validated `wave_{W}_merge_model`. Then create the
+wave branch in every in-scope repo and spawn implementers/reviewers per the roster.
+
+### 5. Mid-wave (on demand) — delegates to `wave_merge_model`
+
+```bash
+python3 .claude/lib/lifecycle.py reachability {P} {W}        # model-aware stranding check
+```
+
+For every in-scope repo it compares the wave branch against `main` and classifies
+the gap against the declared model. A `direct-to-main` wave with commits on the
+wave branch is a hard **violation** (exit 1); a `wave-branch` wave ahead with no
+open wave→main PR is an **advisory** (it will strand unless wrapup opens the PR).
+
+### 6. Wrap up
+
+Merge ready PRs, close resolved issues, clean worktrees (the cross-repo
+orchestration stays in `/wave-wrapup`). Compute + write the counters via the
+authoritative owner, then close the lifecycle pointers:
+
+```bash
+python3 .claude/lib/lifecycle.py counters {P} {W} --write     # → wave_status (authoritative writer)
+python3 .claude/lib/lifecycle.py wave wrapup {W}
+```
+
+`counters --write` upserts the three canonical counter keys (owned by
+`wave_status`; `/wave-retro` Step 2.5 only **verifies** them). `wave wrapup` writes
+only the lifecycle pointers — `wave_{W}_active=false`, `wave_{W}_completed_at`,
+`last_completed_wave` — and deliberately writes **no** counter, so there is exactly
+one counter writer.
+
+### 7. Retro
+
+```bash
+python3 .claude/lib/lifecycle.py wave retro {W}
+```
+
+Stamps `wave_{W}_retro_completed_at` — the key `/wave-kickoff` Step 0a reads to
+gate the NEXT wave (its `scope_reconciled_at` must post-date this). Trust-matrix
+and feedback-log writes remain owned by `/wave-retro` (they are narrative
+assessments, not lifecycle pointers). Do **not** apply charter/process changes
+without owner approval.
+
+## Inspecting state
+
+```bash
+python3 .claude/lib/lifecycle.py state show               # dump the full status file
+python3 .claude/lib/lifecycle.py state digest             # current-wave/phase slice (→ wave_status)
+python3 .claude/lib/lifecycle.py merge-model get {P} {W}
+```
+
+## Why determinism-first
+
+The lifecycle is a state machine; encoding its transitions in code
+(`lifecycle.py`) instead of prose means the keyspace, the counter and the pointers
+can never disagree, every write preserves the file shape and is JSON-validated,
+and re-running a step is idempotent. The skill is the thin human-decision layer on
+top — and, uniquely for noorina, the facade **reuses** the org-scale modules that
+already own cross-repo reconciliation rather than replacing them.

--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -250,3 +250,7 @@ voweled
 wirefilter
 langserver
 typecheck
+
+# --- wave-lifecycle skill (#1019): sibling dogfood repo + state-machine term ---
+botfarm
+keyspace


### PR DESCRIPTION
## What & why

First, **additive-only** PR of epic #1019. Introduces a deterministic
wave-lifecycle core WITHOUT deleting or rewriting the 10 existing `wave-*` /
`phase-*` skills or collapsing the wave hooks — that destructive consolidation
is deferred to follow-ups to avoid conflicts with the in-flight
#1016/#1017/#1018/#1022/#1023 that all touch the same surface.

Adds `.claude/lib/lifecycle.py`, a thin deterministic facade that drives one
wave through **allocate → start → scope → kickoff → wrapup → retro**.

## Org-scale adaptation (the key design decision)

botfarm's `lifecycle.py` owns a private single-repo `.claude/state.json`.
**noorina is cross-repo**: wave state lives in the repo-root
`cross-repo-status.json` and is already driven by three deterministic modules —
`wave_seq.py` (allocator), `wave_merge_model.py` (merge model + reachability),
`wave_status.py` (repos / counters / digest). So `lifecycle.py` is built as a
**wrapper over the existing state**, not a competing state file:

- **Delegates** the transitions that already have code — `allocate` → `wave_seq`,
  `merge-model` / `reachability` → `wave_merge_model`, `counters` → `wave_status`
  — so the keyspace and the counter can never disagree.
- **Adds deterministic writes** for the transitions that until now lived only in
  the `/wave-*` skill prose — `start`, `scope` pointers, the `kickoff` timestamp,
  `wrapup` pointers, `retro` — routing every write through the same
  `upsert_status_keys` helper the modules use, so the file's compact-inline shape
  is preserved and each rewrite is JSON-validated before AND after (main#332/#456).

**Write ownership is respected, not duplicated:** `wrapup` writes only the
lifecycle pointers and **no** counter (`wave_status` stays the authoritative
counter writer per the `lifecycle.md` "Owner of writes" contract); `kickoff`
validates the merge model through `wave_merge_model`'s enum before writing.

## Transition API

| Command | Writes | Backed by |
|---------|--------|-----------|
| `wave peek` / `wave allocate --phase P --write` | `global_wave_seq`, `wave_{W}_phase[_ordinal]` | delegates → `wave_seq` |
| `wave start {W}` | `current_wave`, `wave_{W}_active=true`, `wave_{W}_started_at` | new (facade) |
| `wave scope {W} --repos … [--phase P]` | `wave_{W}_repos_in_scope`, `wave_{W}_scope_reconciled_at` (+`_phase`) | new (facade) |
| `wave kickoff {W} [--merge-model M]` | `wave_{W}_kicked_off_at`, `wave_{W}_active`, `current_wave` (+ validated `wave_{W}_merge_model`) | new (facade) + `wave_merge_model` validator |
| `wave wrapup {W}` | `wave_{W}_active=false`, `wave_{W}_completed_at`, `last_completed_wave` (**no counter**) | new (facade) |
| `wave retro {W}` | `wave_{W}_retro_completed_at` | new (facade) |
| `merge-model get/set`, `reachability`, `counters`, `state show/digest` | — | thin delegations |

Wave ids are **global monotonic** (`wave_25`), not per-phase ordinals (main#804).

## Also included

- `.claude/skills/wave-lifecycle/SKILL.md` — thin skill documenting noorina's
  cross-repo reality and pointing at `lifecycle.py`. Explicitly notes the
  existing `wave-*` skills are unchanged and will be progressively demoted to
  thin references in follow-up PRs.
- `.claude/lib/tests/test_lifecycle.py` — 21 network-free cases exercising the
  transition writes end-to-end against a temp status file, the ownership
  boundaries (wrapup writes no counter; bad merge model raises before writing),
  file-shape preservation, idempotency, and the delegations.
- Two `.cspell` dictionary terms (`botfarm`, `keyspace`).

## On `lifecycle.md`

`wave-lifecycle` is **not** a new ordered bracket step — it is the deterministic
execution *mechanism* the existing ordered steps will delegate to in follow-ups.
`lifecycle.md` stays authoritative for the ordering; the SKILL links back to it.
No new table row was added, deliberately, to avoid misrepresenting the facade as
a step in the bracket.

## Proposed follow-up PR sequence (the deferred destructive consolidation)

1. **This PR** — additive `lifecycle.py` + `wave-lifecycle` skill + tests (no deletions).
2. **After #1016/#1017/#1018/#1022/#1023 land** — demote `/wave-start` &
   `/wave-kickoff` state-transition prose to thin references that call
   `lifecycle.py` (keep only the cross-repo orchestration: branch creation across
   repos, labelling, reviewer slates).
3. Demote `/wave-wrapup` & `/wave-retro` transition prose likewise (counter write
   already flows through `wave_status`; pointers through `lifecycle.py`).
4. Collapse the 4 board hooks into one (per the epic AC), keeping the load-bearing
   `block_squash_wave_merge` + wave-plan validation.
5. Update `lifecycle.md` tables to reference the deterministic commands, and prune
   the now-thin prose from the demoted skills.

## Test / gate results

- `pytest .claude/lib/tests/` — **752 passed** (21 new).
- ruff format + lint, mypy, cspell, markdownlint, skill-graphql-pagination — green.
- Pre-push (mypy + pytest + pytest-skills + budgets + mermaid) — all passed.

Refs #1019 (epic continues — not Closes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QdvQ7Aa4P8DGnKXS2rgobE
