### PR TITLE
fix(#1050): make content_ts required on the shared gate helpers

### DIFF
--- a/.claude/hooks/tests/test_validate_pr_review.py
+++ b/.claude/hooks/tests/test_validate_pr_review.py
@@ -118,6 +118,10 @@ class _CheckCommentReviewsHarness(unittest.TestCase):
                 _CheckCommentReviewsHarness.PR_NUMBER,
                 branch_author,
                 repo=repo,
+                # content_ts is a REQUIRED keyword-only arg (#1050); None is the
+                # explicit "no content binding" value these ~30 pre-#950 callers
+                # exercise (every verdict counted unconditionally).
+                content_ts=None,
             )
 
     @staticmethod
@@ -485,6 +489,55 @@ class LatestVerdictSupersedesTests(_CheckCommentReviewsHarness):
         )
         self.assertIn("nino kavtaradze", result.reviewers)
         self.assertEqual(len(result.stale_verdicts), 1)
+
+
+class ContentTsRequiredTests(unittest.TestCase):
+    """Issue #1050: `content_ts` must be a REQUIRED argument on both shared
+    gate helpers, not a defaulted one.
+
+    #1046 happened because a defaulted `content_ts` let a caller omit it and
+    silently get staleness-filtering OFF rather than an error. This class
+    proves the fix at the signature level: calling either function WITHOUT
+    `content_ts` must now raise `TypeError` at call time — the omission
+    becomes loud instead of a silent fail-open. These tests would RED against
+    the pre-#1050 signatures (which default `content_ts` to `None`).
+    """
+
+    def test_check_comment_reviews_without_content_ts_raises_type_error(self):
+        with self.assertRaises(TypeError):
+            hook.check_comment_reviews(451, "pham", repo="noorinalabs/x")  # missing content_ts
+
+    def test_partition_formal_reviewers_without_content_ts_raises_type_error(self):
+        with self.assertRaises(TypeError):
+            hook.partition_formal_reviewers([], "someone")  # missing content_ts
+
+    def test_check_comment_reviews_still_accepts_explicit_none(self):
+        """`content_ts=None` remains a legitimate VALUE — only omission is barred."""
+        with mock.patch.object(
+            hook.subprocess,
+            "run",
+            side_effect=lambda args, capture_output, text, timeout: mock.MagicMock(
+                returncode=0, stdout="[]"
+            ),
+        ):
+            result = hook.check_comment_reviews(451, "pham", repo="noorinalabs/x", content_ts=None)
+        self.assertEqual(result.undetermined, "")
+
+    def test_partition_formal_reviewers_still_accepts_explicit_none(self):
+        formal, stale = hook.partition_formal_reviewers(
+            [{"author": {"login": "reviewer-a"}, "state": "APPROVED"}],
+            "author-login",
+            None,
+        )
+        self.assertEqual(formal, {"reviewer-a"})
+        self.assertEqual(stale, [])
+
+    def test_check_comment_reviews_repo_is_keyword_only(self):
+        """`repo` moved keyword-only alongside `content_ts` (#1050) — a
+        positional third argument must now raise TypeError rather than
+        silently binding to `repo`."""
+        with self.assertRaises(TypeError):
+            hook.check_comment_reviews(451, "pham", "noorinalabs/x")  # repo positional
 
 
 class ExtractBranchAuthorLastnameTests(unittest.TestCase):
@@ -1014,7 +1067,9 @@ class CommentPaginationTests(_CheckCommentReviewsHarness):
             return result
 
         with mock.patch.object(hook.subprocess, "run", side_effect=fake_run):
-            hook.check_comment_reviews(self.PR_NUMBER, self.BRANCH_AUTHOR, repo=self.REPO)
+            hook.check_comment_reviews(
+                self.PR_NUMBER, self.BRANCH_AUTHOR, repo=self.REPO, content_ts=None
+            )
 
         gh_api_calls = [a for a in captured_args if a[0] == "gh" and a[1] == "api"]
         self.assertEqual(len(gh_api_calls), 1, "exactly one gh api call expected")
@@ -3109,7 +3164,7 @@ class IncompleteCommentScanFailsClosedTests(_NoContentBindingHarness):
     def test_clean_scan_leaves_undetermined_empty(self):
         """The negative match — a successful empty scan must NOT be flagged."""
         with mock.patch.object(hook.subprocess, "run", side_effect=self._fake_run()):
