### PR TITLE
Phase 9 Wave 26 → main (noorinalabs-main)

### DIFF
--- a/.claude/hooks/_shell_parse.py
+++ b/.claude/hooks/_shell_parse.py
@@ -764,6 +764,45 @@ def _default_origin_url_runner(cwd: str) -> str | None:
     return result.stdout
 
 
+# Markers that make a `--repo`/`-R` flag value UNRESOLVABLE as a repo reference:
+# shlex leaves an unexpanded shell variable (`$VAR`, `${VAR}`) or command
+# substitution (`` `...` ``, `$(...)`) as a LITERAL token, and any whitespace in
+# the extracted value means we captured a non-flag fragment (e.g. an
+# attached-short false positive off a `--body "-R x"` token). Treating any of
+# these as a repo name would MISROUTE the downstream `gh` call to the wrong (or
+# a nonexistent) repository — the fail-open #981 closed at the merge gate,
+# applied here to the wave-label hooks' repo resolution.
+_UNRESOLVABLE_REPO_VALUE_RE = re.compile(r"[$`\s]")
+
+
+def repo_short_name_from_flag_value(value: str) -> str | None:
+    """Extract the GitHub repo SHORT NAME from a `--repo`/`-R` flag value.
+
+    The flag value is the pre-shell-expansion token gh would receive, e.g.
+    `noorinalabs/noorinalabs-main`, `noorinalabs/noorinalabs-main.git`, or a
+    full `https://github.com/owner/name` URL. Returns the last path segment
+    with any trailing `.git` stripped:
+
+        noorinalabs/noorinalabs-main                       -> noorinalabs-main
+        https://github.com/noorinalabs/noorinalabs-deploy  -> noorinalabs-deploy
+
+    Returns None when the value is UNRESOLVABLE — an unexpanded shell variable
+    or command substitution (`$DA`, `${REPO}`, `` `...` ``, `$(...)`) that shlex
+    left literal, a whitespace-bearing fragment, or empty. Per #981, an
+    unresolvable repo token must be treated as "no known repo" by the caller
+    (fail-closed: block/skip), NEVER coerced into a repo name — coercing it would
+    misroute the gh call. This is the flag-value sibling of
+    `resolve_repo_short_name` (which resolves the ambient repo from the
+    invocation cwd's `origin` remote); the flag is authoritative over cwd (#985).
+    """
+    if not value or _UNRESOLVABLE_REPO_VALUE_RE.search(value):
+        return None
+    name = value.rstrip("/").split("/")[-1]
+    if name.endswith(".git"):
+        name = name[: -len(".git")]
+    return name or None
+
+
 def resolve_repo_short_name(input_data: dict, *, git_runner=None) -> str | None:
     """Resolve the GitHub repo NAME from the invocation cwd's `origin` remote.
 

--- a/.claude/hooks/_wave_label_parse.py
+++ b/.claude/hooks/_wave_label_parse.py
@@ -55,11 +55,19 @@ Public API
         treats multi-cmd as out-of-pattern (kickoff is single-cmd only).
 
         Result fields (shared with the plural form):
-          repo          — `noorinalabs-<name>` short form (last path segment
-                          of `--repo owner/name` or `--repo=owner/name`), or
-                          None when `--repo` is OMITTED (in-repo invocation,
-                          ambient gh resolution — #650). The consuming hook
-                          resolves the None case from the invocation cwd.
+          repo          — `noorinalabs-<name>` short form from the AUTHORITATIVE
+                          `-R`/`--repo owner/name` flag (all five surface forms,
+                          #985/#1057), or None. `repo_flag_present` disambiguates
+                          the two None cases (flag omitted vs present-but-
+                          unresolvable — see below).
+          repo_flag_present — True iff a `-R`/`--repo` flag was present in the
+                          command (regardless of whether its value resolved).
+                          When `repo` is None: `repo_flag_present=False` means
+                          the flag was OMITTED (in-repo ambient gh resolution,
+                          #650 — consumer resolves from cwd); `repo_flag_present
+                          =True` means the flag was present but unresolvable (an
+                          unexpanded `$VAR`, #981 — consumer fails closed, never
+                          falls back to cwd).
           issue_number  — the bare positional issue number after `edit`.
           add_label     — the FIRST `--add-label "p{N}-wave-{M}"` value, or
                           None if no add operation present.
@@ -122,8 +130,10 @@ from _shell_parse import (  # noqa: E402
     find_gh_subcommand,
     iter_command_segments,
     normalize_command_separators,
+    repo_short_name_from_flag_value,
     strip_heredocs,
     tokenize,
+    walk_flag_values,
 )
 
 # Legacy phase-prefixed form: `p6-wave-16` (grandfathered, still accepted).
@@ -165,17 +175,27 @@ class WaveLabelChange:
 
     At least one of `add_label` / `remove_label` is non-None.
 
-    `repo` is the short repo name from `--repo owner/name` (e.g.
-    `noorinalabs-main`), or None when the command OMITS `--repo` and relies
-    on gh's ambient-git-context resolution. Consumers that need a concrete
-    repo (for a GraphQL/REST call) resolve the None case from the invocation
-    cwd via `_shell_parse.resolve_repo_short_name` (#650).
+    `repo` is the short repo name from the AUTHORITATIVE `-R`/`--repo owner/name`
+    flag (e.g. `noorinalabs-main`), extracted via the #1057-hardened
+    `walk_flag_values` so all five surface forms resolve (`--repo X`, `--repo=X`,
+    `-R X`, `-R=X`, `-RX`). It is None in TWO distinct cases, disambiguated by
+    `repo_flag_present` (#985):
+
+      - `repo_flag_present=False` → the command OMITS the repo flag entirely and
+        relies on gh's ambient-git-context resolution. Consumers resolve the None
+        case from the invocation cwd via `_shell_parse.resolve_repo_short_name`
+        (#650).
+      - `repo_flag_present=True` → the flag WAS present but its value was
+        unresolvable (an unexpanded `$VAR` / command substitution, per #981).
+        Consumers MUST fail closed (skip/block) — NEVER fall back to cwd, which
+        would misroute a child-repo op to the parent.
     """
 
     repo: str | None
     issue_number: str
     add_label: str | None
     remove_label: str | None
