### PR TITLE
fix(#1038): stop tracking gitignored session_handoff.md in ontology checksums

### DIFF
--- a/.claude/hooks/ontology_tracker.py
+++ b/.claude/hooks/ontology_tracker.py
@@ -71,6 +71,11 @@ SKIP_PATTERNS = [
     "ontology/checksums.json",  # Don't track ourselves
     "ontology/structural/",  # GENERATED structural layer — see note below (#857)
     ".claude/annunaki/errors.jsonl",
+    # Gitignored, machine-local, rewritten by the Stop hook after ~every
+    # response — same class as annunaki/errors.jsonl. Tracking it dirtied the
+    # COMMITTED checksums.json every session, so /session-start reported
+    # phantom drift forever (#1038).
+    ".claude/memory/session_handoff.md",
     "__pycache__/",
     ".pyc",
     "node_modules/",
@@ -223,7 +228,10 @@ def check(input_data: dict) -> dict | None:
         CHECKSUMS_FILE.parent.mkdir(parents=True, exist_ok=True)
         tmp = CHECKSUMS_FILE.with_suffix(".tmp")
         with open(tmp, "w", encoding="utf-8") as f:
-            json.dump(data, f, indent=2)
+            # ensure_ascii=False: the on-disk file holds literal UTF-8 in its
+            # top-level ``description``. Re-escaping it here made every touch
+            # emit a spurious one-line diff (#1038).
+            json.dump(data, f, indent=2, ensure_ascii=False)
             f.write("\n")
         tmp.replace(CHECKSUMS_FILE)
     except OSError:

--- a/.claude/hooks/tests/test_ontology_tracker.py
+++ b/.claude/hooks/tests/test_ontology_tracker.py
@@ -245,11 +245,55 @@ class ShouldSkipSessionHandoffTests(_FakeRepoRootMixin, unittest.TestCase):
     """
 
     def test_relative_handoff_path_is_skipped(self):
-        self.assertTrue(hook._should_skip(".claude/memory/session_handoff.md"))
+        """A repo-relative handoff path is skipped BY THE PATTERN, not by luck.
+
+        The ``os.chdir`` here is load-bearing — do not remove it (#1043).
+        ``_should_skip`` resolves a relative path against the *process cwd*, not
+        against the patched ``REPO_ROOT``. Without the chdir this path resolves
+        somewhere outside the fake root and is caught by the pre-existing
+        out-of-repo rule, so the assertion passes even when the
+        ``SKIP_PATTERNS`` entry under test is deleted — an inert test that
+        reports green while covering nothing. Anchoring cwd to the fake root
+        puts the path *inside* the repo, so the pattern is the only thing that
+        can produce the skip and the test genuinely dies if it is removed.
+
+        Relative paths are worth covering: the tracker is anchored on the
+        orchestrator cwd and records relative paths in real flows (see the
+        module docstring on worktree-relative paths).
+        """
+        cwd = os.getcwd()
+        try:
+            os.chdir(self._fake_root)
+            self.assertTrue(hook._should_skip(".claude/memory/session_handoff.md"))
+        finally:
+            os.chdir(cwd)
 
     def test_absolute_handoff_path_is_skipped(self):
         path = str(self._fake_root / ".claude" / "memory" / "session_handoff.md")
         self.assertTrue(hook._should_skip(path))
+
+    def test_skip_is_scoped_to_the_claude_memory_directory(self):
+        """The pattern must stay DIRECTORY-scoped, not a bare filename (#1043).
+
+        Narrowing the entry to ``"session_handoff.md"`` left the whole suite
+        green, so nothing pinned the scoping. A substring denylist matches
+        anywhere in the path, so a bare filename would silently stop tracking
+        any committed file that happens to share the name — e.g. a real
+        ``docs/session_handoff.md``. Only the gitignored machine-local file at
+        ``.claude/memory/`` is exempt; a same-named file elsewhere in the repo
+        is ordinary tracked content.
+        """
+        elsewhere = str(self._fake_root / "docs" / "session_handoff.md")
+        self.assertFalse(hook._should_skip(elsewhere))
+
+    def test_skip_does_not_extend_to_sibling_memory_notes_by_prefix(self):
+        """A path merely *starting* with the handoff name is not exempt (#1043).
+
+        Guards the other narrowing direction — the pattern must match the whole
+        handoff path, so a distinct committed note is unaffected.
+        """
+        sibling = str(self._fake_root / ".claude" / "memory" / "session_handoff_notes.md")
+        self.assertFalse(hook._should_skip(sibling))
 
     def test_check_writes_no_entry_for_handoff(self):
         """End-to-end: a Write to the handoff produces no checksums entry.

--- a/.claude/hooks/tests/test_ontology_tracker.py
+++ b/.claude/hooks/tests/test_ontology_tracker.py
@@ -11,6 +11,7 @@ Or:  python3 .claude/hooks/tests/test_ontology_tracker.py
 
 from __future__ import annotations
 
+import json
 import os
 import sys
 import tempfile
@@ -230,6 +231,136 @@ class ShouldSkipExistingFiltersTests(unittest.TestCase):
 
     def test_annunaki_log_is_skipped(self):
         self.assertTrue(hook._should_skip(".claude/annunaki/errors.jsonl"))
+
+
+class ShouldSkipSessionHandoffTests(_FakeRepoRootMixin, unittest.TestCase):
+    """#1038: the gitignored, machine-local session handoff must NOT be tracked.
+
+    ``.claude/memory/session_handoff.md`` is gitignored and untracked in git,
+    yet the ``Stop`` hook rewrites it after ~every response. Tracking it dirtied
+    the COMMITTED ``ontology/checksums.json`` every session, so ``/session-start``
+    Step 3a reported phantom drift and ``/ontology-rebuild`` had a phantom entry
+    to resolve, forever — eroding a gate whose only value is that "0 dirty"
+    means something. Same class as ``.claude/annunaki/errors.jsonl``.
+    """
+
+    def test_relative_handoff_path_is_skipped(self):
+        self.assertTrue(hook._should_skip(".claude/memory/session_handoff.md"))
+
+    def test_absolute_handoff_path_is_skipped(self):
+        path = str(self._fake_root / ".claude" / "memory" / "session_handoff.md")
+        self.assertTrue(hook._should_skip(path))
+
+    def test_check_writes_no_entry_for_handoff(self):
+        """End-to-end: a Write to the handoff produces no checksums entry.
+
+        ``_should_skip`` is the mechanism, but the defect users saw was a
+        checksums *write*. Drive the dispatcher entry point against a real file
+        and assert the tracker reports "not applicable" and leaves the
+        checksums file untouched.
+        """
+        handoff = self._fake_root / ".claude" / "memory" / "session_handoff.md"
+        handoff.parent.mkdir(parents=True, exist_ok=True)
+        handoff.write_text("# handoff\n", encoding="utf-8")
+
+        checksums = self._fake_root / "ontology" / "checksums.json"
+        checksums.parent.mkdir(parents=True, exist_ok=True)
+        checksums.write_text('{"version": 1, "files": {}}\n', encoding="utf-8")
+        orig_checksums_file = hook.CHECKSUMS_FILE
+        hook.CHECKSUMS_FILE = checksums
+        try:
+            before = checksums.read_bytes()
+            result = hook.check({"tool_name": "Write", "tool_input": {"file_path": str(handoff)}})
+            self.assertIsNone(result)
+            self.assertEqual(checksums.read_bytes(), before)
+        finally:
+            hook.CHECKSUMS_FILE = orig_checksums_file
+
+    def test_other_memory_notes_are_still_tracked(self):
+        """The skip is scoped to the handoff — real project memory still tracks.
+
+        ``.claude/memory/`` is committed, semantic, hand-curated content; only
+        the single gitignored handoff file is exempt. A broader
+        ``.claude/memory/`` skip would silently drop the whole memory store
+        from drift detection.
+        """
+        path = str(self._fake_root / ".claude" / "memory" / "section_ci_tooling.md")
+        self.assertFalse(hook._should_skip(path))
+
+
+class ChecksumsSerializationTests(_FakeRepoRootMixin, unittest.TestCase):
+    """#1038: the tracker must not re-escape literal UTF-8 on every write.
+
+    ``checksums.json``'s top-level ``description`` contains literal ``—``/``×``.
+    Writing with the ``ensure_ascii=True`` default re-escaped them, so the file
+    flip-flopped between escaped and literal depending on which writer touched
+    it last — pure recurring diff noise on a committed file.
+    """
+
+    def test_non_ascii_description_survives_a_write_unescaped(self):
+        checksums = self._fake_root / "ontology" / "checksums.json"
+        checksums.parent.mkdir(parents=True, exist_ok=True)
+        description = "SCOPE (#857, #820/C×T2): semantic overlay — not structural"
+        checksums.write_text(
+            json.dumps({"version": 1, "description": description, "files": {}}, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+        tracked = self._fake_root / "ontology" / "domain.yaml"
+        tracked.write_text("entities: []\n", encoding="utf-8")
+
+        orig_checksums_file = hook.CHECKSUMS_FILE
+        hook.CHECKSUMS_FILE = checksums
+        try:
+            hook.check({"tool_name": "Write", "tool_input": {"file_path": str(tracked)}})
+        finally:
+            hook.CHECKSUMS_FILE = orig_checksums_file
+
+        raw = checksums.read_text(encoding="utf-8")
+        self.assertIn(description, raw)
+        self.assertNotIn("\\u", raw)
+        self.assertEqual(json.loads(raw)["description"], description)
+
+    def test_write_is_byte_stable_across_repeated_tracking(self):
+        """Tracking the same unchanged file twice must not change the bytes.
+
+        This is the property the defect violated: a no-op touch produced a diff.
+        """
+        checksums = self._fake_root / "ontology" / "checksums.json"
+        checksums.parent.mkdir(parents=True, exist_ok=True)
+        checksums.write_text(
+            json.dumps(
+                {"version": 1, "description": "overlay — × scope", "files": {}},
+                indent=2,
+                ensure_ascii=False,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        tracked = self._fake_root / "ontology" / "conventions.md"
+        tracked.write_text("# conventions\n", encoding="utf-8")
+
+        orig_checksums_file = hook.CHECKSUMS_FILE
+        hook.CHECKSUMS_FILE = checksums
+        try:
+            payload = {"tool_name": "Edit", "tool_input": {"file_path": str(tracked)}}
+            hook.check(payload)
+            first = checksums.read_bytes()
+            hook.check(payload)
+            second = checksums.read_bytes()
+        finally:
+            hook.CHECKSUMS_FILE = orig_checksums_file
+
+        # ``tracked_at`` is a timestamp and legitimately moves; everything else
+        # (notably the description encoding and the hashes) must be identical.
+        first_data = json.loads(first)
+        second_data = json.loads(second)
+        for data in (first_data, second_data):
+            for entry in data["files"].values():
+                entry.pop("tracked_at", None)
+        self.assertEqual(first_data, second_data)
+        self.assertNotIn("\\u", second.decode("utf-8"))
 
 
 if __name__ == "__main__":

--- a/.claude/skills/ontology-rebuild/SKILL.md
+++ b/.claude/skills/ontology-rebuild/SKILL.md
@@ -82,6 +82,8 @@ For each processed file, set `last_resolved = last_tracked` and `resolved_at = n
 
 Also update checksums for any ontology files that were modified during this pass.
 
+**Serialization (#1038):** when rewriting `checksums.json` programmatically, use `json.dump(data, f, indent=2, ensure_ascii=False)` and a trailing newline — matching the tracker hook (`.claude/hooks/ontology_tracker.py`). The top-level `description` contains literal UTF-8 (`—`, `×`); a writer that defaults to `ensure_ascii=True` re-escapes it and the file flip-flops between escaped and literal on every touch, producing recurring phantom diffs.
+
 ### 5. Report
 
 ```

--- a/ontology/checksums.json
+++ b/ontology/checksums.json
@@ -1031,12 +1031,6 @@
       "tracked_at": "2026-06-21T21:24:42.415758+00:00",
       "resolved_at": "2026-06-21T22:15:52Z"
     },
-    ".claude/memory/session_handoff.md": {
-      "last_tracked": "e6f4878d8898d3e525f6f8bd2e86cc67a87f3d90246916fb30ac41dde9b4bd74",
-      "last_resolved": "e6f4878d8898d3e525f6f8bd2e86cc67a87f3d90246916fb30ac41dde9b4bd74",
-      "tracked_at": "2026-07-19T15:44:41.601642+00:00",
-      "resolved_at": "2026-07-19T13:55:00Z"
-    },
     ".claude/lib/verify_deployable_merge.py": {
       "last_tracked": "7c2545f87d17c5c35967612f88381444ff510ceb81ba6553ba37497b0d5c3302",
       "last_resolved": "7c2545f87d17c5c35967612f88381444ff510ceb81ba6553ba37497b0d5c3302",


### PR DESCRIPTION
## What changed and why

`.claude/memory/session_handoff.md` is gitignored (`.gitignore:117`) and untracked in git, but the ontology change-tracker hook tracked it anyway. The `Stop` hook rewrites that file after ~every response (~5min throttle), so **every session dirtied `ontology/checksums.json` — a committed file**. `/session-start` Step 3a reported phantom drift and `/ontology-rebuild` had a phantom entry to resolve, forever, eroding a gate whose only value is that "0 dirty" means something. `SKIP_PATTERNS` already carried the exact sibling case (`.claude/annunaki/errors.jsonl` — gitignored, machine-local, constantly rewritten); the handoff was simply a missed entry. This adds it, drops the now-stale `checksums.json` entry, fixes the `ensure_ascii` churn, and adds regression tests.

## Evidence the fix works

Not just "the test passes" — the real hook was exercised against the **real** `session_handoff.md` on disk, with `REPO_ROOT` anchored to the actual repo so path filtering behaves exactly as in production, and writes redirected to a scratch copy of the real `checksums.json`. Comparing `main`'s hook against this branch's:

```
=== BEFORE (main) ===
  check() returned      : {'action': 'tracked', 'path': '.claude/memory/session_handoff.md'}
  checksums.json changed: True
  handoff entry present : True
    last_tracked : b18c7fe0aab8071d      <- differs from last_resolved
    last_resolved: 'e6f4878d8898d3e5…'
  total dirty entries   : 1 ['.claude/memory/session_handoff.md']

=== AFTER  (fix) ===
  check() returned      : None
  checksums.json changed: False
  total dirty entries   : 0 []
```

That is the defect reproduced and then eliminated: one simulated `Stop`-hook handoff write takes the tree from 0 dirty to 1 dirty on `main`, and leaves it untouched here.

Second run, against **this branch's** `checksums.json` (entry already removed) — confirming the entry does not come back:

```
=== fix + PR checksums, simulate a Stop-hook handoff write ===
  handoff entry re-created: False
  file byte-identical     : True
  dirty entries           : 0
```

And the `ensure_ascii` half, tracking a real overlay file (`ontology/domain.yaml`):

```
BEFORE (main): escaped-\u sequences = 2, literal em-dash present = False
AFTER  (fix) : escaped-\u sequences = 0, literal em-dash present = True
```

Independently corroborated by the `checksums.json` diff in this PR: removing the entry via an `ensure_ascii=False` round-trip produced **exactly 6 deleted lines and no other change** — i.e. the round-trip is byte-stable against the file as committed.

## `ensure_ascii` consistency across writers — all writers aligned

I grepped for every writer of `checksums.json`, since fixing one writer while another still defaults to `ensure_ascii=True` merely moves the flip-flop. Findings:

| Writer | Kind | Status |
|---|---|---|
| `.claude/hooks/ontology_tracker.py` | programmatic, committed | **Fixed** — `ensure_ascii=False` |
| `/ontology-rebuild` resolver (`.claude/skills/ontology-rebuild/SKILL.md` § 4) | agent-driven, no serialization specified | **Fixed** — step 4 now mandates `json.dump(..., indent=2, ensure_ascii=False)` + trailing newline |
| `.claude/lib/sync_main.py` | allowlists the path for stash/restore | Not a writer of contents — no change needed |
| `.claude/hooks/session_handoff.py`, `.claude/lib/generic_prompt_tracker.py` | read / skip-list only | Not writers — no change needed |
| `.claude/scratch/wave-merge-bodies/ontology-resolve.py` | one-off, **untracked** in git (`git ls-files` → empty) | Out of scope; not a committed writer |

So: **all writers aligned.** The resolver was the genuine second source of the flip-flop — it is agent-driven and had no serialization specified at all, which is exactly why the file oscillated. Worth a reviewer's eye: that fix is a documented instruction rather than enforced code, because the resolver is a skill, not a module. If a reviewer prefers hard enforcement, the resolver's checksum write should move into a shared `.claude/lib/` helper — I'd support that but it is beyond this bugfix's scope.

## The `check-ignore` generalization was considered and rejected

The issue's proposed fix **point 4** suggested deriving the skip from `git check-ignore` rather than another hardcoded entry. **Deliberately not taken here.** The parent repo `.gitignore`s its child repos wholesale, so `git check-ignore` from `REPO_ROOT` reports every child-repo file as ignored — and child-repo entries are **147 of 284 tracked entries (52%)**, including `noorinalabs-deploy/.github/workflows/deploy-prod.yml` and every child ontology source. That change would silently blind the tracker to half the semantic overlay *while presenting as "0 dirty"* — the gate would look healthier while going blind, which is strictly worse than the nuisance being fixed.

The denylist has now leaked twice for the same class, so the class-level fix is worth doing — properly. Filed as **#1039**, carrying the requirements a correct version needs: resolve each path's **owning** repo (nearest `.git` ancestor) and run `check-ignore` there, **fail open** (track anyway on any error, since not-tracking is silent loss of drift detection), cache the subprocess cost, and keep the 147/284 child-repo case as an explicit regression test.

## Tests

Added to `.claude/hooks/tests/test_ontology_tracker.py`, matching the existing conventions there (`_FakeRepoRootMixin` for invocation-location independence, per #686):

- `ShouldSkipSessionHandoffTests` — relative + absolute handoff paths skipped; an **end-to-end** case driving `check()` against a real file and asserting the checksums file is byte-unchanged; and `test_other_memory_notes_are_still_tracked`, guarding that the skip is scoped to the single gitignored handoff and does **not** silently drop the committed `.claude/memory/` store from drift detection.
- `ChecksumsSerializationTests` — non-ASCII `description` survives a write unescaped, and repeated tracking of an unchanged file is byte-stable modulo the legitimately-moving `tracked_at`.

## Gate results

| Check | Status |
|---|---|
| `pre-commit run --all-files` (ruff-format, ruff-lint, actionlint, cspell, dockerfile-base-pin, fixture-realism, skill-graphql-pagination) | Passed |
| `mypy .claude/hooks/ .claude/lib/` | Passed — no issues in 174 source files |
| `pytest .claude/hooks/tests/ .claude/lib/tests/` | Passed — 2637 passed, 88 subtests |
| Push-stage (mypy, pytest, pytest-skills, memory-budget, headcount-budget, doc-freshness, office-drift, mermaid-render) | All passed |
| `pre_commit_ci_sync.py .` (drift gate) | `OK: pre-commit config mirrors all CI-enforced checks.` |

No known-failing checks, pre-existing or otherwise.

Closes #1038
