### PR TITLE
fix(#940): reviewer set follows each reviewer's latest verdict, not a monotonic union

### DIFF
--- a/.claude/hooks/tests/test_validate_pr_review.py
+++ b/.claude/hooks/tests/test_validate_pr_review.py
@@ -377,6 +377,116 @@ class ReviewerDedupTests(_CheckCommentReviewsHarness):
         self.assertEqual(result.reviewers, set(), "branch author must not self-review")
 
 
+class LatestVerdictSupersedesTests(_CheckCommentReviewsHarness):
+    """Issue #940: the reviewer set is monotonic — an approval cannot be
+    withdrawn, and a reviewer standing at Changes Requested still counts as
+    an approver if they ever approved earlier in the thread.
+
+    The fix keys each reviewer's verdict by their LATEST charter-format
+    comment (chronological = fixture list order, since these tests pass no
+    `content_ts` and so exercise the unbound #950 path). Only a reviewer
+    whose latest verdict is Approved contributes to the reviewer set.
+    """
+
+    @staticmethod
+    def _verdict(requestor: str, ror: str, requestee: str = "Linh Pham") -> dict:
+        return {
+            "body": (
+                f"Requestor: {requestor}\nRequestee: {requestee}\n"
+                f"RequestOrReplied: {ror}\nTechDebt: none"
+            ),
+            "user": {"login": "anyone"},
+        }
+
+    def test_approved_then_changes_requested_is_excluded(self):
+        """Guard for #940: this must RED under the pre-fix monotonic union.
+
+        An Approved followed by a Changes Requested from the SAME reviewer —
+        the fixture shape the issue calls out as the one that proves the
+        defect (a fixture with only the reverse order "passes under both
+        implementations and proves nothing").
+        """
+        comments = [
+            self._verdict("Oyunbileg Batbayar", "Approved"),
+            self._verdict("Oyunbileg Batbayar", "Changes Requested"),
+        ]
+        result = self._run_with_fake_api(comments, self.BRANCH_AUTHOR, repo=self.REPO)
+        self.assertNotIn(
+            "oyunbileg batbayar",
+            result.reviewers,
+            "a later Changes Requested must withdraw the earlier Approved",
+        )
+        self.assertEqual(result.reviewers, set())
+
+    def test_changes_requested_then_approved_is_included(self):
+        """The symmetric case: a later Approved supersedes an earlier block."""
+        comments = [
+            self._verdict("Kwesi Boateng", "Changes Requested"),
+            self._verdict("Kwesi Boateng", "Approved"),
+        ]
+        result = self._run_with_fake_api(comments, self.BRANCH_AUTHOR, repo=self.REPO)
+        self.assertIn("kwesi boateng", result.reviewers)
+
+    def test_da359_shaped_timeline_reproduces_the_correct_verdicts(self):
+        """Reproduces the exact da#359 timeline from #940's report.
+
+        Chronological verdicts:
+          Oyunbileg Batbayar: Approved -> Changes Requested -> Changes Requested
+          Alejandra Reyes-Fuentes: Approved
+          Kwesi Boateng: Changes Requested -> Approved
+
+        Standing verdict is Oyunbileg BLOCKING, Alejandra and Kwesi APPROVED —
+        exactly 2 current approvers, not the pre-fix count of 3.
+        """
+        comments = [
+            self._verdict("Oyunbileg Batbayar", "Approved"),
+            self._verdict("Alejandra Reyes-Fuentes", "Approved"),
+            self._verdict("Oyunbileg Batbayar", "Changes Requested"),
+            self._verdict("Oyunbileg Batbayar", "Changes Requested"),
+            self._verdict("Kwesi Boateng", "Changes Requested"),
+            self._verdict("Kwesi Boateng", "Approved"),
+        ]
+        result = self._run_with_fake_api(comments, self.BRANCH_AUTHOR, repo=self.REPO)
+        self.assertEqual(
+            result.reviewers,
+            {"alejandra reyes-fuentes", "kwesi boateng"},
+        )
+        self.assertNotIn("oyunbileg batbayar", result.reviewers)
+        self.assertEqual(len(result.reviewers), 2)
+
+    def test_stale_verdict_does_not_override_a_later_current_one(self):
+        """A verdict predating T_content is excluded from `latest_verdict`
+        entirely (#950) — it must not be able to overwrite the reviewer's
+        genuinely-latest CURRENT verdict just because it appears later in
+        `stale_verdicts` bookkeeping. Here the reviewer's only CURRENT verdict
+        is Approved; an earlier STALE Changes Requested must not block them.
+        """
+        content_ts = hook._parse_iso8601("2026-01-02T00:00:00Z")
+        stale_ts = "2026-01-01T00:00:00Z"
+        fresh_ts = "2026-01-03T00:00:00Z"
+        comments = [
+            {
+                "body": (
+                    "Requestor: Nino Kavtaradze\nRequestee: Linh Pham\n"
+                    "RequestOrReplied: Changes Requested\nTechDebt: none"
+                ),
+                "created_at": stale_ts,
+            },
+            {
+                "body": (
+                    "Requestor: Nino Kavtaradze\nRequestee: Linh Pham\n"
+                    "RequestOrReplied: Approved\nTechDebt: none"
+                ),
+                "created_at": fresh_ts,
+            },
+        ]
+        result = self._run_with_fake_api_ts(
+            comments, self.BRANCH_AUTHOR, repo=self.REPO, content_ts=content_ts
+        )
+        self.assertIn("nino kavtaradze", result.reviewers)
+        self.assertEqual(len(result.stale_verdicts), 1)
+
+
 class ExtractBranchAuthorLastnameTests(unittest.TestCase):
     """Regression tests for issue #179.
 

--- a/.claude/hooks/validate_pr_review.py
+++ b/.claude/hooks/validate_pr_review.py
@@ -900,9 +900,14 @@ def check_comment_reviews(
     Reviewer identification per charter (resolves #244):
       - Approved / ChangesRequested → reviewer is the Requestor (comment author)
       - Request / Reply → not a review; does not contribute to reviewer set
-      - 2-reviewer threshold counts distinct Requestor values across Approved
-        comments only (ChangesRequested is a verdict-with-TechDebt but does
-        not count toward the threshold).
+      - 2-reviewer threshold counts distinct Requestor values whose LATEST
+        verdict comment is Approved (#940). An approval is a statement about
+        a moment, not a permanent grant: a reviewer's later ChangesRequested
+        withdraws an earlier Approved and drops them from the reviewer set,
+        and a reviewer's later Approved supersedes an earlier ChangesRequested
+        and adds them. Only the reviewer's most recent CURRENT (non-stale, see
+        below) verdict is consulted — earlier verdicts from the same reviewer
+        do not additionally count or block.
 
     `content_ts` is `T_content` (#950) — the committer timestamp of the branch's
     latest non-merge commit, from `get_latest_content_commit`. When supplied, a
@@ -920,6 +925,14 @@ def check_comment_reviews(
     failure raises `CommitFetchError` and hard-blocks upstream of this call.
     """
     result = CommentReviewResult()
+    # Reviewer -> most recent (chronologically-last) CURRENT RequestOrReplied
+    # value, keyed on lowercased full name (#940). An Approved comment is a
+    # statement about a MOMENT, not a permanent grant: a reviewer who approves
+    # and later requests changes must have that later verdict supersede the
+    # earlier one, and a reviewer who requests changes and later approves must
+    # likewise have the approval win. `comments` is already chronological, so
+    # the last write for a given key IS that reviewer's latest verdict.
+    latest_verdict: dict[str, str] = {}
     try:
         owner_repo = _resolve_owner_repo(repo)
         if owner_repo is None:
@@ -966,7 +979,6 @@ def check_comment_reviews(
                 continue
 
             is_verdict_comment = _is_verdict(ror_value)
-            is_approved_comment = _is_approved(ror_value)
 
             # Content binding (#950): a verdict cast before the branch's latest
             # AUTHORED commit reviewed code that has since been rewritten. It is
@@ -987,12 +999,15 @@ def check_comment_reviews(
                     )
                     continue
 
-            # Only Approved comments contribute to the reviewer set toward
-            # the 2-reviewer threshold (charter line 36, resolves #244).
-            if is_approved_comment:
+            # Record this reviewer's latest CURRENT verdict (#940). The
+            # reviewer set toward the 2-reviewer threshold (charter line 36,
+            # resolves #244) is derived from `latest_verdict` AFTER the loop —
+            # not accumulated here — so a later ChangesRequested can withdraw
+            # an earlier Approved (and vice versa) instead of only ever adding.
+            if is_verdict_comment:
                 reviewer_lastname = _name_lastname(requestor)
                 if reviewer_lastname.lower() != branch_author_lastname.lower():
-                    result.reviewers.add(requestor.lower())
+                    latest_verdict[requestor.lower()] = ror_value
 
             # TechDebt attestation is required on every verdict
             # (Approved + ChangesRequested) — issue #147 fix.
@@ -1008,6 +1023,13 @@ def check_comment_reviews(
                         issue_nums = re.findall(r"#(\d+)", td_value)
                         result.tech_debt_issue_numbers.extend(issue_nums)
 
+        # A reviewer counts toward the threshold only if their LATEST verdict
+        # is Approved (#940) — a reviewer whose latest verdict is
+        # ChangesRequested is currently blocking and must not count, even
+        # though they approved at some earlier point in the thread.
+        result.reviewers = {
+            reviewer for reviewer, verdict in latest_verdict.items() if _is_approved(verdict)
+        }
         return result
 
     except (subprocess.TimeoutExpired, json.JSONDecodeError, FileNotFoundError) as exc:


### PR DESCRIPTION
## Summary

Closes #940.

`check_comment_reviews` (Hook 4 / `validate_pr_review.py`) built its reviewer
set by only ever **adding** a Requestor on an `Approved` comment and never
removing one on a later `Changes Requested` — an approval could never be
withdrawn, and a reviewer who moved from `Approved` to `Changes Requested`
still counted toward the 2-reviewer threshold. This was live on
`noorinalabs-data-acquisition` PR #359 at the time of filing.

## Fix

Track each non-author reviewer's **latest** CURRENT (non-stale per #950)
verdict in a single chronological pass over the comment thread, then derive
`result.reviewers` from whichever reviewers' latest verdict is `Approved`. A
later verdict now correctly supersedes an earlier one in **both**
directions (Approved → CR withdraws; CR → Approved grants).

## Tests

Added `LatestVerdictSupersedesTests` in
`.claude/hooks/tests/test_validate_pr_review.py`:
- `test_approved_then_changes_requested_is_excluded` — the guard the issue
  calls out explicitly: this must RED under the pre-fix monotonic union.
- `test_changes_requested_then_approved_is_included` — the symmetric case.
- `test_da359_shaped_timeline_reproduces_the_correct_verdicts` — reproduces
  the exact da#359 timeline from the issue report and asserts the corrected
  2-approver outcome.
- `test_stale_verdict_does_not_override_a_later_current_one` — guards the
  interaction with the #950 staleness binding.

Full local gate green: `pre-commit run --all-files` (commit stage) +
`pre-commit run --hook-stage pre-push --all-files` (mypy + full pytest
suite, 2725 passed) — both clean.

## Reviewers

- **Nino Kavtaradze** (merge-gate)
- **Lucas Ferreira**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018KeNK3VBB3zFyJWxUGWM7z