+    repo_flag_present: bool = False
 
 
 @dataclass(frozen=True)
@@ -274,19 +294,37 @@ def _parse_edit_segment(rest: list[str]) -> WaveLabelChange | None:
     least one canonical wave-label `--add-label`/`--remove-label`. Otherwise
     returns None.
 
-    `--repo` is OPTIONAL (#650): a `gh issue edit <num> --remove-label
-    "p4-wave-5"` run from inside the target repo carries no `--repo` and
-    relies on gh's ambient-git-context resolution. Requiring `--repo` here
-    silently dropped every such in-repo label edit (the change never reached
-    the field-sync hook → board Wave field went unsynced). When `--repo` is
-    absent the returned `repo` is None; the consuming hook resolves the
-    ambient repo from the invocation cwd.
+    The repo is resolved from the AUTHORITATIVE `-R`/`--repo owner/name` flag
+    (#985), extracted up front via the #1057-hardened `walk_flag_values` so all
+    five surface forms resolve: `--repo X`, `--repo=X`, `-R X`, `-R=X`, `-RX`.
+    The flag is GROUND TRUTH for "which repo"; the consuming hook's cwd fallback
+    applies ONLY when no repo flag is present. Three states are surfaced:
+
+      - flag present + resolvable  → `repo=<name>`, `repo_flag_present=True`.
+      - flag absent (#650)         → `repo=None`,   `repo_flag_present=False`
+        (in-repo invocation; consumer resolves the ambient repo from cwd).
+      - flag present + unresolvable → `repo=None`, `repo_flag_present=True`
+        (an unexpanded `$VAR` / command substitution; per #981 the consumer
+        MUST fail closed and NOT fall back to cwd, which would misroute).
+
+    Requiring `--repo` here would silently drop every in-repo label edit (#650);
+    blindly `.split("/")`-ing an unexpanded `$VAR` would misroute it (#981). The
+    tri-state threads both needles.
     """
     if len(rest) < 3 or rest[0] != "issue" or rest[1] != "edit":
         return None
 
+    # Repo from the flag, not cwd (#985). `walk_flag_values` recognizes both the
+    # `--repo` long form and the `-R` short form (all attached/equals/spaced
+    # surfaces, #1057). A present-but-unresolvable value (`$VAR`) yields repo=None
+    # with repo_flag_present=True so the consumer fails closed (#981).
+    repo_values = walk_flag_values(rest, {"--repo", "-R"})
+    repo_flag_present = len(repo_values) > 0
+    repo: str | None = (
+        repo_short_name_from_flag_value(repo_values[0]) if repo_flag_present else None
+    )
+
     issue_number: str | None = None
-    repo: str | None = None
     add_label: str | None = None
     remove_label: str | None = None
 
@@ -296,14 +334,6 @@ def _parse_edit_segment(rest: list[str]) -> WaveLabelChange | None:
         tok = rest[i]
         if issue_number is None and re.fullmatch(r"\d+", tok):
             issue_number = tok
-            i += 1
-            continue
-        if tok == "--repo" and i + 1 < n:
-            repo = rest[i + 1].split("/")[-1]
-            i += 2
-            continue
-        if tok.startswith("--repo="):
-            repo = tok[len("--repo=") :].split("/")[-1]
             i += 1
             continue
         if tok == "--add-label" and i + 1 < n:
@@ -338,6 +368,7 @@ def _parse_edit_segment(rest: list[str]) -> WaveLabelChange | None:
             issue_number=issue_number,
             add_label=add_label,
             remove_label=remove_label,
+            repo_flag_present=repo_flag_present,
         )
     return None
 

--- a/.claude/hooks/post_label_change_wave_field_sync.py
+++ b/.claude/hooks/post_label_change_wave_field_sync.py
@@ -636,8 +636,13 @@ def check(
     Single-cmd result variants:
       None                                       — hook didn't apply
       {"action": "killed", ...}                  — kill-switch env var set
-      {"action": "skip_no_repo_context", ...}    — --repo omitted AND ambient
-                                                   repo unresolvable from cwd
+      {"action": "skip_no_repo_context", ...}    — every change's repo was
+                                                   unresolvable: either --repo
+                                                   omitted AND cwd unresolvable
+                                                   (#650), or an explicit
+                                                   -R/--repo with an unresolvable
+                                                   value (`-R $VAR`, fail-closed
+                                                   per #985/#981 — never cwd)
       {"action": "skip_no_auth_scope", ...}      — gh missing project scope
       {"action": "skip_no_project_ids", ...}     — introspection failed
       {"action": "skip_no_option", ...}          — wave option missing
@@ -696,6 +701,22 @@ def check(
     resolved_changes: list[WaveLabelChange] = []
     for change in changes:
         if change.repo is None:
+            # #985/#981: an explicit `-R`/`--repo` flag whose value did NOT
+            # resolve (an unexpanded `$VAR` / command substitution) must fail
+            # CLOSED. The flag is authoritative over cwd; falling back to the
+            # invocation cwd here would misroute the Wave-field sync to the wrong
+            # repo (the parent org repo when a subagent runs in a child-repo
+            # worktree). Skip this change with a logged, visible reason.
+            if change.repo_flag_present:
+                log_posttooluse_event(
+                    "post_label_change_wave_field_sync",
+                    command,
+                    f"skip_unresolvable_repo: `gh issue edit {change.issue_number}` carried an "
+                    "explicit -R/--repo flag whose value did not resolve to a repo (unexpanded "
+                    "variable or command substitution). Refusing cwd fallback to avoid "
+                    "misrouting the Wave-field sync (#985/#981).",
+                )
+                continue
             if not ambient_resolved:
                 ambient_repo = resolve_repo_short_name(input_data, git_runner=git_runner)
                 ambient_resolved = True

--- a/.claude/hooks/post_wave_kickoff_comment.py
+++ b/.claude/hooks/post_wave_kickoff_comment.py
@@ -162,17 +162,20 @@ def _phase_from_status(status: dict) -> int | None:
     return None
 
 
-def parse_label_apply_command(command: str) -> tuple[str | None, str, str] | None:
-    """Parse `gh issue edit <num> [--repo <repo>] --add-label "p{N}-wave-{M}"`.
+def parse_label_apply_command(command: str) -> tuple[str | None, str, str, bool] | None:
+    """Parse `gh issue edit <num> [-R|--repo <repo>] --add-label "p{N}-wave-{M}"`.
 
-    Returns (repo, issue_number, wave_label) if the command APPLIES a wave
-    label, else None. Tolerates additional flags and arbitrary flag
-    ordering. The kickoff hook only fires on label-APPLY, so commands
+    Returns (repo, issue_number, wave_label, repo_flag_present) if the command
+    APPLIES a wave label, else None. Tolerates additional flags and arbitrary
+    flag ordering. The kickoff hook only fires on label-APPLY, so commands
     that only `--remove-label` a wave label return None here.
 
-    `repo` is None when the command OMITS `--repo` (in-repo invocation,
-    #650); the caller (`check`) resolves the ambient repo from the
-    invocation cwd before using it.
+    `repo` is resolved from the AUTHORITATIVE `-R`/`--repo owner/name` flag
+    (#985). It is None in two cases, disambiguated by `repo_flag_present`:
+    the flag was OMITTED (`repo_flag_present=False` — in-repo invocation #650;
+    the caller resolves the ambient repo from cwd), or the flag was present but
+    its value was unresolvable (`repo_flag_present=True` — an unexpanded `$VAR`
+    per #981; the caller MUST fail closed, never fall back to cwd).
 
     Between-wave relabel filter (#467): commands that ALSO remove a
     canonical wave label in the same invocation
@@ -202,7 +205,7 @@ def parse_label_apply_command(command: str) -> tuple[str | None, str, str] | Non
     # does NOT trigger this filter.
     if change.remove_label is not None:
         return None
-    return change.repo, change.issue_number, change.add_label
+    return change.repo, change.issue_number, change.add_label, change.repo_flag_present
 
 
 def _short_ref(repo: str, issue_number: str) -> str:
@@ -438,6 +441,10 @@ def check(
       {"action": "skip_no_row", ...}           — issue not in any tier
       {"action": "skip_no_repo_context", ...}  — --repo omitted AND ambient
                                                  repo unresolvable from cwd
+      {"action": "skip_unresolvable_repo", ...} — -R/--repo present but its
+                                                 value was unresolvable (e.g.
+                                                 `-R $VAR`); fail-closed, no cwd
+                                                 fallback (#985/#981)
       {"action": "skip_post_failed", ...}      — gh post call failed
 
     Injection points let tests mock external state without mocking
@@ -458,12 +465,29 @@ def check(
     parsed = parse_label_apply_command(command)
     if parsed is None:
         return None
-    repo, issue_number, wave_label = parsed
+    repo, issue_number, wave_label, repo_flag_present = parsed
+
+    # #985/#981: an explicit `-R`/`--repo` flag whose value did NOT resolve to a
+    # repo (an unexpanded `$VAR` / command substitution) must fail CLOSED. The
+    # flag is authoritative; falling back to the invocation cwd here would
+    # misroute the kickoff comment to the wrong repo (the parent org repo when a
+    # subagent runs in a child-repo worktree). Skip with a visible, logged action
+    # rather than silently posting to the wrong issue.
+    if repo is None and repo_flag_present:
+        log_posttooluse_event(
+            "post_wave_kickoff_comment",
+            command,
+            f"skip_unresolvable_repo: label-apply for issue {issue_number} carried an "
+            "explicit -R/--repo flag whose value did not resolve to a repo (unexpanded "
+            "variable or command substitution). Refusing to fall back to the invocation "
+            "cwd to avoid misrouting the kickoff comment (#985/#981).",
+        )
+        return {"action": "skip_unresolvable_repo", "issue": issue_number}
 
     # #650: a label-apply run from inside the target repo carries no `--repo`
-    # (repo=None). Mirror gh's ambient-git-context resolution by recovering
-    # the repo from the invocation cwd; without it the downstream
-    # `--repo noorinalabs/<repo>` call would be malformed.
+    # (repo=None, repo_flag_present=False). Mirror gh's ambient-git-context
+    # resolution by recovering the repo from the invocation cwd; without it the
+    # downstream `--repo noorinalabs/<repo>` call would be malformed.
     if repo is None:
         repo = resolve_repo_short_name(input_data, git_runner=git_runner)
         if repo is None:

--- a/.claude/hooks/tests/test__wave_label_parse.py
+++ b/.claude/hooks/tests/test__wave_label_parse.py
@@ -233,6 +233,56 @@ class CdPrefixedCommand(unittest.TestCase):
         self.assertEqual(changes[0].add_label, "wave-20")
 
 
+class RepoFlagResolution(unittest.TestCase):
+    """#985: the `-R`/`--repo` flag is authoritative and all five surface forms
+    resolve; the `repo_flag_present` bit disambiguates the two repo=None cases
+    (flag omitted #650 vs present-but-unresolvable #981)."""
+
+    def _change(self, cmd: str):
+        change = p.parse_wave_label_change(cmd)
+        assert change is not None
+        return change
+
+    def test_long_repo_flag(self) -> None:
+        c = self._change(
+            'gh issue edit 42 --repo noorinalabs/noorinalabs-deploy --add-label "wave-26"'
+        )
+        self.assertEqual(c.repo, "noorinalabs-deploy")
+        self.assertTrue(c.repo_flag_present)
+
+    def test_short_R_flag_spaced(self) -> None:
+        c = self._change('gh issue edit 42 -R noorinalabs/noorinalabs-deploy --add-label "wave-26"')
+        self.assertEqual(c.repo, "noorinalabs-deploy")
+        self.assertTrue(c.repo_flag_present)
+
+    def test_short_R_flag_attached(self) -> None:
+        c = self._change('gh issue edit 42 -Rnoorinalabs/noorinalabs-deploy --add-label "wave-26"')
+        self.assertEqual(c.repo, "noorinalabs-deploy")
+        self.assertTrue(c.repo_flag_present)
+
+    def test_short_R_flag_equals(self) -> None:
+        c = self._change('gh issue edit 42 -R=noorinalabs/noorinalabs-deploy --add-label "wave-26"')
+        self.assertEqual(c.repo, "noorinalabs-deploy")
+        self.assertTrue(c.repo_flag_present)
+
+    def test_no_repo_flag_absent(self) -> None:
+        c = self._change('gh issue edit 42 --add-label "wave-26"')
+        self.assertIsNone(c.repo)
+        self.assertFalse(c.repo_flag_present)
+
+    def test_unexpanded_var_present_but_unresolvable(self) -> None:
+        """`-R $VAR` → repo=None (shlex left `$DA` literal) AND
+        repo_flag_present=True. The True bit is the #981 fail-closed signal."""
+        c = self._change('gh issue edit 42 -R "$DA" --add-label "wave-26"')
+        self.assertIsNone(c.repo)
+        self.assertTrue(c.repo_flag_present)
+
+    def test_unexpanded_var_long_form_unresolvable(self) -> None:
+        c = self._change('gh issue edit 42 --repo "noorinalabs/$REPO" --add-label "wave-26"')
+        self.assertIsNone(c.repo)
+        self.assertTrue(c.repo_flag_present)
+
+
 class NormalizeCommandSeparators(unittest.TestCase):
     """Direct tests for the shared `_shell_parse.normalize_command_separators`.
 

--- a/.claude/hooks/tests/test_post_label_change_wave_field_sync.py
+++ b/.claude/hooks/tests/test_post_label_change_wave_field_sync.py
@@ -1382,5 +1382,113 @@ class AmbientRepoResolutionTests(unittest.TestCase):
             hook.log_posttooluse_event = orig
 
 
+class RepoFlagAuthoritativeTests(unittest.TestCase):
+    """#985: the -R/--repo flag is AUTHORITATIVE over the invocation cwd for the
+    Wave-field sync.
+
+    A subagent running in a child-repo worktree issues `gh issue edit -R
+    noorinalabs/<child> ...` whose cwd `origin` may still resolve to the PARENT
+    org repo — the recurring W25-retro misroute. The sync must target the flag's
+    repo, not cwd. And an unexpanded `-R $VAR` must fail CLOSED (#981), never
+    misrouting to cwd.
+    """
+
+    _PARENT_ORIGIN = "git@github.com:noorinalabs/noorinalabs-main.git\n"
+
+    def setUp(self):
+        _wipe_cache()
+        hook.CACHE_DIR.mkdir(parents=True, exist_ok=True)
+        hook._write_cache(_ids_blob())
+
+    def tearDown(self):
+        _wipe_cache()
+
+    def test_R_flag_routes_to_flag_repo_not_cwd(self):
+        """The bite: the item-lookup GraphQL must be issued for the `-R` repo
+        (`noorinalabs-deploy`), NOT the cwd-resolved parent (`noorinalabs-main`).
+        Pre-fix the parser was blind to `-R`, so repo fell to None and the hook
+        misrouted the sync to the parent via the cwd fallback."""
+        seen = {}
+
+        def capture_item_lookup(repo, num):
+            seen["repo"] = repo
+            return _item_lookup_response(repo, num)
+
+        router = FakeGraphQLRouter(
+            item_lookup=capture_item_lookup,
+            mutation=_mutation_success_response,
+        )
+        result = hook.check(
+            _bash('gh issue edit 123 -R noorinalabs/noorinalabs-deploy --add-label "p3-wave-11"'),
+            auth_status_runner=_scopes_with_project,
+            graphql_runner=router,
+            git_runner=lambda _cwd: self._PARENT_ORIGIN,
+        )
+        self.assertEqual(result["action"], "set")
+        self.assertEqual(result["repo"], "noorinalabs-deploy")
+        self.assertEqual(
+            seen["repo"],
+            "noorinalabs-deploy",
+            "Wave-field sync must query the -R flag's repo, not the cwd origin",
+        )
+
+    def test_R_flag_does_not_invoke_git_runner(self):
+        calls = [0]
+
+        def runner(_cwd):
+            calls[0] += 1
+            return self._PARENT_ORIGIN
+
+        router = FakeGraphQLRouter(
+            item_lookup=_item_lookup_response,
+            mutation=_mutation_success_response,
+        )
+        hook.check(
+            _bash('gh issue edit 123 -R noorinalabs/noorinalabs-deploy --add-label "p3-wave-11"'),
+            auth_status_runner=_scopes_with_project,
+            graphql_runner=router,
+            git_runner=runner,
+        )
+        self.assertEqual(calls[0], 0, "-R flag must not trigger ambient cwd resolution")
+
+    def test_unexpanded_var_repo_fails_closed_no_cwd_fallback(self):
+        """#985/#981: `-R $VAR` (shlex leaves `$DA` literal) must NOT fall back to
+        cwd. git_runner is wired to a healthy parent origin to prove it is never
+        consulted for a present-but-unresolvable repo flag."""
+        calls = [0]
+
+        def runner(_cwd):
+            calls[0] += 1
+            return self._PARENT_ORIGIN
+
+        result = hook.check(
+            _bash('gh issue edit 123 -R "$DA" --add-label "p3-wave-11"'),
+            auth_status_runner=_scopes_with_project,
+            graphql_runner=FakeGraphQLRouter(),
+            git_runner=runner,
+        )
+        self.assertEqual(result["action"], "skip_no_repo_context")
+        self.assertEqual(calls[0], 0, "unresolvable -R must NOT fall back to cwd")
+
+    def test_unexpanded_var_repo_logs_unresolvable(self):
+        """The per-change skip must log `skip_unresolvable_repo` so
+        /annunaki-attack can pattern-match the fail-closed."""
+        captured = []
+        orig = hook.log_posttooluse_event
+        hook.log_posttooluse_event = lambda *a, **k: captured.append(a)
+        try:
+            hook.check(
+                _bash('gh issue edit 123 -R "$DA" --add-label "p3-wave-11"'),
+                auth_status_runner=_scopes_with_project,
+                git_runner=lambda _cwd: self._PARENT_ORIGIN,
+            )
+            self.assertTrue(
+                any("skip_unresolvable_repo" in str(a) for a in captured),
+                f"unresolvable -R must log skip_unresolvable_repo; captured: {captured}",
+            )
+        finally:
+            hook.log_posttooluse_event = orig
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.claude/hooks/tests/test_post_wave_kickoff_comment.py
+++ b/.claude/hooks/tests/test_post_wave_kickoff_comment.py
@@ -146,7 +146,7 @@ class ParseLabelApplyCommandTests(unittest.TestCase):
             hook.parse_label_apply_command(
                 'gh issue edit 123 --repo noorinalabs/noorinalabs-main --add-label "p3-wave-9"'
             ),
-            ("noorinalabs-main", "123", "p3-wave-9"),
+            ("noorinalabs-main", "123", "p3-wave-9", True),
         )
 
     def test_flag_order_swapped(self):
@@ -154,7 +154,7 @@ class ParseLabelApplyCommandTests(unittest.TestCase):
             hook.parse_label_apply_command(
                 'gh issue edit 456 --add-label "p3-wave-9" --repo noorinalabs/noorinalabs-deploy'
             ),
-            ("noorinalabs-deploy", "456", "p3-wave-9"),
+            ("noorinalabs-deploy", "456", "p3-wave-9", True),
         )
 
     def test_equals_form(self):
@@ -162,7 +162,7 @@ class ParseLabelApplyCommandTests(unittest.TestCase):
             hook.parse_label_apply_command(
                 "gh issue edit 789 --repo=noorinalabs/noorinalabs-isnad-graph --add-label=p3-wave-8"
             ),
-            ("noorinalabs-isnad-graph", "789", "p3-wave-8"),
+            ("noorinalabs-isnad-graph", "789", "p3-wave-8", True),
         )
 
     def test_multiple_add_label_picks_wave_label(self):
@@ -173,7 +173,7 @@ class ParseLabelApplyCommandTests(unittest.TestCase):
                 "gh issue edit 100 --repo noorinalabs/noorinalabs-main "
                 '--add-label "Aino_Virtanen" --add-label "p3-wave-9"'
             ),
-            ("noorinalabs-main", "100", "p3-wave-9"),
+            ("noorinalabs-main", "100", "p3-wave-9", True),
         )
 
     def test_non_wave_label_returns_none(self):
@@ -203,7 +203,7 @@ class ParseLabelApplyCommandTests(unittest.TestCase):
                 "true && gh issue edit 999 --repo noorinalabs/noorinalabs-main "
                 '--add-label "p3-wave-9"'
             ),
-            ("noorinalabs-main", "999", "p3-wave-9"),
+            ("noorinalabs-main", "999", "p3-wave-9", True),
         )
 
     # --- #467 between-wave relabel filter ---
@@ -249,7 +249,7 @@ class ParseLabelApplyCommandTests(unittest.TestCase):
                 "gh issue edit 100 --repo noorinalabs/noorinalabs-main "
                 '--add-label "p3-wave-11" --remove-label "tech-debt"'
             ),
-            ("noorinalabs-main", "100", "p3-wave-11"),
+            ("noorinalabs-main", "100", "p3-wave-11", True),
         )
 
     def test_initial_add_without_remove_still_matches(self):
@@ -261,15 +261,56 @@ class ParseLabelApplyCommandTests(unittest.TestCase):
             hook.parse_label_apply_command(
                 'gh issue edit 200 --repo noorinalabs/noorinalabs-main --add-label "p3-wave-11"'
             ),
-            ("noorinalabs-main", "200", "p3-wave-11"),
+            ("noorinalabs-main", "200", "p3-wave-11", True),
         )
 
     def test_no_repo_returns_none_repo_field(self):
         """#650: a label-apply run from inside the repo omits --repo; the pure
-        parser returns repo=None (the caller resolves it from cwd)."""
+        parser returns repo=None with repo_flag_present=False (the caller
+        resolves it from cwd)."""
         self.assertEqual(
             hook.parse_label_apply_command('gh issue edit 601 --add-label "p4-wave-7"'),
-            (None, "601", "p4-wave-7"),
+            (None, "601", "p4-wave-7", False),
+        )
+
+    # --- #985: -R/--repo flag is authoritative over cwd ---
+
+    def test_short_flag_R_resolves_repo(self):
+        """#985: the `-R owner/name` short flag (not just `--repo`) is parsed and
+        authoritative. Before the fix the parser was blind to `-R`, so a
+        child-repo `-R` op fell through to a cwd-based misroute."""
+        self.assertEqual(
+            hook.parse_label_apply_command(
+                'gh issue edit 42 -R noorinalabs/noorinalabs-deploy --add-label "wave-26"'
+            ),
+            ("noorinalabs-deploy", "42", "wave-26", True),
+        )
+
+    def test_short_flag_R_attached_resolves_repo(self):
+        """#985/#1057: the POSIX attached-short `-Rowner/name` form resolves too."""
+        self.assertEqual(
+            hook.parse_label_apply_command(
+                'gh issue edit 42 -Rnoorinalabs/noorinalabs-deploy --add-label "wave-26"'
+            ),
+            ("noorinalabs-deploy", "42", "wave-26", True),
+        )
+
+    def test_short_flag_R_equals_resolves_repo(self):
+        """#985: the `-R=owner/name` equals form resolves too."""
+        self.assertEqual(
+            hook.parse_label_apply_command(
+                'gh issue edit 42 -R=noorinalabs/noorinalabs-deploy --add-label "wave-26"'
+            ),
+            ("noorinalabs-deploy", "42", "wave-26", True),
+        )
+
+    def test_unexpanded_var_repo_flag_present_but_unresolved(self):
+        """#985/#981: `-R $VAR` (shlex leaves `$VAR` literal) is present-but-
+        unresolvable → repo=None AND repo_flag_present=True. The True bit is
+        what tells `check()` to fail closed instead of misrouting to cwd."""
+        self.assertEqual(
+            hook.parse_label_apply_command('gh issue edit 42 -R "$DA" --add-label "wave-26"'),
+            (None, "42", "wave-26", True),
         )
 
 
@@ -608,6 +649,106 @@ class AmbientRepoResolutionTests(unittest.TestCase):
             )
         self.assertEqual(result["action"], "post")
         self.assertEqual(calls[0], 0, "explicit --repo must not trigger ambient resolution")
+
+
+class RepoFlagAuthoritativeTests(unittest.TestCase):
+    """#985: the -R/--repo flag is AUTHORITATIVE over the invocation cwd.
+
+    A subagent running in a child-repo worktree issues `gh issue edit -R
+    noorinalabs/<child> ...` whose cwd `origin` may still resolve to the PARENT
+    org repo. The kickoff comment must route to the flag's repo, not cwd — the
+    recurring misroute the W25 retro flagged. And an unexpanded `-R $VAR` must
+    fail closed (#981), never silently misroute to cwd.
+    """
+
+    # cwd resolves to the PARENT repo — the misroute source when a child-repo
+    # op runs from a worktree the hook reads as the parent.
+    _PARENT_ORIGIN = "git@github.com:noorinalabs/noorinalabs-main.git\n"
+
+    def _status(self):
+        return {
+            "current_phase": 9,
+            "wave_26_scope": {
+                "tier_1": [
+                    {
+                        "id": "noorinalabs-deploy#42",
+                        "implementer": "Lucas Ferreira",
+                        "reviewer": "Aino Virtanen",
+                        "reviewer_2": "Nino Kavtaradze",
+                    }
+                ]
+            },
+        }
+
+    def _writer(self, td):
+        def fake_writer(body, repo, num):
+            path = Path(td) / f"body-{repo}-{num}.md"
+            path.write_text(body, encoding="utf-8")
+            return path
+
+        return fake_writer
+
+    def test_R_flag_routes_to_flag_repo_not_cwd(self):
+        """The bite: the deploy row is the ONLY row in scope. If the hook used
+        cwd (main) instead of the `-R noorinalabs/noorinalabs-deploy` flag it
+        would search for a `noorinalabs-main#42` row, find none, and return
+        skip_no_row. Routing to the flag's repo is what makes it post."""
+        captured = {}
+
+        def fake_post(repo, num, body_path):
+            captured["repo"] = repo
+            return True
+
+        with tempfile.TemporaryDirectory() as td:
+            result = hook.check(
+                _bash('gh issue edit 42 -R noorinalabs/noorinalabs-deploy --add-label "wave-26"'),
+                status_loader=self._status,
+                comment_fetcher=lambda repo, num: [],
+                comment_poster=fake_post,
+                body_writer=self._writer(td),
+                git_runner=lambda _cwd: self._PARENT_ORIGIN,
+            )
+        self.assertEqual(result["action"], "post")
+        self.assertEqual(result["repo"], "noorinalabs-deploy")
+        self.assertEqual(captured["repo"], "noorinalabs-deploy")
+
+    def test_R_flag_does_not_invoke_git_runner(self):
+        calls = [0]
+
+        def runner(_cwd):
+            calls[0] += 1
+            return self._PARENT_ORIGIN
+
+        with tempfile.TemporaryDirectory() as td:
+            hook.check(
+                _bash('gh issue edit 42 -R noorinalabs/noorinalabs-deploy --add-label "wave-26"'),
+                status_loader=self._status,
+                comment_fetcher=lambda repo, num: [],
+                comment_poster=lambda r, n, p: True,
+                body_writer=self._writer(td),
+                git_runner=runner,
+            )
+        self.assertEqual(calls[0], 0, "-R flag must not trigger ambient cwd resolution")
+
+    def test_unexpanded_var_repo_fails_closed_no_cwd_fallback(self):
+        """#985/#981: `-R $VAR` (shlex leaves `$DA` literal) → skip_unresolvable_repo.
+        The hook must NOT fall back to cwd (which would misroute to the parent);
+        git_runner is wired to a healthy parent origin to prove it is never
+        consulted for a present-but-unresolvable repo flag."""
+        calls = [0]
+
+        def runner(_cwd):
+            calls[0] += 1
+            return self._PARENT_ORIGIN
+
+        result = hook.check(
+            _bash('gh issue edit 42 -R "$DA" --add-label "wave-26"'),
+            status_loader=self._status,
+            git_runner=runner,
+        )
+        self.assertEqual(result["action"], "skip_unresolvable_repo")
+        self.assertEqual(result["issue"], "42")
+        self.assertEqual(calls[0], 0, "unresolvable -R must NOT fall back to cwd")
 
 
 class PhaseAgnosticLabelForm(unittest.TestCase):

--- a/.claude/hooks/tests/test_shell_parse.py
+++ b/.claude/hooks/tests/test_shell_parse.py
@@ -545,5 +545,58 @@ class ResolveRepoShortNameTests(unittest.TestCase):
         self.assertEqual(seen["cwd"], real_dir)
 
 
+class RepoShortNameFromFlagValueTests(unittest.TestCase):
+    """#985: extract the repo SHORT NAME from a `-R`/`--repo` flag value, and
+    fail closed (None) on an unexpanded `$VAR` / command substitution (#981)."""
+
+    def test_owner_name_returns_name(self):
+        self.assertEqual(
+            sp.repo_short_name_from_flag_value("noorinalabs/noorinalabs-main"),
+            "noorinalabs-main",
+        )
+
+    def test_owner_name_dotgit_stripped(self):
+        self.assertEqual(
+            sp.repo_short_name_from_flag_value("noorinalabs/noorinalabs-deploy.git"),
+            "noorinalabs-deploy",
+        )
+
+    def test_https_url_returns_name(self):
+        self.assertEqual(
+            sp.repo_short_name_from_flag_value(
+                "https://github.com/noorinalabs/noorinalabs-design-system"
+            ),
+            "noorinalabs-design-system",
+        )
+
+    def test_trailing_slash_tolerated(self):
+        self.assertEqual(
+            sp.repo_short_name_from_flag_value("noorinalabs/noorinalabs-main/"),
+            "noorinalabs-main",
+        )
+
+    def test_unexpanded_variable_returns_none(self):
+        """The #981 caveat: shlex leaves `$DA` / `${REPO}` literal. Coercing it
+        into a repo name would misroute the gh call — so return None (the caller
+        fails closed)."""
+        for v in ("$DA", "${REPO}", "noorinalabs/$REPO", "noorinalabs/${R}"):
+            with self.subTest(v=v):
+                self.assertIsNone(sp.repo_short_name_from_flag_value(v))
+
+    def test_command_substitution_returns_none(self):
+        for v in ("$(echo noorinalabs/x)", "`echo noorinalabs/x`"):
+            with self.subTest(v=v):
+                self.assertIsNone(sp.repo_short_name_from_flag_value(v))
+
+    def test_whitespace_bearing_value_returns_none(self):
+        """A value with internal whitespace is a captured non-flag fragment
+        (e.g. an attached-short false positive), never a valid repo ref."""
+        self.assertIsNone(sp.repo_short_name_from_flag_value(" foo"))
+        self.assertIsNone(sp.repo_short_name_from_flag_value("owner/na me"))
+
+    def test_empty_returns_none(self):
+        self.assertIsNone(sp.repo_short_name_from_flag_value(""))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.claude/team/charter/agents/orchestration-model.md
+++ b/.claude/team/charter/agents/orchestration-model.md
@@ -245,9 +245,11 @@ Every reviewer-class spawn prompt MUST include, **in order**:
 
 <!-- Promoted from memory: feedback_pr_review_verdict_format.md (P3W9 retro 2026-05-12, owner-approved 2026-05-13) -->
 
-   **Verbatim verdict-comment template (copy-paste into reviewer spawn briefs):**
+   **Verbatim verdict-comment template (COPY-PASTE into reviewer spawn briefs — do NOT paraphrase):**
 
-   > **Canonical source:** see `pull-requests.md § Review Prompt Template (Mandatory)` for the underlying spec. This block is the spawn-brief view; the `pull-requests.md` template is the verbatim source-of-truth reviewers must follow — plain form, no bold markers, no parenthetical descriptions, no extra fields.
+   > **Canonical source:** see `pull-requests.md § Review Prompt Template (Mandatory)` for the underlying spec, and memory `feedback_pr_review_verdict_format` §8 (spawn-brief obligations) + §1 (trailer placement). This block is the spawn-brief view; the `pull-requests.md` template is the verbatim source-of-truth reviewers must follow — plain form, no bold markers, no parenthetical descriptions, no extra fields.
+   >
+   > **COPY, do NOT paraphrase (P9W25, memory §8):** paste these exact tokens into every reviewer spawn brief. An invented field (`Review:`, `Verdict:`) or a paraphrased status (`RequestOrReplied: Request` in place of `Approved`) parses as ZERO approvals — Hook 4 has no parser for the invented name and `Request`/`Reply` do not gate-count. The exact tokens are load-bearing; having the rule in memory is not a substitute for pasting the block.
 
    ```bash
    # Use `gh pr comment <PR#> --body-file <path>` — NOT `gh pr review` (block_gh_pr_review enforces).
@@ -255,20 +257,27 @@ Every reviewer-class spawn prompt MUST include, **in order**:
    # (block_stale_tmp_message_file enforces 30s freshness):
 
    cat > /tmp/<PR#>-review-<reviewer-firstname>.md <<'BODYEOF'
-   Requestor: <reviewer-firstname> <reviewer-lastname>
-   Requestee: <PR-author-firstname> <PR-author-lastname>
-   RequestOrReplied: Approved
-   TechDebt: none
-
    <verdict body — prose, line comments, throughline observations…>
 
    ## Throughline observations
 
    <per § Reviewer spawn brief — throughline-watch>
+
+   ---
+   Requestor: <reviewer's exact space-form roster name> (YOU — not the author, not the paired reviewer)
+   Requestee: <PR author's exact space-form roster name>
+   RequestOrReplied: Approved
+   TechDebt: none
    BODYEOF
 
    gh pr comment <PR#> --body-file /tmp/<PR#>-review-<reviewer-firstname>.md
    ```
+
+   **Placement (critical — memory §1):** the 4-line trailer is the **LAST** lines of the comment, immediately after a **sole `---`** on its own line. Hook 4 reads verdict fields ONLY from the trailer block (text after the LAST bare-line `---`); any `Field:` line ABOVE a later `---` is invisible, so the trailer must never precede the prose (a long review that used `---` as a mid-body horizontal rule once silently skipped its verdict — main#940).
+
+   **The `(YOU — …)` parenthetical is a which-name pointer for the template ONLY — DROP it when posting.** Substitute your bare space-form roster name (e.g. `Aino Virtanen`) for the placeholder and post `Requestor: Aino Virtanen`. A parenthetical or dotted form left in the posted value fails Hook 4's roster-validation (lowercased space-form match against `.claude/team/roster/`) → the verdict counts as a NON-roster Requestor → 0 of 2 approvals (memory §3).
+
+   **Read back before reporting "posted":** after `gh pr comment`, re-fetch the comment body (`gh api repos/noorinalabs/<REPO>/issues/comments/<id>`) and confirm the trailer parses — import the hook and check (`from validate_pr_review import _extract_charter_field, _is_approved`, memory §7) rather than trusting a visual scan. Report the verdict to the requestor only after the read-back confirms a counted Approved; "Approved, posted" without a read-back is the exact claim that surfaces as a silent zero at merge time (memory §8).
 
    > Inline `gh pr comment <PR#> --body "..."` is also valid when no /tmp file is involved; `--body-file <path>` is the required form when the body is written to /tmp first (`block_stale_tmp_message_file` 30s freshness rule applies only when a /tmp file is the source). This reconciles the new block above with `pull-requests.md § Review Prompt Template (Mandatory)` lines 47–53 which use inline `--body "..."` — both are legitimate; flag form follows write-path.
 


### PR DESCRIPTION
Final wave merge for noorinalabs-main. 2 PRs reviewed and merged to wave branch: #1061 (#984 verdict-trailer template), #1059 (#985 -R/--repo authoritative in wave-label hooks). Both 2/2 reviewed. Wave branch brought current with main (kickoff + wrapup bookkeeping merged in).

Wave: Phase 9 Wave 26 — 'Parse recovery & name quality'.