### PR TITLE
refactor(#1048): share one verdict-set entry point between Hook 4 and pr_review_state

### DIFF
--- a/.claude/hooks/tests/test_validate_pr_review.py
+++ b/.claude/hooks/tests/test_validate_pr_review.py
@@ -2098,6 +2098,161 @@ class VerdictFixtureSanityTests(unittest.TestCase):
         self.assertEqual(result.stale_verdicts, [])
 
 
+class ResolveReviewVerdictsSharedBoundaryTests(unittest.TestCase):
+    """#1048: `resolve_review_verdicts` is the ONE shared entry point `check()`
+    and `pr_review_state.compute_review_state` both call — neither re-derives
+    the content-binding / comment-scan / roster-filter / union pipeline with
+    its own argument list, which is the #1046 defect class.
+
+    Mutation-sensitivity was manually confirmed while writing this refactor:
+    temporarily stripping `content_ts=content_ts` from the feature-branch
+    `check_comment_reviews` call inside `resolve_review_verdicts` turned 4
+    tests in `.claude/lib/tests/test_pr_review_state.py::ContentStalenessTests`
+    red immediately, because that class drives `compute_review_state` through
+    the REAL `resolve_review_verdicts` over a faked `gh api` boundary. The
+    test below is the equivalent DIRECT guard at the shared function itself.
+    """
+
+    REPO = "noorinalabs/noorinalabs-main"
+
+    @staticmethod
+    def _pr_data(head_ref="L.Ferreira/1040-x", author="parametrization", reviews=(), labels=()):
+        return {
+            "author": author,
+            "number": 1040,
+            "reviews": list(reviews),
+            "headRefName": head_ref,
+            "labels": list(labels),
+        }
+
+    def test_stale_comment_verdict_is_excluded_from_the_reviewer_set(self):
+        """Direct kill-shot on the shared boundary (#950 x #1048): a stale
+        Approved must not count toward `distinct_reviewers`, and must be
+        recorded on `stale_verdicts_comment` so a caller (either check()'s
+        block message or the driver's report) can name it. This would RED if
+        `resolve_review_verdicts` ever stopped forwarding `content_ts` to
+        `check_comment_reviews`.
+        """
+        stale_comment = {
+            "body": (
+                "Requestor: Lucas Ferreira\nRequestee: Someone Else\n"
+                "RequestOrReplied: Approved\nTechDebt: none"
+            ),
+            "created_at": "2026-01-01T00:00:00Z",
+        }
+
+        def fake_run(args, capture_output, text, timeout):
+            result = mock.MagicMock()
+            result.returncode = 0
+            if args[0] == "gh" and args[1:3] == ["repo", "view"]:
+                result.stdout = json.dumps({"owner": {"login": "noorinalabs"}, "name": "r"})
+            else:
+                result.stdout = json.dumps([stale_comment])
+            return result
+
+        with (
+            mock.patch.object(hook.subprocess, "run", side_effect=fake_run),
+            mock.patch.object(
+                hook,
+                "get_latest_content_commit",
+                return_value=("ac8bcfa", hook._parse_iso8601("2026-01-02T00:00:00Z")),
+            ),
+            mock.patch.object(hook, "_load_roster_names", return_value={"lucas ferreira"}),
+        ):
+            verdicts = hook.resolve_review_verdicts(self._pr_data(), repo=self.REPO)
+
+        self.assertEqual(verdicts.distinct_reviewers, set())
+        self.assertEqual(len(verdicts.stale_verdicts_comment), 1)
+        self.assertEqual(verdicts.stale_verdicts_comment[0].reviewer, "Lucas Ferreira")
+        self.assertEqual(verdicts.stale_verdicts_formal, [])
+        self.assertEqual(verdicts.stale_verdicts, verdicts.stale_verdicts_comment)
+
+    def test_check_delegates_to_resolve_review_verdicts_and_trusts_it(self):
+        """`check()` must call the shared entry point and use its output
+        DIRECTLY, rather than reassembling the pipeline inline — the concrete
+        guard for #1048's acceptance criterion ('neither check() nor
+        compute_review_state re-derives the verdict set'). A fake
+        `ReviewVerdicts` with 2 distinct current reviewers and no missing
+        TechDebt must ALLOW the merge without `check()` ever recomputing
+        `distinct_reviewers` itself.
+        """
+        input_data = {
+            "tool_name": "Bash",
+            "tool_input": {"command": "gh pr merge 1040 --repo noorinalabs/noorinalabs-main"},
+        }
+        fake_verdicts = hook.ReviewVerdicts(
+            number=1040,
+            head_ref="L.Ferreira/1040-x",
+            labels=[],
+            branch_author_lastname="Ferreira",
+            content_sha="ac8bcfa",
+            content_ts=None,
+            formal_reviewers=set(),
+            comment_reviewers={"nino kavtaradze", "weronika zielinska"},
+            non_roster_requestors=set(),
+            roster_comment_reviewers={"nino kavtaradze", "weronika zielinska"},
+            roster_names={"nino kavtaradze", "weronika zielinska"},
+            distinct_reviewers={"nino kavtaradze", "weronika zielinska"},
+            stale_verdicts_comment=[],
+            stale_verdicts_formal=[],
+            reviews_missing_tech_debt=[],
+            tech_debt_issue_numbers=[],
+            wave_bootstrap_exception=False,
+        )
+        with (
+            mock.patch.object(
+                hook,
+                "get_pr_data",
+                return_value={
+                    "author": "someone",
+                    "number": 1040,
+                    "reviews": [],
+                    "headRefName": "L.Ferreira/1040-x",
+                    "labels": [],
+                },
+            ),
+            mock.patch.object(
+                hook, "resolve_review_verdicts", return_value=fake_verdicts
+            ) as mock_resolve,
+        ):
+            result = hook.check(input_data)
+
+        mock_resolve.assert_called_once()
+        self.assertIsNone(result, "2 distinct current reviewers must ALLOW the merge")
+
+    def test_check_translates_stale_verdict_error_into_a_block(self):
+        """`CommentScanUndeterminedError` from the shared boundary must reach
+        `check()`'s own #981 block message — proving the exception, not a
+        re-derived `undetermined` flag, is what drives the block."""
+        input_data = {
+            "tool_name": "Bash",
+            "tool_input": {"command": "gh pr merge 1040 --repo noorinalabs/noorinalabs-main"},
+        }
+        with (
+            mock.patch.object(
+                hook,
+                "get_pr_data",
+                return_value={
+                    "author": "someone",
+                    "number": 1040,
+                    "reviews": [],
+                    "headRefName": "L.Ferreira/1040-x",
+                    "labels": [],
+                },
+            ),
+            mock.patch.object(
+                hook,
+                "resolve_review_verdicts",
+                side_effect=hook.CommentScanUndeterminedError("HTTP 403: Forbidden"),
+            ),
+        ):
+            result = hook.check(input_data)
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result["decision"], "block")
+        self.assertIn("HTTP 403: Forbidden", result["reason"])
+
+
 class StaleVerdictBindingTests(unittest.TestCase):
     """A verdict cast before the latest non-merge commit does not count (#950)."""
 

