### PR TITLE
Lean-brief tooling: skeleton target, oversized-brief advisory, hygiene playbook (#1020)

### DIFF
--- a/.claude/hooks/tests/test_warn_oversized_brief.py
+++ b/.claude/hooks/tests/test_warn_oversized_brief.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Unit tests for warn_oversized_brief.py — issue #1020.
+
+The hook is an ADVISORY (never-blocking) lean-brief guard. Coverage:
+  - a brief that pastes a whole context file's substantial lines → advisory,
+    naming the file, never a block
+  - a brief that extracts only a small section stays under threshold → no-op
+  - short shared lines never accumulate a false positive (the _MIN_LINE_LEN
+    substantial-line filter bites)
+  - a charter SUB-document (charter/<subdir>/*.md) is covered too — noorina's
+    charter is a directory tree, so the source glob must recurse
+  - non-Agent tools and empty prompts are no-ops
+  - the source set is resolved from CLAUDE_PROJECT_DIR, so tests are hermetic
+
+The overlap threshold and the substantial-line floor are pinned directly, so a
+future loosening (dropping the floor, or lowering the char threshold to zero)
+reddens a test rather than silently changing the advisory's bite.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+HOOK = Path(__file__).resolve().parents[1] / "warn_oversized_brief.py"
+spec = importlib.util.spec_from_file_location("warn_oversized_brief", HOOK)
+assert spec is not None and spec.loader is not None
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+
+def _long_lines(n: int, width: int = 80) -> str:
+    """n distinct lines, each `width` chars (>= _MIN_LINE_LEN)."""
+    return "\n".join(f"line {i:03d} " + "x" * (width - 10) for i in range(n))
+
+
+def _seed_charter(root: Path, name: str, body: str) -> Path:
+    """Seed a top-level charter sub-document (charter/<name>)."""
+    charter_dir = root / ".claude" / "team" / "charter"
+    charter_dir.mkdir(parents=True, exist_ok=True)
+    path = charter_dir / name
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def _seed_charter_subdir(root: Path, rel: str, body: str) -> Path:
+    """Seed a nested charter sub-document (charter/<subdir>/<name>)."""
+    path = root / ".claude" / "team" / "charter" / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def _agent(prompt: str) -> dict:
+    return {"tool_name": "Agent", "tool_input": {"prompt": prompt}}
+
+
+# ---------------------------------------------------------------------------
+# Fires: a whole-file paste
+# ---------------------------------------------------------------------------
+
+
+def test_whole_file_paste_returns_advisory(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    body = _long_lines(60)  # ~60*80 chars of substantial lines, well over 2000
+    _seed_charter(tmp_path, "agents.md", body)
+
+    result = mod.check(_agent(f"Here is the whole charter:\n{body}\nGo review."))
+    assert result is not None
+    assert result.get("decision") != "block"  # advisory only
+    msg = result["systemMessage"]
+    assert "agents.md" in msg
+    assert "#1020" in msg
+
+
+def test_claude_md_paste_is_detected(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    body = _long_lines(60)
+    (tmp_path / "CLAUDE.md").write_text(body, encoding="utf-8")
+
+    result = mod.check(_agent(body))
+    assert result is not None
+    assert "CLAUDE.md" in result["systemMessage"]
+
+
+def test_top_level_charter_md_is_detected(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    body = _long_lines(60)
+    charter = tmp_path / ".claude" / "team" / "charter.md"
+    charter.parent.mkdir(parents=True, exist_ok=True)
+    charter.write_text(body, encoding="utf-8")
+
+    result = mod.check(_agent(body))
+    assert result is not None
+    assert result["systemMessage"].count("charter.md")
+
+
+def test_charter_subdir_document_is_detected(tmp_path, monkeypatch):
+    """A paste of a nested split charter file must be caught — the glob recurses."""
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    body = _long_lines(60)
+    _seed_charter_subdir(tmp_path, "pull-requests/reviews.md", body)
+
+    result = mod.check(_agent(f"Review per this:\n{body}"))
+    assert result is not None
+    assert "pull-requests/reviews.md" in result["systemMessage"]
+
+
+# ---------------------------------------------------------------------------
+# No-ops: lean extract, short lines, wrong tool, empty
+# ---------------------------------------------------------------------------
+
+
+def test_small_section_extract_is_noop(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    body = _long_lines(60)
+    _seed_charter(tmp_path, "agents.md", body)
+
+    # Paste only the first few lines — a lean section-extract, under threshold.
+    excerpt = "\n".join(body.splitlines()[:5])
+    assert mod.check(_agent(f"Relevant section:\n{excerpt}")) is None
+
+
+def test_short_lines_do_not_accumulate(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    # Many SHORT lines (< _MIN_LINE_LEN) — even pasted whole, none count.
+    short_body = "\n".join(f"item {i}" for i in range(400))
+    _seed_charter(tmp_path, "agents.md", short_body)
+
+    assert mod.check(_agent(short_body)) is None
+
+
+def test_non_agent_tool_is_noop(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    body = _long_lines(60)
+    _seed_charter(tmp_path, "agents.md", body)
+    assert mod.check({"tool_name": "Bash", "tool_input": {"command": body}}) is None
+
+
+def test_empty_prompt_is_noop(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    _seed_charter(tmp_path, "agents.md", _long_lines(60))
+    assert mod.check(_agent("")) is None
+
+
+# ---------------------------------------------------------------------------
+# Threshold / floor bite
+# ---------------------------------------------------------------------------
+
+
+def test_overlap_threshold_is_the_bite(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    body = _long_lines(60)
+    _seed_charter(tmp_path, "agents.md", body)
+    lines = body.splitlines()
+
+    # Accumulate whole lines until just under, then just over, the char cap.
+    acc, under = 0, []
+    for ln in lines:
+        if acc + len(ln) >= mod._OVERLAP_WARN_CHARS:
+            break
+        under.append(ln)
+        acc += len(ln)
+    assert mod.check(_agent("\n".join(under))) is None, "under-threshold must not fire"
+
+    over = under + [lines[len(under)], lines[len(under) + 1]]
+    assert mod.check(_agent("\n".join(over))) is not None, "over-threshold must fire"

--- a/.claude/hooks/warn_oversized_brief.py
+++ b/.claude/hooks/warn_oversized_brief.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: advisory when an Agent brief pastes a whole charter/CLAUDE.md file.
+
+Background (issue #1020, the lean-brief tooling program)
+========================================================
+
+The single largest per-token waste is the orchestrator pasting large verbatim
+context — full ``CLAUDE.md``, whole charter sub-documents — into every subagent
+brief, re-paying on every Opus/Sonnet spawn for context the role will never use.
+The standing rule (charter ``agents/spawn-discipline.md``, and the
+Session-Hygiene Playbook at ``agents/session-hygiene.md``) is: quote only the
+*section* a task needs, then point the agent at the file+anchor for the rest.
+
+This hook is the advisory backstop for that rule. On an ``Agent`` spawn it
+measures how much of the brief is a *verbatim* run of a tracked context file
+(``CLAUDE.md`` at the project root, ``.claude/team/charter.md``, and every
+``.claude/team/charter/**/*.md`` sub-document). When a single source file's
+substantial lines reproduce in the brief past a generous threshold, it surfaces
+a MODEL-VISIBLE advisory nudging toward a section-extract + pointer.
+
+Why advisory-only (never blocks)
+================================
+
+An over-long brief is a **cost smell, not a correctness fault** — a spawn that
+carries too much context still works. Blocking would risk stalling a wave over a
+heuristic. So this hook fails OPEN in every direction: a non-Agent call, a small
+brief, an unreadable source file, or any internal error all exit 0 with no
+message. It can only ever ADD a ``systemMessage``; it never returns ``block``.
+
+Detection (a heuristic, deliberately conservative)
+==================================================
+  * Only *substantial* source lines count (``>= _MIN_LINE_LEN`` chars after
+    whitespace-normalisation), so short shared boilerplate (fences, ``---``,
+    one-word headings) never accumulates a false positive.
+  * A source file trips the advisory only when its matched substantial lines sum
+    to ``>= _OVERLAP_WARN_CHARS`` characters — a single extracted section stays
+    under; a whole-file (or multi-section) paste blows past.
+
+Exit codes:
+  0 — always (advisory; never blocks)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+# A source line must be at least this long (post-normalisation) to count toward
+# the overlap, so common short lines (```bash, ---, `## PR Template`) never
+# accumulate a false positive.
+_MIN_LINE_LEN = 40
+
+# A single source file trips the advisory when its matched substantial lines sum
+# to at least this many characters. Generous on purpose: a lean section-extract
+# stays well under; pasting a whole charter file / CLAUDE.md sails past.
+_OVERLAP_WARN_CHARS = 2000
+
+# Cap how much of the brief we scan, so a pathological input can't make the hook
+# slow. Well above any sane brief size.
+_MAX_SCAN_CHARS = 400_000
+
+
+def _project_root() -> Path:
+    """Repo root: ``$CLAUDE_PROJECT_DIR`` if set, else two levels up from here
+    (``.claude/hooks/`` → repo root)."""
+    env = os.environ.get("CLAUDE_PROJECT_DIR")
+    if env:
+        return Path(env)
+    return Path(__file__).resolve().parents[2]
+
+
+def _source_files(root: Path) -> list[Path]:
+    """The tracked context files a brief should point at rather than paste.
+
+    Noorina's charter is BOTH a single top-level ``charter.md`` AND a directory
+    tree of per-concern sub-documents (``charter/agents/*.md``,
+    ``charter/pull-requests/*.md``, …), so the sub-document glob is recursive —
+    a paste of any one split file (e.g. ``charter/pull-requests/reviews.md``) is
+    caught, not only the top-level files.
+    """
+    files: list[Path] = []
+    claude_md = root / "CLAUDE.md"
+    if claude_md.is_file():
+        files.append(claude_md)
+    charter = root / ".claude" / "team" / "charter.md"
+    if charter.is_file():
+        files.append(charter)
+    charter_dir = root / ".claude" / "team" / "charter"
+    if charter_dir.is_dir():
+        files.extend(sorted(charter_dir.rglob("*.md")))
+    return files
+
+
+def _norm(line: str) -> str:
+    """Collapse internal whitespace and strip, so trivial reflow does not defeat
+    the verbatim match."""
+    return " ".join(line.split())
+
+
+def _overlap_chars(brief_norm: str, source_text: str) -> int:
+    """Sum of the lengths of ``source_text``'s substantial lines that appear
+    verbatim (whitespace-normalised) inside ``brief_norm``."""
+    total = 0
+    seen: set[str] = set()
+    for raw in source_text.splitlines():
+        norm = _norm(raw)
+        if len(norm) < _MIN_LINE_LEN or norm in seen:
+            continue
+        seen.add(norm)
+        if norm in brief_norm:
+            total += len(norm)
+    return total
+
+
+def _find_oversized_source(prompt: str) -> tuple[str, int] | None:
+    """Return ``(filename, matched_chars)`` for the first source file whose
+    verbatim overlap with the brief crosses the threshold, else None."""
+    brief_norm = _norm(prompt[:_MAX_SCAN_CHARS])
+    root = _project_root()
+    for path in _source_files(root):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        overlap = _overlap_chars(brief_norm, text)
+        if overlap >= _OVERLAP_WARN_CHARS:
+            try:
+                rel = path.relative_to(root).as_posix()
+            except ValueError:
+                rel = path.name
+            return rel, overlap
+    return None
+
+
+def _build_message(rel: str, overlap: int) -> str:
+    return (
+        "LEAN-BRIEF ADVISORY (#1020): this Agent brief reproduces a large verbatim "
+        f"run (~{overlap} chars) of a tracked context file:\n    {rel}\n\n"
+        "Pasting a whole charter/CLAUDE.md file into a brief re-pays for context "
+        "the role will not use — the single largest per-token waste across a wave. "
+        "Prefer a section-extract + pointer:\n"
+        "  - Quote only the SECTION the task needs, then cite the file+anchor for "
+        "the rest (the agent can Read it on demand).\n"
+        "  - The PR charter is pre-split for this: point a reviewer at "
+        "charter/pull-requests/reviews.md, a merger at charter/pull-requests/wave-merge.md, "
+        "an author at charter/pull-requests/authoring.md — not the whole PR charter.\n"
+        "  - Identity/branching/commit rules live in the roster file "
+        "(.claude/team/roster/<member>.md) + charter; point at them, do not re-transcribe.\n"
+        "  - For a CODE subtree, pack a signatures-only skeleton instead of pasting "
+        "whole files: `make skeleton DIR=<subtree> INCLUDE='<glob>'`.\n"
+        "See charter/agents/session-hygiene.md § Lean Section-Extract Briefs (#1020). "
+        "Advisory only — your spawn is not blocked."
+    )
+
+
+def check(input_data: dict) -> dict | None:
+    """Return a non-blocking ``systemMessage`` advisory when an Agent brief pastes
+    a whole context file, else None. Never returns a ``block`` decision.
+
+    (Also usable by a dispatcher, though this hook is registered standalone in
+    settings.json's ``Agent`` matcher — noorina has no Agent dispatcher.)"""
+    if input_data.get("tool_name", "") != "Agent":
+        return None
+    prompt = input_data.get("tool_input", {}).get("prompt", "")
+    if not prompt:
+        return None
+    hit = _find_oversized_source(prompt)
+    if hit is None:
+        return None
+    rel, overlap = hit
+    return {"systemMessage": _build_message(rel, overlap)}
+
+
+def main() -> None:
+    try:
+        input_data = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        sys.exit(0)
+    try:
+        result = check(input_data)
+    except Exception:
+        # Advisory: never let a heuristic crash a spawn.
+        sys.exit(0)
+    if result is not None:
+        # Emit the advisory as a bare top-level ``systemMessage`` (no permission
+        # decision): ``systemMessage`` surfaces the warning to the model, and exit 0
+        # with no ``decision`` is the default allow — so the spawn is never gated.
+        print(json.dumps(result))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -23,6 +23,11 @@
             "type": "command",
             "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/enforce_ontology_context.py",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/warn_oversized_brief.py",
+            "timeout": 10
           }
         ]
       },

