### PR TITLE
fix(#1047): premise_check no longer treats a bare slash as a path signal

### DIFF
--- a/.claude/lib/premise_check.py
+++ b/.claude/lib/premise_check.py
@@ -32,6 +32,13 @@ Verdict policy (deterministic):
     deliberately NOT a STOP: a missing local checkout is an environment gap, not
     evidence the premise rotted — a false STOP there would block scope on
     tooling state, the opposite of the gate's purpose.
+  * a ``.claude/``-rooted path that MISSES in a child repo but resolves in the
+    parent (``noorinalabs-main``) -> ``CROSS_REPO`` -> verdict ``WARN`` (main#1047
+    da#427): very often a legitimate reference to org-wide config, worth a
+    manual look rather than a hard block.
+  * a bare (slash-free) filename that misses at repo root but resolves
+    uniquely elsewhere in the tree -> ``EXISTS`` via a basename fallback
+    (main#1047 da#373).
   * everything present, or no concrete refs to check -> ``OK``.
 
 An issue may also declare explicit ``paths`` / ``symbols`` arrays (deliberate
@@ -77,6 +84,12 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 EXISTS = "exists"
 MISSING = "missing"
 UNVERIFIABLE = "unverifiable"
+# A `.claude/`-rooted path that misses in a CHILD repo but resolves in the
+# parent (`noorinalabs-main`) — very often a legitimate reference to org-wide
+# config from a child-repo issue (main#1047 da#427). Treated as WARN, not
+# STOP: the reference is real, but reading it against the wrong repo is worth
+# a manual look, not a hard block.
+CROSS_REPO = "cross_repo"
 
 # Per-issue verdicts.
 OK = "ok"
@@ -132,14 +145,73 @@ _PATH_TOKEN_RE = re.compile(r"[\w./\-]+")
 # Backtick code span: ``foo`` -> foo. Non-greedy, single line.
 _BACKTICK_RE = re.compile(r"`([^`\n]+)`")
 
+# Leading path components that are a positive signal a slash-containing token
+# is a real repo path even without a recognized extension (main#1047: a slash
+# alone is NOT evidence — "A/B", "recall/precision", "origin/main", "986/650"
+# all contain "/" and are not paths). Covers this org's top-level source roots
+# plus every child repo name (a cross-repo mention like
+# `noorinalabs-deploy/terraform/...` is a real path even mid-prose).
+_KNOWN_ROOT_COMPONENTS = frozenset(
+    {
+        "src",
+        "docs",
+        "doc",
+        "tests",
+        "test",
+        ".claude",
+        ".github",
+        "data",
+        "ontology",
+        "scripts",
+        "terraform",
+        "alembic",
+        "docker",
+        "integration-tests",
+        "noorinalabs-main",
+        "noorinalabs-isnad-graph",
+        "noorinalabs-user-service",
+        "noorinalabs-deploy",
+        "noorinalabs-design-system",
+        "noorinalabs-data-acquisition",
+        "noorinalabs-isnad-ingest-platform",
+        "noorinalabs-landing-page",
+    }
+)
+
+# Known git refs / ref prefixes: `origin/main`, `refs/heads/x`, `HEAD` are
+# never file paths even though `origin/main` contains a slash (main#1047).
+_GIT_REF_LITERALS = frozenset({"HEAD"})
+_GIT_REF_PREFIXES = ("origin/", "refs/")
+
+
+def _all_components_numeric(tok: str) -> bool:
+    """True when every ``/``-separated component of ``tok`` is digits/commas.
+
+    Catches counts written as a fraction, e.g. ``986/650`` (main#1047 wave-26:
+    "650,986/650,986 rows") — never a path, whatever the extension heuristic
+    below would otherwise decide (there is no extension to check anyway).
+    """
+    parts = tok.split("/")
+    return all(part and re.fullmatch(r"[\d,]+", part) for part in parts)
+
 
 def looks_like_path(token: str) -> bool:
     """True when ``token`` is plausibly a repo-relative file/dir path.
 
     Precision over recall: a false negative just means one fewer thing checked;
-    a false positive turns prose into a spurious STOP. Accepts a token only when
-    it is whitespace-free, path-character-only, and EITHER contains a ``/``
-    (directory structure) OR ends in a known code extension.
+    a false positive turns prose into a spurious STOP. A slash is NOT itself
+    evidence (main#1047: the wave-26 scope run flagged 12/12 issues as
+    premise-rot purely because prose like ``A/B``, ``recall/precision``, or the
+    git ref ``origin/main`` contains a ``/``). A token is accepted only when it
+    is whitespace-free, path-character-only, not a bare git ref, not an
+    all-numeric fraction, and EITHER:
+
+      * it ends in a known code/doc extension (``foo.py``, ``bar/baz.md``), OR
+      * it contains a ``/`` AND its leading component is a known repo-root
+        directory (``src/``, ``docs/``, ``.claude/``, a child-repo name, …).
+
+    A slash-containing token with neither signal (e.g. ``ism/kunya``,
+    ``boundary/particle``) is prose, not a path.
     """
     tok = token.strip()
     if not tok or " " in tok or "\t" in tok:
@@ -151,10 +223,18 @@ def looks_like_path(token: str) -> bool:
     # A bare issue/anchor ref or a number is never a path.
     if tok.lstrip("#").isdigit():
         return False
-    if "/" in tok:
-        return True
+    if tok == "/":
+        return False
+    if tok in _GIT_REF_LITERALS or tok.startswith(_GIT_REF_PREFIXES):
+        return False
     ext = tok.rsplit(".", 1)[-1].lower() if "." in tok else ""
-    return ext in _CODE_EXTENSIONS
+    if ext in _CODE_EXTENSIONS:
+        return True
+    if "/" in tok and not _all_components_numeric(tok):
+        first = tok.split("/", 1)[0]
+        if first in _KNOWN_ROOT_COMPONENTS:
+            return True
+    return False
 
 
 def normalize_path(token: str) -> str:
@@ -226,17 +306,39 @@ def git_ref_exists(repo_dir: str, ref: str) -> bool:
     return proc.returncode == 0
 
 
+def _basename_resolves(repo_dir: str, ref: str, basename: str) -> bool:
+    """True when some tracked path at ``ref`` ends in ``/<basename>`` (or is it).
+
+    Basename fallback (main#1047 da#373): an issue naming a bare filename like
+    ``composition.py`` may not mean the repo root — the file can live at
+    ``src/parse/composition.py``. Only applies to slash-free candidates; a real
+    subpath that misses at its literal location is still MISSING, never
+    re-resolved by searching the whole tree.
+    """
+    proc = _run_git(repo_dir, ["ls-tree", "-r", "--name-only", ref])
+    if proc.returncode != 0:
+        return False
+    suffix = "/" + basename
+    return any(line == basename or line.endswith(suffix) for line in proc.stdout.splitlines())
+
+
 def git_path_status(repo_dir: str, ref: str, path: str) -> str:
     """Existence of ``path`` at ``ref`` via ``git cat-file -e``.
 
     Returns :data:`UNVERIFIABLE` when the repo dir or ref cannot be read (an
     environment gap, never treated as premise rot), otherwise :data:`EXISTS` /
-    :data:`MISSING`.
+    :data:`MISSING`. A slash-free ``path`` that misses at its literal location
+    gets one more chance via :func:`_basename_resolves` before being declared
+    MISSING (main#1047 basename fallback).
     """
     if not git_ref_exists(repo_dir, ref):
         return UNVERIFIABLE
     proc = _run_git(repo_dir, ["cat-file", "-e", f"{ref}:{path}"])
-    return EXISTS if proc.returncode == 0 else MISSING
+    if proc.returncode == 0:
+        return EXISTS
+    if "/" not in path and _basename_resolves(repo_dir, ref, path):
+        return EXISTS
+    return MISSING
 
 
 def git_symbol_status(repo_dir: str, ref: str, symbol: str, pathspec: str | None = None) -> str:
@@ -270,8 +372,9 @@ SymbolChecker = Callable[[str, str, str, "str | None"], str]
 class CandidateResult:
     kind: str  # "path" | "symbol"
     value: str
-    status: str  # EXISTS | MISSING | UNVERIFIABLE
+    status: str  # EXISTS | MISSING | UNVERIFIABLE | CROSS_REPO
     pathspec: str | None = None
+    note: str | None = None
 
 
 @dataclass
@@ -291,11 +394,15 @@ class IssueResult:
     def unverifiable(self) -> list[CandidateResult]:
         return [c for c in self.candidates if c.status == UNVERIFIABLE]
 
+    @property
+    def cross_repo(self) -> list[CandidateResult]:
+        return [c for c in self.candidates if c.status == CROSS_REPO]
+
 
 def _verdict_for(candidates: list[CandidateResult]) -> str:
     if any(c.status == MISSING for c in candidates):
         return STOP
-    if any(c.status == UNVERIFIABLE for c in candidates):
+    if any(c.status in (UNVERIFIABLE, CROSS_REPO) for c in candidates):
         return WARN
     return OK
 
@@ -349,19 +456,42 @@ def check_issue(
     path_checker: PathChecker = git_path_status,
     symbol_checker: SymbolChecker = git_symbol_status,
 ) -> IssueResult:
-    """Verify every named premise of one scoped issue against its repo HEAD."""
+    """Verify every named premise of one scoped issue against its repo HEAD.
+
+    A `.claude/`-rooted path that MISSES in a child repo gets one more check
+    against the parent (`noorinalabs-main`) before being declared MISSING
+    (main#1047 da#427): a child-repo issue very often names a legitimate
+    org-wide config path. A parent-side hit downgrades that candidate to
+    :data:`CROSS_REPO` (-> WARN), not a bare pass — the reference is real, but
+    checking it against the wrong repo is still worth a manual look.
+    """
     repo_dir = resolve_repo_dir(issue, repos_root)
     git_ref = issue.get("git_ref") or default_ref
+    repo_name = str(issue.get("repo") or "noorinalabs-main")
     candidates: list[CandidateResult] = []
     for kind, value, pathspec in collect_candidates(issue):
         if kind == "path":
             status = path_checker(repo_dir, git_ref, value)
+            note: str | None = None
+            if (
+                status == MISSING
+                and repo_name != "noorinalabs-main"
+                and value.startswith(".claude/")
+            ):
+                parent_status = path_checker(str(repos_root), git_ref, value)
+                if parent_status == EXISTS:
+                    status = CROSS_REPO
+                    note = (
+                        f"resolves in parent repo noorinalabs-main, not child repo "
+                        f"{repo_name} — verify this is a deliberate cross-repo reference"
+                    )
+            candidates.append(CandidateResult(kind, value, status, pathspec, note))
         else:
             status = symbol_checker(repo_dir, git_ref, value, pathspec)
-        candidates.append(CandidateResult(kind, value, status, pathspec))
+            candidates.append(CandidateResult(kind, value, status, pathspec))
     return IssueResult(
         ref=str(issue.get("ref", "?")),
-        repo=str(issue.get("repo", "noorinalabs-main")),
+        repo=repo_name,
         repo_dir=repo_dir,
         git_ref=git_ref,
         verdict=_verdict_for(candidates),
@@ -381,7 +511,12 @@ def check_issues(
 
 # --- reporting + CLI --------------------------------------------------------
 
-_STATUS_GLYPH = {EXISTS: "ok", MISSING: "MISSING", UNVERIFIABLE: "unverifiable"}
+_STATUS_GLYPH = {
+    EXISTS: "ok",
+    MISSING: "MISSING",
+    UNVERIFIABLE: "unverifiable",
+    CROSS_REPO: "cross-repo (found in parent)",
+}
 
 
 def render_report(results: list[IssueResult]) -> str:
@@ -397,7 +532,8 @@ def render_report(results: list[IssueResult]) -> str:
         lines.append(f"[{tag}] {r.ref}  ({r.repo} @ {r.git_ref})")
         for c in r.candidates:
             scope = f" in {c.pathspec}" if c.pathspec else ""
-            lines.append(f"    - {c.kind} `{c.value}`{scope}: {_STATUS_GLYPH[c.status]}")
+            note = f" — {c.note}" if c.note else ""
+            lines.append(f"    - {c.kind} `{c.value}`{scope}: {_STATUS_GLYPH[c.status]}{note}")
 
     lines.append("")
     if stops:
@@ -410,11 +546,12 @@ def render_report(results: list[IssueResult]) -> str:
             lines.append(f"  - {r.ref}: {refs}")
     if warns:
         lines.append(
-            f"WARN: {len(warns)} issue(s) could not be verified "
-            "(repo not cloned / ref not fetched / unreadable). Verify manually:"
+            f"WARN: {len(warns)} issue(s) could not be fully verified "
+            "(repo not cloned / ref not fetched / unreadable, or a cross-repo "
+            "reference). Verify manually:"
         )
         for r in warns:
-            refs = ", ".join(f"{c.kind} {c.value}" for c in r.unverifiable)
+            refs = ", ".join(f"{c.kind} {c.value}" for c in r.unverifiable + r.cross_repo)
             lines.append(f"  - {r.ref} ({r.repo_dir} @ {r.git_ref}): {refs}")
     if not stops and not warns:
         lines.append("All named files/symbols verified present at origin HEAD.")
@@ -429,7 +566,13 @@ def _result_to_dict(r: IssueResult) -> dict:
         "git_ref": r.git_ref,
         "verdict": r.verdict,
         "candidates": [
-            {"kind": c.kind, "value": c.value, "status": c.status, "pathspec": c.pathspec}
+            {
+                "kind": c.kind,
+                "value": c.value,
+                "status": c.status,
+                "pathspec": c.pathspec,
+                "note": c.note,
+            }
             for c in r.candidates
         ],
     }

--- a/.claude/lib/tests/test_premise_check.py
+++ b/.claude/lib/tests/test_premise_check.py
@@ -58,6 +58,75 @@ class LooksLikePathTest(unittest.TestCase):
     def test_rejects_whitespace(self) -> None:
         self.assertFalse(pc.looks_like_path("a b.py"))
 
+    def test_rejects_slash_prose_main_1047(self) -> None:
+        """main#1047: a slash alone is NOT a positive path signal.
+
+        Every one of these is a verbatim false-positive token from the wave-26
+        scope run (12/12 STOP, 0 genuine rot) — none has a code extension and
+        none has a known repo-root leading component, so all must be rejected.
+        """
+        for tok in (
+            "/",
+            "A/B",
+            "Latin/English",
+            "benediction/Prophet-title",
+            "ism/kunya",
+            "token-count/matn-density",
+            "recall/precision",
+            "display/graph",
+            "Identity/matching",
+            "taṣliya/eulogy",
+            "pollution/mc",
+            "resolve/load",
+            "collectors/commentators",
+            "Validate/scrub",
+            "boundary/particle",
+            "name/nisba",
+            "transliteration/cross-script",
+            "Code/git",
+        ):
+            self.assertFalse(pc.looks_like_path(tok), tok)
+
+    def test_rejects_numeric_fraction_main_1047(self) -> None:
+        # "650,986/650,986 rows" -> the bare token "986/650" is a count, not a path.
+        self.assertFalse(pc.looks_like_path("986/650"))
+        self.assertFalse(pc.looks_like_path("650,986/650,986"))
+
+    def test_rejects_git_ref_main_1047(self) -> None:
+        # A git ref contains a slash but is never a path.
+        self.assertFalse(pc.looks_like_path("origin/main"))
+        self.assertFalse(pc.looks_like_path("refs/heads/main"))
+
+    def test_accepts_known_root_component_without_extension(self) -> None:
+        # A leading known-root directory is a positive signal even with no
+        # recognized extension on the final component.
+        self.assertTrue(pc.looks_like_path("src/parse"))
+        self.assertTrue(pc.looks_like_path("noorinalabs-deploy/terraform/main"))
+
+    def test_accepts_true_positive_paths_main_1047(self) -> None:
+        # Every one of these genuinely resolved OK in the wave-26 run — the
+        # fix must not regress real paths into false negatives.
+        for tok in (
+            "src/resolve/ner.py",
+            "src/utils/arabic.py",
+            "docs/testing-on-subsets.md",
+            "data/curated/narrators_canonical.parquet",
+        ):
+            self.assertTrue(pc.looks_like_path(tok), tok)
+
+    def test_mutation_guard_slash_alone_would_readmit_prose(self) -> None:
+        """Pin the exact defect shape so a regression of the `"/" in tok`
+        short-circuit (main#1047's root cause) is caught even if someone
+        "simplifies" the extension/root-component branches back together.
+        """
+        prose_with_slash = "recall/precision"
+        self.assertFalse(pc.looks_like_path(prose_with_slash))
+        # The old (buggy) rule as a local re-implementation, for contrast only
+        # — NOT calling into pc, just documenting what must NOT be true.
+        old_buggy_rule = "/" in prose_with_slash
+        self.assertTrue(old_buggy_rule)  # sanity: the token does contain "/"
+        self.assertNotEqual(pc.looks_like_path(prose_with_slash), old_buggy_rule)
+
 
 class NormalizePathTest(unittest.TestCase):
     def test_strips_backticks_and_trailing_punct(self) -> None:
@@ -94,6 +163,86 @@ class ExtractPathCandidatesTest(unittest.TestCase):
 
     def test_empty(self) -> None:
         self.assertEqual(pc.extract_path_candidates(""), [])
+
+    def test_wave_26_regression_fixture_no_false_positives(self) -> None:
+        """main#1047: pin all 12 wave-26 scope-run issue bodies as a fixture.
+
+        Every body below produced a false STOP under the old `"/" in tok`
+        rule. None of them should extract as path candidates now; the four
+        genuine paths embedded alongside the prose must still extract.
+        """
+        bodies = [
+            "Needs bidirectional A/B fixtures to compare recall/precision.",
+            "Handle Latin/English transliteration mismatches in `src/resolve/ner.py`.",
+            "The benediction/Prophet-title (taṣliya/eulogy) detector over-fires.",
+            "Distinguish ism/kunya name-parts per `src/utils/arabic.py`.",
+            "Tune token-count/matn-density thresholds; see `docs/testing-on-subsets.md`.",
+            "Row counts read 650,986/650,986 after the backfill.",
+            "Diff against origin/main before merging.",
+            "display/graph parity check for the new collectors/commentators view.",
+            "Identity/matching regression on the boundary/particle splitter.",
+            "resolve/load ordering bug affects name/nisba resolution.",
+            "Validate/scrub step needs a transliteration/cross-script pass.",
+            "Code/git housekeeping only; touches `data/curated/narrators_canonical.parquet`.",
+        ]
+        real_paths = {
+            "src/resolve/ner.py",
+            "src/utils/arabic.py",
+            "docs/testing-on-subsets.md",
+            "data/curated/narrators_canonical.parquet",
+        }
+        false_positive_tokens = {
+            "A/B",
+            "recall/precision",
+            "Latin/English",
+            "benediction/Prophet-title",
+            "taṣliya/eulogy",
+            "ism/kunya",
+            "token-count/matn-density",
+            "986/650",
+            "650,986/650,986",
+            "origin/main",
+            "display/graph",
+            "collectors/commentators",
+            "Identity/matching",
+            "boundary/particle",
+            "resolve/load",
+            "name/nisba",
+            "Validate/scrub",
+            "transliteration/cross-script",
+            "Code/git",
+        }
+        seen_real_paths: set[str] = set()
+        for body in bodies:
+            got = set(pc.extract_path_candidates(body))
+            leaked = got & false_positive_tokens
+            self.assertEqual(leaked, set(), f"false positive(s) in body: {body!r} -> {leaked}")
+            seen_real_paths |= got & real_paths
+        self.assertEqual(seen_real_paths, real_paths)
+
+    def test_mutation_verify_old_rule_would_fail_this_fixture(self) -> None:
+        """Restoring the old `"/" in tok` short-circuit must fail the wave-26
+        fixture above — proves the regression test actually exercises the fix
+        (main#1047 mutation-verification requirement).
+        """
+
+        def _old_looks_like_path(token: str) -> bool:
+            tok = token.strip()
+            if not tok or " " in tok or "\t" in tok:
+                return False
+            if "://" in tok:
+                return False
+            if not __import__("re").fullmatch(r"[\w./\-]+", tok):
+                return False
+            if tok.lstrip("#").isdigit():
+                return False
+            if "/" in tok:
+                return True
+            ext = tok.rsplit(".", 1)[-1].lower() if "." in tok else ""
+            return ext in pc._CODE_EXTENSIONS
+
+        self.assertTrue(_old_looks_like_path("recall/precision"))
+        self.assertFalse(pc.looks_like_path("recall/precision"))
 
 
 # --- verdict layer with injected (fake) checkers ----------------------------
@@ -166,6 +315,36 @@ class CheckIssueVerdictTest(unittest.TestCase):
         }
         res = self._check(issue, {"a.py": pc.EXISTS, "b/c.py": pc.EXISTS})
         self.assertEqual({c.value for c in res.candidates}, {"a.py", "b/c.py"})
+
+    def test_cross_repo_resolution_is_warn_not_stop(self) -> None:
+        """main#1047 da#427: a `.claude/`-rooted path that MISSES in the child
+        repo but EXISTS in the parent downgrades to CROSS_REPO -> WARN.
+        """
+        target = ".claude/memory/feedback_drop_gate_bidirectional_ab.md"
+        issue = {
+            "ref": "da#427",
+            "repo": "noorinalabs-data-acquisition",
+            "body": f"see `{target}`",
+        }
+
+        def _path(repo_dir: str, _ref: str, value: str) -> str:
+            # MISSING in the child repo dir, EXISTS at the parent (repos_root).
+            return pc.EXISTS if repo_dir == "/repos" else pc.MISSING
+
+        res = pc.check_issue(issue, Path("/repos"), "origin/main", _path, _checker({})[1])
+        self.assertEqual(res.verdict, pc.WARN)
+        self.assertEqual(res.candidates[0].status, pc.CROSS_REPO)
+        self.assertIsNotNone(res.candidates[0].note)
+
+    def test_non_claude_missing_in_child_repo_is_still_stop(self) -> None:
+        # Only `.claude/`-rooted paths get the cross-repo second chance.
+        issue = {
+            "ref": "da#1",
+            "repo": "noorinalabs-data-acquisition",
+            "body": "see `src/parse/composition.py`",
+        }
+        res = self._check(issue, {"src/parse/composition.py": pc.MISSING})
+        self.assertEqual(res.verdict, pc.STOP)
 
 
 class ResolveRepoDirTest(unittest.TestCase):
@@ -266,6 +445,42 @@ class GitIntegrationTest(unittest.TestCase):
             self.assertEqual(statuses[("path", "doomed.py")], pc.MISSING)
             self.assertEqual(statuses[("symbol", "kept_symbol")], pc.EXISTS)
             self.assertEqual(statuses[("symbol", "vanished_symbol")], pc.MISSING)
+            self.assertEqual(res.verdict, pc.STOP)
+
+    def test_basename_fallback_resolves_nested_file(self) -> None:
+        """main#1047 da#373: a bare filename named `composition.py` that lives
+        at `src/parse/composition.py` must resolve OK, not MISSING.
+        """
+        with TemporaryDirectory() as d:
+            root = Path(d)
+            self._git(root, "init", "-q")
+            self._git(root, "config", "user.email", "t@t")
+            self._git(root, "config", "user.name", "t")
+            nested = root / "src" / "parse"
+            nested.mkdir(parents=True)
+            (nested / "composition.py").write_text("x = 1\n")
+            self._git(root, "add", "-A")
+            self._git(root, "commit", "-q", "-m", "base")
+
+            issue = {
+                "ref": "da#373",
+                "repo": "noorinalabs-main",
+                "body": "fix a bug in `composition.py`",
+            }
+            res = pc.check_issue(issue, root, "HEAD")
+            statuses = {c.value: c.status for c in res.candidates}
+            self.assertEqual(statuses["composition.py"], pc.EXISTS)
+            self.assertEqual(res.verdict, pc.OK)
+
+    def test_basename_fallback_does_not_resurrect_a_real_deletion(self) -> None:
+        # A genuinely deleted slash-free file must still STOP — the basename
+        # fallback only helps when the name resolves SOMEWHERE in the tree.
+        with TemporaryDirectory() as d:
+            root = Path(d)
+            self._make_repo(root)
+            issue = {"ref": "main#705", "repo": "noorinalabs-main", "body": "`doomed.py`"}
+            res = pc.check_issue(issue, root, "HEAD")
+            self.assertEqual(res.candidates[0].status, pc.MISSING)
             self.assertEqual(res.verdict, pc.STOP)
 
     def test_unknown_ref_is_unverifiable(self) -> None:

--- a/.claude/skills/wave-scope/SKILL.md
+++ b/.claude/skills/wave-scope/SKILL.md
@@ -265,13 +265,23 @@ gate closes that — it is the scope-time twin of [[feedback_spawn_brief_protoco
 (spawn-time) and [[feedback_verify_diagnosis_before_delegating]].
 
 The deterministic check is `.claude/lib/premise_check.py`. It auto-extracts
-path-like tokens from each in-scope issue's body (backtick spans + a strict path
-regex, so prose never produces a false STOP), then runs `git cat-file -e
-<ref>:<path>` per path (and `git grep` per explicitly-declared symbol) against
-the repo's origin HEAD. Verdicts: a path/symbol the ref can read but does not
-contain → **STOP** (premise rot); a repo/ref that cannot be read at all (child
-not cloned, origin not fetched) → **WARN** (an environment gap, deliberately not
-a STOP); everything present → **OK**.
+path-like tokens from each in-scope issue's body (backtick spans + a path-token
+regex), then classifies each token with `looks_like_path` — accepted only when
+it ends in a known code/doc extension, OR contains a `/` **and** its leading
+component is a known repo-root directory (`src/`, `.claude/`, a child-repo
+name, …). A bare `/` is NOT itself evidence of a path (main#1047 — a slash
+alone previously flagged prose like `A/B`, `recall/precision`, and the git ref
+`origin/main` as paths, a 12/12 false-STOP on the wave-26 scope run); git refs
+and all-numeric fractions (`986/650`) are explicitly excluded. It then runs
+`git cat-file -e <ref>:<path>` per path (and `git grep` per
+explicitly-declared symbol) against the repo's origin HEAD — with a basename
+fallback for a slash-free filename that misses at repo root but resolves
+uniquely elsewhere in the tree. Verdicts: a path/symbol the ref can read but
+does not contain → **STOP** (premise rot); a repo/ref that cannot be read at
+all (child not cloned, origin not fetched), or a `.claude/`-rooted path that
+misses in a child repo but resolves in the parent `noorinalabs-main` → **WARN**
+(an environment gap or a likely cross-repo reference, deliberately not a
+STOP); everything present → **OK**.
 
 Run it over the actual labeled scope (Step 4 output). Fetch each in-scope repo's
 `origin` first so the check resolves against real HEADs (an unfetched repo only


### PR DESCRIPTION
## Summary

`premise_check.py`'s `looks_like_path` accepted any backtick token containing `/` unconditionally — this produced a **12/12 false-STOP** on the wave-26 `/wave-scope` run (`A/B`, `recall/precision`, `origin/main`, `986/650`, etc. all contain a slash but are not paths).

## Fix

- `looks_like_path` now requires a positive signal: a known code/doc extension, OR a slash **plus** a known repo-root leading component (`src/`, `.claude/`, a child-repo name, ...). A bare slash is no longer sufficient.
- Explicitly rejects a bare `/`, all-numeric fractions (`986/650`), and git refs (`origin/*`, `refs/*`, `HEAD`).
- **Basename fallback** (da#373): a slash-free filename that misses at its literal path but resolves uniquely elsewhere in the tree (via `git ls-tree`) is now `EXISTS`, not `MISSING`.
- **Cross-repo resolution** (da#427): a `.claude/`-rooted path that misses in a child repo but resolves in the parent `noorinalabs-main` downgrades to a new `CROSS_REPO` status → `WARN`, not `STOP`.
- Corrected `/wave-scope` SKILL.md § 6.5's inaccurate "prose never produces a false STOP" description of the mechanism.

## Tests

- Pins all 12 wave-26 false-positive issue bodies as a regression fixture (`test_wave_26_regression_fixture_no_false_positives`), asserting `OK` across the board while the 4 genuine paths in that run still extract.
- Mutation-verification test (`test_mutation_verify_old_rule_would_fail_this_fixture`) proves the old `"/" in tok` rule fails the fixture.
- New coverage for the basename fallback and cross-repo downgrade, both with real-git integration tests.
- Full `.claude/lib/tests/` suite passes (791 tests); `pre-commit run --all-files` + push-stage (mypy, pytest) all green.

Closes #1047

**Reviewers:** Aino Virtanen (merge-gate) + Nurul Hakim