### PR TITLE
fix(#1060): harden walk_flag_values to match real gh/cobra flag semantics

### DIFF
--- a/.claude/hooks/_repo_flag_parse.py
+++ b/.claude/hooks/_repo_flag_parse.py
@@ -82,10 +82,18 @@ _REPO_FALLBACK_RE = re.compile(r"(?:^|\s)(?:(?:--repo|-R)(?:=|\s+)|-R)(\S+)")
 
 
 def extract_repo(command: str) -> str | None:
-    """Extract the `--repo` / `-R` `OWNER/NAME` value, or None if absent."""
+    """Extract the `--repo` / `-R` `OWNER/NAME` value, or None if absent.
+
+    Last-occurrence wins (main#1060): real `gh`'s `--repo`/`-R` is a
+    single-value pflag `StringVarP`, so a REPEATED flag resolves to its
+    LAST occurrence, not its first — `gh issue edit 1 -R a/b -R c/d` acts on
+    `c/d`. `walk_flag_values` itself stays first-to-last source order (it
+    has other callers that legitimately accumulate a repeatable flag, e.g.
+    `--add-label`); this is the caller-side choice for a single-value flag.
+    """
     tokens = tokenize(command)
     if tokens is None:
-        match = _REPO_FALLBACK_RE.search(command)
-        return match.group(1) if match else None
+        matches = list(_REPO_FALLBACK_RE.finditer(command))
+        return matches[-1].group(1) if matches else None
     values = walk_flag_values(tokens, _REPO_FLAGS)
-    return values[0] if values else None
+    return values[-1] if values else None

--- a/.claude/hooks/_shell_parse.py
+++ b/.claude/hooks/_shell_parse.py
@@ -92,6 +92,24 @@ Public API
         arrive as a SINGLE shlex token, never preceded by a flag from
         `wanted`.
 
+        gh/cobra semantics hardening (main#1060):
+          - A value-less flag immediately followed by a flag-shaped token
+            (starts with `-`) does NOT consume that token as its value —
+            real gh/cobra errors ("flag needs an argument") rather than
+            silently swallowing the next flag. The flag-shaped token is
+            left for the scan to process in its own right.
+          - A literal `--` token (POSIX end-of-options) stops the scan
+            entirely — everything after it is positional, never a flag,
+            matching real `gh`/cobra behavior.
+          - Repeated occurrences of the same flag are returned in source
+            order (first-to-last); this helper does NOT pick a winner.
+            Callers that need real gh's last-flag-wins semantics for a
+            single-value `StringVarP` flag (e.g. `--repo`/`-R`) must take
+            `values[-1]`; callers accumulating a repeatable flag (e.g.
+            `--add-label`) iterate all of `values` — see
+            `_repo_flag_parse.extract_repo` for the former and
+            `validate_labels.extract_labels` for the latter.
+
     first_flag_value(command, wanted, *, regex_fallback=True) -> str | None
         Convenience wrapper: tokenizes `command` via `tokenize()` and
         returns the first value from `walk_flag_values()`. If tokenize
@@ -538,6 +556,17 @@ def is_gh_subcommand(tokens: list[str], *verbs: str) -> bool:
     return False
 
 
+def _looks_like_flag(tok: str) -> bool:
+    """Return True if `tok` has the surface shape of a flag (`-x` / `--xxx`).
+
+    A bare `-` (the conventional "read from stdin" positional sentinel used
+    by many CLIs, including some `gh`/`git` subcommands) is deliberately
+    NOT treated as a flag — only genuine `-`-prefixed multi-character
+    tokens are (main#1060).
+    """
+    return len(tok) > 1 and tok[0] == "-"
+
+
 def walk_flag_values(tokens: list[str], wanted: set[str]) -> list[str]:
     """Return values for `wanted` flag names, only when they appear as flags.
 
@@ -563,15 +592,37 @@ def walk_flag_values(tokens: list[str], wanted: set[str]) -> list[str]:
 
     Order is preserved: values appear in the order they were encountered
     in the token stream.
+
+    gh/cobra semantics hardening (main#1060):
+
+      - **Value-less flag never eats the next flag.** `-R --add-label X`
+        would have real `gh` error ("flag needs an argument: 'R'"); this
+        helper can't raise, but it must not silently treat `--add-label` as
+        `-R`'s value either (that previously made `repo_short_name_from_...`
+        route on a bogus `repo='--add-label'`, main#1059's motivating case).
+        A token immediately after a `wanted` flag is only consumed as its
+        value when it does NOT itself look like a flag (`-`-prefixed,
+        length > 1 — a bare `-` is the common stdin/positional sentinel,
+        never a flag). When the next token looks like a flag, the current
+        flag yields no value (same as the trailing-flag-with-no-successor
+        case) and the flag-shaped token is left for the next loop
+        iteration to scan on its own.
+      - **`--` (POSIX end-of-options) stops the scan.** Everything after a
+        literal `--` token is positional in real `gh`/cobra, never a flag —
+        continuing to scan past it let `-- --repo X` resolve `--repo` as if
+        it were still in flag position.
     """
     values: list[str] = []
     i = 0
     n = len(tokens)
     while i < n:
         tok = tokens[i]
+        if tok == "--":
+            break
         if tok in wanted:
-            if i + 1 < n:
-                values.append(tokens[i + 1])
+            nxt = tokens[i + 1] if i + 1 < n else None
+            if nxt is not None and not _looks_like_flag(nxt):
+                values.append(nxt)
                 i += 2
                 continue
             i += 1
@@ -607,7 +658,7 @@ def walk_flag_values(tokens: list[str], wanted: set[str]) -> list[str]:
 
 
 def first_flag_value(command: str, wanted: set[str], *, regex_fallback: bool = True) -> str | None:
-    """Tokenize `command` and return the first value for any flag in `wanted`.
+    """Tokenize `command` and return the FIRST value for any flag in `wanted`.
 
     Returns None if no wanted flag is present. If shlex tokenization fails
     (malformed quotes) and `regex_fallback=True` (default), falls back to a
@@ -615,6 +666,18 @@ def first_flag_value(command: str, wanted: set[str], *, regex_fallback: bool = T
     `--repo` is preferred over a hypothetical shorter prefix collision.
     With `regex_fallback=False`, returns None on tokenize failure (the
     fail-closed shape used by security-critical matchers).
+
+    First-wins is this function's deliberate, pinned contract (see
+    `test_returns_first_value`) — its only current callers
+    (`validate_branch_freshness.extract_base`/`extract_head`) are an
+    advisory freshness gate, not a fail-closed/fail-open routing decision,
+    so a repeated `--base`/`--head` picking the first occurrence is not the
+    main#1060 hazard class. main#1060 instead scoped the last-flag-wins fix
+    to the DIRECT `walk_flag_values` callers that resolve `--repo`/`-R` for
+    authoritative routing (`_repo_flag_parse.extract_repo`,
+    `_wave_label_parse._parse_edit_segment`,
+    `block_squash_wave_merge._iter_squash_merges`) — this function was left
+    alone rather than repurposed for a use case it doesn't have today.
     """
     tokens = tokenize(command)
     if tokens is None:

--- a/.claude/hooks/_wave_label_parse.py
+++ b/.claude/hooks/_wave_label_parse.py
@@ -318,10 +318,14 @@ def _parse_edit_segment(rest: list[str]) -> WaveLabelChange | None:
     # `--repo` long form and the `-R` short form (all attached/equals/spaced
     # surfaces, #1057). A present-but-unresolvable value (`$VAR`) yields repo=None
     # with repo_flag_present=True so the consumer fails closed (#981).
+    #
+    # Last occurrence wins (main#1060): `--repo`/`-R` is a single-value pflag
+    # `StringVarP` in real gh, so a repeated flag resolves to its LAST value,
+    # not its first.
     repo_values = walk_flag_values(rest, {"--repo", "-R"})
     repo_flag_present = len(repo_values) > 0
     repo: str | None = (
-        repo_short_name_from_flag_value(repo_values[0]) if repo_flag_present else None
+        repo_short_name_from_flag_value(repo_values[-1]) if repo_flag_present else None
     )
 
     issue_number: str | None = None

--- a/.claude/hooks/block_squash_wave_merge.py
+++ b/.claude/hooks/block_squash_wave_merge.py
@@ -83,8 +83,11 @@ def _iter_squash_merges(command):
         pr = next((t for t in rest[2:] if t.isdigit()), None)
         if pr is None:
             continue
+        # Last occurrence wins (main#1060): real gh's `--repo`/`-R` is a
+        # single-value pflag `StringVarP`, so a repeated flag resolves to
+        # its LAST value, not its first.
         repo_vals = walk_flag_values(rest, {"--repo", "-R"})
-        yield pr, (repo_vals[0] if repo_vals else None)
+        yield pr, (repo_vals[-1] if repo_vals else None)
 
 
 def _resolve_base_ref(pr, repo, *, runner=None):

--- a/.claude/hooks/tests/test__wave_label_parse.py
+++ b/.claude/hooks/tests/test__wave_label_parse.py
@@ -282,6 +282,35 @@ class RepoFlagResolution(unittest.TestCase):
         self.assertIsNone(c.repo)
         self.assertTrue(c.repo_flag_present)
 
+    def test_repeated_repo_flag_last_wins(self) -> None:
+        """main#1060 finding #3: gh's `--repo`/`-R` is a single-value pflag,
+        so a repeated flag resolves to its LAST occurrence."""
+        c = self._change(
+            'gh issue edit 42 -R noorinalabs/repo-a --repo noorinalabs/repo-b --add-label "wave-26"'
+        )
+        self.assertEqual(c.repo, "repo-b")
+        self.assertTrue(c.repo_flag_present)
+
+    def test_value_less_short_flag_does_not_misroute_to_add_label(self) -> None:
+        """main#1060 finding #1 — the #1059 motivating reproducer: a
+        value-less `-R` immediately followed by `--add-label` must not
+        resolve `repo='--add-label'`. Real gh would error here; this parser
+        must yield `repo=None, repo_flag_present=False` (no capturable
+        value), not misroute onto the neighboring flag's own text."""
+        c = self._change('gh issue edit 42 -R --add-label "wave-26"')
+        self.assertIsNone(c.repo)
+        self.assertFalse(c.repo_flag_present)
+        # The neighboring flag is still parsed correctly as its own flag,
+        # not swallowed as `-R`'s bogus value.
+        self.assertEqual(c.add_label, "wave-26")
+
+    def test_repo_after_double_dash_terminator_not_resolved(self) -> None:
+        """main#1060 finding #2: `--repo` appearing after a literal `--`
+        (POSIX end-of-options) is positional in real gh, never a flag."""
+        c = self._change('gh issue edit 42 --add-label "wave-26" -- --repo noorinalabs/repo-c')
+        self.assertIsNone(c.repo)
+        self.assertFalse(c.repo_flag_present)
+
 
 class NormalizeCommandSeparators(unittest.TestCase):
     """Direct tests for the shared `_shell_parse.normalize_command_separators`.

--- a/.claude/hooks/tests/test_block_squash_wave_merge.py
+++ b/.claude/hooks/tests/test_block_squash_wave_merge.py
@@ -96,6 +96,24 @@ class BlocksSquashIntoWaveBranch(unittest.TestCase):
         self.assertEqual(result["decision"], "block")
 
 
+class RepeatedRepoFlagLastWins(unittest.TestCase):
+    """main#1060 finding #3: real gh's `--repo`/`-R` is a single-value pflag,
+    so a repeated flag resolves to its LAST occurrence — the resolved repo
+    fed to `_resolve_base_ref` (and echoed in the block reason) must be the
+    last one, not the first."""
+
+    def test_repeated_repo_flag_echoes_last_value(self):
+        result = hook.check(
+            _input("gh pr merge 218 --squash --repo noorinalabs/repo-a --repo noorinalabs/repo-b"),
+            base_runner=_runner({"218": WAVE}),
+        )
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+        self.assertIn("--repo noorinalabs/repo-b", result["reason"])
+        self.assertNotIn("repo-a", result["reason"])
+
+
 class AllowsLegitimateMerges(unittest.TestCase):
     def test_squash_into_main_allows(self):
         # The standard GitHub-flow squash for feature work targets main — untouched.

--- a/.claude/hooks/tests/test_repo_flag_parse.py
+++ b/.claude/hooks/tests/test_repo_flag_parse.py
@@ -141,6 +141,49 @@ class AbsentAndMalformedTests(unittest.TestCase):
         self.assertIsNone(parser.extract_repo(cmd))
 
 
+class RepeatedRepoFlagTests(unittest.TestCase):
+    """main#1060 finding #3: real gh's `--repo`/`-R` is a single-value pflag
+    `StringVarP`, so a repeated flag resolves to its LAST occurrence — not
+    its first, which `walk_flag_values` alone would return (it preserves
+    encounter order without picking a winner)."""
+
+    def test_repeated_long_form_last_wins(self):
+        cmd = "gh issue edit 42 --repo owner/a --repo owner/b"
+        self.assertEqual(parser.extract_repo(cmd), "owner/b")
+
+    def test_repeated_short_form_last_wins(self):
+        cmd = "gh issue edit 42 -R owner/a -R owner/b"
+        self.assertEqual(parser.extract_repo(cmd), "owner/b")
+
+    def test_mixed_short_then_long_last_wins(self):
+        cmd = "gh issue edit 42 -R owner/a --repo owner/b"
+        self.assertEqual(parser.extract_repo(cmd), "owner/b")
+
+    def test_regex_fallback_repeated_flag_last_wins(self):
+        """Last-wins holds on the regex-fallback path too (malformed shell
+        forces tokenize() to fail), so both paths stay in parity."""
+        cmd = "echo 'unterminated && gh issue edit 42 --repo owner/a --repo owner/b --body x"
+        self.assertEqual(parser.extract_repo(cmd), "owner/b")
+
+
+class DoubleDashTerminatorTests(unittest.TestCase):
+    """main#1060 finding #2: `--repo`/`-R` appearing after a literal `--`
+    (POSIX end-of-options) is positional in real gh, never a flag."""
+
+    def test_repo_after_double_dash_not_resolved(self):
+        cmd = 'gh issue edit 42 --add-label "wave-26" -- --repo owner/repo-c'
+        self.assertIsNone(parser.extract_repo(cmd))
+
+
+class ValueLessFlagTests(unittest.TestCase):
+    """main#1060 finding #1: a value-less `-R`/`--repo` glued to the next
+    recognized flag must not resolve to that flag's own text as the repo."""
+
+    def test_value_less_short_flag_before_add_label_returns_none(self):
+        cmd = 'gh issue edit 42 -R --add-label "wave-26" --add-label "p3-wave-9"'
+        self.assertIsNone(parser.extract_repo(cmd))
+
+
 class RegexFallbackTests(unittest.TestCase):
     """When `_shell_parse.tokenize` returns None (malformed shell), the
     helper falls back to the conservative regex. Both paths must agree

--- a/.claude/hooks/tests/test_shell_parse.py
+++ b/.claude/hooks/tests/test_shell_parse.py
@@ -266,6 +266,71 @@ class WalkFlagValuesTests(unittest.TestCase):
         trailing forms)."""
         self.assertEqual(sp.walk_flag_values(["gh", "-R"], {"-R"}), [])
 
+    # -- main#1060: gh/cobra semantics hardening -----------------------------
+
+    def test_value_less_flag_does_not_eat_next_long_flag(self):
+        """A value-less `-R` immediately followed by `--add-label` must NOT
+        yield `repo='--add-label'` (main#1060's motivating reproducer, filed
+        during #1059 review). Real gh would error ("flag needs an argument:
+        'R'"); this helper can't raise, but must not silently misroute
+        either — `-R` yields nothing, and `--add-label` is still scanned as
+        its own flag."""
+        tokens = [
+            "gh",
+            "issue",
+            "edit",
+            "42",
+            "-R",
+            "--add-label",
+            "wave-26",
+            "--add-label",
+            "p3-wave-9",
+        ]
+        self.assertEqual(sp.walk_flag_values(tokens, {"-R", "--repo"}), [])
+        self.assertEqual(
+            sp.walk_flag_values(tokens, {"--add-label"}),
+            ["wave-26", "p3-wave-9"],
+        )
+
+    def test_value_less_flag_does_not_eat_next_short_flag(self):
+        """Same hazard, short-flag-shaped successor."""
+        self.assertEqual(sp.walk_flag_values(["gh", "-R", "-l", "bug"], {"-R"}), [])
+        self.assertEqual(sp.walk_flag_values(["gh", "-R", "-l", "bug"], {"-l"}), ["bug"])
+
+    def test_value_looking_like_negative_number_still_rejected(self):
+        """A flag-shaped successor is rejected even when it isn't itself in
+        `wanted` — the guard is "does this token look like a flag", not "is
+        this token itself a wanted flag"."""
+        self.assertEqual(sp.walk_flag_values(["gh", "-R", "--unknown-flag"], {"-R"}), [])
+
+    def test_bare_dash_after_flag_is_still_a_valid_value(self):
+        """A LONE `-` (the conventional stdin/positional sentinel) is NOT
+        flag-shaped, so it is still accepted as a value — only genuine
+        multi-character `-`-prefixed tokens are rejected."""
+        self.assertEqual(sp.walk_flag_values(["gh", "-F", "-"], {"-F"}), ["-"])
+
+    def test_double_dash_terminator_stops_scan(self):
+        """A literal `--` (POSIX end-of-options) stops the scan entirely —
+        a `--repo`/`-R` appearing after it is positional in real gh/cobra,
+        never a flag (main#1060 reproducer #2)."""
+        tokens = ["gh", "issue", "edit", "42", "--add-label", "wave-26", "--", "--repo", "x/y"]
+        self.assertEqual(sp.walk_flag_values(tokens, {"--repo", "-R"}), [])
+        # Flags BEFORE the terminator are unaffected.
+        self.assertEqual(sp.walk_flag_values(tokens, {"--add-label"}), ["wave-26"])
+
+    def test_double_dash_terminator_with_no_flags_after_is_a_noop(self):
+        tokens = ["gh", "issue", "edit", "42", "--repo", "x/y", "--"]
+        self.assertEqual(sp.walk_flag_values(tokens, {"--repo"}), ["x/y"])
+
+    def test_repeated_flag_returns_both_in_source_order(self):
+        """`walk_flag_values` itself does not pick a winner for a repeated
+        flag — it returns every value in source order (main#1060 finding
+        #3). Callers needing gh's real last-flag-wins semantics for a
+        single-value flag take `values[-1]` themselves (see
+        `_repo_flag_parse.extract_repo`)."""
+        tokens = ["gh", "issue", "edit", "42", "-R", "a/b", "-R", "c/d"]
+        self.assertEqual(sp.walk_flag_values(tokens, {"-R", "--repo"}), ["a/b", "c/d"])
+
 
 class FirstFlagValueTests(unittest.TestCase):
     """Convenience wrapper combining tokenize + walk_flag_values + regex fallback."""


### PR DESCRIPTION
## Summary

`walk_flag_values` diverged from real `gh` (cobra/pflag) flag parsing in
three ways, found during #1059 review — which raised the stakes by making
the extracted `--repo`/`-R` value **authoritative** for fail-closed/fail-open
routing decisions across `_wave_label_parse.py`, `_repo_flag_parse.py`,
`block_squash_wave_merge.py`, and `validate_wave_label_evidence.py`.

Closes #1060.

## The three findings and fixes

1. **Value-less flag ate the next flag.** `-R --add-label X` silently
   resolved `repo='--add-label'` (real gh errors: "flag needs an argument").
   `walk_flag_values` now only consumes the next token as a flag's value
   when that token does NOT itself look like a flag (`-`-prefixed,
   length > 1 — a bare `-` stdin sentinel is exempted). A flag-shaped
   successor is left unconsumed and still scanned as its own flag.
2. **No `--` (POSIX end-of-options) support.** A `--repo`/`-R` after a
   literal `--` was still parsed as authoritative. The scan now stops
   entirely at a bare `--` token.
3. **Repeated `-R`/`--repo`: first-occurrence-wins everywhere**, but real
   gh's single-value pflag `StringVarP` is last-flag-wins. Scope: the three
   DIRECT `walk_flag_values` callers that resolve `--repo`/`-R` for
   authoritative routing now take `values[-1]`:
   - `_repo_flag_parse.extract_repo` (both the tokenizer path and the
     regex fallback)
   - `_wave_label_parse._parse_edit_segment`
   - `block_squash_wave_merge._iter_squash_merges`

   `walk_flag_values` itself is unchanged (still returns every value in
   source order) — other callers legitimately accumulate a *repeatable*
   flag (e.g. `--add-label`, iterated in full by `validate_labels.py` /
   `validate_wave_label_evidence.py`). `first_flag_value` (used only for
   `--base`/`--head` in `validate_branch_freshness.py`, never `--repo`) was
   deliberately left first-wins, matching its own pinned test
   (`test_returns_first_value`) — documented in its docstring per the
   issue's "or explicitly document why first-wins is the deliberate choice."

## Tests, mutation-verified

For each of the three findings: reverted the corresponding fix, confirmed
the new test(s) fail, restored the fix, confirmed green. New coverage:

- `test_shell_parse.py::WalkFlagValuesTests` — 7 new cases (value-less flag
  vs. long/short flag successor, flag-shaped-but-unwanted successor still
  rejected, bare `-` still accepted as a value, `--` terminator with and
  without trailing flags, repeated-flag source-order confirmation).
- `test_repo_flag_parse.py` — `RepeatedRepoFlagTests` (tokenizer + regex
  fallback last-wins parity), `DoubleDashTerminatorTests`,
  `ValueLessFlagTests`.
- `test__wave_label_parse.py::RepoFlagResolution` — 3 new cases (last-wins,
  value-less-flag-no-misroute, `--` terminator).
- `test_block_squash_wave_merge.py::RepeatedRepoFlagLastWins` — confirms the
  repo fed to `_resolve_base_ref` (and echoed in the block reason) is the
  last occurrence.

## Test plan

- [x] `ENVIRONMENT=test python3 -m pytest .claude/hooks/tests .claude/lib/tests -q` — 2738 passed, 97 subtests passed
- [x] `pre-commit run --all-files` — all commit-stage hooks green
- [x] `git push` — all pre-push hooks green (mypy, pytest, pytest-skills, memory-budget, headcount-budget, doc-freshness, office-drift, mermaid-render)
- [x] Mutation check per finding: reverted each fix individually, confirmed the corresponding new test(s) failed; restored, confirmed green

## Reviewers

Nino Kavtaradze (merge-gate) + Aino Virtanen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018KeNK3VBB3zFyJWxUGWM7z