-            result = hook.check_comment_reviews(451, "pham", repo="noorinalabs/x")
+            result = hook.check_comment_reviews(451, "pham", repo="noorinalabs/x", content_ts=None)
         self.assertEqual(result.undetermined, "")
         self.assertEqual(result.reviewers, set())
 
@@ -3119,7 +3174,7 @@ class IncompleteCommentScanFailsClosedTests(_NoContentBindingHarness):
             "run",
             side_effect=self._fake_run(returncode=1, stdout="", stderr="HTTP 403: Forbidden"),
         ):
-            result = hook.check_comment_reviews(451, "pham", repo="noorinalabs/x")
+            result = hook.check_comment_reviews(451, "pham", repo="noorinalabs/x", content_ts=None)
         self.assertTrue(result.undetermined)
         self.assertIn("403", result.undetermined)
 
@@ -3127,19 +3182,19 @@ class IncompleteCommentScanFailsClosedTests(_NoContentBindingHarness):
         with mock.patch.object(
             hook.subprocess, "run", side_effect=hook.subprocess.TimeoutExpired("gh", 30)
         ):
-            result = hook.check_comment_reviews(451, "pham", repo="noorinalabs/x")
+            result = hook.check_comment_reviews(451, "pham", repo="noorinalabs/x", content_ts=None)
         self.assertIn("TimeoutExpired", result.undetermined)
 
     def test_unparseable_json_sets_undetermined(self):
         with mock.patch.object(
             hook.subprocess, "run", side_effect=self._fake_run(stdout="not json")
         ):
-            result = hook.check_comment_reviews(451, "pham", repo="noorinalabs/x")
+            result = hook.check_comment_reviews(451, "pham", repo="noorinalabs/x", content_ts=None)
         self.assertIn("JSONDecodeError", result.undetermined)
 
     def test_unresolvable_owner_repo_sets_undetermined(self):
         with mock.patch.object(hook, "_resolve_owner_repo", return_value=None):
-            result = hook.check_comment_reviews(451, "pham", repo=None)
+            result = hook.check_comment_reviews(451, "pham", repo=None, content_ts=None)
         self.assertIn("could not resolve the target repository", result.undetermined)
 
     def test_check_hard_blocks_on_an_incomplete_scan(self):

--- a/.claude/hooks/validate_pr_review.py
+++ b/.claude/hooks/validate_pr_review.py
@@ -890,8 +890,9 @@ def _name_lastname(full_name: str) -> str:
 def check_comment_reviews(
     pr_number: str | int,
     branch_author_lastname: str,
+    *,
     repo: str | None = None,
-    content_ts: datetime | None = None,
+    content_ts: datetime | None,
 ) -> CommentReviewResult:
     """Check PR comments for charter-format review comments from different authors.
 
@@ -920,10 +921,15 @@ def check_comment_reviews(
     secondary attestation either. A verdict whose own `created_at` is missing or
     unparseable is treated as STALE, not fresh (fail closed).
 
-    `content_ts=None` means "no content binding" — either the PR has no non-merge
-    commits, or the caller is a legacy/unit call — and every verdict is counted
-    as before. `check()` never passes None on a real merge: a commit-fetch
-    failure raises `CommitFetchError` and hard-blocks upstream of this call.
+    `content_ts` is a REQUIRED keyword-only argument (#1050) — it must be
+    passed explicitly on every call, though `None` remains a legitimate
+    VALUE meaning "no content binding" (either the PR has no non-merge
+    commits, or a caller intentionally wants every verdict counted
+    unconditionally). Making it required converts an omitted argument from a
+    silent fail-open (the #1046 shape: staleness-filtering silently OFF) into
+    a loud `TypeError` at call time. `check()` never passes `None` on a real
+    merge: a commit-fetch failure raises `CommitFetchError` and hard-blocks
+    upstream of this call.
     """
     result = CommentReviewResult()
     # Reviewer -> most recent (chronologically-last) CURRENT RequestOrReplied
