### PR TITLE
fix(#1057): recognize attached short-flag -R<repo> so the #981 gate can't be bypassed

### DIFF
--- a/.claude/hooks/_repo_flag_parse.py
+++ b/.claude/hooks/_repo_flag_parse.py
@@ -32,12 +32,13 @@ Public API
 
     extract_repo(command: str) -> str | None
         Parse a bash command. Returns the `OWNER/NAME` value passed via any
-        of `--repo X`, `--repo=X`, `-R X`, `-R=X`, or None if no `--repo` /
-        `-R` flag is present.
+        of `--repo X`, `--repo=X`, `-R X`, `-R=X`, `-RX` (attached short —
+        POSIX getopt / cobra shorthand, e.g. `-Rowner/name` or the
+        unexpanded `-R$DA`), or None if no `--repo` / `-R` flag is present.
 
         Tokenizer-first via `_shell_parse.walk_flag_values`; falls back to
         a conservative regex when shlex tokenization fails (e.g. command
-        contains a malformed quote). Both paths recognize all four forms.
+        contains a malformed quote). Both paths recognize all five forms.
 
 Design notes
 ============
@@ -67,12 +68,17 @@ from _shell_parse import (  # noqa: E402
 # Flags whose VALUE is a repo specifier (OWNER/REPO).
 _REPO_FLAGS = {"--repo", "-R"}
 
-# Regex covering all 4 surface forms when tokenize() fails:
-#   --repo X    --repo=X    -R X    -R=X
-# Anchored on a token boundary at the front so `--no-repo` etc. cannot
-# false-match. `(\\S+)` is greedy-to-whitespace; matches any non-whitespace
-# value form gh accepts (gh itself validates the OWNER/NAME shape).
-_REPO_FALLBACK_RE = re.compile(r"(?:^|\s)(?:--repo|-R)(?:=|\s+)(\S+)")
+# Regex covering all 5 surface forms when tokenize() fails:
+#   --repo X    --repo=X    -R X    -R=X    -RX  (attached short)
+# The separated/equals branch `(?:--repo|-R)(?:=|\s+)` runs FIRST so `-R=X`
+# yields `X` (not `=X`) and `-R X` yields `X`; the attached branch is a
+# short-flag-only `-R(\S+)` fallback that fires when no `=`/space separator
+# follows `-R`. Anchored on a token boundary at the front so `--no-repo` etc.
+# cannot false-match, and the attached branch is `-R`-only (never `--repo`)
+# so no long flag is split on a bare prefix. `(\\S+)` is greedy-to-whitespace;
+# matches any non-whitespace value form gh accepts (gh itself validates the
+# OWNER/NAME shape).
+_REPO_FALLBACK_RE = re.compile(r"(?:^|\s)(?:(?:--repo|-R)(?:=|\s+)|-R)(\S+)")
 
 
 def extract_repo(command: str) -> str | None:

--- a/.claude/hooks/_shell_parse.py
+++ b/.claude/hooks/_shell_parse.py
@@ -84,11 +84,13 @@ Public API
 
     walk_flag_values(tokens, wanted) -> list[str]
         Walks `tokens` and returns the value of every flag in `wanted`,
-        in source order. Handles both the two-token form (`--flag value`)
-        and the equals form (`--flag=value`). Values inside another flag's
-        value (e.g. inside `--body "...--flag X..."`) are correctly
-        ignored because they arrive as a SINGLE shlex token, never
-        preceded by a flag from `wanted`.
+        in source order. Handles the two-token form (`--flag value`), the
+        equals form (`--flag=value`), and the attached-short form
+        (`-Rvalue`, single-char short flags only — `--repofoo` is never
+        split). Values inside another flag's value (e.g. inside
+        `--body "...--flag X..."`) are correctly ignored because they
+        arrive as a SINGLE shlex token, never preceded by a flag from
+        `wanted`.
 
     first_flag_value(command, wanted, *, regex_fallback=True) -> str | None
         Convenience wrapper: tokenizes `command` via `tokenize()` and
