### PR TITLE
fix(ci): pin ruff to 0.15.11 to match pre-commit (#1129)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,11 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: pip install ruff
+      # Pin to the exact ruff the pre-commit hook uses (.pre-commit-config.yaml
+      # ruff-pre-commit rev: v0.15.11). Unpinned, CI drifts to a newer ruff whose
+      # formatter touches python code blocks embedded in markdown, red-gating
+      # `.claude/skills/**/SKILL.md` that pass locally + in pre-commit (#1129).
+      - run: pip install ruff==0.15.11
       # .claude/skills/ added per #326: skill helper/test .py (validate_matrix_names.py,
       # promotion-audit/helpers.py, the per-skill tests/, …) was previously
       # un-linted, violating criterion #5 ("anything in the tree gets the same
@@ -49,7 +53,11 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: pip install ruff
+      # Pin to the exact ruff the pre-commit hook uses (.pre-commit-config.yaml
+      # ruff-pre-commit rev: v0.15.11). Unpinned, CI drifts to a newer ruff whose
+      # formatter touches python code blocks embedded in markdown, red-gating
+      # `.claude/skills/**/SKILL.md` that pass locally + in pre-commit (#1129).
+      - run: pip install ruff==0.15.11
       - run: ruff format --check .claude/hooks/ .claude/lib/ .claude/skills/
 
   typecheck:


### PR DESCRIPTION
Closes #1129.

## Problem
`.github/workflows/ci.yml` installs ruff **unpinned** (`pip install ruff`) in the Ruff lint and Ruff format jobs. CI drifts to the newest ruff, whose formatter reformats python code blocks embedded in markdown, red-gating `.claude/skills/**/SKILL.md` that pass locally and in pre-commit. This blocks every `.claude/` PR on **Ruff format check** — observed on main **#1126** and **#1128**.

## Fix
Pin both CI install sites to `ruff==0.15.11`, matching `.pre-commit-config.yaml` (`astral-sh/ruff-pre-commit` `rev: v0.15.11`). CI and pre-commit now use the same ruff.

Unblocks #1126 and #1128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)