### PR TITLE
fix(#1064): exclude wave_{N}_carry_forward from wave_seq seed (unskip the next wave)

### DIFF
--- a/.claude/lib/tests/test_wave_seq.py
+++ b/.claude/lib/tests/test_wave_seq.py
@@ -53,6 +53,29 @@ class TestExistingWaveNumbers(unittest.TestCase):
         # wave_4_ must not match wave_42_.
         self.assertEqual(wave_seq.existing_wave_numbers({"wave_42_active": True}), {42})
 
+    def test_carry_forward_key_excluded_from_seed(self) -> None:
+        # #1064: carry_forward stages an id for the UPCOMING wave and must not
+        # count as an allocated id. A committed-allocation key for the same wave
+        # still counts (so a genuinely-allocated wave is never dropped).
+        self.assertEqual(wave_seq.existing_wave_numbers({"wave_27_carry_forward": []}), set())
+        self.assertEqual(
+            wave_seq.existing_wave_numbers({"wave_27_carry_forward": [], "wave_26_active": True}),
+            {26},
+        )
+
+    def test_carry_forward_does_not_skip_next_wave(self) -> None:
+        # #1064 end-to-end: global_wave_seq at N-1 with only a wave_N carry_forward
+        # staged must peek/allocate to N, not N+1. This is the exact P9W26 state
+        # (committed 26, wave_27_carry_forward written by /wave-wrapup).
+        status = {
+            "global_wave_seq": 26,
+            "current_wave": "wave-26",
+            "wave_26_active": True,
+            "wave_27_carry_forward": ["noorinalabs-main#1062"],
+        }
+        self.assertEqual(wave_seq.next_global_wave(status), 27)
+        self.assertEqual(wave_seq.allocation_target(status), 27)
+
 
 class TestSeedAndCounter(unittest.TestCase):
     def test_seed_respects_historical_floor(self) -> None:

--- a/.claude/lib/wave_seq.py
+++ b/.claude/lib/wave_seq.py
@@ -85,13 +85,37 @@ HISTORICAL_FLOOR = 15
 # makes `wave_4_` match `wave_4_active` but never `wave_42_active`.
 _WAVE_KEY_RE = re.compile(r"^wave_(\d+)_")
 
+# Forward-reservation key kinds name a wave id that is STAGED for an upcoming
+# wave but is NOT yet allocated (``global_wave_seq`` has not advanced to it).
+# They must NOT seed the counter, or ``peek``/``allocate`` would skip the very
+# wave they stage (#1064). ``carry_forward`` is written by ``/wave-wrapup`` for
+# the UPCOMING wave, so a live ``wave_{N}_carry_forward`` alongside
+# ``global_wave_seq == N-1`` must still leave ``next == N``.
+#
+# ``meta_issue`` is the OTHER reservation kind but is deliberately NOT listed
+# here: without a committed counter (the migration path) ``reserved_wave``
+# returns None, so the seed is the only thing that keeps a hand-set
+# ``wave_{N}_meta_issue`` from being re-allocated; with a committed counter the
+# ``reserved_wave`` check at ``committed + 1`` masks any meta_issue seed
+# inflation before it matters. ``carry_forward`` has no such rescue, which is
+# exactly why it needs excluding at the source.
+_FORWARD_RESERVATION_SUFFIXES = ("carry_forward",)
+
 
 def existing_wave_numbers(status: dict) -> set[int]:
-    """Every wave id that appears in a top-level ``wave_{X}_*`` key name."""
+    """Every wave id that appears in a top-level ``wave_{X}_*`` key name.
+
+    Forward-reservation keys (``_FORWARD_RESERVATION_SUFFIXES``) are excluded:
+    they stage an id for a wave not yet allocated and would otherwise inflate
+    the seed past it (#1064).
+    """
     out: set[int] = set()
     for key in status:
         m = _WAVE_KEY_RE.match(key)
         if m:
+            remainder = key[m.end() :]  # the part after "wave_{N}_"
+            if remainder in _FORWARD_RESERVATION_SUFFIXES:
+                continue
             out.add(int(m.group(1)))
     return out
 


### PR DESCRIPTION
Closes #1064.

## Problem
`/wave-wrapup` writes `wave_{N}_carry_forward` for the **upcoming** wave. `existing_wave_numbers()` matched that key (`_WAVE_KEY_RE = ^wave_(\d+)_`) and fed it into `seed_value`, so with `global_wave_seq=N-1`:
```
seed_value = max(FLOOR, N) = N   →   current_seq = max(N-1, N) = N   →   next_global_wave = N+1
```
`reserved_wave()` only rescues the `wave_{N}_meta_issue` reservation kind, so `carry_forward` fell through to `next_global_wave`. Net: `peek`/`allocate` **skip wave N**, and the next `/wave-scope` or `/wave-start` would allocate N+1 and strand all wave-N-labeled + carried-forward work. Observed at the P9W26 retro: committed 26 + `wave_27_carry_forward` ⇒ peek **28**.

## Fix
Exclude forward-reservation key kinds at the source: `existing_wave_numbers()` skips any `wave_{N}_<suffix>` whose suffix is in `_FORWARD_RESERVATION_SUFFIXES = ("carry_forward",)`.

`meta_issue` is **deliberately not** excluded: without a committed counter (migration path) `reserved_wave` returns None, so the seed is the only guard keeping a hand-set `meta_issue` from re-allocation; with a committed counter the `reserved_wave` check at `committed+1` masks any meta_issue seed inflation. `carry_forward` has no such rescue — hence the source-level exclusion.

## Tests
- `test_carry_forward_key_excluded_from_seed` — `existing_wave_numbers` drops `carry_forward` but still counts a committed key (`wave_26_active`) for the same/other wave.
- `test_carry_forward_does_not_skip_next_wave` — the exact P9W26 state (committed 26 + `wave_27_carry_forward`) now `next_global_wave`/`allocation_target` == **27**.
- Full suite green: `test_wave_seq` 26/26, `test_lifecycle` + `test_wave_status` 46/46. ruff clean.

## Impact / rollout
Unblocks a clean wave-27 allocation. No status-file migration needed — the fix is read-path only; the live `wave_27_carry_forward` key is now correctly ignored by the seed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)