@@ -540,10 +542,24 @@ def walk_flag_values(tokens: list[str], wanted: set[str]) -> list[str]:
     """Return values for `wanted` flag names, only when they appear as flags.
 
     A token is treated as a wanted-flag value only if the immediately
-    preceding token is exactly one of `wanted` (e.g. `--label`). The
-    `--flag=value` equals form is also handled. Values inside other flags
-    (e.g. inside the value of `--body`) are ignored because they are a
-    SINGLE shlex token, never preceded by a flag from `wanted`.
+    preceding token is exactly one of `wanted` (e.g. `--label`). Three
+    surface forms are recognized:
+
+      - two-token form   `--flag value` / `-R value`
+      - equals form      `--flag=value` / `-R=value`
+      - attached-short   `-Rvalue`  (POSIX getopt / cobra shorthand:
+                          `-Rvalue` == `-R value`)
+
+    The attached form applies to SINGLE-CHARACTER SHORT flags ONLY (`-R`,
+    `-l`, `-e`, ...). A long flag must use `=` or a space, so `--repofoo`
+    must NEVER be split into `--repo` + `foo` — the `len(flag) == 2` guard
+    below enforces that. This closes the `-R$DA` fail-open where an attached
+    short-flag repo value was dropped to None, letting a `gh pr merge` skip
+    the repo-confusion / 2-reviewer gate (main#1057, sibling of #981).
+
+    Values inside other flags (e.g. inside the value of `--body`) are
+    ignored because they are a SINGLE shlex token, never preceded by a flag
+    from `wanted`.
 
     Order is preserved: values appear in the order they were encountered
     in the token stream.
@@ -562,8 +578,25 @@ def walk_flag_values(tokens: list[str], wanted: set[str]) -> list[str]:
             continue
         matched = False
         for flag in wanted:
+            # Equals form (long OR short). Checked BEFORE the attached-short
+            # branch so `-R=value` yields `value`, not `=value`.
             if tok.startswith(flag + "="):
                 values.append(tok[len(flag) + 1 :])
+                matched = True
+                break
+            # Attached-short form `-Rvalue`. Scoped to single-character short
+            # flags (`len(flag) == 2`, `-X`) so no long flag is ever split on a
+            # bare prefix (`--repofoo` != `--repo` + `foo`). `len(tok) > 2`
+            # excludes the bare `-R` (which the exact-match branch above already
+            # handled) so a value-less short flag still yields nothing.
+            if (
+                len(flag) == 2
+                and flag[0] == "-"
+                and flag[1] != "-"
+                and len(tok) > 2
+                and tok.startswith(flag)
+            ):
+                values.append(tok[2:])
                 matched = True
                 break
         if matched:

--- a/.claude/hooks/tests/test_repo_flag_parse.py
+++ b/.claude/hooks/tests/test_repo_flag_parse.py
@@ -56,6 +56,46 @@ class FourFormsTests(unittest.TestCase):
         self.assertEqual(parser.extract_repo(cmd), self.EXPECTED)
 
 
+class AttachedShortFlagTests(unittest.TestCase):
+    """`-Rvalue` attached short-flag form (POSIX getopt / cobra shorthand,
+    main#1057). `-Rvalue` == `-R value`. Before this, `extract_repo` recognized
+    only `-R X` / `-R=X`; an attached `-R$DA` (the shape a shell hands the hook
+    PRE-expansion) fell through to None, so Hook 4's merge gate never saw the
+    repo argument and the 2-reviewer gate was bypassable via the attached
+    spelling — the #981 fail-open through an alternate flag form."""
+
+    def test_attached_unexpanded_variable_returned_verbatim(self):
+        """THE #1057 fix. `-R$DA` must yield the LITERAL `$DA` (unchanged for
+        pass-through) so #1056's `repo_argument_defect` classifier can flag it
+        as an unexpanded shell variable and HARD BLOCK the merge. Pre-fix this
+        returned None → the classifier never ran → cwd fallthrough → bypass."""
+        self.assertEqual(parser.extract_repo("gh pr merge 451 -R$DA --merge"), "$DA")
+
+    def test_attached_literal_repo_resolves(self):
+        """A LEGITIMATE attached form must resolve to the full repo string, not
+        merely fail closed."""
+        self.assertEqual(
+            parser.extract_repo("gh pr merge 451 -Rnoorinalabs/noorinalabs-data-acquisition"),
+            "noorinalabs/noorinalabs-data-acquisition",
+        )
+
+    def test_attached_short_equals_still_strips_separator(self):
+        """`-R=X` remains the equals form (value `X`, not `=X`) — the equals
+        branch is checked before the attached-short branch."""
+        self.assertEqual(parser.extract_repo("gh pr merge 451 -R=owner/repo"), "owner/repo")
+
+    def test_long_flag_is_never_split_on_bare_prefix(self):
+        """Attached values are SHORT-flag only. `--repofoo` / `--reponsense`
+        must NOT parse as `--repo` + suffix — a long flag requires `=` or a
+        space. This pins the `len(flag) == 2` scope guard."""
+        self.assertIsNone(parser.extract_repo("gh issue create --repofoo bar"))
+        self.assertIsNone(parser.extract_repo("gh issue create --reponsense --title t"))
+
+    def test_bare_trailing_short_flag_returns_none(self):
+        """A trailing `-R` with no attached value → None (no value to capture)."""
+        self.assertIsNone(parser.extract_repo("gh pr merge 451 -R"))
+
+
 class MixedWithOtherFlagsTests(unittest.TestCase):
     """`--repo` co-existing with other flags must not false-match."""
 
@@ -127,6 +167,17 @@ class RegexFallbackTests(unittest.TestCase):
     def test_fallback_short_equals(self):
         cmd = self._malformed("-R=owner/repo")
         self.assertEqual(parser.extract_repo(cmd), "owner/repo")
+
+    def test_fallback_attached_short(self):
+        """Attached-short `-Rvalue` must resolve on the regex-fallback path too,
+        so the tokenizer and fallback paths stay in parity on all five forms
+        (main#1057)."""
+        cmd = self._malformed("-Rowner/repo")
+        self.assertEqual(parser.extract_repo(cmd), "owner/repo")
+
+    def test_fallback_attached_short_unexpanded(self):
+        cmd = self._malformed("-R$DA")
+        self.assertEqual(parser.extract_repo(cmd), "$DA")
 
     def test_fallback_absent_returns_none(self):
         cmd = self._malformed("--label bug")

--- a/.claude/hooks/tests/test_shell_parse.py
+++ b/.claude/hooks/tests/test_shell_parse.py
@@ -237,6 +237,35 @@ class WalkFlagValuesTests(unittest.TestCase):
         tokens = ["gh", "issue", "create", "--label"]
         self.assertEqual(sp.walk_flag_values(tokens, {"--label"}), [])
 
+    def test_attached_short_flag_value(self):
+        """POSIX getopt / cobra `-Rvalue` == `-R value` (main#1057).
+
+        A single-char short flag takes an attached value. Before the fix
+        `-R$DA` matched neither the exact-token nor the equals branch, so the
+        value was silently dropped to `[]` — the fail-open that let a
+        `gh pr merge -R$DA` skip the repo-confusion gate (sibling of #981).
+        """
+        self.assertEqual(sp.walk_flag_values(["gh", "-Rowner/repo"], {"-R"}), ["owner/repo"])
+        self.assertEqual(sp.walk_flag_values(["gh", "-R$DA"], {"-R"}), ["$DA"])
+
+    def test_attached_short_equals_precedes_attached_branch(self):
+        """`-R=value` stays the equals form (`value`, not `=value`): the
+        equals branch is evaluated before the attached-short branch."""
+        self.assertEqual(sp.walk_flag_values(["gh", "-R=owner/repo"], {"-R"}), ["owner/repo"])
+
+    def test_long_flag_never_split_on_bare_prefix(self):
+        """A LONG flag must never take an attached value: `--repofoo` is NOT
+        `--repo` + `foo` (attached values are single-char short flags only).
+        The `len(flag) == 2` guard pins this — the security-relevant negative."""
+        self.assertEqual(sp.walk_flag_values(["gh", "--repofoo"], {"--repo", "-R"}), [])
+        self.assertEqual(sp.walk_flag_values(["gh", "--reponsense", "v"], {"--repo", "-R"}), [])
+
+    def test_bare_short_flag_not_treated_as_attached(self):
+        """A lone `-R` (len == 2) has no attached value → nothing captured
+        via the attached branch (the exact-token branch handles two-token /
+        trailing forms)."""
+        self.assertEqual(sp.walk_flag_values(["gh", "-R"], {"-R"}), [])
+
 
 class FirstFlagValueTests(unittest.TestCase):
     """Convenience wrapper combining tokenize + walk_flag_values + regex fallback."""

--- a/.claude/hooks/tests/test_validate_pr_review.py
+++ b/.claude/hooks/tests/test_validate_pr_review.py
@@ -2684,6 +2684,22 @@ class UnresolvableRepoFailsClosedTests(_NoContentBindingHarness):
         assert result is not None
         self.assertEqual(result["decision"], "block")
 
+    def test_attached_short_flag_unexpanded_var_blocks(self):
+        """THE #1057 SECURITY ASSERTION — the composition with #1056's classifier.
+
+        `gh pr merge 451 -R$DA` (ATTACHED short-flag, no space) must reach
+        `decision: block` through `check()`. Pre-#1057 `extract_repo` returned
+        None for the attached spelling, so `repo_argument_defect(None)` was None,
+        the mocked-approved `get_pr_data` short-circuited to allow, and the merge
+        bypassed the 2-reviewer gate — the #981 hole via the attached form. This
+        is the sibling of `test_unexpanded_repo_var_blocks` (which pins the
+        SPACED `-R $DA` shape) for the attached `-R$DA` shape."""
+        result = self._check_with_passing_downstream("gh pr merge 451 -R$DA --merge")
+        self.assertIsNotNone(result, "attached -R$DA must not fall through to allow")
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+        self.assertIn("UNEXPANDED", result["reason"])
+
     def test_block_happens_before_any_network_call(self):
         """The guard is deterministic — it must not depend on a fetch failing.
 
@@ -2723,6 +2739,30 @@ class UnresolvableRepoFailsClosedTests(_NoContentBindingHarness):
     def test_no_repo_flag_on_approved_pr_still_allows(self):
         result = self._check_with_passing_downstream("gh pr merge 451 --merge")
         self.assertIsNone(result, "absent --repo is legitimate cwd resolution")
+
+    def test_attached_short_flag_literal_repo_resolves_and_threads_through(self):
+        """A LEGITIMATE attached `-Rowner/name` must RESOLVE (not just fail
+        closed): the parsed repo string is threaded into `get_pr_data`, and a
+        2-approver PR still merges. Pre-#1057 the attached form parsed to None,
+        so `get_pr_data` was called with `repo=None` (cwd resolution) — this
+        test's `repo=` assertion bites that regression."""
+        review_result = hook.CommentReviewResult()
+        review_result.reviewers = {"aino virtanen", "nadia khoury"}
+        with (
+            mock.patch.object(
+                hook, "get_pr_data", return_value=self._approved_pr_data()
+            ) as get_mock,
+            mock.patch.object(hook, "check_comment_reviews", return_value=review_result),
+            mock.patch.object(
+                hook, "_load_roster_names", return_value={"aino virtanen", "nadia khoury"}
+            ),
+        ):
+            result = hook.check(
+                self._input("gh pr merge 451 -Rnoorinalabs/noorinalabs-data-acquisition --merge")
+            )
+        self.assertIsNone(result, "attached literal repo + 2 approvers must still allow")
+        _, kwargs = get_mock.call_args
+        self.assertEqual(kwargs.get("repo"), "noorinalabs/noorinalabs-data-acquisition")
 
     # --- Requirement (c): the two failure kinds are diagnostically distinct ---
 


### PR DESCRIPTION
## Summary

`extract_repo("gh pr merge 451 -R$DA --merge")` returned **None** — a sibling of
the #981 repo-confusion fail-open, reached through the **attached short-flag**
spelling. The shared tokenizer (`_shell_parse.walk_flag_values`) recognized a
flag value only as an exact-token form (`-R X`) or an equals form (`-R=X`); the
POSIX getopt / cobra **attached** form (`-Rvalue`, one token) matched neither
branch and was silently dropped. Hook 4 then saw no repo argument, fell through
to cwd resolution, and the 2-reviewer gate was bypassable for that repo. #1056's
classifier (which correctly blocks `$DA` once it *receives* it) never fired,
because the value was lost upstream in the tokenizer before the classifier ran.

`Refs #1057`.

## Before / after `extract_repo`

| command | before | after |
|---|---|---|
| `gh pr merge 451 -R$DA --merge` | `None` (BUG → bypass) | `"$DA"` → #1056 classifier HARD BLOCKS |
| `gh pr merge 451 -Rnoorinalabs/noorinalabs-data-acquisition` | `None` (legit form lost) | `"noorinalabs/noorinalabs-data-acquisition"` (resolves) |
| `gh pr merge 451 -R $DA --merge` (spaced) | `"$DA"` | `"$DA"` (unchanged) |
| `gh pr merge 451 --repo=$DA --merge` (equals) | `"$DA"` | `"$DA"` (unchanged) |
| `gh ... --repofoo` / `--reponsense` (long) | `None` | `None` (unchanged — long flag never split) |
| trailing bare `-R` | `None` | `None` (unchanged) |

## Design decision — fix in `walk_flag_values`, not `_repo_flag_parse`

Fixed in the **shared** `_shell_parse.walk_flag_values` so every `-R`-style
consumer benefits and the `test_gh_command_parser_invariant.py` invariant stays
satisfied (no new private regex — the sanctioned machinery is extended). The new
attached-value branch is **scoped to single-character short flags**
(`len(flag) == 2 and flag[0] == '-' and flag[1] != '-'`) and evaluated **after**
the equals branch so `-R=X` still yields `X` (not `=X`), and a long flag is
**never** split on a bare prefix (`--repofoo` != `--repo` + `foo`). The one
sanctioned fallback regex `_REPO_FALLBACK_RE` gains a matching `-R(\S+)`
alternative so the tokenizer and malformed-quote paths stay in parity on all
five forms.

### Blast-radius assessment (every `walk_flag_values` / `first_flag_value` caller)

| caller | `wanted` | short flags | effect |
|---|---|---|---|
| `_repo_flag_parse` (extract_repo) | `{--repo, -R}` | `-R` | **target fix** — attached `-Rowner/repo`/`-R$DA` now parse |
| `block_squash_wave_merge` | `{--repo, -R}` | `-R` | consistent — attached `-R…` now recognized (same repo semantics) |
| `validate_labels` | `{--label, -l}` | `-l` | improvement — attached `-lbug` now validated (was a sibling hole) |
| `validate_wave_label_evidence` (create) | `{--label, -l}` | `-l` | same as above |
| `validate_branch_freshness` | `{--base, -B}`, `{--head, -H}` | `-B`, `-H` | improvement — attached `-Bmain`/`-Hfeat` now parse (real gh forms) |
| `smart_grep_ontology` (advisory) | `{-e, --regexp}` | `-e` | improvement — attached `-epattern` now parses (real grep form) |

Every short flag in use is a genuine gh/grep short flag that **does** accept the
attached form per its real CLI parser (cobra/pflag for gh, getopt for grep), so
the central change is strictly *more correct* everywhere and also closes the
sibling attached-value holes in label and branch-freshness parsing. **All long
flags** (`--repo`, `--label`, `--add-label`, `--remove-label`, `--regexp`,
`--base`, `--head`) are **unaffected** (`len(flag) == 2` guard). All seven
downstream consumer suites (labels, review-comment-format, branch-freshness,
pr-ci-status, wave-label-evidence, squash-merge, smart-grep) pass unchanged.

## End-to-end composition (`-R$DA` → block)

New test `UnresolvableRepoFailsClosedTests::test_attached_short_flag_unexpanded_var_blocks`
drives `gh pr merge 451 -R$DA --merge` through `check()` with a mocked-approved
downstream state that would otherwise **allow**, and asserts
`decision: block` + an `UNEXPANDED` diagnostic. The legit attached form is also
proven to *resolve* (not just fail closed):
`test_attached_short_flag_literal_repo_resolves_and_threads_through` asserts
`get_pr_data` is called with `repo="noorinalabs/noorinalabs-data-acquisition"`.

## Each new test fails pre-fix (bites)

Reverted the two source hunks (via `git stash push` of the source files only,
tests kept) and ran the new tests against original source. The **7 positive
tests went red** (attached-value parsing + the two end-to-end composition
tests); the **negative-guard tests stayed green** (they assert the `len==2`
scope constraint, which original source also satisfies — the guards, not the
biting assertions). Restored the fix → all green (#1041/#1043).

## Tests added

- `test_repo_flag_parse.py`: `AttachedShortFlagTests` (verbatim `$DA`, literal
  repo resolves, equals-precedence, long-flag-never-split, bare-trailing→None)
  + `RegexFallbackTests` attached-short coverage.
- `test_shell_parse.py`: `WalkFlagValuesTests` attached-short + long-flag-never-split guards.
- `test_validate_pr_review.py`: attached-form block + resolve-through-check tests.

## Gates

`pre-commit run --all-files` (commit + pre-push stages), `mypy`, both pytest
suites (`2693 passed`), and the `pre_commit_ci_sync.py` drift gate — all green.

**TechDebt:** none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4RB6kXqh5c6ckHC8p9xHf