--- a/.claude/hooks/validate_pr_review.py
+++ b/.claude/hooks/validate_pr_review.py
@@ -163,6 +163,7 @@ Exit codes:
       so verdict freshness cannot be established)
 """
 
+import dataclasses
 import json
 import os
 import re
@@ -1247,6 +1248,168 @@ def ensure_issues_on_board(repo: str, issue_numbers: list[str]) -> None:
             pass  # Best-effort — don't block merge on board failures
 
 
+class CommentScanUndeterminedError(Exception):
+    """Raised by `resolve_review_verdicts` when the comment scan could not
+    complete (#981 defense-in-depth).
+
+    An empty reviewer set that came from a FAILED scan is not evidence of
+    anything — it is the absence of evidence, and treating it as "no
+    approvals found" is the same category of error as counting an
+    unverifiable merge as approved. Carries `.reason` (the underlying
+    `CommentReviewResult.undetermined` string) so callers can render their
+    OWN block/error message without re-deriving why the scan failed.
+    """
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+@dataclasses.dataclass
+class ReviewVerdicts:
+    """The full review-verdict set for a PR (#1048) — content binding,
+    formal + comment reviewer partitioning, roster filtering, and the
+    union/threshold inputs.
+
+    This is the SINGLE shared entry point `check()` and
+    `pr_review_state.compute_review_state` both consume via
+    `resolve_review_verdicts`; neither re-derives this pipeline with its own
+    argument list. That re-derivation was exactly the #1046 defect class —
+    the driver called `check_comment_reviews` without `content_ts` and
+    silently drifted from the gate. A single shared computation cannot drift
+    from itself.
+
+    Deliberately carries every intermediate value BOTH callers need for
+    their OWN rendering (`check()`'s block message; the driver's text/JSON
+    report) — this dataclass is the shared PIPELINE OUTPUT, not a merge
+    decision. `check()` still owns its message construction; the driver
+    still owns `ReviewState.passes()` and its report rendering.
+    """
+
+    number: str | int
+    head_ref: str
+    labels: list[str]
+    branch_author_lastname: str | None
+    content_sha: str
+    content_ts: datetime | None
+    formal_reviewers: set[str]
+    # ALL Approved comment Requestors (full names, lowercased) BEFORE roster
+    # filtering — needed for the roster-mismatch diagnostic (#498).
+    comment_reviewers: set[str]
+    non_roster_requestors: set[str]
+    roster_comment_reviewers: set[str]
+    roster_names: set[str]
+    distinct_reviewers: set[str]  # formal_reviewers | roster_comment_reviewers
+    # Kept as TWO separate lists rather than pre-concatenated, so a caller that
+    # needs to tag each verdict's SOURCE for its own report (the driver's
+    # `stale_verdicts[].source` field) doesn't have to reconstruct which
+    # sub-list a given entry came from. `stale_verdicts` combines them, in
+    # that order, for a caller (check()'s block message) that just needs one
+    # unified list.
+    stale_verdicts_comment: list[StaleVerdict]
+    stale_verdicts_formal: list[StaleVerdict]
+    reviews_missing_tech_debt: list[str]
+    tech_debt_issue_numbers: list[str]
+    wave_bootstrap_exception: bool
+
+    @property
+    def stale_verdicts(self) -> list[StaleVerdict]:
+        """Combined stale verdicts, comment-based then formal."""
+        return self.stale_verdicts_comment + self.stale_verdicts_formal
+
+    @property
+    def total_distinct(self) -> int:
+        """Count toward the 2-reviewer threshold (charter line 36)."""
+        return len(self.distinct_reviewers)
+
+
+def resolve_review_verdicts(pr_data: dict, repo: str | None = None) -> ReviewVerdicts:
+    """Compute a PR's full review-verdict set (#1048) — the shared pipeline
+    previously re-assembled independently by `check()` and
+    `pr_review_state.compute_review_state`:
+
+      1. `get_latest_content_commit` → T_content (`content_ts`/`content_sha`, #950).
+      2. `partition_formal_reviewers` + `check_comment_reviews`, both bound to
+         T_content, on the feature-branch or wave-merge head-ref path.
+      3. `_load_roster_names` and non-roster Requestor filtering (#498).
+      4. Union formal + roster-filtered comment reviewers into the distinct
+         reviewer set, plus the wave-bootstrap single-reviewer exception (#228).
+
+    `pr_data` is the dict `get_pr_data` returns (author, reviews, headRefName,
+    number, labels) — fetching and validating the PR itself stays the
+    caller's responsibility, matching how both callers already fetch it
+    before doing anything else.
+
+    Raises:
+        CommitFetchError: T_content could not be established (#950) —
+            propagated verbatim from `get_latest_content_commit`.
+        CommentScanUndeterminedError: the comment thread could not be
+            completely scanned (#981) — carries `.reason`.
+        RosterResolutionError: a named child repo's roster could not be
+            resolved (#552) — propagated verbatim from `_load_roster_names`.
+
+    Callers translate each exception into their OWN block/error
+    presentation; this function never renders a message, only computes.
+    """
+    author = pr_data["author"]
+    reviews = pr_data["reviews"]
+    head_ref = pr_data["headRefName"]
+    number = pr_data["number"]
+    labels = pr_data["labels"]
+
+    latest_content = get_latest_content_commit(number, repo=repo)
+    content_ts = latest_content[1] if latest_content else None
+    content_sha = latest_content[0] if latest_content else ""
+
+    formal_reviewers, stale_formal = partition_formal_reviewers(reviews, author, content_ts)
+
+    comment_result = CommentReviewResult()
+    branch_author_lastname = None
+    if head_ref:
+        branch_author_lastname = extract_branch_author_lastname(head_ref)
+        if branch_author_lastname:
+            comment_result = check_comment_reviews(
+                number, branch_author_lastname, repo=repo, content_ts=content_ts
+            )
+        elif head_ref.startswith("deployments/") and "/wave-" in head_ref:
+            # Wave-merge PR (head = deployments/phase-{N}/wave-{M}); no
+            # implementer-branch author. Empty sentinel admits any non-empty
+            # reviewer. See main#294.
+            comment_result = check_comment_reviews(number, "", repo=repo, content_ts=content_ts)
+
+    if comment_result.undetermined:
+        raise CommentScanUndeterminedError(comment_result.undetermined)
+
+    roster_names = _load_roster_names(repo=repo)
+
+    non_roster_requestors = {r for r in comment_result.reviewers if r not in roster_names}
+    roster_comment_reviewers = comment_result.reviewers - non_roster_requestors
+
+    distinct_reviewers = formal_reviewers | roster_comment_reviewers
+
+    wave_bootstrap_exception = is_single_reviewer_exception(labels, distinct_reviewers, repo=repo)
+
+    return ReviewVerdicts(
+        number=number,
+        head_ref=head_ref,
+        labels=labels,
+        branch_author_lastname=branch_author_lastname,
+        content_sha=content_sha,
+        content_ts=content_ts,
+        formal_reviewers=formal_reviewers,
+        comment_reviewers=set(comment_result.reviewers),
+        non_roster_requestors=non_roster_requestors,
+        roster_comment_reviewers=roster_comment_reviewers,
+        roster_names=roster_names,
+        distinct_reviewers=distinct_reviewers,
+        stale_verdicts_comment=list(comment_result.stale_verdicts),
+        stale_verdicts_formal=list(stale_formal),
+        reviews_missing_tech_debt=list(comment_result.reviews_missing_tech_debt),
+        tech_debt_issue_numbers=list(comment_result.tech_debt_issue_numbers),
+        wave_bootstrap_exception=wave_bootstrap_exception,
+    )
+
+
 def check(input_data: dict) -> dict | None:
     """Check PR review requirements. Returns result dict if blocking/warning, None if allowed."""
     tool_name = input_data.get("tool_name", "")
@@ -1385,21 +1548,20 @@ def check(input_data: dict) -> dict | None:
         log_pretooluse_block("validate_pr_review", command, result["reason"])
         return result
 
-    author = pr_data["author"]
-    reviews = pr_data["reviews"]
-    head_ref = pr_data["headRefName"]
-    number = pr_data["number"]
-    labels = pr_data["labels"]
-
-    # Content binding (#950). Establish T_content — the committer timestamp of the
-    # branch's latest NON-MERGE commit — BEFORE counting any verdict, because a
-    # verdict cast before it did not review the code being merged. On a fetch
-    # failure T_content is unknown, so NO verdict's freshness can be established:
-    # HARD BLOCK rather than fall back to counting everything, which is precisely
-    # the pre-#950 fail-open (`feedback_safety_direction_over_ux_friction`).
+    # Resolve the full review-verdict set through the ONE shared pipeline
+    # (#1048) — content binding, formal + comment reviewer partitioning,
+    # roster filtering, and the union/threshold inputs. `check()` and
+    # `pr_review_state.compute_review_state` both call `resolve_review_verdicts`
+    # rather than each re-assembling this pipeline with their own argument
+    # list; that re-derivation was the #1046 defect class.
     try:
-        latest_content = get_latest_content_commit(number, repo=repo)
+        verdicts = resolve_review_verdicts(pr_data, repo=repo)
     except CommitFetchError as exc:
+        # Content binding (#950): T_content — the committer timestamp of the
+        # branch's latest NON-MERGE commit — could not be established. Without
+        # it NO verdict's freshness is knowable: HARD BLOCK rather than fall
+        # back to counting everything, which is precisely the pre-#950
+        # fail-open (`feedback_safety_direction_over_ux_friction`).
         result = {
             "decision": "block",
             "reason": (
@@ -1423,45 +1585,19 @@ def check(input_data: dict) -> dict | None:
         }
         log_pretooluse_block("validate_pr_review", command, result["reason"])
         return result
-
-    content_ts = latest_content[1] if latest_content else None
-    content_sha = latest_content[0] if latest_content else ""
-
-    # Formal GitHub reviews are bound to T_content by the SAME rule (#950) — a
-    # stale formal review is no better evidence than a stale comment verdict, and
-    # leaving it unbound would be a hole straight through the fix. Shared with the
-    # #707 driver via `partition_formal_reviewers` so the two cannot drift (#1046).
-    formal_reviewers, stale_formal = partition_formal_reviewers(reviews, author, content_ts)
-
-    comment_review_result = CommentReviewResult()
-    branch_author_lastname = None
-    if head_ref:
-        branch_author_lastname = extract_branch_author_lastname(head_ref)
-        if branch_author_lastname:
-            comment_review_result = check_comment_reviews(
-                number, branch_author_lastname, repo=repo, content_ts=content_ts
-            )
-        elif head_ref.startswith("deployments/") and "/wave-" in head_ref:
-            # Wave-merge PR (head = deployments/phase-{N}/wave-{M}); no implementer-branch
-            # author. Pass empty sentinel so the reviewer-vs-author lastname comparison
-            # admits any non-empty reviewer name. See main#294.
-            comment_review_result = check_comment_reviews(
-                number, "", repo=repo, content_ts=content_ts
-            )
-
-    # Incomplete comment scan (#981 defense-in-depth). An empty reviewer set that
-    # came from a FAILED scan is not evidence of anything — it is the absence of
-    # evidence, and counting it as "0 approvals found" is the same category of
-    # error as counting an unverifiable merge as approved. Hard-block with the
-    # underlying reason.
-    if comment_review_result.undetermined:
+    except CommentScanUndeterminedError as exc:
+        # Incomplete comment scan (#981 defense-in-depth). An empty reviewer
+        # set that came from a FAILED scan is not evidence of anything — it is
+        # the absence of evidence, and counting it as "0 approvals found" is
+        # the same category of error as counting an unverifiable merge as
+        # approved. Hard-block with the underlying reason.
         result = {
             "decision": "block",
             "reason": (
                 f"BLOCKED: PR {pr_display} — the charter-format review comments could not "
                 "be read, so the hook cannot tell whether this PR has two approving "
                 "reviewers.\n"
-                f"Detail: {comment_review_result.undetermined}\n\n"
+                f"Detail: {exc.reason}\n\n"
                 "This blocks rather than treating an unreadable comment thread as an "
                 "empty one: a failed scan and a genuinely unreviewed PR are "
                 "indistinguishable from the reviewer set alone, and silently reporting "
@@ -1476,27 +1612,13 @@ def check(input_data: dict) -> dict | None:
         }
         log_pretooluse_block("validate_pr_review", command, result["reason"])
         return result
-
-    stale_verdicts = comment_review_result.stale_verdicts + stale_formal
-
-    # Filter charter-format (comment-based) reviewers against the roster before
-    # counting them toward the 2-reviewer gate (#498). The 2-reviewer rule
-    # exists to ensure two distinct ROSTER MEMBERS reviewed; without this
-    # filter, fictional / non-roster Requestor strings (e.g., the P3W11 #487
-    # "Camila Restrepo" / "Imelda Santos" incident) slip through unchallenged.
-    # Formal GitHub reviews (`formal_reviewers`) are NOT filtered — those are
-    # real GitHub identities authenticated by the platform, not persona names
-    # that need cross-checking against `.claude/team/roster/`.
-    #
-    # The roster is resolved relative to the PR's TARGET repo (#552): the parent
-    # roster is unioned with the named child repo's `.claude/team/roster/`, so a
-    # reviewer valid in EITHER the org-level team or the target child repo
-    # passes. If a child repo is named but its roster dir is unreadable, fail in
-    # the SAFE direction (HARD BLOCK with diagnostic — never silent parent-only
-    # fallback, which would re-block legitimate child reviewers as #552 did).
-    try:
-        roster_names = _load_roster_names(repo=repo)
     except RosterResolutionError as exc:
+        # Roster resolved relative to the PR's TARGET repo (#552): the parent
+        # roster is unioned with the named child repo's `.claude/team/roster/`.
+        # If a child repo is named but its roster dir is unreadable, fail in
+        # the SAFE direction (HARD BLOCK with diagnostic — never silent
+        # parent-only fallback, which would re-block legitimate child
+        # reviewers as #552 did).
         result = {
             "decision": "block",
             "reason": (
@@ -1518,16 +1640,18 @@ def check(input_data: dict) -> dict | None:
         log_pretooluse_block("validate_pr_review", command, result["reason"])
         return result
 
-    non_roster_requestors = {r for r in comment_review_result.reviewers if r not in roster_names}
-    roster_comment_reviewers = comment_review_result.reviewers - non_roster_requestors
-
-    distinct_reviewers = formal_reviewers | roster_comment_reviewers
-    total_distinct = len(distinct_reviewers)
+    content_ts = verdicts.content_ts
+    content_sha = verdicts.content_sha
+    stale_verdicts = verdicts.stale_verdicts
+    roster_names = verdicts.roster_names
+    non_roster_requestors = verdicts.non_roster_requestors
+    roster_comment_reviewers = verdicts.roster_comment_reviewers
+    total_distinct = verdicts.total_distinct
 
     # Single-Reviewer Exception (resolves #228) — wave-bootstrap PRs reviewed
     # by a charter enforcer may merge with one Approved comment instead of
     # two. Charter-enforcer role check uses the target-repo-resolved roster.
-    if total_distinct == 1 and is_single_reviewer_exception(labels, distinct_reviewers, repo=repo):
+    if total_distinct == 1 and verdicts.wave_bootstrap_exception:
         # Exception applies — fall through to TechDebt check, then allow.
         pass
     elif total_distinct < 2:
@@ -1576,7 +1700,7 @@ def check(input_data: dict) -> dict | None:
                 if roster_names
                 else "Valid roster: <empty — local roster dir could not be read>"
             )
-            raw_total = len(comment_review_result.reviewers)
+            raw_total = len(verdicts.comment_reviewers)
             roster_count = len(roster_comment_reviewers)
             roster_diagnostic = (
                 f"BLOCKED: PR {pr_display} has {raw_total} distinct Requestor string(s) "
@@ -1660,7 +1784,7 @@ def check(input_data: dict) -> dict | None:
         log_pretooluse_block("validate_pr_review", command, result["reason"])
         return result
 
-    missing = comment_review_result.reviews_missing_tech_debt
+    missing = verdicts.reviews_missing_tech_debt
     if missing:
         names = ", ".join(missing)
         result = {
@@ -1682,7 +1806,7 @@ def check(input_data: dict) -> dict | None:
         return result
 
     # All checks passed — ensure any referenced tech-debt issues are on the board
-    td_issues = comment_review_result.tech_debt_issue_numbers
+    td_issues = verdicts.tech_debt_issue_numbers
     if td_issues:
         board_repo_name = ""
         if repo and "/" in repo:

--- a/.claude/lib/pr_review_state.py
+++ b/.claude/lib/pr_review_state.py
@@ -9,23 +9,31 @@ PreToolUse block. There was no way to ASK the same question ahead of time:
   - before spawning reviewers — is this PR already reviewed, and by whom?
   - before `gh pr merge`   — will the gate pass, or who is missing TechDebt?
 
-This CLI answers that question by REUSING the hook's functions verbatim —
-`get_pr_data`, `extract_branch_author_lastname`, `get_latest_content_commit`,
-`partition_formal_reviewers`, `check_comment_reviews`, `_load_roster_names`,
-and `is_single_reviewer_exception`. It deliberately does NOT reimplement the
-charter-comment parsing: a fork would silently drift from the gate, and that
-drift is the exact failure #707 exists to prevent. The PASS/FAIL verdict
-computed here mirrors `validate_pr_review.check()` step for step (T_content
-verdict staleness, formal + roster-filtered comment reviewers, the wave-merge
-head-ref sentinel, the single-reviewer exception, and the missing-TechDebt
-block).
+This CLI answers that question by REUSING the hook's own pipeline verbatim —
+`get_pr_data` plus the SINGLE shared `resolve_review_verdicts` entry point
+(#1048), which itself wraps `extract_branch_author_lastname`,
+`get_latest_content_commit`, `partition_formal_reviewers`,
+`check_comment_reviews`, `_load_roster_names`, and
+`is_single_reviewer_exception`. It deliberately does NOT reimplement the
+charter-comment parsing, nor re-assemble that pipeline with its own argument
+list: a fork would silently drift from the gate, and that drift is the exact
+failure #707 exists to prevent. The PASS/FAIL verdict computed here mirrors
+`validate_pr_review.check()` step for step (T_content verdict staleness,
+formal + roster-filtered comment reviewers, the wave-merge head-ref sentinel,
+the single-reviewer exception, and the missing-TechDebt block) because both
+now compute it via the same `resolve_review_verdicts` call.
 
 Reusing the gate's functions is necessary but NOT sufficient for parity — the
 ARGUMENTS matter as much as the callee. #1046: this driver called
 `check_comment_reviews` without the `content_ts` keyword, so `T_content` was
 never computed, `stale_verdicts` stayed empty, and the tool reported PASS on
-approvals the gate would reject as stale (observed live on main#1040). When
-adding a parameter to a shared gate function, audit THIS file's call sites —
+approvals the gate would reject as stale (observed live on main#1040). #1048
+closes the defect CLASS rather than just the one instance: `check()` and
+`compute_review_state` no longer each re-assemble the content-binding /
+comment-scan / roster-filter / union pipeline with their own argument list —
+they both call `gate.resolve_review_verdicts(pr_data, repo=repo)`, so a
+future parameter added to that pipeline is threaded through ONE call site,
+not two that can silently drift apart.
 `.claude/lib/tests/test_pr_review_state.py::ContentStalenessTests` is the
 regression guard and is mutation-verified against exactly that omission.
 
@@ -123,17 +131,19 @@ class ReviewStateError(Exception):
 def compute_review_state(pr_number: str, repo: str | None = None) -> ReviewState:
     """Compute a PR's review state by replaying the merge gate's own logic.
 
-    Reuses `gate.get_pr_data`, `gate.extract_branch_author_lastname`,
-    `gate.get_latest_content_commit`, `gate.partition_formal_reviewers`,
-    `gate.check_comment_reviews`, `gate._load_roster_names`, and
-    `gate.is_single_reviewer_exception`, forwarding `content_ts` to every
-    staleness-aware call so this driver and Hook 4 cannot drift (#1046).
+    Fetches the PR via `gate.get_pr_data`, then hands the pipeline entirely
+    to `gate.resolve_review_verdicts` (#1048) — the SAME shared entry point
+    `validate_pr_review.check()` calls. Neither this driver nor `check()`
+    re-derives the content-binding / comment-scan / roster-filter / union
+    pipeline with its own argument list; #1046 happened precisely because
+    this driver's OWN copy of that pipeline omitted `content_ts` on one call.
+    A single shared computation cannot drift from itself.
 
     Raises `ReviewStateError` when the PR cannot be fetched, the PR's commit
     list cannot be fetched (T_content unknown ⇒ no verdict's freshness is
-    knowable), or a named child repo's roster cannot be resolved — the
-    determinate-failure cases the gate hard-blocks on (exit code 2), distinct
-    from a gate FAIL (exit code 1).
+    knowable), the comment scan could not complete, or a named child repo's
+    roster cannot be resolved — the determinate-failure cases the gate
+    hard-blocks on (exit code 2), distinct from a gate FAIL (exit code 1).
     """
     # An unresolvable `--repo` is deterministic, not transient, so name it
     # specifically instead of sending the operator to re-check `gh auth status`
@@ -155,22 +165,17 @@ def compute_review_state(pr_number: str, repo: str | None = None) -> ReviewState
             + " — check the PR number, --repo value, and `gh auth status`."
         )
 
-    author = pr_data["author"]
-    reviews = pr_data["reviews"]
-    head_ref = pr_data["headRefName"]
     number = pr_data["number"]
-    labels = pr_data["labels"]
 
-    # Content binding (#950), mirroring check(): establish T_content — the
-    # committer timestamp of the branch's latest NON-MERGE commit — BEFORE
-    # counting any verdict. A commit-fetch failure means NO verdict's freshness
-    # can be established, so it is a determinate failure (exit 2), NOT a
-    # fallback to `content_ts=None`. Defaulting to None here would count every
-    # verdict regardless of age — reinstating precisely the #1046 fail-open this
-    # function is being fixed for.
     try:
-        latest_content = gate.get_latest_content_commit(number, repo=repo)
+        verdicts = gate.resolve_review_verdicts(pr_data, repo=repo)
     except gate.CommitFetchError as exc:
+        # Content binding (#950): T_content — the committer timestamp of the
+        # branch's latest NON-MERGE commit — could not be established. A
+        # fetch failure means NO verdict's freshness can be established, so
+        # it is a determinate failure (exit 2), not a fallback to
+        # `content_ts=None` (which would count every verdict regardless of
+        # age — precisely the #1046 fail-open).
         raise ReviewStateError(
             f"could not fetch the commit list for PR #{number}"
             + (f" in {repo}" if repo else "")
@@ -178,65 +183,32 @@ def compute_review_state(pr_number: str, repo: str | None = None) -> ReviewState
             "knowable and the gate's own verdict cannot be replayed. Hook 4 hard-blocks "
             "here rather than counting verdicts of unknown freshness (#950)."
         ) from exc
-
-    content_ts = latest_content[1] if latest_content else None
-    content_sha = latest_content[0] if latest_content else ""
-
-    # Formal GitHub reviews from non-authors (not roster-filtered — these are
-    # platform-authenticated identities, exactly as the gate treats them), bound
-    # to T_content by the gate's own shared helper rather than a local copy.
-    formal_reviewers, stale_formal = gate.partition_formal_reviewers(reviews, author, content_ts)
-
-    # Resolve head ref -> branch-author lastname, then fetch comment reviews.
-    # Mirrors check(): a normal feature branch yields a lastname; a wave-merge
-    # head (deployments/phase-N/wave-M) has no implementer author, so the gate
-    # passes an empty sentinel that admits any non-empty reviewer. `content_ts`
-    # MUST be forwarded on both call sites — omitting it silently disables
-    # staleness filtering and reports PASS on stale approvals (#1046).
-    comment_result = gate.CommentReviewResult()
-    branch_author_lastname = None
-    if head_ref:
-        branch_author_lastname = gate.extract_branch_author_lastname(head_ref)
-        if branch_author_lastname:
-            comment_result = gate.check_comment_reviews(
-                number, branch_author_lastname, repo=repo, content_ts=content_ts
-            )
-        elif head_ref.startswith("deployments/") and "/wave-" in head_ref:
-            comment_result = gate.check_comment_reviews(
-                number, "", repo=repo, content_ts=content_ts
-            )
-
-    # An INCOMPLETE comment scan is a determinate failure, not a zero-approval
-    # result (#981). Mirrors the gate's hard-block: reporting an unreadable
-    # comment thread as an empty one would make this driver answer FAIL (exit 1,
-    # "this PR lacks approvals") when the honest answer is "could not determine"
-    # (exit 2) — and would drift from Hook 4, which is what #1046 was.
-    if comment_result.undetermined:
+    except gate.CommentScanUndeterminedError as exc:
+        # An INCOMPLETE comment scan is a determinate failure, not a
+        # zero-approval result (#981). Reporting an unreadable comment thread
+        # as an empty one would make this driver answer FAIL (exit 1, "this
+        # PR lacks approvals") when the honest answer is "could not
+        # determine" (exit 2) — and would drift from Hook 4, which is what
+        # #1046 was.
         raise ReviewStateError(
             f"comment reviews for PR #{number} could not be read: "
-            f"{comment_result.undetermined}\nWithout them the gate's verdict cannot be "
+            f"{exc.reason}\nWithout them the gate's verdict cannot be "
             "replayed, so this is a determinate failure rather than a zero-approval result."
-        )
-
-    # Filter comment-based Approved reviewers against the roster (gate #498):
-    # only real roster personas count toward the threshold. A missing child
-    # roster is a hard-block in the gate, surfaced here as ReviewStateError.
-    try:
-        roster_names = gate._load_roster_names(repo=repo)
+        ) from exc
     except gate.RosterResolutionError as exc:
+        # Filter comment-based Approved reviewers against the roster (#498):
+        # only real roster personas count toward the threshold. A missing
+        # child roster is a hard-block in the gate, surfaced here as
+        # ReviewStateError.
         raise ReviewStateError(
             f"child-repo roster could not be resolved for --repo '{repo}': {exc}"
         ) from exc
 
-    non_roster = {r for r in comment_result.reviewers if r not in roster_names}
-    roster_comment_reviewers = comment_result.reviewers - non_roster
-
-    distinct = formal_reviewers | roster_comment_reviewers
-
-    wave_bootstrap = gate.is_single_reviewer_exception(labels, distinct, repo=repo)
-
-    # Stale verdicts from BOTH sources, in the gate's own order (comment, then
-    # formal), flattened to dicts so the dataclass stays JSON-serializable.
+    # Stale verdicts from BOTH sources, tagged by source and flattened to
+    # dicts so the dataclass stays JSON-serializable. `resolve_review_verdicts`
+    # keeps the two sources as separate lists precisely so a caller that wants
+    # to tag provenance (this driver's `stale_verdicts[].source` field) can,
+    # without reconstructing which sub-list a given entry came from.
     stale_verdicts = [
         {
             "reviewer": sv.reviewer,
@@ -244,27 +216,27 @@ def compute_review_state(pr_number: str, repo: str | None = None) -> ReviewState
             "created_at": sv.created_at,
             "source": source,
         }
-        for source, verdicts in (
-            ("comment", comment_result.stale_verdicts),
-            ("formal", stale_formal),
+        for source, svs in (
+            ("comment", verdicts.stale_verdicts_comment),
+            ("formal", verdicts.stale_verdicts_formal),
         )
-        for sv in verdicts
+        for sv in svs
     ]
 
     return ReviewState(
         pr_number=str(number),
         repo=repo,
-        head_ref=head_ref,
-        branch_author_lastname=branch_author_lastname,
-        formal_reviewers=sorted(formal_reviewers),
-        comment_reviewers=sorted(roster_comment_reviewers),
-        non_roster_requestors=sorted(non_roster),
-        distinct_reviewer_count=len(distinct),
-        wave_bootstrap_exception=wave_bootstrap,
-        reviews_missing_tech_debt=list(comment_result.reviews_missing_tech_debt),
-        tech_debt_issue_numbers=list(comment_result.tech_debt_issue_numbers),
-        content_sha=content_sha,
-        content_ts=content_ts.isoformat() if content_ts else None,
+        head_ref=verdicts.head_ref,
+        branch_author_lastname=verdicts.branch_author_lastname,
+        formal_reviewers=sorted(verdicts.formal_reviewers),
+        comment_reviewers=sorted(verdicts.roster_comment_reviewers),
+        non_roster_requestors=sorted(verdicts.non_roster_requestors),
+        distinct_reviewer_count=verdicts.total_distinct,
+        wave_bootstrap_exception=verdicts.wave_bootstrap_exception,
+        reviews_missing_tech_debt=list(verdicts.reviews_missing_tech_debt),
+        tech_debt_issue_numbers=list(verdicts.tech_debt_issue_numbers),
+        content_sha=verdicts.content_sha,
+        content_ts=verdicts.content_ts.isoformat() if verdicts.content_ts else None,
         stale_verdicts=stale_verdicts,
     )
 

--- a/.claude/lib/tests/test_pr_review_state.py
+++ b/.claude/lib/tests/test_pr_review_state.py
@@ -195,6 +195,62 @@ class ComputeReviewStateTests(unittest.TestCase):
             with self.assertRaises(prs.ReviewStateError):
                 prs.compute_review_state("707", repo="noorinalabs/noorinalabs-main")
 
+    def test_delegates_to_the_shared_resolve_review_verdicts_entry_point(self):
+        """#1048: `compute_review_state` must call `gate.resolve_review_verdicts`
+        and use its output DIRECTLY rather than reassembling the
+        content-binding / comment-scan / roster-filter / union pipeline
+        inline — the concrete guard for #1048's acceptance criterion
+        ('neither check() nor compute_review_state re-derives the verdict
+        set'). A fake `ReviewVerdicts` drives the whole result.
+        """
+        fake_verdicts = prs.gate.ReviewVerdicts(
+            number="707",
+            head_ref="S.Ferreira/0707-pr-review-state",
+            labels=[],
+            branch_author_lastname="Ferreira",
+            content_sha="ac8bcfa",
+            content_ts=_NOW,
+            formal_reviewers=set(),
+            comment_reviewers={"aino virtanen", "nadia khoury"},
+            non_roster_requestors=set(),
+            roster_comment_reviewers={"aino virtanen", "nadia khoury"},
+            roster_names={"aino virtanen", "nadia khoury"},
+            distinct_reviewers={"aino virtanen", "nadia khoury"},
+            stale_verdicts_comment=[],
+            stale_verdicts_formal=[],
+            reviews_missing_tech_debt=[],
+            tech_debt_issue_numbers=["808"],
+            wave_bootstrap_exception=False,
+        )
+        with (
+            mock.patch.object(prs.gate, "get_pr_data", return_value=_pr_data()),
+            mock.patch.object(
+                prs.gate, "resolve_review_verdicts", return_value=fake_verdicts
+            ) as mock_resolve,
+        ):
+            state = prs.compute_review_state("707", repo="noorinalabs/noorinalabs-main")
+
+        mock_resolve.assert_called_once()
+        self.assertEqual(state.distinct_reviewer_count, 2)
+        self.assertEqual(state.tech_debt_issue_numbers, ["808"])
+        self.assertTrue(state.passes())
+
+    def test_comment_scan_undetermined_raises_review_state_error(self):
+        """`CommentScanUndeterminedError` from the shared boundary must reach
+        this driver's own `ReviewStateError` (exit 2) — proving the
+        exception, not a re-derived `undetermined` flag, is what drives it."""
+        with (
+            mock.patch.object(prs.gate, "get_pr_data", return_value=_pr_data()),
+            mock.patch.object(
+                prs.gate,
+                "resolve_review_verdicts",
+                side_effect=prs.gate.CommentScanUndeterminedError("HTTP 403: Forbidden"),
+            ),
+        ):
+            with self.assertRaises(prs.ReviewStateError) as ctx:
+                prs.compute_review_state("707", repo="noorinalabs/noorinalabs-main")
+        self.assertIn("HTTP 403: Forbidden", str(ctx.exception))
+
 
 # ---------------------------------------------------------------------------
 # #1046 — content-staleness binding


### PR DESCRIPTION
## Summary

Closes #1048. Follow-up to #1046 point 5.

#1046 delivered the narrow half of this: `partition_formal_reviewers`, shared
by `check()` and `pr_review_state.py`. This closes the rest — the
comment/roster/threshold pipeline was still re-assembled **independently**
by `check()` and `compute_review_state`, each separately calling
`get_latest_content_commit`, `check_comment_reviews` (twice — feature-branch
vs wave-merge), `_load_roster_names`, and `is_single_reviewer_exception`, then
unioning formal + comment reviewers and applying the threshold. Any future
parameter added to that pipeline had to be threaded through **two** call
sites by hand — the exact #1046 defect class, just not yet triggered again.

## Fix

Extracted the shared pipeline into `resolve_review_verdicts(pr_data, repo) ->
ReviewVerdicts` in `validate_pr_review.py`:

1. `get_latest_content_commit` → T_content (`content_ts`/`content_sha`, #950)
2. `partition_formal_reviewers` + `check_comment_reviews`, both bound to
   T_content, on the feature-branch or wave-merge head-ref path
3. `_load_roster_names` + non-roster Requestor filtering (#498)
4. Union formal + roster-filtered comment reviewers, plus the wave-bootstrap
   single-reviewer exception (#228)

`check()` and `pr_review_state.compute_review_state` now both call this ONE
function and use its output directly — **neither re-derives the verdict
set**. Message/report rendering stays with each caller: `check()` keeps its
block-message construction; the driver keeps `ReviewState.passes()` and its
text/JSON report.

Three exceptions surface the pipeline's determinate-failure cases so each
caller renders its own message: `CommitFetchError` and `RosterResolutionError`
propagate verbatim (unchanged); a new `CommentScanUndeterminedError` carries
the #981 incomplete-scan reason that previously lived on
`CommentReviewResult.undetermined`.

## Behavior preservation

All 214 pre-existing `test_validate_pr_review.py` tests and all 27
pre-existing `test_pr_review_state.py` tests pass **unchanged** — this is a
pure extraction, not a behavior change.

## Mutation verification (per the issue's acceptance criterion)

Manually confirmed by temporarily stripping `content_ts=content_ts` from the
feature-branch `check_comment_reviews` call inside `resolve_review_verdicts`
and rerunning the suite: **4 tests in `ContentStalenessTests` went red
immediately**, because that class drives `compute_review_state` through the
REAL `resolve_review_verdicts` over a faked `gh api` boundary — exactly the
#1046 mutation, now caught at the new shared boundary.

Added as permanent guards:
- `ResolveReviewVerdictsSharedBoundaryTests` (hook tests) — a direct
  stale-verdict kill-shot on `resolve_review_verdicts` itself, plus
  delegation tests (`test_check_delegates_to_resolve_review_verdicts_and_trusts_it`,
  `test_check_translates_stale_verdict_error_into_a_block`) that patch the
  function and assert `check()` calls it exactly once and trusts its output.
- `test_delegates_to_the_shared_resolve_review_verdicts_entry_point` /
  `test_comment_scan_undetermined_raises_review_state_error` (driver tests) —
  the same delegation guard on `compute_review_state`.

## Local gate

`pre-commit run --all-files` (commit stage) + `pre-commit run --hook-stage
pre-push --all-files` (mypy + full pytest suite, 2726 passed) — both clean.

## Acceptance (from #1048)

- [x] Single shared entry point; neither `check()` nor `compute_review_state`
      re-derives the verdict set.
- [x] Behaviour-preserving: the existing Hook 4 and driver suites pass
      unchanged.
- [x] Mutation-verified the same way #1046 was — dropping a parameter at the
      shared boundary fails a test.

## Reviewers

- **Weronika Zielinska** (merge-gate)
- **Lucas Ferreira**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018KeNK3VBB3zFyJWxUGWM7z
