### PR TITLE
fix(#1046): bind pr_review_state to T_content so stale verdicts stop reading as PASS

### DIFF
--- a/.claude/hooks/validate_pr_review.py
+++ b/.claude/hooks/validate_pr_review.py
@@ -911,6 +911,57 @@ def check_comment_reviews(
         return result
 
 
+def partition_formal_reviewers(
+    reviews: list[dict],
+    author: str,
+    content_ts: datetime | None = None,
+) -> tuple[set[str], list[StaleVerdict]]:
+    """Split formal GitHub reviews into CURRENT reviewers and STALE verdicts (#950).
+
+    Formal GitHub reviews are bound to `T_content` by the SAME rule as comment
+    verdicts: a review submitted before the branch's latest authored commit
+    reviewed code that has since been rewritten. Leaving formal reviews unbound
+    would be a hole straight through the #950 fix.
+
+    Returns `(formal_reviewers, stale_formal)` where `formal_reviewers` holds
+    lowercased logins of non-author reviewers whose review is CURRENT, and
+    `stale_formal` holds a `StaleVerdict` per excluded review (for the
+    diagnostic). Self-reviews (login == `author`) and reviews with no login are
+    dropped entirely — they are not evidence and not staleness.
+
+    `submittedAt` missing or unparseable while `content_ts` is known ⇒ STALE,
+    not fresh (fail closed). `content_ts=None` means "no content binding" and
+    every non-author review counts, as before the content binding existed.
+
+    This function is the SHARED implementation for `check()` (Hook 4) and
+    `.claude/lib/pr_review_state.py` (the #707 ahead-of-time driver). Both must
+    partition formal reviews identically; a second hand-rolled copy in the
+    driver is exactly the drift that let #1046 ship, where the driver reported
+    PASS on verdicts the gate would have rejected as stale. Do not inline it
+    back into either caller.
+    """
+    formal_reviewers: set[str] = set()
+    stale_formal: list[StaleVerdict] = []
+    for review in reviews:
+        login = review.get("author", {}).get("login", "")
+        if not login or login == author:
+            continue
+        if content_ts is not None:
+            submitted_raw = review.get("submittedAt", "") or ""
+            submitted_at = _parse_iso8601(submitted_raw)
+            if submitted_at is None or submitted_at < content_ts:
+                stale_formal.append(
+                    StaleVerdict(
+                        reviewer=login,
+                        verdict=str(review.get("state", "REVIEW")),
+                        created_at=submitted_raw,
+                    )
+                )
+                continue
+        formal_reviewers.add(login.lower())
+    return formal_reviewers, stale_formal
+
+
 def _iter_roster_entries(
     role_prefix_filter: tuple[str, ...] | None = None,
     roster_dir: Path | None = None,
@@ -1207,27 +1258,9 @@ def check(input_data: dict) -> dict | None:
 
     # Formal GitHub reviews are bound to T_content by the SAME rule (#950) — a
     # stale formal review is no better evidence than a stale comment verdict, and
-    # leaving it unbound would be a hole straight through the fix. `submittedAt`
-    # missing or unparseable while T_content is known ⇒ stale, not fresh.
-    formal_reviewers: set[str] = set()
-    stale_formal: list[StaleVerdict] = []
-    for review in reviews:
-        login = review.get("author", {}).get("login", "")
-        if not login or login == author:
-            continue
-        if content_ts is not None:
-            submitted_raw = review.get("submittedAt", "") or ""
-            submitted_at = _parse_iso8601(submitted_raw)
-            if submitted_at is None or submitted_at < content_ts:
-                stale_formal.append(
-                    StaleVerdict(
-                        reviewer=login,
-                        verdict=str(review.get("state", "REVIEW")),
-                        created_at=submitted_raw,
-                    )
-                )
-                continue
-        formal_reviewers.add(login.lower())
+    # leaving it unbound would be a hole straight through the fix. Shared with the
+    # #707 driver via `partition_formal_reviewers` so the two cannot drift (#1046).
+    formal_reviewers, stale_formal = partition_formal_reviewers(reviews, author, content_ts)
 
     comment_review_result = CommentReviewResult()
     branch_author_lastname = None

--- a/.claude/lib/pr_review_state.py
+++ b/.claude/lib/pr_review_state.py
@@ -10,25 +10,39 @@ PreToolUse block. There was no way to ASK the same question ahead of time:
   - before `gh pr merge`   — will the gate pass, or who is missing TechDebt?
 
 This CLI answers that question by REUSING the hook's functions verbatim —
-`get_pr_data`, `extract_branch_author_lastname`, `check_comment_reviews`,
-`_load_roster_names`, and `is_single_reviewer_exception`. It deliberately does
-NOT reimplement the charter-comment parsing: a fork would silently drift from
-the gate, and that drift is the exact failure #707 exists to prevent. The
-PASS/FAIL verdict computed here mirrors `validate_pr_review.check()` step for
-step (formal + roster-filtered comment reviewers, the wave-merge head-ref
-sentinel, the single-reviewer exception, and the missing-TechDebt block).
+`get_pr_data`, `extract_branch_author_lastname`, `get_latest_content_commit`,
+`partition_formal_reviewers`, `check_comment_reviews`, `_load_roster_names`,
+and `is_single_reviewer_exception`. It deliberately does NOT reimplement the
+charter-comment parsing: a fork would silently drift from the gate, and that
+drift is the exact failure #707 exists to prevent. The PASS/FAIL verdict
+computed here mirrors `validate_pr_review.check()` step for step (T_content
+verdict staleness, formal + roster-filtered comment reviewers, the wave-merge
+head-ref sentinel, the single-reviewer exception, and the missing-TechDebt
+block).
+
+Reusing the gate's functions is necessary but NOT sufficient for parity — the
+ARGUMENTS matter as much as the callee. #1046: this driver called
+`check_comment_reviews` without the `content_ts` keyword, so `T_content` was
+never computed, `stale_verdicts` stayed empty, and the tool reported PASS on
+approvals the gate would reject as stale (observed live on main#1040). When
+adding a parameter to a shared gate function, audit THIS file's call sites —
+`.claude/lib/tests/test_pr_review_state.py::ContentStalenessTests` is the
+regression guard and is mutation-verified against exactly that omission.
 
 Usage:
     python3 .claude/lib/pr_review_state.py <pr_number> --repo <owner/repo>
     python3 .claude/lib/pr_review_state.py <pr_number> --repo <owner/repo> --json
 
 Exit codes:
-    0 — the merge gate would PASS (>=2 distinct Approved reviewers, or exactly
-        one with the wave-bootstrap exception, and no verdict missing TechDebt)
-    1 — the merge gate would BLOCK (too few reviewers, or a verdict missing the
-        TechDebt line)
-    2 — review state could not be determined (PR fetch failed, or a named child
-        repo's roster could not be resolved — mirrors the hook's hard-block)
+    0 — the merge gate would PASS (>=2 distinct CURRENT Approved reviewers, or
+        exactly one with the wave-bootstrap exception, and no verdict missing
+        TechDebt)
+    1 — the merge gate would BLOCK (too few current reviewers, or a verdict
+        missing the TechDebt line)
+    2 — review state could not be determined (PR fetch failed, the PR's commit
+        list could not be fetched so no verdict's freshness is knowable, or a
+        named child repo's roster could not be resolved — each mirrors a hook
+        hard-block)
 """
 
 from __future__ import annotations
@@ -71,13 +85,29 @@ class ReviewState:
     wave_bootstrap_exception: bool
     reviews_missing_tech_debt: list[str]
     tech_debt_issue_numbers: list[str]
+    # Content binding (#950/#1046). `content_sha` / `content_ts` describe
+    # T_content — the branch's latest NON-MERGE commit, the line a verdict must
+    # sit at or after to count. Empty/None means the PR has no non-merge commits,
+    # so nothing can be stale against it.
+    content_sha: str = ""
+    content_ts: str | None = None
+    # Verdicts EXCLUDED as stale — dicts of reviewer/verdict/created_at/source.
+    # Kept as plain dicts so `dataclasses.asdict` serializes them for --json.
+    # These are already subtracted from `distinct_reviewer_count`; they are
+    # carried so the report can NAME them. A stale verdict that is silently
+    # subtracted reads to an operator as a broken tool (#950 diagnostic lesson).
+    stale_verdicts: list[dict] = dataclasses.field(default_factory=list)
 
     def passes(self) -> bool:
         """True iff `validate_pr_review` would ALLOW the merge.
 
-        Mirrors `check()`: pass when there are >=2 distinct reviewers, OR
-        exactly one reviewer who qualifies for the wave-bootstrap single-
+        Mirrors `check()`: pass when there are >=2 distinct CURRENT reviewers,
+        OR exactly one reviewer who qualifies for the wave-bootstrap single-
         reviewer exception — AND no verdict is missing its TechDebt line.
+
+        Stale verdicts (#950) are already excluded from
+        `distinct_reviewer_count` upstream in `compute_review_state`, exactly as
+        the gate excludes them, so this method needs no separate staleness term.
         """
         if self.reviews_missing_tech_debt:
             return False
@@ -94,12 +124,16 @@ def compute_review_state(pr_number: str, repo: str | None = None) -> ReviewState
     """Compute a PR's review state by replaying the merge gate's own logic.
 
     Reuses `gate.get_pr_data`, `gate.extract_branch_author_lastname`,
+    `gate.get_latest_content_commit`, `gate.partition_formal_reviewers`,
     `gate.check_comment_reviews`, `gate._load_roster_names`, and
-    `gate.is_single_reviewer_exception` so this driver and Hook 4 cannot drift.
+    `gate.is_single_reviewer_exception`, forwarding `content_ts` to every
+    staleness-aware call so this driver and Hook 4 cannot drift (#1046).
 
-    Raises `ReviewStateError` when the PR cannot be fetched or a named child
-    repo's roster cannot be resolved — the determinate-failure cases the gate
-    hard-blocks on (exit code 2), distinct from a gate FAIL (exit code 1).
+    Raises `ReviewStateError` when the PR cannot be fetched, the PR's commit
+    list cannot be fetched (T_content unknown ⇒ no verdict's freshness is
+    knowable), or a named child repo's roster cannot be resolved — the
+    determinate-failure cases the gate hard-blocks on (exit code 2), distinct
+    from a gate FAIL (exit code 1).
     """
     pr_data = gate.get_pr_data(pr_number, repo=repo)
     if pr_data is None:
@@ -115,26 +149,50 @@ def compute_review_state(pr_number: str, repo: str | None = None) -> ReviewState
     number = pr_data["number"]
     labels = pr_data["labels"]
 
+    # Content binding (#950), mirroring check(): establish T_content — the
+    # committer timestamp of the branch's latest NON-MERGE commit — BEFORE
+    # counting any verdict. A commit-fetch failure means NO verdict's freshness
+    # can be established, so it is a determinate failure (exit 2), NOT a
+    # fallback to `content_ts=None`. Defaulting to None here would count every
+    # verdict regardless of age — reinstating precisely the #1046 fail-open this
+    # function is being fixed for.
+    try:
+        latest_content = gate.get_latest_content_commit(number, repo=repo)
+    except gate.CommitFetchError as exc:
+        raise ReviewStateError(
+            f"could not fetch the commit list for PR #{number}"
+            + (f" in {repo}" if repo else "")
+            + f": {exc}\nWithout it there is no T_content, so no verdict's freshness is "
+            "knowable and the gate's own verdict cannot be replayed. Hook 4 hard-blocks "
+            "here rather than counting verdicts of unknown freshness (#950)."
+        ) from exc
+
+    content_ts = latest_content[1] if latest_content else None
+    content_sha = latest_content[0] if latest_content else ""
+
     # Formal GitHub reviews from non-authors (not roster-filtered — these are
-    # platform-authenticated identities, exactly as the gate treats them).
-    formal_reviewers: set[str] = set()
-    for review in reviews:
-        login = review.get("author", {}).get("login", "")
-        if login and login != author:
-            formal_reviewers.add(login.lower())
+    # platform-authenticated identities, exactly as the gate treats them), bound
+    # to T_content by the gate's own shared helper rather than a local copy.
+    formal_reviewers, stale_formal = gate.partition_formal_reviewers(reviews, author, content_ts)
 
     # Resolve head ref -> branch-author lastname, then fetch comment reviews.
-    # Mirrors check() lines 845-854: a normal feature branch yields a lastname;
-    # a wave-merge head (deployments/phase-N/wave-M) has no implementer author,
-    # so the gate passes an empty sentinel that admits any non-empty reviewer.
+    # Mirrors check(): a normal feature branch yields a lastname; a wave-merge
+    # head (deployments/phase-N/wave-M) has no implementer author, so the gate
+    # passes an empty sentinel that admits any non-empty reviewer. `content_ts`
+    # MUST be forwarded on both call sites — omitting it silently disables
+    # staleness filtering and reports PASS on stale approvals (#1046).
     comment_result = gate.CommentReviewResult()
     branch_author_lastname = None
     if head_ref:
         branch_author_lastname = gate.extract_branch_author_lastname(head_ref)
         if branch_author_lastname:
-            comment_result = gate.check_comment_reviews(number, branch_author_lastname, repo=repo)
+            comment_result = gate.check_comment_reviews(
+                number, branch_author_lastname, repo=repo, content_ts=content_ts
+            )
         elif head_ref.startswith("deployments/") and "/wave-" in head_ref:
-            comment_result = gate.check_comment_reviews(number, "", repo=repo)
+            comment_result = gate.check_comment_reviews(
+                number, "", repo=repo, content_ts=content_ts
+            )
 
     # Filter comment-based Approved reviewers against the roster (gate #498):
     # only real roster personas count toward the threshold. A missing child
@@ -153,6 +211,22 @@ def compute_review_state(pr_number: str, repo: str | None = None) -> ReviewState
 
     wave_bootstrap = gate.is_single_reviewer_exception(labels, distinct, repo=repo)
 
+    # Stale verdicts from BOTH sources, in the gate's own order (comment, then
+    # formal), flattened to dicts so the dataclass stays JSON-serializable.
+    stale_verdicts = [
+        {
+            "reviewer": sv.reviewer,
+            "verdict": sv.verdict,
+            "created_at": sv.created_at,
+            "source": source,
+        }
+        for source, verdicts in (
+            ("comment", comment_result.stale_verdicts),
+            ("formal", stale_formal),
+        )
+        for sv in verdicts
+    ]
+
     return ReviewState(
         pr_number=str(number),
         repo=repo,
@@ -165,6 +239,9 @@ def compute_review_state(pr_number: str, repo: str | None = None) -> ReviewState
         wave_bootstrap_exception=wave_bootstrap,
         reviews_missing_tech_debt=list(comment_result.reviews_missing_tech_debt),
         tech_debt_issue_numbers=list(comment_result.tech_debt_issue_numbers),
+        content_sha=content_sha,
+        content_ts=content_ts.isoformat() if content_ts else None,
+        stale_verdicts=stale_verdicts,
     )
 
 
@@ -193,6 +270,34 @@ def _render_text(state: ReviewState) -> str:
             + ", ".join(state.non_roster_requestors)
         )
 
+    # Content binding (#950/#1046). Name every stale verdict: an operator seeing
+    # a low count on a PR with visible `Approved` comments will conclude the tool
+    # is broken unless it says WHICH verdict went stale and WHAT invalidated it.
+    content_line = (
+        f"  content commit (T_content): {state.content_sha or '(none — no non-merge commits)'}"
+    )
+    if state.content_ts:
+        content_line += f" @ {state.content_ts}"
+    lines.append(content_line)
+
+    if state.stale_verdicts:
+        lines.append(f"  STALE verdicts EXCLUDED from the count: {len(state.stale_verdicts)}")
+        for sv in sorted(state.stale_verdicts, key=lambda v: v.get("created_at") or ""):
+            cast_at = sv.get("created_at") or "<no timestamp>"
+            lines.append(
+                f"    {sv.get('reviewer', '?')} — {sv.get('verdict', '?')}"
+                f" [{sv.get('source', '?')}] cast {cast_at}"
+                f" x STALE (before {state.content_sha or 'T_content'})"
+            )
+        lines.append(
+            "    A verdict cast BEFORE the branch's latest non-merge commit reviewed code "
+            "that has since been rewritten, so it does not count. Branch updates from "
+            "`main` (merge commits) do NOT invalidate a verdict; only new authored "
+            "commits do. Fix: ask the reviewer to re-review at the current head."
+        )
+    else:
+        lines.append("  stale verdicts: none")
+
     lines.append(
         "  wave-bootstrap single-reviewer exception: "
         + ("APPLIES" if state.wave_bootstrap_exception else "no")
@@ -216,9 +321,12 @@ def _render_text(state: ReviewState) -> str:
 
 
 def _render_json(state: ReviewState) -> str:
+    # `asdict` carries content_sha / content_ts / stale_verdicts through, so the
+    # JSON consumer sees the staleness evidence, not just its arithmetic effect.
     payload = dataclasses.asdict(state)
     payload["passes"] = state.passes()
     payload["threshold"] = REVIEW_THRESHOLD
+    payload["stale_verdict_count"] = len(state.stale_verdicts)
     return json.dumps(payload, indent=2, sort_keys=True)
 
 

--- a/.claude/lib/tests/test_pr_review_state.py
+++ b/.claude/lib/tests/test_pr_review_state.py
@@ -12,12 +12,19 @@ gate functions (never the network). Coverage:
      lastname Requestor).
   7. non-roster Approved Requestor is filtered out of the reviewer count.
   8. a PR-fetch failure -> ReviewStateError -> CLI exit 2.
+  9. content-staleness binding (#1046, ContentStalenessTests): T_content is
+     computed and FORWARDED as `content_ts` to every check_comment_reviews call
+     site; stale comment + formal verdicts are excluded from the count, drive
+     PASS -> BLOCK, and are surfaced in both renders. A commit-fetch failure is
+     a determinate error (exit 2), never a silent content_ts=None fail-open.
 """
 
 from __future__ import annotations
 
+import json
 import sys
 import unittest
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest import mock
 
@@ -27,19 +34,30 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import pr_review_state as prs  # noqa: E402
 
+# T_content fixtures (#1046). NOW is the branch's latest non-merge commit time;
+# a verdict cast at BEFORE predates it and is stale, one at AFTER is current.
+_NOW = datetime(2026, 7, 20, 12, 0, 0, tzinfo=timezone.utc)
+_BEFORE = _NOW - timedelta(hours=6)
+_AFTER = _NOW + timedelta(hours=1)
+_CONTENT_COMMIT = ("ac8bcfa", _NOW)
+
 
 def _comment_result(
-    reviewers=(), missing_tech_debt=(), tech_debt_issues=()
+    reviewers=(), missing_tech_debt=(), tech_debt_issues=(), stale=()
 ) -> "prs.gate.CommentReviewResult":
     """Build a CommentReviewResult like check_comment_reviews would return.
 
     `reviewers` are full names (any case); they are stored lowercased, matching
-    the gate's dedup key.
+    the gate's dedup key. `stale` is a sequence of (reviewer, verdict,
+    created_at) tuples recorded as excluded-stale verdicts (#950).
     """
     result = prs.gate.CommentReviewResult()
     result.reviewers = {r.lower() for r in reviewers}
     result.reviews_missing_tech_debt = list(missing_tech_debt)
     result.tech_debt_issue_numbers = list(tech_debt_issues)
+    result.stale_verdicts = [
+        prs.gate.StaleVerdict(reviewer=r, verdict=v, created_at=c) for r, v, c in stale
+    ]
     return result
 
 
@@ -63,9 +81,11 @@ class ComputeReviewStateTests(unittest.TestCase):
         comment_result,
         roster_names,
         single_reviewer_exception=False,
+        latest_content=_CONTENT_COMMIT,
     ) -> prs.ReviewState:
         with (
             mock.patch.object(prs.gate, "get_pr_data", return_value=pr_data),
+            mock.patch.object(prs.gate, "get_latest_content_commit", return_value=latest_content),
             mock.patch.object(prs.gate, "check_comment_reviews", return_value=comment_result),
             mock.patch.object(prs.gate, "_load_roster_names", return_value=roster_names),
             mock.patch.object(
@@ -134,7 +154,7 @@ class ComputeReviewStateTests(unittest.TestCase):
         exclusion, so it must be the value handed to check_comment_reviews."""
         captured = {}
 
-        def fake_check(number, lastname, repo=None):
+        def fake_check(number, lastname, repo=None, content_ts=None):
             captured["number"] = number
             captured["lastname"] = lastname
             return _comment_result(reviewers=())
@@ -145,6 +165,7 @@ class ComputeReviewStateTests(unittest.TestCase):
                 "get_pr_data",
                 return_value=_pr_data(head_ref="S.Ferreira/0707-pr-review-state"),
             ),
+            mock.patch.object(prs.gate, "get_latest_content_commit", return_value=_CONTENT_COMMIT),
             mock.patch.object(prs.gate, "check_comment_reviews", side_effect=fake_check),
             mock.patch.object(prs.gate, "_load_roster_names", return_value=set()),
             mock.patch.object(prs.gate, "is_single_reviewer_exception", return_value=False),
@@ -173,6 +194,267 @@ class ComputeReviewStateTests(unittest.TestCase):
         with mock.patch.object(prs.gate, "get_pr_data", return_value=None):
             with self.assertRaises(prs.ReviewStateError):
                 prs.compute_review_state("707", repo="noorinalabs/noorinalabs-main")
+
+
+# ---------------------------------------------------------------------------
+# #1046 — content-staleness binding
+#
+# The driver called `gate.check_comment_reviews` WITHOUT `content_ts`, so
+# T_content was never computed, `stale_verdicts` stayed empty, and the tool
+# reported PASS on approvals the merge gate rejects as stale (observed live on
+# main#1040: two Approved verdicts cast at 7428f25, additive commit ac8bcfa
+# pushed, driver still said PASS).
+#
+# MUTATION-SENSITIVITY IS THE POINT of this class. Deleting `content_ts=...`
+# from either call site in `compute_review_state` MUST turn these red. The
+# end-to-end test therefore runs the REAL `check_comment_reviews` over a faked
+# `gh api` payload rather than a canned return value — a mock that ignores its
+# arguments cannot detect an argument going missing, which is precisely how the
+# original defect passed a green suite.
+# ---------------------------------------------------------------------------
+
+
+def _charter_comment(requestor: str, verdict: str, created_at: datetime) -> dict:
+    """A charter-format review comment as the `gh api` comments endpoint returns it."""
+    return {
+        "body": (
+            f"Requestor: {requestor}\nRequestee: Someone Else\n"
+            f"RequestOrReplied: {verdict}\nTechDebt: none"
+        ),
+        "created_at": created_at.isoformat().replace("+00:00", "Z"),
+    }
+
+
+class ContentStalenessTests(unittest.TestCase):
+    REPO = "noorinalabs/noorinalabs-main"
+
+    def _compute_with_real_comment_check(self, comments, *, roster, latest_content, reviews=()):
+        """Drive compute_review_state through the REAL check_comment_reviews.
+
+        Only the network boundary (`gh api`) is faked, so `content_ts` actually
+        governs the filtering. If the driver stops forwarding it, the stale
+        comments below start counting and the assertions fail — which is the
+        regression guard this whole class exists to provide.
+        """
+
+        def fake_run(cmd, **kwargs):
+            return mock.Mock(returncode=0, stdout=json.dumps(comments), stderr="")
+
+        with (
+            mock.patch.object(
+                prs.gate,
+                "get_pr_data",
+                # Branch author is Mwangi, NOT one of the reviewers below — a
+                # same-lastname reviewer is dropped as a self-review by the gate,
+                # which would make the staleness assertions pass for the wrong
+                # reason (caught by the anti-vacuity guard while writing these).
+                return_value=_pr_data(head_ref="W.Mwangi/1040-example", reviews=reviews),
+            ),
+            mock.patch.object(prs.gate, "get_latest_content_commit", return_value=latest_content),
+            mock.patch.object(prs.gate.subprocess, "run", side_effect=fake_run),
+            mock.patch.object(prs.gate, "_load_roster_names", return_value=roster),
+            mock.patch.object(prs.gate, "is_single_reviewer_exception", return_value=False),
+        ):
+            return prs.compute_review_state("1040", repo=self.REPO)
+
+    def test_fixture_yields_a_pass_when_verdicts_are_fresh(self):
+        """Anti-vacuity guard (mirrors the gate suite's own fixture check).
+
+        Every assertion below claims a verdict was NOT counted. If this fixture
+        failed to produce counted approvals in the FRESH case, those assertions
+        would pass for the wrong reason and certify nothing.
+        """
+        state = self._compute_with_real_comment_check(
+            [
+                _charter_comment("Lucas Ferreira", "Approved", _AFTER),
+                _charter_comment("Nino Kavtaradze", "Approved", _AFTER),
+            ],
+            roster={"lucas ferreira", "nino kavtaradze"},
+            latest_content=_CONTENT_COMMIT,
+        )
+        self.assertEqual(state.distinct_reviewer_count, 2)
+        self.assertEqual(state.stale_verdicts, [])
+        self.assertTrue(state.passes(), "fixture must PASS when fresh, or the tests are vacuous")
+
+    def test_main1040_stale_approvals_do_not_pass(self):
+        """The live #1040 reproduction: both approvals predate the head content commit.
+
+        Pre-fix this reported `passes: true` with 2/2 reviewers. It must BLOCK.
+        """
+        state = self._compute_with_real_comment_check(
+            [
+                _charter_comment("Lucas Ferreira", "Approved", _BEFORE),
+                _charter_comment("Nino Kavtaradze", "Approved", _BEFORE),
+            ],
+            roster={"lucas ferreira", "nino kavtaradze"},
+            latest_content=_CONTENT_COMMIT,
+        )
+        self.assertEqual(state.distinct_reviewer_count, 0)
+        self.assertEqual(state.comment_reviewers, [])
+        self.assertFalse(state.passes())
+        self.assertEqual(
+            sorted(sv["reviewer"] for sv in state.stale_verdicts),
+            ["Lucas Ferreira", "Nino Kavtaradze"],
+        )
+
+    def test_mixed_freshness_counts_only_the_current_verdict(self):
+        state = self._compute_with_real_comment_check(
+            [
+                _charter_comment("Lucas Ferreira", "Approved", _BEFORE),
+                _charter_comment("Nino Kavtaradze", "Approved", _AFTER),
+            ],
+            roster={"lucas ferreira", "nino kavtaradze"},
+            latest_content=_CONTENT_COMMIT,
+        )
+        self.assertEqual(state.comment_reviewers, ["nino kavtaradze"])
+        self.assertEqual(state.distinct_reviewer_count, 1)
+        self.assertFalse(state.passes())
+        self.assertEqual([sv["reviewer"] for sv in state.stale_verdicts], ["Lucas Ferreira"])
+
+    def test_content_ts_forwarded_on_feature_branch_call_site(self):
+        """Direct kill-shot for the #1046 mutation on the `:135` call site."""
+        captured = {}
+
+        def fake_check(number, lastname, repo=None, content_ts=None):
+            captured["content_ts"] = content_ts
+            return _comment_result(reviewers=())
+
+        with (
+            mock.patch.object(
+                prs.gate, "get_pr_data", return_value=_pr_data(head_ref="L.Ferreira/1040-x")
+            ),
+            mock.patch.object(prs.gate, "get_latest_content_commit", return_value=_CONTENT_COMMIT),
+            mock.patch.object(prs.gate, "check_comment_reviews", side_effect=fake_check),
+            mock.patch.object(prs.gate, "_load_roster_names", return_value=set()),
+            mock.patch.object(prs.gate, "is_single_reviewer_exception", return_value=False),
+        ):
+            prs.compute_review_state("1040", repo=self.REPO)
+
+        self.assertEqual(
+            captured["content_ts"],
+            _NOW,
+            "compute_review_state must forward T_content to check_comment_reviews (#1046)",
+        )
+
+    def test_content_ts_forwarded_on_wave_merge_call_site(self):
+        """The `:137` wave-merge call site is a SECOND omission surface (#1046)."""
+        captured = {}
+
+        def fake_check(number, lastname, repo=None, content_ts=None):
+            captured["content_ts"] = content_ts
+            captured["lastname"] = lastname
+            return _comment_result(reviewers=())
+
+        with (
+            mock.patch.object(
+                prs.gate,
+                "get_pr_data",
+                return_value=_pr_data(head_ref="deployments/phase-9/wave-26"),
+            ),
+            mock.patch.object(prs.gate, "get_latest_content_commit", return_value=_CONTENT_COMMIT),
+            mock.patch.object(prs.gate, "check_comment_reviews", side_effect=fake_check),
+            mock.patch.object(prs.gate, "_load_roster_names", return_value=set()),
+            mock.patch.object(prs.gate, "is_single_reviewer_exception", return_value=False),
+        ):
+            prs.compute_review_state("1040", repo=self.REPO)
+
+        self.assertEqual(captured["lastname"], "")
+        self.assertEqual(captured["content_ts"], _NOW)
+
+    def test_stale_formal_review_is_excluded_and_recorded(self):
+        """Formal GitHub reviews are bound to T_content by the same rule (#950).
+
+        The driver shares `gate.partition_formal_reviewers` with Hook 4 rather
+        than re-deriving the rule, so this cannot drift the way #1046 did.
+        """
+        state = self._compute_with_real_comment_check(
+            [],
+            roster=set(),
+            latest_content=_CONTENT_COMMIT,
+            reviews=[
+                {
+                    "author": {"login": "stale-reviewer"},
+                    "state": "APPROVED",
+                    "submittedAt": _BEFORE.isoformat().replace("+00:00", "Z"),
+                },
+                {
+                    "author": {"login": "fresh-reviewer"},
+                    "state": "APPROVED",
+                    "submittedAt": _AFTER.isoformat().replace("+00:00", "Z"),
+                },
+            ],
+        )
+        self.assertEqual(state.formal_reviewers, ["fresh-reviewer"])
+        self.assertEqual(
+            [(sv["reviewer"], sv["source"]) for sv in state.stale_verdicts],
+            [("stale-reviewer", "formal")],
+        )
+        self.assertFalse(state.passes())
+
+    def test_no_non_merge_commits_means_nothing_is_stale(self):
+        """`get_latest_content_commit` returning None = no content binding."""
+        state = self._compute_with_real_comment_check(
+            [
+                _charter_comment("Lucas Ferreira", "Approved", _BEFORE),
+                _charter_comment("Nino Kavtaradze", "Approved", _BEFORE),
+            ],
+            roster={"lucas ferreira", "nino kavtaradze"},
+            latest_content=None,
+        )
+        self.assertEqual(state.distinct_reviewer_count, 2)
+        self.assertEqual(state.stale_verdicts, [])
+        self.assertTrue(state.passes())
+
+    def test_commit_fetch_failure_is_an_error_not_a_fail_open(self):
+        """A commit-fetch failure must raise (exit 2), never degrade to content_ts=None.
+
+        Swallowing `CommitFetchError` and passing None would count every verdict
+        regardless of age — reinstating the exact #1046 fail-open. Hook 4
+        hard-blocks here; the driver must be equally determinate.
+
+        Every downstream collaborator is mocked to a SUCCESS value, and the
+        message is asserted, so the only thing that can raise is the commit-fetch
+        path. A bare `assertRaises(ReviewStateError)` here is NOT enough: with
+        the swallow mutation applied, execution fell through to the roster
+        resolver, which raised `ReviewStateError` for an unrelated reason and the
+        test passed green against the very defect it was written to catch.
+        """
+        with (
+            mock.patch.object(prs.gate, "get_pr_data", return_value=_pr_data()),
+            mock.patch.object(
+                prs.gate,
+                "get_latest_content_commit",
+                side_effect=prs.gate.CommitFetchError("boom"),
+            ),
+            mock.patch.object(prs.gate, "check_comment_reviews", return_value=_comment_result()),
+            mock.patch.object(prs.gate, "_load_roster_names", return_value=set()),
+            mock.patch.object(prs.gate, "is_single_reviewer_exception", return_value=False),
+        ):
+            with self.assertRaises(prs.ReviewStateError) as ctx:
+                prs.compute_review_state("1040", repo=self.REPO)
+
+        message = str(ctx.exception)
+        self.assertIn("commit list", message)
+        self.assertIn("boom", message)
+
+    def test_stale_verdicts_are_visible_in_both_renders(self):
+        """A stale verdict must be SURFACED, not silently subtracted (#1046 point 2)."""
+        state = self._compute_with_real_comment_check(
+            [_charter_comment("Lucas Ferreira", "Approved", _BEFORE)],
+            roster={"lucas ferreira"},
+            latest_content=_CONTENT_COMMIT,
+        )
+
+        text = prs._render_text(state)
+        self.assertIn("STALE", text)
+        self.assertIn("Lucas Ferreira", text)
+        self.assertIn("ac8bcfa", text)
+
+        payload = json.loads(prs._render_json(state))
+        self.assertEqual(payload["stale_verdict_count"], 1)
+        self.assertEqual(payload["stale_verdicts"][0]["reviewer"], "Lucas Ferreira")
+        self.assertEqual(payload["content_sha"], "ac8bcfa")
+        self.assertFalse(payload["passes"])
 
 
 class CliExitCodeTests(unittest.TestCase):


### PR DESCRIPTION
Closes #1046

## What was wrong

`.claude/lib/pr_review_state.py` called `gate.check_comment_reviews(...)` without the `content_ts` keyword. `T_content` was never computed, `CommentReviewResult.stale_verdicts` stayed empty, and the driver reported `passes: true` on approvals the real merge gate rejects as stale — under-reporting against the gate it exists to replay. Team memory instructs agents to trust this tool over the spawn brief, so the silence read as approval.

## Changes

**`.claude/lib/pr_review_state.py`**
- Compute `T_content` via `gate.get_latest_content_commit` and forward `content_ts` to **both** `check_comment_reviews` call sites — the feature-branch one and the `deployments/**/wave-*` one.
- Exclude stale verdicts from `distinct_reviewer_count` / `passes()` (inherited from the gate's own filtering, not re-implemented).
- Surface `content_sha`, `content_ts`, and `stale_verdicts` on `ReviewState`, in `_render_text` (each stale verdict is named, with when it was cast and what invalidated it) and in `_render_json` (plus a `stale_verdict_count` convenience key).
- Correct the module docstring. It asserted the driver and Hook 4 "cannot drift" while the drift was live; per `ontology/conventions.md` :257 code wins, so the doc is fixed to match, with an added note that reusing a gate function is not parity unless the **arguments** match.

**`.claude/hooks/validate_pr_review.py`**
- Extracted `partition_formal_reviewers(reviews, author, content_ts)` and replaced Hook 4's inline loop with a call to it. Behaviour-preserving for the hook (full gate suite unchanged and green).

## Two things the issue did not have

**1. Hook 4 also binds FORMAL GitHub reviews to `T_content`** (`validate_pr_review.py` :1208-1230), and the driver's formal-reviewer loop was equally unbound. The issue's 5-point fix only covered comment verdicts, so implementing it literally would have left half the drift in place. Rather than hand-roll the rule a second time in the driver — a fresh copy of exactly the logic that drifted — I extracted the shared helper. This is the narrow, low-risk half of the issue's point 5, done here because the alternative was actively worse.

**2. A commit-fetch failure must be a determinate error, not a degrade to `content_ts=None`.** Hook 4 hard-blocks on `CommitFetchError`. The obvious implementation — wrap in `try`, fall back to `None` — reinstates the identical fail-open under a different name. `compute_review_state` now raises `ReviewStateError` (exit 2), and there is a test pinning it.

## Mutation verification

Three mutations, each reverted after measurement. Literal output:

```
########## BASELINE (fix in place) ##########
21 passed in 0.34s

########## MUTATION 1: drop content_ts from BOTH check_comment_reviews call sites ##########
FAILED .claude/lib/tests/test_pr_review_state.py::ContentStalenessTests::test_content_ts_forwarded_on_feature_branch_call_site
FAILED .claude/lib/tests/test_pr_review_state.py::ContentStalenessTests::test_content_ts_forwarded_on_wave_merge_call_site
FAILED .claude/lib/tests/test_pr_review_state.py::ContentStalenessTests::test_main1040_stale_approvals_do_not_pass
FAILED .claude/lib/tests/test_pr_review_state.py::ContentStalenessTests::test_mixed_freshness_counts_only_the_current_verdict
FAILED .claude/lib/tests/test_pr_review_state.py::ContentStalenessTests::test_stale_verdicts_are_visible_in_both_renders
5 failed, 16 passed in 0.44s

########## MUTATION 2: swallow CommitFetchError -> content_ts=None fail-open ##########
FAILED .claude/lib/tests/test_pr_review_state.py::ContentStalenessTests::test_commit_fetch_failure_is_an_error_not_a_fail_open
1 failed, 20 passed in 0.39s

########## MUTATION 3: unbind formal reviews from T_content ##########
FAILED .claude/lib/tests/test_pr_review_state.py::ContentStalenessTests::test_stale_formal_review_is_excluded_and_recorded
1 failed, 20 passed in 0.39s

########## RESTORED ##########
21 passed in 0.36s
```

### Two inert tests the mutation pass caught in my own work

Worth recording, because both would have shipped as green-but-worthless:

- **Mutation 2 initially SURVIVED (`21 passed`).** `test_commit_fetch_failure_is_an_error_not_a_fail_open` used a bare `assertRaises(ReviewStateError)`. With the swallow applied, execution fell through to the roster resolver, which raised `ReviewStateError` for a completely unrelated reason — the test passed against the exact defect it was written to catch. Fixed by mocking every downstream collaborator to a success value and asserting the message (`"commit list"`, `"boom"`).
- **An anti-vacuity guard caught a bad fixture.** `test_fixture_yields_a_pass_when_verdicts_are_fresh` (modelled on the gate suite's own fixture check) failed because I had named a reviewer "Lucas Ferreira" on an `L.Ferreira/...` head ref — the gate dropped him as a self-review, so the staleness assertions would have passed for the wrong reason. Head ref changed to `W.Mwangi/...`.

The end-to-end tests deliberately drive the **real** `check_comment_reviews` over a faked `gh api` payload rather than a canned return value: a mock that ignores its arguments cannot detect an argument going missing, which is precisely how the original defect passed a green suite.

## Live verification against #1040

Ran the fixed driver against the real PR #1040 (the issue's reproduction):

```
PR #1040 (noorinalabs/noorinalabs-main) — merge gate would PASS
  distinct Approved reviewers: 2/2 required — lucas ferreira, nino kavtaradze
  content commit (T_content): ac8bcfa9 @ 2026-07-20T03:28:37+00:00
  STALE verdicts EXCLUDED from the count: 2
    Lucas Ferreira — Approved [comment] cast 2026-07-20T03:23:36Z x STALE (before ac8bcfa9)
    Nino Kavtaradze — Approved [comment] cast 2026-07-20T03:24:37Z x STALE (before ac8bcfa9)
```

It now names both originally-stale verdicts while correctly counting the two **fresh re-confirmations** the reviewers posted at `ac8bcfa`. PASS is the right answer for #1040's current state — the point is that pre-fix it was the right answer *by accident*, with the staleness invisible. Note `TechDebt issue numbers` drops from 5 to 1, which is correct: the gate exempts stale verdicts from the TechDebt requirement, and the driver now inherits that.

## Scope call

Issue point 5 (a single shared entry point for the whole verdict set) is **not** in this PR beyond the formal-review extraction. `check()` interleaves the pipeline with its block-message rendering, and `validate_pr_review.py` is the highest-fan-in module in the repo graph (centrality rank #11) — restructuring it inside a bug fix whose value is a mutation-verified guard would mix a mechanical change with a risky one. Filed as **#1048**.

## Gates

`ruff-format`, `ruff-lint`, `actionlint`, `cspell`, `fixture-realism`, `skill-graphql-pagination`, `mermaid-render` (pre-push) all pass; `mypy` clean over 174 files; `pre_commit_ci_sync.py` reports parity. Full suite: **2648 passed, 88 subtests passed**.

## Reviewers

Not merging — assigning left to the Standards Lead's requestor per the brief.

TechDebt: #1048