### PR TITLE
fix(#1042): extract shared checksums_io helper for both checksums.json writers

### DIFF
--- a/.claude/hooks/ontology_tracker.py
+++ b/.claude/hooks/ontology_tracker.py
@@ -123,6 +123,15 @@ CHECKSUMS_FILE = REPO_ROOT / "ontology" / "checksums.json"
 # process. See "Owning-repo check-ignore (#1039)" in the module docstring.
 _GIT_CHECK_IGNORE_CACHE: dict[tuple[str, str], bool] = {}
 
+# Shared read/write helpers (#1042): both this hook and the /ontology-rebuild
+# resolver's `mark-resolved` CLI go through checksums_io so neither has to
+# remember the ensure_ascii=False + atomic-replace serialization convention —
+# see .claude/lib/checksums_io.py's module docstring for the full rationale.
+_LIB = Path(__file__).resolve().parent.parent / "lib"
+if str(_LIB) not in sys.path:
+    sys.path.insert(0, str(_LIB))
+import checksums_io  # noqa: E402
+
 # Substring patterns: skip if any appears anywhere in the file path.
 SKIP_PATTERNS = [
     "ontology/checksums.json",  # Don't track ourselves
@@ -351,12 +360,7 @@ def check(input_data: dict) -> dict | None:
     rel_path = _relative_path(file_path)
     now = datetime.now(timezone.utc).isoformat()
 
-    try:
-        with open(CHECKSUMS_FILE, "r", encoding="utf-8") as f:
-            data = json.load(f)
-    except (OSError, json.JSONDecodeError):
-        data = {"version": 1, "files": {}}
-
+    data = checksums_io.read_checksums(CHECKSUMS_FILE)
     files = data.setdefault("files", {})
 
     existing = files.get(rel_path, {})
@@ -368,15 +372,7 @@ def check(input_data: dict) -> dict | None:
     }
 
     try:
-        CHECKSUMS_FILE.parent.mkdir(parents=True, exist_ok=True)
-        tmp = CHECKSUMS_FILE.with_suffix(".tmp")
-        with open(tmp, "w", encoding="utf-8") as f:
-            # ensure_ascii=False: the on-disk file holds literal UTF-8 in its
-            # top-level ``description``. Re-escaping it here made every touch
-            # emit a spurious one-line diff (#1038).
-            json.dump(data, f, indent=2, ensure_ascii=False)
-            f.write("\n")
-        tmp.replace(CHECKSUMS_FILE)
+        checksums_io.write_checksums(CHECKSUMS_FILE, data)
     except OSError:
         pass  # Never fail the hook
 

--- a/.claude/lib/checksums_io.py
+++ b/.claude/lib/checksums_io.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Shared read/write helpers for ``ontology/checksums.json`` (#1042).
+
+PR #1040 (closes #1038) fixed `ensure_ascii=True` re-escaping churn on the
+committed ``ontology/checksums.json`` for the one *programmatic, committed*
+writer — ``.claude/hooks/ontology_tracker.py``. The other writer, the
+``/ontology-rebuild`` resolver, is agent-driven (a ``SKILL.md`` prose
+instruction, not a code module), so the fix there was documentation only:
+nothing enforced that the agent executing the skill actually followed the
+"use ``ensure_ascii=False``" instruction. A future resolver run — or an edit
+to the skill that drops the reminder — reintroduces the exact flip-flop
+diff-noise class #1038 fixed, just moved to the other writer instead of
+closed.
+
+This module closes the class rather than documenting around it: both the
+tracker hook and the ``/ontology-rebuild`` resolver call the SAME
+``read_checksums`` / ``write_checksums`` functions (the resolver via the
+``mark-resolved`` CLI below, since it is agent-driven and has no Python
+module of its own to import from). Neither caller needs to remember the
+serialization convention — it is the only path either has to write the file.
+
+Byte-stability contract
+========================
+``write_checksums`` always writes with ``json.dump(data, f, indent=2,
+ensure_ascii=False)`` plus a trailing newline, via an atomic tmp-file
+``rename``. ``ensure_ascii=False`` preserves literal UTF-8 in the top-level
+``description`` field (``—``, ``×``); the ``ensure_ascii=True`` default
+re-escapes it into ``\\uXXXX`` sequences on every write, producing a
+permanent flip-flop diff on the committed file (#1038). The atomic
+tmp-file-then-``Path.replace()`` write means a concurrent reader (e.g. the
+librarian, or a second hook invocation) never observes a partially written
+file.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# The empty-file default shape both callers fall back to when the checksums
+# file is missing or unparseable — never raise from a read (the tracker hook
+# must never fail the calling tool call; the resolver CLI degrades the same
+# way for consistency).
+_EMPTY: dict[str, Any] = {"version": 1, "files": {}}
+
+
+def read_checksums(path: Path) -> dict[str, Any]:
+    """Read and parse ``checksums.json``, defaulting to an empty structure.
+
+    Returns a fresh ``{"version": 1, "files": {}}`` if the file is missing or
+    is not valid JSON — matching the tracker hook's historical fail-open
+    behavior (a PostToolUse hook must never raise).
+    """
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return dict(_EMPTY)
+    if not isinstance(data, dict):
+        return dict(_EMPTY)
+    return data
+
+
+def write_checksums(path: Path, data: dict[str, Any]) -> None:
+    """Atomically write ``checksums.json`` with the byte-stable serialization.
+
+    See the module docstring's "Byte-stability contract" for why
+    ``ensure_ascii=False`` and the atomic-replace write are both load-bearing.
+    Creates the parent directory if needed (mirrors the tracker hook's prior
+    inline behavior).
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+    tmp.replace(path)
+
+
+def mark_resolved(data: dict[str, Any], rel_paths: list[str], now: str) -> list[str]:
+    """Set ``last_resolved = last_tracked`` and ``resolved_at = now`` for each path.
+
+    Mutates ``data["files"]`` in place and returns the subset of ``rel_paths``
+    that were actually present and resolved (a path not yet in ``files`` is
+    not an entry to resolve — silently skipped rather than raising, since the
+    resolver may be handed a path list wider than what the tracker has ever
+    seen).
+    """
+    files = data.setdefault("files", {})
+    resolved: list[str] = []
+    for rel in rel_paths:
+        entry = files.get(rel)
+        if entry is None:
+            continue
+        entry["last_resolved"] = entry.get("last_tracked", "")
+        entry["resolved_at"] = now
+        resolved.append(rel)
+    return resolved
+
+
+def _default_checksums_path() -> Path:
+    """``ontology/checksums.json`` relative to this file's repo root.
+
+    Mirrors ``ontology_tracker.py``'s ``REPO_ROOT`` derivation
+    (``.claude/lib/checksums_io.py`` is two levels below the repo root, same
+    as ``.claude/hooks/ontology_tracker.py``).
+    """
+    repo_root = Path(__file__).resolve().parent.parent.parent
+    return repo_root / "ontology" / "checksums.json"
+
+
+def main(argv: list[str]) -> int:
+    """CLI entry point for the ``/ontology-rebuild`` resolver (#1042).
+
+    The resolver is agent-driven (a ``SKILL.md`` prose instruction), so it has
+    no Python module of its own to import ``mark_resolved`` from directly.
+    Exposing a ``mark-resolved`` subcommand here means the skill's step 4 can
+    shell out to THIS module instead of hand-rolling a ``json.dump`` call —
+    the resolver never needs to remember the ``ensure_ascii=False`` convention
+    because it never writes the file itself.
+
+    Usage:
+        python3 .claude/lib/checksums_io.py mark-resolved <path> [<path> ...]
+        python3 .claude/lib/checksums_io.py mark-resolved --checksums <file> <path> ...
+
+    Exit codes:
+        0 — success (including "nothing to resolve", still 0)
+        2 — usage error
+    """
+    if len(argv) < 2 or argv[1] != "mark-resolved":
+        print(
+            "usage: checksums_io.py mark-resolved [--checksums PATH] <rel-path> [<rel-path> ...]",
+            file=sys.stderr,
+        )
+        return 2
+
+    rest = argv[2:]
+    checksums_path = _default_checksums_path()
+    if rest and rest[0] == "--checksums":
+        if len(rest) < 2:
+            print("error: --checksums requires a PATH argument", file=sys.stderr)
+            return 2
+        checksums_path = Path(rest[1])
+        rest = rest[2:]
+
+    if not rest:
+        print("error: at least one <rel-path> is required", file=sys.stderr)
+        return 2
+
+    data = read_checksums(checksums_path)
+    now = datetime.now(timezone.utc).isoformat()
+    resolved = mark_resolved(data, rest, now)
+    write_checksums(checksums_path, data)
+
+    skipped = [p for p in rest if p not in resolved]
+    print(f"Resolved {len(resolved)} file(s) in {checksums_path}.")
+    if skipped:
+        print(f"Skipped (not tracked): {', '.join(skipped)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.claude/lib/checksums_io.py
+++ b/.claude/lib/checksums_io.py
@@ -34,6 +34,7 @@ file.
 
 from __future__ import annotations
 
+import copy
 import json
 import sys
 from datetime import datetime, timezone
@@ -43,7 +44,10 @@ from typing import Any
 # The empty-file default shape both callers fall back to when the checksums
 # file is missing or unparseable — never raise from a read (the tracker hook
 # must never fail the calling tool call; the resolver CLI degrades the same
-# way for consistency).
+# way for consistency). This is a TEMPLATE, not a shared return value: every
+# fail-open branch returns a `copy.deepcopy(_EMPTY)` so callers that mutate the
+# nested `"files"` dict (e.g. `ontology_tracker.check()` on a missing file)
+# never pollute this module-global.
 _EMPTY: dict[str, Any] = {"version": 1, "files": {}}
 
 
@@ -58,9 +62,9 @@ def read_checksums(path: Path) -> dict[str, Any]:
         with open(path, "r", encoding="utf-8") as f:
             data = json.load(f)
     except (OSError, json.JSONDecodeError):
-        return dict(_EMPTY)
+        return copy.deepcopy(_EMPTY)
     if not isinstance(data, dict):
-        return dict(_EMPTY)
+        return copy.deepcopy(_EMPTY)
     return data
 
 

--- a/.claude/lib/tests/test_checksums_io.py
+++ b/.claude/lib/tests/test_checksums_io.py
@@ -1,0 +1,201 @@
+"""Tests for checksums_io — the shared ontology/checksums.json read/write helper (#1042).
+
+Closes the gap left by #1040 (which fixed the ensure_ascii=True re-escaping
+churn only in the one code-enforced writer, ontology_tracker.py, leaving the
+agent-driven /ontology-rebuild resolver's serialization a documentation-only
+convention with nothing to attach a test to). This module gives the resolver
+a real CLI subcommand (`mark-resolved`) to shell out to instead, so the
+byte-stability contract is enforced by code on BOTH writers, not just one.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import checksums_io  # noqa: E402
+
+
+@contextmanager
+def _tmp_file(contents: str):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "checksums.json"
+        path.write_text(contents, encoding="utf-8")
+        yield path
+
+
+@contextmanager
+def _tmp_dir():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield Path(tmpdir)
+
+
+class ReadChecksumsTests(unittest.TestCase):
+    def test_reads_valid_json(self) -> None:
+        with _tmp_file('{"version": 1, "files": {"a.yaml": {"last_tracked": "x"}}}') as path:
+            data = checksums_io.read_checksums(path)
+        self.assertEqual(data["files"]["a.yaml"]["last_tracked"], "x")
+
+    def test_missing_file_returns_empty_default(self) -> None:
+        missing = Path("/nonexistent/path/checksums.json")
+        data = checksums_io.read_checksums(missing)
+        self.assertEqual(data, {"version": 1, "files": {}})
+
+    def test_invalid_json_returns_empty_default(self) -> None:
+        with _tmp_file("{not valid json") as path:
+            data = checksums_io.read_checksums(path)
+        self.assertEqual(data, {"version": 1, "files": {}})
+
+    def test_non_dict_json_returns_empty_default(self) -> None:
+        """A JSON array (or any non-mapping) is not a valid checksums document."""
+        with _tmp_file("[1, 2, 3]") as path:
+            data = checksums_io.read_checksums(path)
+        self.assertEqual(data, {"version": 1, "files": {}})
+
+
+class WriteChecksumsTests(unittest.TestCase):
+    def test_write_then_read_round_trips(self) -> None:
+        with _tmp_dir() as tmpdir:
+            path = tmpdir / "sub" / "checksums.json"
+            data = {"version": 1, "files": {"a.yaml": {"last_tracked": "abc"}}}
+            checksums_io.write_checksums(path, data)
+            self.assertTrue(path.is_file())
+            self.assertEqual(checksums_io.read_checksums(path), data)
+
+    def test_non_ascii_description_survives_unescaped(self) -> None:
+        """#1038: the writer must not re-escape literal UTF-8 to \\uXXXX."""
+        with _tmp_dir() as tmpdir:
+            path = tmpdir / "checksums.json"
+            description = "SCOPE (#857, #820/C×T2): semantic overlay — not structural"
+            checksums_io.write_checksums(
+                path, {"version": 1, "description": description, "files": {}}
+            )
+            raw = path.read_text(encoding="utf-8")
+            self.assertIn(description, raw)
+            self.assertNotIn("\\u", raw)
+
+    def test_write_creates_parent_directory(self) -> None:
+        with _tmp_dir() as tmpdir:
+            path = tmpdir / "does" / "not" / "exist" / "checksums.json"
+            checksums_io.write_checksums(path, {"version": 1, "files": {}})
+            self.assertTrue(path.is_file())
+
+    def test_write_ends_with_trailing_newline(self) -> None:
+        with _tmp_dir() as tmpdir:
+            path = tmpdir / "checksums.json"
+            checksums_io.write_checksums(path, {"version": 1, "files": {}})
+            self.assertTrue(path.read_text(encoding="utf-8").endswith("\n"))
+
+    def test_write_leaves_no_tmp_file_behind(self) -> None:
+        with _tmp_dir() as tmpdir:
+            path = tmpdir / "checksums.json"
+            checksums_io.write_checksums(path, {"version": 1, "files": {}})
+            self.assertFalse(path.with_suffix(".tmp").exists())
+
+    def test_write_is_byte_stable_across_repeated_writes_of_same_data(self) -> None:
+        """A no-op re-write of identical data must not change the bytes."""
+        with _tmp_dir() as tmpdir:
+            path = tmpdir / "checksums.json"
+            data = {"version": 1, "description": "overlay — × scope", "files": {}}
+            checksums_io.write_checksums(path, data)
+            first = path.read_bytes()
+            checksums_io.write_checksums(path, data)
+            second = path.read_bytes()
+            self.assertEqual(first, second)
+
+
+class MarkResolvedTests(unittest.TestCase):
+    def test_resolves_a_tracked_file(self) -> None:
+        data: dict[str, Any] = {
+            "version": 1,
+            "files": {
+                "ontology/domain.yaml": {
+                    "last_tracked": "sha123",
+                    "last_resolved": "sha_old",
+                    "tracked_at": "2026-01-01T00:00:00+00:00",
+                    "resolved_at": "2025-12-01T00:00:00+00:00",
+                }
+            },
+        }
+        resolved = checksums_io.mark_resolved(
+            data, ["ontology/domain.yaml"], "2026-01-02T00:00:00+00:00"
+        )
+        self.assertEqual(resolved, ["ontology/domain.yaml"])
+        entry = data["files"]["ontology/domain.yaml"]
+        self.assertEqual(entry["last_resolved"], "sha123")
+        self.assertEqual(entry["resolved_at"], "2026-01-02T00:00:00+00:00")
+
+    def test_untracked_path_is_skipped_not_raised(self) -> None:
+        data: dict[str, Any] = {"version": 1, "files": {}}
+        resolved = checksums_io.mark_resolved(data, ["nope.yaml"], "2026-01-02T00:00:00+00:00")
+        self.assertEqual(resolved, [])
+        self.assertEqual(data["files"], {})
+
+    def test_mixed_tracked_and_untracked_paths(self) -> None:
+        data: dict[str, Any] = {
+            "version": 1,
+            "files": {"a.yaml": {"last_tracked": "sha_a", "last_resolved": ""}},
+        }
+        resolved = checksums_io.mark_resolved(data, ["a.yaml", "b.yaml"], "now")
+        self.assertEqual(resolved, ["a.yaml"])
+        self.assertEqual(data["files"]["a.yaml"]["last_resolved"], "sha_a")
+
+
+class MainCliTests(unittest.TestCase):
+    def test_mark_resolved_cli_end_to_end(self) -> None:
+        with _tmp_dir() as tmpdir:
+            path = tmpdir / "checksums.json"
+            path.write_text(
+                json.dumps(
+                    {
+                        "version": 1,
+                        "files": {
+                            "ontology/domain.yaml": {
+                                "last_tracked": "shaXYZ",
+                                "last_resolved": "",
+                                "tracked_at": "t",
+                                "resolved_at": "",
+                            }
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+            rc = checksums_io.main(
+                [
+                    "checksums_io.py",
+                    "mark-resolved",
+                    "--checksums",
+                    str(path),
+                    "ontology/domain.yaml",
+                ]
+            )
+            self.assertEqual(rc, 0)
+            data = json.loads(path.read_text(encoding="utf-8"))
+            self.assertEqual(
+                data["files"]["ontology/domain.yaml"]["last_resolved"],
+                "shaXYZ",
+            )
+
+    def test_no_subcommand_is_usage_error(self) -> None:
+        self.assertEqual(checksums_io.main(["checksums_io.py"]), 2)
+
+    def test_unknown_subcommand_is_usage_error(self) -> None:
+        self.assertEqual(checksums_io.main(["checksums_io.py", "bogus"]), 2)
+
+    def test_mark_resolved_with_no_paths_is_usage_error(self) -> None:
+        self.assertEqual(checksums_io.main(["checksums_io.py", "mark-resolved"]), 2)
+
+    def test_checksums_flag_missing_value_is_usage_error(self) -> None:
+        self.assertEqual(checksums_io.main(["checksums_io.py", "mark-resolved", "--checksums"]), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/lib/tests/test_checksums_io.py
+++ b/.claude/lib/tests/test_checksums_io.py
@@ -59,6 +59,30 @@ class ReadChecksumsTests(unittest.TestCase):
             data = checksums_io.read_checksums(path)
         self.assertEqual(data, {"version": 1, "files": {}})
 
+    def test_missing_file_default_does_not_alias_module_global(self) -> None:
+        """The fail-open default must be a FRESH structure each call.
+
+        Regression for the shallow-copy defect: returning ``dict(_EMPTY)`` left
+        the nested ``"files"`` dict aliasing the module-global. A caller that
+        mutates the returned mapping's ``"files"`` (exactly what
+        ``ontology_tracker.check()`` does on a missing checksums file) then
+        polluted the module-global process-wide, so a later ``read_checksums``
+        no longer returned an empty default.
+        """
+        missing = Path("/nonexistent/path/checksums.json")
+        first = checksums_io.read_checksums(missing)
+        first["files"]["polluted.yaml"] = {"last_tracked": "x"}
+        second = checksums_io.read_checksums(missing)
+        self.assertEqual(second, {"version": 1, "files": {}})
+
+    def test_invalid_file_default_does_not_alias_module_global(self) -> None:
+        """Same fresh-structure guarantee on the invalid/parse-failure path."""
+        with _tmp_file("{not valid json") as path:
+            first = checksums_io.read_checksums(path)
+            first["files"]["polluted.yaml"] = {"last_tracked": "x"}
+            second = checksums_io.read_checksums(path)
+        self.assertEqual(second, {"version": 1, "files": {}})
+
 
 class WriteChecksumsTests(unittest.TestCase):
     def test_write_then_read_round_trips(self) -> None:

--- a/.claude/skills/ontology-rebuild/SKILL.md
+++ b/.claude/skills/ontology-rebuild/SKILL.md
@@ -78,11 +78,17 @@ After processing all dirty files:
 
 ### 4. Update checksums
 
-For each processed file, set `last_resolved = last_tracked` and `resolved_at = now` in `checksums.json`.
+For each processed file, set `last_resolved = last_tracked` and `resolved_at = now` in `checksums.json` — plus any ontology files that were themselves modified during this pass.
 
-Also update checksums for any ontology files that were modified during this pass.
+**Do not hand-roll a `json.dump` call for this (#1042).** Call the shared `mark-resolved` CLI in `.claude/lib/checksums_io.py` instead — it is the SAME read/write path `.claude/hooks/ontology_tracker.py` uses, so the byte-stability contract (`ensure_ascii=False` + trailing newline + atomic tmp-file replace — #1038: the top-level `description` holds literal UTF-8 like `—`/`×`, and a writer that defaults to `ensure_ascii=True` re-escapes it, flip-flopping the file on every touch) is enforced by code on both writers instead of being a convention this skill's prose has to be remembered and followed correctly by whichever agent executes it:
 
-**Serialization (#1038):** when rewriting `checksums.json` programmatically, use `json.dump(data, f, indent=2, ensure_ascii=False)` and a trailing newline — matching the tracker hook (`.claude/hooks/ontology_tracker.py`). The top-level `description` contains literal UTF-8 (`—`, `×`); a writer that defaults to `ensure_ascii=True` re-escapes it and the file flip-flops between escaped and literal on every touch, producing recurring phantom diffs.
+```bash
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+PYTHONPATH="$REPO_ROOT/.claude/lib" python3 "$REPO_ROOT/.claude/lib/checksums_io.py" \
+  mark-resolved ontology/domain.yaml ontology/services.yaml ontology/conventions.md
+```
+
+Pass every dirty path resolved in this run as a separate argument (a path not present in `checksums.json` is silently skipped, not an error — see `checksums_io.mark_resolved`'s docstring). Use `--checksums <path>` before the path list only if resolving a non-default `checksums.json` location.
 
 ### 5. Report
 


### PR DESCRIPTION
## Summary

PR #1040 (closes #1038) fixed `ensure_ascii=True` re-escaping churn on the committed `ontology/checksums.json` for the one *programmatic, committed* writer — `.claude/hooks/ontology_tracker.py`. The other writer, the `/ontology-rebuild` resolver, is agent-driven (a `SKILL.md` prose instruction, not a code module), so the fix there landed as documentation only:

> `.claude/skills/ontology-rebuild/SKILL.md` § 4: "when rewriting `checksums.json` programmatically, use `json.dump(data, f, indent=2, ensure_ascii=False)` and a trailing newline"

Nothing enforced that the agent executing the skill actually followed this instruction. A future resolver run (or an edit to the skill that drops the reminder) reintroduces the exact flip-flop diff-noise class #1038 fixed — just moved to the other writer instead of closed.

## Fix

Extract `.claude/lib/checksums_io.py` — `read_checksums`, `write_checksums`, `mark_resolved` — encapsulating the byte-stability contract (`ensure_ascii=False` + trailing newline + atomic tmp-file replace) in one place:

- `ontology_tracker.py`'s `check()` now calls `checksums_io.read_checksums`/`write_checksums` instead of hand-rolling the `json.dump` + atomic-replace logic inline.
- The resolver is agent-driven and has no Python module of its own to import from, so `checksums_io.py` exposes a `mark-resolved` CLI subcommand it can shell out to instead:
  ```bash
  PYTHONPATH="$REPO_ROOT/.claude/lib" python3 "$REPO_ROOT/.claude/lib/checksums_io.py" \
    mark-resolved ontology/domain.yaml ontology/services.yaml
  ```
- `/ontology-rebuild`'s `SKILL.md` step 4 is updated to call this CLI instead of documenting the `json.dump` convention in prose.

Neither writer can now forget the serialization convention, because neither writes the file directly anymore — this closes the class rather than documenting around it (per the reviewer's own suggestion on PR #1040).

## Tests

18 new tests in `.claude/lib/tests/test_checksums_io.py`:
- `read_checksums`: valid JSON, missing file, invalid JSON, non-dict JSON — all degrade to the empty default, never raise.
- `write_checksums`: round-trip, non-ASCII survives unescaped (#1038 regression), parent-dir creation, trailing newline, no leftover `.tmp`, byte-stability across repeated writes of identical data.
- `mark_resolved`: resolves a tracked file, skips (not raises) an untracked path, mixed tracked/untracked.
- `main` CLI: end-to-end `mark-resolved`, and the four usage-error paths (no subcommand, unknown subcommand, no paths, `--checksums` missing its value).

The existing 31 `ontology_tracker` tests continue to pass against the refactor (49 combined). Full local gate green: ruff, mypy, cspell, full pytest suite (pre-push).

## Reviewers

Merge-gate: **Nurul Hakim**. Second reviewer: **Nino Kavtaradze**.

Closes #1042