@@ -1046,7 +1052,7 @@ def check_comment_reviews(
 def partition_formal_reviewers(
     reviews: list[dict],
     author: str,
-    content_ts: datetime | None = None,
+    content_ts: datetime | None,
 ) -> tuple[set[str], list[StaleVerdict]]:
     """Split formal GitHub reviews into CURRENT reviewers and STALE verdicts (#950).
 
@@ -1062,8 +1068,12 @@ def partition_formal_reviewers(
     dropped entirely — they are not evidence and not staleness.
 
     `submittedAt` missing or unparseable while `content_ts` is known ⇒ STALE,
-    not fresh (fail closed). `content_ts=None` means "no content binding" and
-    every non-author review counts, as before the content binding existed.
+    not fresh (fail closed). `content_ts` is a REQUIRED positional argument
+    (#1050) — every caller must pass it explicitly, though `None` remains a
+    legitimate VALUE meaning "no content binding" (every non-author review
+    counts, as before the content binding existed). Requiring it converts an
+    omitted argument from a silent fail-open (the #1046 shape) into a loud
+    `TypeError` at call time.
 
     This function is the SHARED implementation for `check()` (Hook 4) and
     `.claude/lib/pr_review_state.py` (the #707 ahead-of-time driver). Both must

--- a/.claude/lib/pr_review_state.py
+++ b/.claude/lib/pr_review_state.py
@@ -37,6 +37,13 @@ not two that can silently drift apart.
 `.claude/lib/tests/test_pr_review_state.py::ContentStalenessTests` is the
 regression guard and is mutation-verified against exactly that omission.
 
+#1050 closes the residual hazard #1046 left: `content_ts` on
+`check_comment_reviews` and `partition_formal_reviewers` is now a REQUIRED
+argument (`datetime | None`, so `None` is still a legitimate VALUE meaning
+"no content binding" — only OMITTING the argument is barred). A future third
+caller that forgets `content_ts` now gets a loud `TypeError` at call time
+instead of the #1046 shape shipping silently again.
+
 Usage:
     python3 .claude/lib/pr_review_state.py <pr_number> --repo <owner/repo>
     python3 .claude/lib/pr_review_state.py <pr_number> --repo <owner/repo> --json


### PR DESCRIPTION
## Summary

Closes #1050.

Follow-up from the merge-gate review of #1049 (fixed #1046). #1046 happened
because `check_comment_reviews(..., content_ts: datetime | None = None)`
let a caller omit the keyword and silently get staleness-filtering OFF
rather than an error — `pr_review_state.py` omitted it and reported PASS on
verdicts Hook 4 would reject. #1049 fixed the two production call sites but
left the defaulted parameter itself in place, so a future third caller could
reintroduce the exact same fail-open with no warning.

## Fix

Make `content_ts` a **required** argument on both `check_comment_reviews`
(keyword-only, alongside `repo`) and `partition_formal_reviewers`
(positional), keeping the `datetime | None` type. `content_ts=None` remains
a legitimate *value* (`get_latest_content_commit` returns `None` when a PR
has no non-merge commits — "no content binding exists"), but **omitting**
the argument now raises `TypeError` at call time instead of silently
disabling staleness filtering.

Both production callers already pass it explicitly:
- `validate_pr_review.py`'s `check()` (`partition_formal_reviewers`, and
  both `check_comment_reviews` call sites)
- `pr_review_state.py`'s `compute_review_state` (same three call sites)

So this is behavior-preserving for every real merge. Only test call sites
needed an explicit `content_ts=None` — 9 call sites across
`test_validate_pr_review.py` (the shared `_run_with_fake_api` harness used
by ~30 tests, plus 6 standalone calls in the pagination and #981
incomplete-scan test classes).

## Tests

Added `ContentTsRequiredTests`:
- `test_check_comment_reviews_without_content_ts_raises_type_error` /
  `test_partition_formal_reviewers_without_content_ts_raises_type_error` —
  guard the requiredness itself; RED against the pre-fix defaulted
  signatures.
- `test_check_comment_reviews_still_accepts_explicit_none` /
  `test_partition_formal_reviewers_still_accepts_explicit_none` — `None`
  stays a valid value, only omission is barred.
- `test_check_comment_reviews_repo_is_keyword_only` — `repo` moved
  keyword-only alongside `content_ts` (required for Python's
  no-default-after-default ordering); a positional third argument must now
  TypeError.

Full local gate green: `pre-commit run --all-files` (commit stage) +
`pre-commit run --hook-stage pre-push --all-files` (mypy + full pytest
suite, 2726 passed) — both clean.

## Reviewers

- **Nadia Khoury** (merge-gate)
- **Nurul Hakim**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018KeNK3VBB3zFyJWxUGWM7z