--- a/.claude/team/charter/agents.md
+++ b/.claude/team/charter/agents.md
@@ -43,3 +43,6 @@ Periodic liveness checks so zero-output stalls surface before the wave ends. →
 
 ## Throttle-Stall Recovery — Trigger Thresholds
 Trigger thresholds for the orchestrator takeover of a throttle-stalled implementer. → [agents/lifecycle.md](agents/lifecycle.md#throttle-stall-recovery--trigger-thresholds)
+
+## Session-Hygiene Playbook & Lean Briefs
+`/clear` at wave boundaries, proactive `/compact`, cache-prefix discipline, tool-result clearing, and lean section-extract briefs (`warn_oversized_brief.py`, `make skeleton`). → [agents/session-hygiene.md](agents/session-hygiene.md#session-hygiene-playbook--lean-briefs-1020)

--- a/.claude/team/charter/agents/session-hygiene.md
+++ b/.claude/team/charter/agents/session-hygiene.md
@@ -1,0 +1,166 @@
+# Session-Hygiene Playbook & Lean Briefs (#1020)
+
+> **What this file governs.** How to keep a long-lived session cheap — the re-billed
+> context tail, cache-prefix discipline, tool-result clearing — and how to keep a
+> spawn brief lean (section-extract over whole-file paste; signatures-only code
+> skeletons). The `warn_oversized_brief.py` advisory hook and the `make skeleton`
+> target are the machine backstops for the lean-brief half; the rest is discipline.
+
+## Lean Section-Extract Briefs
+
+**Pass a subagent only the charter/CLAUDE.md *section* its task needs — never the whole
+file.** A brief that pastes full `CLAUDE.md` + a whole charter sub-document into every
+spawn re-pays for context the role will never use; across the Opus/Sonnet subagents a
+cross-repo wave spawns, that is the single largest per-token waste. The rule is standing,
+not per-wave:
+
+- **Extract the section, cite the path.** Quote (or tightly paraphrase) just the relevant
+  section, then point the agent at the file+anchor for the rest — e.g. a reviewer gets a
+  [`charter/pull-requests/reviews.md`](../pull-requests/reviews.md) pointer, not the whole
+  PR charter. An agent can always `Read` the deeper file on demand; it should not carry it
+  by default.
+- **The PR charter is pre-split for exactly this** — [`charter/pull-requests.md`](../pull-requests.md)
+  is a thin index over `reviews.md` / `authoring.md` / `wave-merge.md` / `ci-gates.md` /
+  `evidence-standards.md` / `acceptance-scope.md`. Route a role to the one sub-file it needs.
+- **Identity/branching/commit rules live in the roster file and the charter** — a brief
+  points at them (`.claude/team/roster/<member>.md`, `charter.md` § Commit Identity), it
+  does not re-transcribe them.
+- **Tool scope is declared, not briefed.** The `.claude/agents/<role>.md` frontmatter
+  `tools:` list restricts a role to the tools it uses (an allowlist), so a text-only role
+  loads no unused tool schemas — the brief need not re-list them.
+
+**Advisory backstop.** [`warn_oversized_brief.py`](../../hooks/warn_oversized_brief.py) is
+a non-blocking PreToolUse advisory on `Agent` spawns (registered in the `Agent` matcher of
+`.claude/settings.json`): it warns when a single brief embeds a very large block of
+verbatim `CLAUDE.md` / `charter.md` / `charter/**/*.md` prose, nudging toward a
+section-extract + pointer. It never blocks a spawn (fail-open by design — an over-long
+brief is a cost smell, not a correctness fault).
+
+### Repomix skeleton packing for a CODE subtree
+
+The same "extract, don't paste the whole thing" rule applies to code, not just charter
+prose. When a spawn genuinely needs the *shape* of a subtree wider than the ontology's own
+`path:line` pointers (orientation across many files, not one symbol lookup — the ontology
+stays the tool for that), pack a Tree-sitter **skeleton** (signatures kept, bodies
+stripped, roughly halving to two-thirds off raw token count) instead of pasting whole
+files:
+
+```
+make skeleton DIR=.claude/lib/ontology_gen INCLUDE='*.py' OUT=/tmp/skeleton.xml
+```
+
+Paste the output file's contents into the brief. `DIR` narrows to the subtree the ontology
+already selected as relevant; `INCLUDE` narrows further to a glob within it when the whole
+subtree is still too broad. The ontology **selects** which files matter; this
+**compresses** them for the brief — the two compose, they don't compete.
+
+**Dependency note.** `make skeleton` shells out to `npx --yes repomix` (Tree-sitter
+compression), which fetches repomix on demand — it needs Node's `npx` on PATH but adds
+nothing to the repo. If `npx` is absent the target fails fast with a clear message; install
+Node, or fall back to a hand-picked section extract.
+
+## Session-Hygiene Playbook
+
+**The API is stateless: every turn re-sends — and re-bills — the entire context tail.**
+A long-lived session is not "free after the first turn"; each subsequent turn re-pays for
+every token still in context. The four disciplines below keep that re-billed tail small.
+
+### The cost mechanics (why this pays)
+
+Grounded in Opus 4.8 pricing ($5 / Mtok input, $25 / Mtok output) and the caching
+economics (verified against the `claude-api` skill — `shared/prompt-caching.md`):
+
+- **Output costs 5× input, per token** ($25 vs $5). Output is written once and is small;
+  the input tail is re-sent every turn and grows without bound. On a long session the
+  **re-billed input tail — not the output — is the dominant cost.**
+- **A cache *read* costs ≈ 0.1× input; a cache *write* costs 1.25× input** (5-minute TTL;
+  2× at 1-hour). So a token that stays in a stable, cached prefix re-bills at **one-tenth**
+  the price of the same token in the volatile (uncached) tail. Keeping the prefix cacheable
+  is a 10× lever on the re-billed tail.
+- **`usage.cache_read_input_tokens` + `cache_creation_input_tokens` + `input_tokens` = the
+  full prompt.** `input_tokens` is only the *uncached remainder* — read all three, not the
+  one field, to see the true size (and to prove caching is working; see § Verifying below).
+
+### 1. `/clear` at every wave/task boundary — the biggest single-session saving
+
+When one task ends and an unrelated one begins, **`/clear`** — do not let the new work
+inherit a 100K-token tail it will never reference but will re-bill on every turn. A wave
+boundary, a task pickup that shares nothing with the last, a context switch from
+implementing to a long review of unrelated code: all are `/clear` points. The old tail
+carries zero value into the new task and pure cost. This is the largest lever because it
+drops the *entire* accumulated tail at once, not a slice of it.
+
+### 2. Proactive `/compact` at ~60% — don't ride to auto-compact at 95%
+
+Auto-compaction fires only when context is nearly full (~95%), by which point you have
+already re-billed the bloated tail across many turns. **`/compact` proactively at ~60%**
+so the summary replaces the tail *before* it has been re-paid dozens of times. Compaction
+summarizes (unlike `/clear`, which drops), so it is the right tool when the current task
+must continue but its history has grown heavy. **Afterward, verify load-bearing state
+survived the summary** — an open PR number, a branch name, a not-yet-pushed SHA, a
+half-applied migration. A summary that silently drops a load-bearing fact is worse than the
+tail it replaced; re-state the fact after compacting.
+
+### 3. Cache-prefix discipline — stable content to the FRONT, volatile to the BACK
+
+Caching is a **prefix match**: render order is `tools → system → messages`, and **one
+changed byte anywhere in the prefix invalidates every cache entry after it** (drops those
+tokens from 0.1× back to 1×). Two rules follow:
+
+- **Keep the stable prefix byte-identical mid-session.** `CLAUDE.md`, the `@import`-ed
+  `MEMORY.md`, the charter text a session loads, and the tool definitions sit at the front
+  — do not mutate them mid-session (a reworded `CLAUDE.md`, an added/removed/reordered tool
+  busts the cache for everything after it). The Opus 4.8 minimum cacheable prefix is **4096
+  tokens**, so the prefix has to be both stable *and* substantial to cache at all.
+- **Push volatile content to the back.** Live git status, the shared task list, freshly
+  recalled memory, timestamps — anything that changes per turn — belongs *after* the stable
+  content, never interpolated into the front. This is exactly why the wave/status digest is
+  read on demand (`wave_status.py digest`) rather than embedded in `MEMORY.md`, and why the
+  volatile handoff summary lives in the gitignored `session_handoff.md`, not in the
+  always-loaded index (see [[project_ontology_system]] and CLAUDE.md § Project Memory).
+
+### 4. Tool-result clearing — `clear_tool_uses_20250919` where the harness exposes it
+
+Stale tool results (file dumps, CI logs, `git archive` extractions) linger in context and
+re-bill every turn. Where the harness exposes context editing
+(`context_management.edits` with `clear_tool_uses_20250919`, beta
+`context-management-2025-06-27`), clear them — but tune it:
+
+- **`clear_at_least ≥ 5000`.** Each clear *rewrites* the prefix boundary, and a rewrite is
+  a cache **write** (1.25× input). Clearing a trickle of tokens costs more in cache-write
+  churn than it saves; batch the clears so each one frees a worthwhile block.
+- **`exclude_tools` for results you will re-reference.** A file you are actively editing or
+  a diff you keep citing should not be cleared out from under you — exclude it, or you pay
+  to re-read it.
+
+### Verifying the cache-prefix claim
+
+The claim "the stable prefix actually caches" is checked against
+`usage.cache_read_input_tokens`, the same field the `claude-api` skill prescribes:
+
+1. **Live signal.** Across turns whose prefix (`CLAUDE.md` + `MEMORY.md` + charter + tools)
+   was *not* touched, `cache_read_input_tokens` must be **non-zero and roughly the prefix
+   size** while `input_tokens` stays small (the uncached tail only). Zero cache reads across
+   an unchanged-prefix stretch = a silent invalidator busting the prefix — find the byte
+   that changed (a `datetime.now()`-style header, a reordered tool, a reworded `CLAUDE.md`).
+2. **Mid-session mutation is the anti-signal.** If any wave edits `CLAUDE.md`, `MEMORY.md`,
+   or the charter *and continues the same session*, expect one turn of elevated
+   `cache_creation_input_tokens` (the prefix was rewritten) — that is the cache-bust the
+   discipline exists to avoid, made visible. Prefer editing those files at a `/clear`
+   boundary, not mid-task.
+
+## Web-Fetch Discipline: ask for the fact, not "summarize the page"
+
+External fetches are the other major token sink alongside code-retrieval — a
+"summarize this page" `WebFetch` dumps raw HTML/prose into context that then gets re-billed
+on every subsequent turn (see § Session-Hygiene Playbook above for why the re-billed tail
+dominates cost).
+
+`WebFetch(url, prompt)` runs the fetched content through a small model scoped to `prompt`
+*before* it reaches the calling agent's context — a narrow prompt ("what is the current LTS
+version of Node.js per this page?") returns a sentence; a broad one ("summarize this page")
+returns paragraphs, most of which the task never uses. **Default to the narrow form** — ask
+the specific question the task needs answered. Widen only when the task genuinely needs the
+whole document, not as the default shape of the call. A web fact worth re-reading across
+sessions belongs in a `reference` memory (`capture_reference.py`), not re-fetched every
+session (CLAUDE.md § Durable web-fetch capture).

--- a/.claude/team/charter/agents/session-hygiene.md
+++ b/.claude/team/charter/agents/session-hygiene.md
@@ -29,7 +29,7 @@ not per-wave:
   `tools:` list restricts a role to the tools it uses (an allowlist), so a text-only role
   loads no unused tool schemas — the brief need not re-list them.
 
-**Advisory backstop.** [`warn_oversized_brief.py`](../../hooks/warn_oversized_brief.py) is
+**Advisory backstop.** [`warn_oversized_brief.py`](../../../hooks/warn_oversized_brief.py) is
 a non-blocking PreToolUse advisory on `Agent` spawns (registered in the `Agent` matcher of
 `.claude/settings.json`): it warns when a single brief embeds a very large block of
 verbatim `CLAUDE.md` / `charter.md` / `charter/**/*.md` prose, nudging toward a

--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -101,6 +101,7 @@ jsonc
 frontmatter
 repo
 repos
+repomix
 canonicalized
 disambiguation
 disambiguate

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help setup-hooks lint format docs
+.PHONY: help setup-hooks lint format docs skeleton
 
 help:
 	@echo "Targets:"
@@ -6,6 +6,8 @@ help:
 	@echo "  lint                          Run ruff lint on .claude/hooks/"
 	@echo "  format                        Run ruff format on .claude/hooks/"
 	@echo "  docs                          Regenerate MS Office docs from their markdown sources"
+	@echo "  skeleton                      Signatures-only skeleton of a subtree for a token-lean spawn brief"
+	@echo "                                (DIR=dir INCLUDE=glob OUT=path)"
 
 setup-hooks:
 	@command -v pre-commit >/dev/null 2>&1 || { \
@@ -34,3 +36,26 @@ format:
 # docs/office/README.md.
 docs:
 	scripts/gen-office.sh
+
+# ---- Lean-brief tooling (#1020) --------------------------------------------
+#
+# Pack a Tree-sitter-compressed *skeleton* of a code subtree (signatures kept,
+# bodies stripped — roughly halving to two-thirds off raw token count) for a
+# token-lean spawn brief. Paste the OUT file's contents into the brief instead
+# of whole source files. The ontology already SELECTS which subtree matters
+# (see /ontology-librarian); this COMPRESSES it — the two compose. See
+# .claude/team/charter/agents/session-hygiene.md § Lean Section-Extract Briefs.
+#
+# Dependency: repomix, fetched on demand via `npx --yes repomix` (needs Node's
+# npx on PATH; nothing is added to the repo). `--include` narrows to specific
+# files/globs within DIR when the whole subtree is too broad.
+DIR     ?= .
+INCLUDE ?=
+OUT     ?= /tmp/repomix-skeleton.xml
+
+skeleton:
+	@command -v npx >/dev/null 2>&1 || { echo "ERROR: npx not found (Node required for repomix)"; exit 1; }
+	npx --yes repomix --compress --style xml --no-file-summary --no-directory-structure \
+		$(if $(INCLUDE),--include "$(INCLUDE)") -o "$(OUT)" "$(DIR)"
+	@echo ""
+	@echo "Skeleton written to $(OUT) — paste its contents into the spawn brief instead of whole files."


### PR DESCRIPTION
## Summary

Lean-brief tooling for the context-efficiency program (#1020), ported from botfarm and adapted to noorina's config-driven hook dispatch (#1018) and charter layout. Three deliverables:

### 1. `make skeleton` target
Packs a Tree-sitter-compressed, **signatures-only** skeleton of a code subtree (function bodies stripped) for a token-lean spawn brief, via `npx --yes repomix --compress` with `DIR` / `INCLUDE` / `OUT` knobs. Added to `.PHONY` and `make help`. The ontology *selects* which files matter; this *compresses* them for the brief.
- **Dependency:** repomix is fetched on demand by `npx` (needs Node's `npx` on PATH; nothing is added to the repo). Absent `npx`, the target fails fast with a clear message. Verified end-to-end (`make skeleton DIR=.claude/lib/ontology_gen INCLUDE='aggregate.py'` → 1,906-token skeleton).

### 2. `warn_oversized_brief.py` — advisory hook
Non-blocking PreToolUse advisory on the `Agent` matcher that warns when a spawn brief pastes a large verbatim run of a tracked context file (`CLAUDE.md`, `charter.md`, or any `charter/**/*.md` — the source glob **recurses**, since noorina's charter is a directory tree of per-concern split files). Advisory-only: it fails open in every direction and can only add a `systemMessage`, never a `block`.

**How it is registered:** standalone in the `Agent` matcher of `.claude/settings.json`, alongside the existing `validate_wave_context` and `enforce_ontology_context` entries. noorina has **no Agent dispatcher** — #1018's config-driven `hooks.*` lists cover only the Bash/Edit/Write/NotebookEdit dispatchers, and the existing Agent hooks are already registered standalone. Standalone registration satisfies the #698 registration-coverage guard (`test_every_check_exposing_hook_is_reachable`), which passes here.

Tests (`.claude/hooks/tests/test_warn_oversized_brief.py`): whole-file paste, `CLAUDE.md`, top-level `charter.md`, a nested `charter/pull-requests/reviews.md` subdir file, lean-extract no-op, short-line floor, wrong-tool/empty no-ops, and the threshold bite.

### 3. Session-Hygiene Playbook
Consolidated charter doc at `.claude/team/charter/agents/session-hygiene.md`, indexed from `charter/agents.md`: `/clear` at wave boundaries, proactive `/compact` at ~60%, byte-identical cache-prefix discipline, tool-result clearing, lean section-extract briefs, the skeleton workflow, and "WebFetch: ask for the fact, not summarize the page". The cost mechanics (Opus 4.8 $5/$25 per Mtok; cache read 0.1×, cache write 1.25×/2×; 4096-token minimum cacheable prefix) were verified against the `claude-api` skill.

## Stacking

**Stacked on #1018 → #1017. Retarget up the chain as each merges to main.**
Base is `A.Virtanen/1018-framework-config` (PR #1029) because #1020 depends on that branch's charter/settings structure.

## Test results
- Full hooks suite: **1863 passed** (69 subtests)
- ruff (lint + format), mypy: clean
- Pre-push gates (mypy + pytest): green
- `make skeleton`: verified end-to-end

Closes #1020

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QdvQ7Aa4P8DGnKXS2rgobE
