### PR TITLE
fix(kickoff-hook): merge-model-aware branch base + wrapper-tolerant label parsing + reconciliation sweep (#1141)

### DIFF
--- a/.claude/hooks/_shell_parse.py
+++ b/.claude/hooks/_shell_parse.py
@@ -64,13 +64,13 @@ Public API
         (where the dependency is declared); a bare checkout without it still
         works via the shlex/regex fallback (zero-setup-on-pull is preserved).
 
-    strip_command_prefixes(segment) -> list[str]
-        Drops the leading run of compound-statement keywords (`do`, `then`,
-        `if`, ...) and transparent command-prefix wrappers (`timeout 45`,
-        `env`, `nohup`, `sudo`, ...) from a segment, returning the tokens
-        of the command that actually runs (main#1141).
+    strip_command_prefixes(segment, *, compound_leaders=True) -> list[str]
+        Drops the leading run of transparent command-prefix wrappers
+        (`timeout 45`, `env`, `nohup`, `sudo`, ...) and — when
+        `compound_leaders=True` — compound-statement keywords (`do`, `then`,
+        `if`, ...), returning the tokens of the command that runs (main#1141).
 
-        **Lockstep invariant:** EVERY function in this module that keys on a
+        **Lockstep invariant:** every function in this module that keys on a
         command-position token must apply this strip — `find_git_subcommand`,
         `find_gh_subcommand`, `extract_dash_c_pairs`,
         `extract_leading_cd_target`. A new segment-consuming helper that
@@ -79,8 +79,23 @@ Public API
         That produced a FALSE POSITIVE (a compliant
         `timeout 60 git -c user.name=… commit` blocked for a missing flag it
         had passed), which is strictly worse than the evasion the strip was
-        added to close. `test_strip_lockstep_across_segment_consumers` pins
-        the invariant.
+        added to close.
+
+        **…but the invariant is "apply the strip", NOT "apply it with the
+        same arguments."** Round 3 of the same review: applying it uniformly
+        shipped a live misroute. Pick the value by what the caller DOES:
+
+          - **Gate matcher** (validates/blocks a command) -> `True`.
+            Over-matching a guarded body is conservative — worst case you
+            inspect a command that would not have run.
+          - **Routing resolver** (decides which repo/target an action hits)
+            -> `False`. Over-matching is destructive — it sends output where
+            the command never went. A compound leader guards a body that may
+            not execute; a wrapper always execs. Only wrappers are safe to
+            assume for routing.
+
+        `test_strip_lockstep_across_segment_consumers` pins the invariant;
+        `GuardedCdMustNotRoute` pins the carve-out.
 
     find_git_subcommand(segment) -> tuple[list[str], list[str]] | None
         Given a single segment's tokens, returns (global_opts, [subcommand,
@@ -650,10 +665,8 @@ def _consume_wrapper_options(rest: list[str], value_flags: frozenset[str], posit
     return i
 
 
-def strip_command_prefixes(segment: list[str]) -> list[str]:
-    """Strip leading compound-statement keywords and command-prefix wrappers.
-
-    Returns the tokens of the command that ACTUALLY runs in `segment`:
+def strip_command_prefixes(segment: list[str], *, compound_leaders: bool = True) -> list[str]:
+    """Strip leading command-prefix wrappers, and optionally compound keywords.
 
         ["timeout", "45", "gh", "issue", "edit", …] -> ["gh", "issue", "edit", …]
         ["do", "gh", "issue", "edit", …]            -> ["gh", "issue", "edit", …]
@@ -665,13 +678,47 @@ def strip_command_prefixes(segment: list[str]) -> list[str]:
     so a segment whose head is any other command is returned untouched. The
     returned list is a fresh object or the original list — callers must not rely
     on identity (main#1141).
+
+    `compound_leaders` — the distinction that decides which callers may say
+    True (main#1141 review round 3)
+    ======================================================================
+
+    The two prefix kinds are NOT equivalent, and conflating them shipped a
+    live misroute:
+
+      - A **wrapper** (`timeout`, `env`, `nice`, `nohup`, `sudo`) ALWAYS execs
+        what follows. Stripping it is unconditionally sound: the wrapped
+        command runs.
+      - A **compound leader** (`then`, `do`, `else`, `{`, `(`) guards a body
+        that MAY NOT RUN. `if [ -f /nonexistent ]; then cd /other-repo; fi`
+        contains a `cd` the shell never executes.
+
+    Whether that matters depends on what the caller does with the answer:
+
+      - A **gate matcher** (`find_git_subcommand`, `find_gh_subcommand`, and
+        `extract_dash_c_pairs` reading a matched segment's flags) errs
+        CONSERVATIVELY by over-matching: at worst it validates a command that
+        would not have run. Harmless. These pass `compound_leaders=True`.
+      - A **routing resolver** (`extract_leading_cd_target`, which decides
+        WHICH REPO an action targets) errs DESTRUCTIVELY by over-matching: it
+        sends output where the command never went. Under
+        `compound_leaders=True` the example above resolved the repo to
+        `noorinalabs-deploy` and would have posted a kickoff comment to
+        `deploy#5` instead of `main#5` — on the #981/#985 misrouting path.
+        Routing callers MUST pass `compound_leaders=False`.
+
+    Non-goal, deliberately: `for r in …; do cd /wt; gh …; done` — a cd inside
+    a loop body that DOES run — is not recovered under
+    `compound_leaders=False`. Distinguishing it from the never-taken `then`
+    body needs block-closure tracking, and the shape is speculative (no
+    observed bug) while the misroute was live. Not worth the machinery.
     """
     tokens = segment
     for _ in range(_MAX_PREFIX_STRIP_ROUNDS):
         if not tokens:
             return tokens
         head = tokens[0]
-        if head in _COMPOUND_LEADERS:
+        if compound_leaders and head in _COMPOUND_LEADERS:
             tokens = tokens[1:]
             continue
         spec = _COMMAND_PREFIX_WRAPPERS.get(head)
@@ -1008,19 +1055,26 @@ def extract_leading_cd_target(command: str) -> str | None:
     command itself even though the harness `cwd` field points at the
     orchestrator's spawn-time directory.
 
-    Strips command prefixes for the same lockstep reason as
-    `extract_dash_c_pairs` (main#1141 review). Once `find_gh_subcommand` can
-    see the `gh` inside `for r in …; do cd /worktree; gh issue edit …; done`,
-    a `cd` that is still invisible in the SAME loop leaves the repo resolved
-    from the wrong directory — one half of the command visible, the other
-    half blind. Both halves strip, or neither should.
+    Strips WRAPPERS ONLY — `compound_leaders=False` (main#1141 review round 3).
+    This function ROUTES (it decides which repo an action targets), and a
+    routing resolver must never assume a guarded body ran:
+
+        if [ -f /nonexistent ] ; then cd /repo-b ; fi ; gh issue edit 5 …
+
+    The shell never executes that `cd`. Stripping `then` made this resolve to
+    repo-b and would have posted to `repo-b#5` instead of `repo-a#5` — the
+    #981/#985 misrouting class. Over-matching is conservative for a GATE
+    (worst case: validate a command that would not run) and destructive for a
+    RESOLVER (send output where the command never went), so the two kinds of
+    caller take different values of `compound_leaders`. `timeout 5 cd /x` and
+    friends still strip: a wrapper always execs what follows.
     """
     tokens = tokenize(command)
     if tokens is None:
         return None
     target: str | None = None
     for raw_segment in iter_command_segments(tokens):
-        segment = strip_command_prefixes(raw_segment)
+        segment = strip_command_prefixes(raw_segment, compound_leaders=False)
         if len(segment) == 2 and segment[0] == "cd" and segment[1].startswith("/"):
             target = segment[1]
     return target

--- a/.claude/hooks/_shell_parse.py
+++ b/.claude/hooks/_shell_parse.py
@@ -81,21 +81,28 @@ Public API
         had passed), which is strictly worse than the evasion the strip was
         added to close.
 
-        **…but the invariant is "apply the strip", NOT "apply it with the
-        same arguments."** Round 3 of the same review: applying it uniformly
-        shipped a live misroute. Pick the value by what the caller DOES:
+        **…but the invariant binds MATCHERS, not every consumer.** Round 3 of
+        the same review: applying it uniformly shipped a live misroute. Which
+        rule a caller follows is decided by what it DOES with the answer:
 
-          - **Gate matcher** (validates/blocks a command) -> `True`.
-            Over-matching a guarded body is conservative — worst case you
-            inspect a command that would not have run.
-          - **Routing resolver** (decides which repo/target an action hits)
-            -> `False`. Over-matching is destructive — it sends output where
-            the command never went. A compound leader guards a body that may
-            not execute; a wrapper always execs. Only wrappers are safe to
-            assume for routing.
+          - **Gate matcher** (validates/blocks a command) — strip everything.
+            Over-matching a guarded body is conservative: worst case you
+            inspect a command that would not have run. `find_git_subcommand`,
+            `find_gh_subcommand`, `extract_dash_c_pairs`.
+          - **Routing resolver** (decides which repo/target an action hits) —
+            strip NOTHING. Over-matching is destructive: it sends output where
+            the command never went, and three hooks downstream WRITE.
+            `extract_leading_cd_target` is the only one in this module, and it
+            opts out entirely (a leader may not run; and an exec-wrapper
+            cannot carry `cd` at all, since `cd` is a shell builtin).
+
+        `compound_leaders=False` exists for a caller that wants wrappers but
+        not leaders. Nothing needs it today — the one routing caller wants
+        neither — but the flag keeps the two prefix families separable rather
+        than welded together for whoever needs the middle position next.
 
         `test_strip_lockstep_across_segment_consumers` pins the invariant;
-        `GuardedCdMustNotRoute` pins the carve-out.
+        `CdRoutingAgainstShellTruth` pins the carve-out against a real shell.
 
     find_git_subcommand(segment) -> tuple[list[str], list[str]] | None
         Given a single segment's tokens, returns (global_opts, [subcommand,
@@ -1055,26 +1062,52 @@ def extract_leading_cd_target(command: str) -> str | None:
     command itself even though the harness `cwd` field points at the
     orchestrator's spawn-time directory.
 
-    Strips WRAPPERS ONLY — `compound_leaders=False` (main#1141 review round 3).
-    This function ROUTES (it decides which repo an action targets), and a
-    routing resolver must never assume a guarded body ran:
+    Strips NOTHING — `cd` must be token 0 of its segment (main#1141 review
+    round 3). This function ROUTES: it decides which repo an action targets,
+    and three hooks on its chain WRITE (`post_wave_kickoff_comment`,
+    `auto_add_issue_to_board`, `post_label_change_wave_field_sync`), so a
+    wrong answer is an unrecoverable write into the wrong repository. Both
+    prefix families are unsafe here, for two different reasons:
 
-        if [ -f /nonexistent ] ; then cd /repo-b ; fi ; gh issue edit 5 …
+    1. **Compound leaders** (`then`, `do`, `else`, `{`, `(`) guard a body that
+       may not run. `if [ -f /nonexistent ]; then cd /repo-b; fi; gh issue
+       edit 5` never executes that `cd`; stripping `then` resolved it to
+       repo-b and would have posted to `repo-b#5` instead of `repo-a#5`.
+    2. **Command-prefix wrappers** (`timeout`, `env`, `nice`, `nohup`) cannot
+       carry a `cd` AT ALL — `cd` is a shell builtin, so an exec-wrapper runs
+       a subprocess (or nothing) and the calling shell's directory is
+       unchanged. Verified in both bash and zsh: `env FOO=1 cd /dest; pwd`
+       prints the ORIGINAL directory. Stripping the wrapper here would have
+       claimed a `cd` that provably never happened. (`command cd` is worse
+       than useless as a signal: bash honours it, zsh does not.)
 
-    The shell never executes that `cd`. Stripping `then` made this resolve to
-    repo-b and would have posted to `repo-b#5` instead of `repo-a#5` — the
-    #981/#985 misrouting class. Over-matching is conservative for a GATE
-    (worst case: validate a command that would not run) and destructive for a
-    RESOLVER (send output where the command never went), so the two kinds of
-    caller take different values of `compound_leaders`. `timeout 5 cd /x` and
-    friends still strip: a wrapper always execs what follows.
+    That is the asymmetry with the matchers, stated exactly: over-matching is
+    conservative for a GATE (worst case, inspect a command that would not have
+    run) and destructive for a RESOLVER (send output where the command never
+    went). So `find_git_subcommand` / `find_gh_subcommand` /
+    `extract_dash_c_pairs` strip everything and this function strips nothing.
+
+    Accepted cost — UNDER-recovery. A `cd` in a body that DOES run (a taken
+    `else`, a real loop iteration) is not recovered, so the caller falls back
+    to the invocation cwd. That is the pre-#1141 behaviour and it is the safe
+    direction: claiming no knowledge is recoverable, claiming the wrong
+    directory is not.
+
+    Known residual, tracked by main#1151 — NOT closed here, and not closable
+    at this layer: (a) a short-circuit `true || cd /elsewhere` puts `cd` at
+    token 0 of its own segment with no leader to withhold, and (b) this
+    function returns the LAST `cd` anywhere in the command with no positional
+    relation to the `gh` node, so `gh issue edit 5 …; cd /elsewhere`
+    misroutes. Both predate main#1141 and both need the bashlex AST
+    (`iter_command_segments_ast`) to answer "is this `cd` unconditional, and
+    does it precede the gh node?" — `iter_command_segments` has already
+    discarded the control flow by the time this loop runs.
     """
     tokens = tokenize(command)
     if tokens is None:
         return None
     target: str | None = None
-    for raw_segment in iter_command_segments(tokens):
-        segment = strip_command_prefixes(raw_segment, compound_leaders=False)
+    for segment in iter_command_segments(tokens):
         if len(segment) == 2 and segment[0] == "cd" and segment[1].startswith("/"):
             target = segment[1]
     return target

--- a/.claude/hooks/_shell_parse.py
+++ b/.claude/hooks/_shell_parse.py
@@ -68,8 +68,19 @@ Public API
         Drops the leading run of compound-statement keywords (`do`, `then`,
         `if`, ...) and transparent command-prefix wrappers (`timeout 45`,
         `env`, `nohup`, `sudo`, ...) from a segment, returning the tokens
-        of the command that actually runs. Applied automatically by
-        `find_git_subcommand` / `find_gh_subcommand` (main#1141).
+        of the command that actually runs (main#1141).
+
+        **Lockstep invariant:** EVERY function in this module that keys on a
+        command-position token must apply this strip — `find_git_subcommand`,
+        `find_gh_subcommand`, `extract_dash_c_pairs`,
+        `extract_leading_cd_target`. A new segment-consuming helper that
+        skips it re-opens the main#1141-review regression: two functions
+        reading ONE segment with different views of where the command starts.
+        That produced a FALSE POSITIVE (a compliant
+        `timeout 60 git -c user.name=… commit` blocked for a missing flag it
+        had passed), which is strictly worse than the evasion the strip was
+        added to close. `test_strip_lockstep_across_segment_consumers` pins
+        the invariant.
 
     find_git_subcommand(segment) -> tuple[list[str], list[str]] | None
         Given a single segment's tokens, returns (global_opts, [subcommand,
@@ -909,8 +920,22 @@ def extract_dash_c_pairs(segment: list[str]) -> list[tuple[str, str]]:
     already unquoted the value half, so `-c user.name="A B"` arrives here as
     `["-c", "user.name=A B"]` (two tokens; the inner `=` is the key/value
     separator handled by `split("=", 1)`).
+
+    MUST strip command prefixes, in lockstep with `find_git_subcommand`
+    (main#1141 review). `validate_commit_identity` calls BOTH on the SAME
+    segment: `find_git_subcommand` to recognize the `commit` verb, then this
+    to read the identity flags. When only the first stripped,
+    `timeout 60 git -c user.name=… commit` was recognized as a commit but its
+    `-c` pairs came back EMPTY, so the gate blocked a fully compliant commit
+    with "missing `-c user.name=` flag" — naming the exact flag the operator
+    had passed. Two functions holding different views of one segment is the
+    hazard; keeping the strip symmetric is the invariant that prevents it.
+    A false positive is strictly worse than the evasion it came from: an
+    evasion costs one missed gate, a false positive blocks correct work for
+    everyone with a message that reads as a lie.
     """
     pairs: list[tuple[str, str]] = []
+    segment = strip_command_prefixes(segment)
     if not segment or segment[0] != "git":
         return pairs
 
@@ -982,12 +1007,20 @@ def extract_leading_cd_target(command: str) -> str | None:
     bug (#521): `cd /worktree && gh pr create` carries the real cwd in the
     command itself even though the harness `cwd` field points at the
     orchestrator's spawn-time directory.
+
+    Strips command prefixes for the same lockstep reason as
+    `extract_dash_c_pairs` (main#1141 review). Once `find_gh_subcommand` can
+    see the `gh` inside `for r in …; do cd /worktree; gh issue edit …; done`,
+    a `cd` that is still invisible in the SAME loop leaves the repo resolved
+    from the wrong directory — one half of the command visible, the other
+    half blind. Both halves strip, or neither should.
     """
     tokens = tokenize(command)
     if tokens is None:
         return None
     target: str | None = None
-    for segment in iter_command_segments(tokens):
+    for raw_segment in iter_command_segments(tokens):
+        segment = strip_command_prefixes(raw_segment)
         if len(segment) == 2 and segment[0] == "cd" and segment[1].startswith("/"):
             target = segment[1]
     return target

--- a/.claude/hooks/_shell_parse.py
+++ b/.claude/hooks/_shell_parse.py
@@ -64,16 +64,28 @@ Public API
         (where the dependency is declared); a bare checkout without it still
         works via the shlex/regex fallback (zero-setup-on-pull is preserved).
 
+    strip_command_prefixes(segment) -> list[str]
+        Drops the leading run of compound-statement keywords (`do`, `then`,
+        `if`, ...) and transparent command-prefix wrappers (`timeout 45`,
+        `env`, `nohup`, `sudo`, ...) from a segment, returning the tokens
+        of the command that actually runs. Applied automatically by
+        `find_git_subcommand` / `find_gh_subcommand` (main#1141).
+
     find_git_subcommand(segment) -> tuple[list[str], list[str]] | None
         Given a single segment's tokens, returns (global_opts, [subcommand,
         ...rest]) if it's a `git ...` invocation, else None. Skips git
         global options (`-c k=v`, `-C dir`, `--git-dir=...`,
         `--work-tree=...`, etc.) so the returned subcommand is the actual
-        git verb (`commit`, `config`, `worktree`, ...).
+        git verb (`commit`, `config`, `worktree`, ...). Leading wrappers /
+        compound keywords are stripped first (main#1141), so
+        `timeout 60 git commit ...` and `do git commit ...` resolve.
 
     find_gh_subcommand(segment) -> tuple[list[str], list[str]] | None
         Same shape for `gh ...`. Returns (gh_global_opts, [topic, action,
-        ...rest]) — e.g. ([], ["pr", "create", "--repo", ...]).
+        ...rest]) — e.g. ([], ["pr", "create", "--repo", ...]). Same
+        leading-wrapper / compound-keyword tolerance (main#1141), so
+        `timeout 45 gh issue edit ...` and the `do`-prefixed body of a
+        `for … ; do gh issue edit … ; done` loop both resolve.
 
     is_gh_subcommand(tokens, *verbs) -> bool
         Yes/no convenience for "does this token list contain a `gh <verb1>
@@ -530,6 +542,135 @@ def _is_equals_form_global(tok: str) -> bool:
     )
 
 
+# ---------------------------------------------------------------------------
+# Command-prefix wrappers + compound-statement leaders (main#1141)
+# ---------------------------------------------------------------------------
+#
+# `find_git_subcommand` / `find_gh_subcommand` keyed on `segment[0]` being
+# literally `git` / `gh`. Two ordinary shapes put something else there and made
+# every consuming hook silently no-op:
+#
+#   timeout 45 gh issue edit 1114 --add-label "wave-29"    -> segment[0] == "timeout"
+#   for n in …; do gh issue edit 1114 --add-label "wave-29"; done
+#                                                          -> segment[0] == "do"
+#
+# For the kickoff hook that meant 14 issues labeled and ZERO kickoff comments
+# posted (main#1141); for the BLOCKING hooks on the same primitive
+# (`block_gh_pr_review`, `block_squash_wave_merge`, `validate_wave_label_evidence`,
+# `validate_commit_identity` via the git twin) it is a gate-evasion class — a
+# `timeout`/`nice`/loop prefix walked straight past the gate.
+#
+# The fix is an ALLOWLIST, never a "scan the segment for a `gh` token anywhere":
+# loose scanning would re-introduce the data-position false-positive class this
+# whole module exists to prevent (`echo gh issue edit 5 …` must NOT match). Only
+# wrappers that transparently exec the following command, with their own option
+# grammar spelled out, are skipped.
+#
+# Each entry maps a wrapper name to (flags that consume a following VALUE,
+# number of bare POSITIONAL args consumed before the wrapped command). Boolean
+# flags, `--flag=value` and attached-short forms need no table entry — any
+# remaining `-`-prefixed token is skipped generically.
+_COMMAND_PREFIX_WRAPPERS: dict[str, tuple[frozenset[str], int]] = {
+    # `timeout DURATION cmd …` — the one positional is the duration.
+    "timeout": (frozenset({"-k", "--kill-after", "-s", "--signal"}), 1),
+    "nice": (frozenset({"-n", "--adjustment"}), 0),
+    "ionice": (frozenset({"-c", "-n", "-p", "--class", "--classdata", "--pid"}), 0),
+    "stdbuf": (frozenset({"-i", "-o", "-e", "--input", "--output", "--error"}), 0),
+    # `env [-u NAME] [KEY=value …] cmd …` — the KEY=value run is skipped by the
+    # generic env-assignment branch in `_consume_wrapper_options`.
+    "env": (frozenset({"-u", "--unset", "-C", "--chdir", "-S", "--split-string"}), 0),
+    "nohup": (frozenset(), 0),
+    "setsid": (frozenset(), 0),
+    "command": (frozenset(), 0),
+    "builtin": (frozenset(), 0),
+    "exec": (frozenset(), 0),
+    "time": (frozenset({"-f", "--format", "-o", "--output"}), 0),
+    "sudo": (
+        frozenset(
+            {"-u", "--user", "-g", "--group", "-p", "--prompt", "-U", "-C", "-h", "-T", "-R"}
+        ),
+        0,
+    ),
+    "doas": (frozenset({"-u", "-C", "-L"}), 0),
+}
+
+# Shell keywords that can occupy position 0 of a segment while the COMMAND
+# follows them in the same segment. `for` / `case` / `select` are deliberately
+# absent: what follows them is a variable name or a word list, not a command
+# (`for n in 1114 …` must not resolve `n` as a command).
+_COMPOUND_LEADERS = frozenset({"do", "then", "else", "if", "elif", "while", "until", "!", "{", "("})
+
+# Bound on the wrapper/keyword unwrap loop. `do timeout 45 nohup gh …` is 3
+# rounds; anything past this is pathological input, not a real command.
+_MAX_PREFIX_STRIP_ROUNDS = 8
+
+
+def _consume_wrapper_options(rest: list[str], value_flags: frozenset[str], positionals: int) -> int:
+    """Return the index in `rest` where a wrapper's own arguments end.
+
+    Walks the wrapper's option run: value-taking flags consume their value,
+    any other flag-shaped token consumes itself, `KEY=value` env assignments
+    are skipped (`env FOO=1 gh …`), and up to `positionals` bare words are
+    consumed (the `timeout DURATION` slot). A literal `--` ends the option run
+    immediately. The first token that is none of those is the wrapped command.
+    """
+    i = 0
+    n = len(rest)
+    while i < n:
+        tok = rest[i]
+        if tok == "--":
+            return i + 1
+        if tok in value_flags:
+            # Mirror `walk_flag_values`: a value-less flag never eats the next
+            # flag-shaped token.
+            i += 2 if (i + 1 < n and not _looks_like_flag(rest[i + 1])) else 1
+            continue
+        if _looks_like_flag(tok):
+            i += 1
+            continue
+        if _ENV_ASSIGN_RE.match(tok):
+            i += 1
+            continue
+        if positionals > 0:
+            positionals -= 1
+            i += 1
+            continue
+        break
+    return i
+
+
+def strip_command_prefixes(segment: list[str]) -> list[str]:
+    """Strip leading compound-statement keywords and command-prefix wrappers.
+
+    Returns the tokens of the command that ACTUALLY runs in `segment`:
+
+        ["timeout", "45", "gh", "issue", "edit", …] -> ["gh", "issue", "edit", …]
+        ["do", "gh", "issue", "edit", …]            -> ["gh", "issue", "edit", …]
+        ["echo", "gh", "issue", "edit", …]          -> unchanged (echo is not a
+                                                       transparent wrapper — its
+                                                       args are DATA, not a command)
+
+    Only names in `_COMMAND_PREFIX_WRAPPERS` / `_COMPOUND_LEADERS` are stripped,
+    so a segment whose head is any other command is returned untouched. The
+    returned list is a fresh object or the original list — callers must not rely
+    on identity (main#1141).
+    """
+    tokens = segment
+    for _ in range(_MAX_PREFIX_STRIP_ROUNDS):
+        if not tokens:
+            return tokens
+        head = tokens[0]
+        if head in _COMPOUND_LEADERS:
+            tokens = tokens[1:]
+            continue
+        spec = _COMMAND_PREFIX_WRAPPERS.get(head)
+        if spec is None:
+            return tokens
+        value_flags, positionals = spec
+        tokens = tokens[1 + _consume_wrapper_options(tokens[1:], value_flags, positionals) :]
+    return tokens
+
+
 def find_git_subcommand(segment: list[str]) -> tuple[list[str], list[str]] | None:
     """If `segment` is a `git ...` invocation, return (global_opts, [subcmd, ...]).
 
@@ -540,9 +681,15 @@ def find_git_subcommand(segment: list[str]) -> tuple[list[str], list[str]] | Non
       --work-tree=path / --work-tree path
       --no-pager / -p / --paginate / --no-replace-objects   (no value)
 
-    Returns None if `segment` is empty, doesn't start with `git`, or doesn't
-    have a subcommand after the global-option run.
+    Leading compound-statement keywords and transparent command-prefix wrappers
+    are stripped first (main#1141), so `timeout 60 git commit …` and the
+    `do`-prefixed body of a loop resolve to the `commit` verb instead of
+    silently bypassing every consuming gate.
+
+    Returns None if `segment` is empty, doesn't start with `git` (after that
+    strip), or doesn't have a subcommand after the global-option run.
     """
+    segment = strip_command_prefixes(segment)
     if not segment or segment[0] != "git":
         return None
 
@@ -577,7 +724,15 @@ def find_gh_subcommand(segment: list[str]) -> tuple[list[str], list[str]] | None
 
     `gh` has no pre-subcommand global options worth skipping for the matchers
     in this codebase, so this is a thin shape-mirror of `find_git_subcommand`.
+
+    Leading compound-statement keywords and transparent command-prefix wrappers
+    are stripped first (main#1141): `timeout 45 gh issue edit …` and the
+    `do`-prefixed body of `for n in …; do gh issue edit …; done` both resolve.
+    Before that fix each returned None, and every consuming hook — the kickoff
+    comment poster AND the blocking `gh pr review` / squash-merge gates —
+    silently did nothing.
     """
+    segment = strip_command_prefixes(segment)
     if not segment or segment[0] != "gh":
         return None
     if len(segment) < 2:

--- a/.claude/hooks/_wave_label_parse.py
+++ b/.claude/hooks/_wave_label_parse.py
@@ -77,6 +77,17 @@ Public API
         At least one of `add_label` / `remove_label` is non-None when the
         function returns a result; otherwise it returns None.
 
+    parse_unresolved_wave_label_edits(command) -> list[UnresolvedWaveLabelEdit]
+        The visibility companion (main#1141): every `gh issue edit …
+        --add-label "<wave label>"` segment whose ISSUE NUMBER could not be
+        resolved — the `for n in 1114 1116; do gh issue edit "$n" …; done`
+        shape, where shlex leaves the literal `$n` and no digit run exists in
+        the command at all. Those segments are invisible to
+        `parse_wave_label_changes` by construction; this function lets a
+        consumer LOG the decline instead of silently doing nothing (the
+        main#1141 failure mode: 14 issues labeled, 0 kickoff comments, caught
+        only by an unrelated audit days later).
+
     is_wave_label(value: str) -> bool
         True if `value` matches the canonical wave-label shape
         `p{N}-wave-{M}` exactly (anchored). Used by callers that already
@@ -287,41 +298,54 @@ def wave_label_to_option_name(value: str) -> str | None:
     return f"P{spec.phase}W{spec.wave}"
 
 
-def _parse_edit_segment(rest: list[str]) -> WaveLabelChange | None:
-    """Parse the rest of a tokenized `gh issue edit <num> ...` segment.
+@dataclass(frozen=True)
+class UnresolvedWaveLabelEdit:
+    """A wave-label `gh issue edit` whose ISSUE NUMBER did not resolve (main#1141).
 
-    Returns the WaveLabelChange if the segment has an issue_number AND at
-    least one canonical wave-label `--add-label`/`--remove-label`. Otherwise
-    returns None.
+    Emitted by `parse_unresolved_wave_label_edits` for the shape
 
-    The repo is resolved from the AUTHORITATIVE `-R`/`--repo owner/name` flag
-    (#985), extracted up front via the #1057-hardened `walk_flag_values` so all
-    five surface forms resolve: `--repo X`, `--repo=X`, `-R X`, `-R=X`, `-RX`.
-    The flag is GROUND TRUTH for "which repo"; the consuming hook's cwd fallback
-    applies ONLY when no repo flag is present. Three states are surfaced:
+        for n in 1114 1116; do gh issue edit "$n" --add-label "wave-29"; done
 
-      - flag present + resolvable  → `repo=<name>`, `repo_flag_present=True`.
-      - flag absent (#650)         → `repo=None`,   `repo_flag_present=False`
-        (in-repo invocation; consumer resolves the ambient repo from cwd).
-      - flag present + unresolvable → `repo=None`, `repo_flag_present=True`
-        (an unexpanded `$VAR` / command substitution; per #981 the consumer
-        MUST fail closed and NOT fall back to cwd, which would misroute).
+    where shlex leaves `$n` literal and the command carries no digit run to
+    key on. `parse_wave_label_changes` cannot return anything useful here —
+    there is genuinely no issue number in the string — but a consumer that
+    silently returns None is the main#1141 bug (labels land, nobody is told
+    they own anything). Consumers use this to LOG the decline.
 
-    Requiring `--repo` here would silently drop every in-repo label edit (#650);
-    blindly `.split("/")`-ing an unexpanded `$VAR` would misroute it (#981). The
-    tri-state threads both needles.
+    `issue_token` is the offending token when it looks like an unexpanded
+    shell expansion (`$n`, `${n}`, `` `…` ``), else None (e.g. an issue URL
+    or a genuinely missing positional).
+    """
+
+    repo: str | None
+    issue_token: str | None
+    add_label: str | None
+    remove_label: str | None
+    repo_flag_present: bool = False
+
+
+# A positional token that shlex left as an unexpanded shell expansion. Same
+# marker set as `_shell_parse._UNRESOLVABLE_REPO_VALUE_RE` minus whitespace
+# (a whitespace-bearing token is never a positional issue ref).
+_UNEXPANDED_TOKEN_RE = re.compile(r"[$`]")
+
+
+def _scan_edit_segment(
+    rest: list[str],
+) -> tuple[str | None, bool, str | None, str | None, str | None, str | None] | None:
+    """Low-level scan of a `gh issue edit …` segment's tokens.
+
+    Returns `(repo, repo_flag_present, issue_number, issue_token, add_label,
+    remove_label)` for any `issue edit` segment, or None when `rest` is not
+    one. `issue_number` is the first bare digit-run positional; `issue_token`
+    is the first positional that looks like an unexpanded shell expansion.
+    Both may be None. Shared by `_parse_edit_segment` (which requires a
+    resolved number) and `parse_unresolved_wave_label_edits` (which reports
+    the segments that lack one) so the two agree by construction.
     """
     if len(rest) < 3 or rest[0] != "issue" or rest[1] != "edit":
         return None
 
-    # Repo from the flag, not cwd (#985). `walk_flag_values` recognizes both the
-    # `--repo` long form and the `-R` short form (all attached/equals/spaced
-    # surfaces, #1057). A present-but-unresolvable value (`$VAR`) yields repo=None
-    # with repo_flag_present=True so the consumer fails closed (#981).
-    #
-    # Last occurrence wins (main#1060): `--repo`/`-R` is a single-value pflag
-    # `StringVarP` in real gh, so a repeated flag resolves to its LAST value,
-    # not its first.
     repo_values = walk_flag_values(rest, {"--repo", "-R"})
     repo_flag_present = len(repo_values) > 0
     repo: str | None = (
@@ -329,6 +353,7 @@ def _parse_edit_segment(rest: list[str]) -> WaveLabelChange | None:
     )
 
     issue_number: str | None = None
+    issue_token: str | None = None
     add_label: str | None = None
     remove_label: str | None = None
 
@@ -338,6 +363,18 @@ def _parse_edit_segment(rest: list[str]) -> WaveLabelChange | None:
         tok = rest[i]
         if issue_number is None and re.fullmatch(r"\d+", tok):
             issue_number = tok
+            i += 1
+            continue
+        # An unexpanded positional (`gh issue edit "$n"`). Guarded on the
+        # PREVIOUS token not being flag-shaped so a `--repo "$REPO"` /
+        # `--body "$MSG"` VALUE is never mistaken for the issue ref — only a
+        # true positional slot is reported.
+        if (
+            issue_token is None
+            and _UNEXPANDED_TOKEN_RE.search(tok)
+            and not rest[i - 1].startswith("-")
+        ):
+            issue_token = tok
             i += 1
             continue
         if tok == "--add-label" and i + 1 < n:
@@ -365,6 +402,44 @@ def _parse_edit_segment(rest: list[str]) -> WaveLabelChange | None:
             i += 1
             continue
         i += 1
+
+    return repo, repo_flag_present, issue_number, issue_token, add_label, remove_label
+
+
+def _parse_edit_segment(rest: list[str]) -> WaveLabelChange | None:
+    """Parse the rest of a tokenized `gh issue edit <num> ...` segment.
+
+    Returns the WaveLabelChange if the segment has an issue_number AND at
+    least one canonical wave-label `--add-label`/`--remove-label`. Otherwise
+    returns None — see `parse_unresolved_wave_label_edits` for the
+    "wave label present but no resolvable issue number" case, which a
+    consumer should log rather than swallow (main#1141).
+
+    The repo is resolved from the AUTHORITATIVE `-R`/`--repo owner/name` flag
+    (#985), extracted up front via the #1057-hardened `walk_flag_values` so all
+    five surface forms resolve: `--repo X`, `--repo=X`, `-R X`, `-R=X`, `-RX`.
+    The flag is GROUND TRUTH for "which repo"; the consuming hook's cwd fallback
+    applies ONLY when no repo flag is present. Three states are surfaced:
+
+      - flag present + resolvable  → `repo=<name>`, `repo_flag_present=True`.
+      - flag absent (#650)         → `repo=None`,   `repo_flag_present=False`
+        (in-repo invocation; consumer resolves the ambient repo from cwd).
+      - flag present + unresolvable → `repo=None`, `repo_flag_present=True`
+        (an unexpanded `$VAR` / command substitution; per #981 the consumer
+        MUST fail closed and NOT fall back to cwd, which would misroute).
+
+    Requiring `--repo` here would silently drop every in-repo label edit (#650);
+    blindly `.split("/")`-ing an unexpanded `$VAR` would misroute it (#981). The
+    tri-state threads both needles.
+
+    The token walk itself lives in `_scan_edit_segment` (the repo tri-state
+    included); this function is the narrowing layer that requires a resolved
+    issue number.
+    """
+    scanned = _scan_edit_segment(rest)
+    if scanned is None:
+        return None
+    repo, repo_flag_present, issue_number, _issue_token, add_label, remove_label = scanned
 
     if issue_number and (add_label or remove_label):
         return WaveLabelChange(
@@ -398,16 +473,25 @@ def parse_wave_label_changes(command: str) -> list[WaveLabelChange]:
       - The command doesn't tokenize cleanly (unbalanced quotes).
       - No segment contains a `gh issue edit` with a wave-label flag.
 
-    For-loop shape note: `for N in 1 2 3; do gh issue edit $N ...; done`
-    tokenizes the LITERAL `$N` token (shlex does not expand variables),
-    so the parsed `issue_number` would be `$N` and the change would be
-    rejected by the `re.fullmatch(r"\\d+", tok)` issue-number filter.
-    For-loops are handled by the harness expanding them BEFORE the hook
-    sees the command — in practice the harness passes either the
-    expanded form or each iteration as a separate Bash call. The
-    multi-cmd fix covers `gh issue edit 1 ... ; gh issue edit 2 ...` and
-    `gh issue edit 1 ... && gh issue edit 2 ...` shapes which is the
-    dominant batch shape.
+    Wrapper / compound-statement shapes (main#1141): a `timeout 45 gh …`
+    prefix and the `do`-prefixed body of a `for … ; do gh … ; done` loop
+    BOTH used to return nothing, because `find_gh_subcommand` required `gh`
+    at token 0 of the segment. `_shell_parse.strip_command_prefixes` now
+    strips the leading wrapper/keyword run, so those forms parse. The
+    correction main#1141 records: the loop CONSTRUCT was the defeater, not
+    variable expansion — a loop carrying a literal issue number failed
+    identically, and it parses now.
+
+    For-loop VARIABLE note (the residual, and it is not fixable here):
+    `for n in 1114 1116; do gh issue edit "$n" …; done` tokenizes the
+    LITERAL `$n` (shlex does not expand variables), so no issue number
+    exists in the command string at all and the `re.fullmatch(r"\\d+", tok)`
+    filter correctly rejects it. Do NOT paper over this by accepting `$n` as
+    an issue ref — it would post to a nonexistent issue. Instead the shape is
+    reported by `parse_unresolved_wave_label_edits` so the consumer LOGS the
+    decline, and `/wave-kickoff`'s state-based reconciliation sweep
+    (`.claude/lib/kickoff_sweep.py`) closes it for real by keying on the
+    labels that actually landed rather than on the command string.
     """
     # Strip heredocs FIRST (its regex needs the raw newlines to find the body),
     # THEN normalize command separators so a leading `cd "$(...)"`-newline or a
@@ -427,6 +511,55 @@ def parse_wave_label_changes(command: str) -> list[WaveLabelChange]:
         change = _parse_edit_segment(rest)
         if change is not None:
             out.append(change)
+    return out
+
+
+def parse_unresolved_wave_label_edits(command: str) -> list[UnresolvedWaveLabelEdit]:
+    """Report wave-label edits whose issue number did NOT resolve (main#1141).
+
+    Returns one `UnresolvedWaveLabelEdit` per `gh issue edit …` segment that
+    carries a canonical wave-label `--add-label`/`--remove-label` but no bare
+    digit-run issue number. The dominant real case is the loop-variable shape
+    (`do gh issue edit "$n" --add-label "wave-29"`); an issue-URL positional or
+    an outright missing positional land here too.
+
+    This is deliberately a SEPARATE function rather than a widened
+    `WaveLabelChange`: consumers that act on a change (post a comment, mutate a
+    board field) must never be handed a row they could mistake for actionable.
+    The only correct use of this result is to LOG that the hook declined —
+    silence in the unsafe direction is the main#1141 bug itself.
+
+    Segments that ALSO remove a wave label are still reported (the caller
+    applies its own between-wave-relabel policy, per the #467 filter).
+    """
+    cleaned = normalize_command_separators(strip_heredocs(command))
+    tokens = tokenize(cleaned)
+    if tokens is None:
+        return []
+
+    out: list[UnresolvedWaveLabelEdit] = []
+    for segment in iter_command_segments(tokens):
+        gh = find_gh_subcommand(segment)
+        if gh is None:
+            continue
+        _globals, rest = gh
+        scanned = _scan_edit_segment(rest)
+        if scanned is None:
+            continue
+        repo, repo_flag_present, issue_number, issue_token, add_label, remove_label = scanned
+        if issue_number is not None:
+            continue  # resolvable — `parse_wave_label_changes` already covers it
+        if not (add_label or remove_label):
+            continue  # not a wave-label edit at all
+        out.append(
+            UnresolvedWaveLabelEdit(
+                repo=repo,
+                issue_token=issue_token,
+                add_label=add_label,
+                remove_label=remove_label,
+                repo_flag_present=repo_flag_present,
+            )
+        )
     return out
 
 

--- a/.claude/hooks/fixtures/post_wave_kickoff_comment/happy_label_apply_explicit_issue.json
+++ b/.claude/hooks/fixtures/post_wave_kickoff_comment/happy_label_apply_explicit_issue.json
@@ -1,8 +1,9 @@
 {
-  "description": "Happy path: gh issue edit on an explicit-issue scope row (W7+W8 shape with `id: repo#NNN`). Hook should resolve the assignment row, render the charter-format kickoff comment, and 'post' it via the injected poster mock.",
+  "description": "Happy path: gh issue edit on an explicit-issue scope row (W7+W8 shape with `id: repo#NNN`). Hook should resolve the assignment row, render the charter-format kickoff comment, and 'post' it via the injected poster mock. Declares the `wave-branch` merge model so the wave-branch base below is asserted for the model it belongs to (main#1141) rather than as an unconditional hardcode.",
   "command": "gh issue edit 123 --repo noorinalabs/noorinalabs-main --add-label \"p3-wave-9\"",
   "status": {
     "wave_9_meta_issue": 347,
+    "wave_9_merge_model": "wave-branch",
     "wave_9_scope": {
       "tier_1_test": [
         {"id": "noorinalabs-main#123", "implementer": "Aino Virtanen", "reviewer": "Nadia Khoury", "reviewer_2": "Santiago Ferreira", "priority": "tech-debt"}

--- a/.claude/hooks/fixtures/post_wave_kickoff_comment/merge_model_absent_defaults_to_main.json
+++ b/.claude/hooks/fixtures/post_wave_kickoff_comment/merge_model_absent_defaults_to_main.json
@@ -1,0 +1,20 @@
+{
+  "description": "main#1141 regression: with NO merge model recorded anywhere, the kickoff renders `main` and says the model was not declared. Asymmetric failure choice — a nonexistent wave branch hard-blocks the implementer, whereas branching from `main` on a wave-branch wave is a recoverable PR-base retarget. Prefer the recoverable failure.",
+  "command": "gh issue edit 1114 --repo noorinalabs/noorinalabs-main --add-label \"wave-29\"",
+  "status": {
+    "current_phase": 10,
+    "wave_29_scope": {
+      "tier_1_track_g": [
+        {"id": "noorinalabs-main#1114", "ref": "main#1114", "implementer": "Nino Kavtaradze", "reviewer": "Aino Virtanen", "priority": "tech-debt"}
+      ]
+    }
+  },
+  "existing_comments": [],
+  "post_succeeds": true,
+  "expect_action": "post",
+  "expect_body_contains": [
+    "- Branch from: `main`",
+    "wave merge model NOT declared in cross-repo-status.json",
+    "confirm the base with the orchestrator before opening the PR"
+  ]
+}

--- a/.claude/hooks/fixtures/post_wave_kickoff_comment/merge_model_direct_to_main.json
+++ b/.claude/hooks/fixtures/post_wave_kickoff_comment/merge_model_direct_to_main.json
@@ -1,0 +1,24 @@
+{
+  "description": "main#1141 regression: on a `direct-to-main` wave there is no wave branch, so the kickoff comment must instruct branching from `main`. Before the fix this rendered `deployments/phase-10/wave-29` — a ref that will never exist — for every issue in waves 28 and 29.",
+  "command": "timeout 45 gh issue edit 1114 --repo noorinalabs/noorinalabs-main --add-label \"wave-29\"",
+  "status": {
+    "current_phase": 10,
+    "wave_29_meta_issue": 1133,
+    "wave_29_merge_model": "direct-to-main",
+    "wave_29_scope": {
+      "merge_model": "direct-to-main",
+      "tier_1_track_g": [
+        {"id": "noorinalabs-main#1114", "ref": "main#1114", "implementer": "Nino Kavtaradze", "reviewer": "Aino Virtanen", "reviewer_2": null, "priority": "tech-debt"}
+      ]
+    }
+  },
+  "existing_comments": [],
+  "post_succeeds": true,
+  "expect_action": "post",
+  "expect_body_contains": [
+    "Requestee: Nino Kavtaradze",
+    "**Wave 29 Kickoff — Phase 10**",
+    "- Branch from: `main`",
+    "- PR base: `main` (wave merge model: `direct-to-main`)"
+  ]
+}

--- a/.claude/hooks/fixtures/post_wave_kickoff_comment/merge_model_scope_key_wave_branch.json
+++ b/.claude/hooks/fixtures/post_wave_kickoff_comment/merge_model_scope_key_wave_branch.json
@@ -1,0 +1,20 @@
+{
+  "description": "main#1141 regression: the merge model is read from `wave_{M}_scope.merge_model` when the top-level `wave_{M}_merge_model` key is absent — /wave-scope writes the scope copy, `wave_merge_model.py set` writes the top-level one, and a wave may carry only one of them. `wave-branch` keeps the pre-#1141 base, unchanged.",
+  "command": "for x in a; do gh issue edit 1114 --repo noorinalabs/noorinalabs-main --add-label \"wave-29\"; done",
+  "status": {
+    "current_phase": 10,
+    "wave_29_scope": {
+      "merge_model": "wave-branch",
+      "tier_1_track_g": [
+        {"id": "noorinalabs-main#1114", "ref": "main#1114", "implementer": "Nino Kavtaradze", "reviewer": "Aino Virtanen", "priority": "tech-debt"}
+      ]
+    }
+  },
+  "existing_comments": [],
+  "post_succeeds": true,
+  "expect_action": "post",
+  "expect_body_contains": [
+    "- Branch from: `deployments/phase-10/wave-29`",
+    "- PR base: `deployments/phase-10/wave-29` (wave merge model: `wave-branch`)"
+  ]
+}

--- a/.claude/hooks/post_wave_kickoff_comment.py
+++ b/.claude/hooks/post_wave_kickoff_comment.py
@@ -33,7 +33,12 @@ Behavior summary
        /wave-scope shape) — synthesizes a placeholder row so the kickoff
        posts with `(unassigned)` slots instead of silently skipping.
 3. If found, render a charter-format kickoff comment using the row's
-   `implementer` / `reviewer` / `reviewer_2` fields.
+   `implementer` / `reviewer` / `reviewer_2` fields. The branch base
+   follows the wave's DECLARED MERGE MODEL (#1141): `main` under
+   `direct-to-main`, `deployments/phase-{P}/wave-{M}` under
+   `wave-branch`, and `main` when the model is unreadable (a
+   nonexistent wave branch hard-blocks the implementer; a wrong-but-
+   existing `main` base is a recoverable retarget).
 4. Skip if the issue == `wave_{M}_meta_issue` (meta-issue gets its own
    all-hands kickoff comment, owned separately by /wave-kickoff Step 8b).
 5. Idempotency: skip if the issue already has a kickoff comment whose
@@ -47,6 +52,16 @@ Behavior summary
    gh CLI failure → annunaki-log-and-skip. The underlying label-apply
    already succeeded (this is PostToolUse); the hook never raises a
    failure on the user-visible tool call.
+8. Declining LOUDLY (#1141): a label apply whose issue number cannot be
+   recovered from the command string (`for n in …; do gh issue edit "$n"
+   --add-label "wave-29"; done`) is annunaki-logged and returned as
+   `skip_unresolved_issue_number`, which `EMIT_DISPATCH_SUMMARY` turns
+   into an operator-visible systemMessage. A silent no-op here is the
+   primary bug class this hook exists to prevent — labels land, the wave
+   looks kicked off, and nobody is told they own anything. The actual
+   backfill is state-based, not command-based: `/wave-kickoff` Step 7b
+   runs `.claude/lib/kickoff_sweep.py`, which keys on the labels that
+   LANDED and is idempotent against the check in (5).
 
 The hook is best-effort post-action automation. PostToolUse hooks cannot
 fail the original tool call by design (the tool has already run); a
@@ -66,7 +81,11 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _shell_parse import resolve_repo_short_name  # noqa: E402
-from _wave_label_parse import parse_wave_label_change, parse_wave_label_spec  # noqa: E402
+from _wave_label_parse import (  # noqa: E402
+    parse_unresolved_wave_label_edits,
+    parse_wave_label_change,
+    parse_wave_label_spec,
+)
 from annunaki_log import log_posttooluse_event  # noqa: E402
 
 # Dispatcher opt-in (#425): when post_dispatcher sees this attribute set
@@ -92,6 +111,22 @@ SCRATCH_DIR = REPO_ROOT / ".claude" / "scratch"
 # future, update this constant — there is no roster lookup for "who runs
 # wave-kickoff" because that role is implicit.
 KICKOFF_REQUESTOR = "Fatima Okonkwo"
+
+# The two merge models (`.claude/lib/wave_merge_model.py` is the source of
+# truth — these literals mirror its DIRECT_TO_MAIN / WAVE_BRANCH constants).
+# They are duplicated rather than imported so the hook keeps zero dependency on
+# `.claude/lib` at PostToolUse time; the values are a fixed two-element enum
+# pinned by `test_merge_model_constants_match_wave_merge_model`.
+DIRECT_TO_MAIN = "direct-to-main"
+WAVE_BRANCH = "wave-branch"
+
+# What to render when the wave's merge model cannot be read (#1141). `main` is
+# the SAFE default in the asymmetric sense: under a direct-to-main wave the
+# hardcoded `deployments/phase-{P}/wave-{M}` names a ref that will never exist,
+# which hard-blocks the implementer; under a wave-branch wave, branching from
+# `main` is a recoverable retarget of the PR base. Prefer the recoverable
+# failure.
+DEFAULT_BRANCH_BASE = "main"
 
 # Regex matching the kickoff comment heading the charter requires
 # (`**Wave {M} Kickoff — Phase {N}**`). Used for idempotency check. The
@@ -159,6 +194,31 @@ def _phase_from_status(status: dict) -> int | None:
     m = re.fullmatch(r"phase-(\d+)", str(status.get("phase", "")))
     if m:
         return int(m.group(1))
+    return None
+
+
+def read_merge_model(status: dict, wave_num: int) -> str | None:
+    """Return the wave's declared merge model, or None if unreadable (#1141).
+
+    Two recorded locations, checked in that order (both are written by the
+    lifecycle tooling; the top-level key is `wave_merge_model.py set`'s home
+    and the scope copy is `/wave-scope`'s):
+
+      1. top-level `wave_{M}_merge_model`
+      2. `wave_{M}_scope.merge_model`
+
+    A value that is not one of the two known models is treated as UNREADABLE
+    (None) rather than passed through — a typo'd model must fall back to the
+    safe `main` default, never render a branch instruction derived from a
+    string nobody validated.
+    """
+    candidates = [status.get(f"wave_{wave_num}_merge_model")]
+    scope = status.get(f"wave_{wave_num}_scope")
+    if isinstance(scope, dict):
+        candidates.append(scope.get("merge_model"))
+    for value in candidates:
+        if isinstance(value, str) and value in (DIRECT_TO_MAIN, WAVE_BRANCH):
+            return value
     return None
 
 
@@ -284,7 +344,40 @@ def find_assignment_row(status: dict, repo: str, issue_number: str, wave_num: in
     return None
 
 
-def render_kickoff_comment(row: dict, wave_num: int, phase_num: int, repo: str) -> str:
+def resolve_branch_base(merge_model: str | None, wave_num: int, phase_num: int) -> tuple[str, str]:
+    """Return `(branch_base, model_note)` for the wave's merge model (#1141).
+
+      - `direct-to-main` → `main`. Under this model there is no wave branch to
+        base on; every PR bases on `main`.
+      - `wave-branch`    → `deployments/phase-{P}/wave-{M}` (the pre-#1141
+        behavior, now conditional instead of unconditional).
+      - anything else / unreadable → `main`, with a note telling the
+        implementer to confirm the base before opening the PR.
+
+    Since the 2026-06-09 every-wave-merges-to-main directive `direct-to-main`
+    is the COMMON case, so the old hardcode was the default-wrong path: waves
+    28 and 29 were both direct-to-main and every kickoff comment pointed at a
+    ref that will never exist.
+    """
+    if merge_model == WAVE_BRANCH:
+        base = f"deployments/phase-{phase_num}/wave-{wave_num}"
+        return base, f"wave merge model: `{WAVE_BRANCH}`"
+    if merge_model == DIRECT_TO_MAIN:
+        return DEFAULT_BRANCH_BASE, f"wave merge model: `{DIRECT_TO_MAIN}`"
+    return (
+        DEFAULT_BRANCH_BASE,
+        "wave merge model NOT declared in cross-repo-status.json — defaulting to "
+        "`main`; confirm the base with the orchestrator before opening the PR",
+    )
+
+
+def render_kickoff_comment(
+    row: dict,
+    wave_num: int,
+    phase_num: int,
+    repo: str,
+    merge_model: str | None = None,
+) -> str:
     """Render the charter-format kickoff comment body per pull-requests.md
     § Kickoff Comment Format / wave-kickoff SKILL.md Step 8 template.
 
@@ -292,13 +385,18 @@ def render_kickoff_comment(row: dict, wave_num: int, phase_num: int, repo: str) 
     `priority`. Missing optional fields are rendered as "(unassigned)"
     placeholders rather than blanking the bullet — the orchestrator
     follow-up sweep can backfill, and an empty bullet looks like a bug.
+
+    `merge_model` selects the branch base (see `resolve_branch_base`). It
+    defaults to None — i.e. the safe `main` base — so a caller that has not
+    been taught about merge models cannot emit an instruction to branch from a
+    wave branch that may not exist (#1141).
     """
     implementer = row.get("implementer") or "(unassigned)"
     reviewer = row.get("reviewer") or "(unassigned)"
     reviewer_2 = row.get("reviewer_2") or "(unassigned)"
     priority = row.get("priority") or "feature"
 
-    branch_base = f"deployments/phase-{phase_num}/wave-{wave_num}"
+    branch_base, model_note = resolve_branch_base(merge_model, wave_num, phase_num)
 
     lines = [
         f"Requestor: {KICKOFF_REQUESTOR}",
@@ -311,6 +409,7 @@ def render_kickoff_comment(row: dict, wave_num: int, phase_num: int, repo: str) 
         f"- Peer reviewer: {reviewer}",
         f"- Secondary reviewer: {reviewer_2}",
         f"- Branch from: `{branch_base}`",
+        f"- PR base: `{branch_base}` ({model_note})",
         "- Branch naming: `{FirstInitial}.{LastName}/{IIII}-{issue-slug}`",
         f"- Priority: {priority} (per charter § Wave Planning & Priority)",
         "",
@@ -421,6 +520,56 @@ def _write_fresh_body_file(body: str, repo: str, issue_number: str) -> Path:
     return path
 
 
+def _report_unresolved_label_applies(command: str) -> dict | None:
+    """Surface a wave-label apply the parser could not act on (#1141).
+
+    Called when `parse_label_apply_command` returned None. Most such commands
+    are simply not wave-label applies at all — those still return None and the
+    hook stays quiet. But the `for n in …; do gh issue edit "$n" --add-label
+    "wave-29"; done` shape IS a real label apply that the hook is about to
+    ignore, and ignoring it silently is the whole #1141 failure: 14 issues
+    labeled, 0 kickoff comments, discovered days later by an unrelated audit.
+
+    So: annunaki-log it and return an action-shaped dict. Because this module
+    sets `EMIT_DISPATCH_SUMMARY = True`, the dispatcher turns that dict into an
+    operator-visible `systemMessage` at the moment of the apply — a loud
+    decline instead of a silent one. The label apply itself already succeeded
+    (PostToolUse); `/wave-kickoff`'s reconciliation sweep
+    (`.claude/lib/kickoff_sweep.py`) is what actually backfills the comment.
+
+    Between-wave relabels (add AND remove in the same command) are filtered
+    out here for the same reason `parse_label_apply_command` filters them —
+    they are carry-forward moves, not kickoffs, and logging them re-creates
+    the #467 annunaki noise burst.
+    """
+    unresolved = [
+        e
+        for e in parse_unresolved_wave_label_edits(command)
+        if e.add_label is not None and e.remove_label is None
+    ]
+    if not unresolved:
+        return None
+
+    tokens = sorted({e.issue_token for e in unresolved if e.issue_token})
+    labels = sorted({e.add_label for e in unresolved if e.add_label})
+    log_posttooluse_event(
+        "post_wave_kickoff_comment",
+        command,
+        f"skip_unresolved_issue_number: {len(unresolved)} wave-label apply(ies) for "
+        f"label(s) {', '.join(labels)} carried no resolvable issue number "
+        f"({'unexpanded ' + ', '.join(tokens) if tokens else 'no issue positional'}) — "
+        'typically a `for n in …; do gh issue edit "$n" …; done` loop, where the '
+        "number never appears in the command string. NO kickoff comment was posted "
+        "for these issues. Run the /wave-kickoff reconciliation sweep "
+        "(.claude/lib/kickoff_sweep.py) to backfill from the labels that landed (#1141).",
+    )
+    return {
+        "action": "skip_unresolved_issue_number",
+        "count": len(unresolved),
+        "labels": ",".join(labels),
+    }
+
+
 def check(
     input_data: dict,
     status_loader=None,
@@ -446,6 +595,12 @@ def check(
                                                  `-R $VAR`); fail-closed, no cwd
                                                  fallback (#985/#981)
       {"action": "skip_post_failed", ...}      — gh post call failed
+      {"action": "skip_unresolved_issue_number", ...} — a wave label WAS
+                                                 applied but the issue number
+                                                 is not in the command string
+                                                 (loop-variable shape); logged
+                                                 + surfaced, never silent
+                                                 (#1141)
 
     Injection points let tests mock external state without mocking
     subprocess: `status_loader()` returns the status dict, `comment_fetcher
@@ -464,7 +619,7 @@ def check(
 
     parsed = parse_label_apply_command(command)
     if parsed is None:
-        return None
+        return _report_unresolved_label_applies(command)
     repo, issue_number, wave_label, repo_flag_present = parsed
 
     # #985/#981: an explicit `-R`/`--repo` flag whose value did NOT resolve to a
@@ -589,7 +744,9 @@ def check(
     ):
         return {"action": "skip_idempotent", "repo": repo, "issue": issue_number}
 
-    body = render_kickoff_comment(row, wave_num, phase_num, repo)
+    body = render_kickoff_comment(
+        row, wave_num, phase_num, repo, merge_model=read_merge_model(status, wave_num)
+    )
     writer = body_writer or _write_fresh_body_file
     body_path = writer(body, repo, issue_number)
 

--- a/.claude/hooks/post_wave_kickoff_comment.py
+++ b/.claude/hooks/post_wave_kickoff_comment.py
@@ -128,6 +128,13 @@ WAVE_BRANCH = "wave-branch"
 # failure.
 DEFAULT_BRANCH_BASE = "main"
 
+# Tri-state results of the kickoff-comment idempotency probe (main#1145).
+# UNKNOWN is deliberately NOT foldable into ABSENT — see
+# `kickoff_comment_state`.
+KICKOFF_PRESENT = "present"
+KICKOFF_ABSENT = "absent"
+KICKOFF_UNKNOWN = "unknown"
+
 # Regex matching the kickoff comment heading the charter requires
 # (`**Wave {M} Kickoff — Phase {N}**`). Used for idempotency check. The
 # emdash is the literal character in the template; we tolerate either
@@ -430,24 +437,63 @@ def kickoff_already_posted(
     `wave_num=None` the legacy wave-agnostic match is used (any kickoff
     heading counts).
 
-    The `fetch_comments` callable defaults to a real `gh issue view` call;
-    tests inject a mock. Returns False on any error fetching comments
-    (don't suppress on broken state — let the hook attempt to post and
-    surface real errors via annunaki on the actual post call).
+    **Returns False for BOTH "no kickoff comment" and "could not fetch"**
+    (main#1145). That collapse is deliberate HERE and wrong elsewhere:
+
+      - For the HOOK, failing open is correct and bounded. The hook posts
+        at most one comment per label-apply — an explicit operator action —
+        and the failure it is guarding against is #286, a kickoff that
+        never gets posted. One possibly-duplicate comment beats a silently
+        missing assignment, and a real post failure still surfaces via
+        annunaki on the post call.
+      - For the SWEEP, failing open is unbounded. `/wave-kickoff` Step 7b
+        defines completion as "zero would_post", so under a sustained fetch
+        failure every `--apply` pass appends another duplicate and reports
+        `posted` — the operator follows the documented procedure into a
+        loop that never converges. And a fetch is likeliest to fail during
+        a GitHub incident, which is exactly when kickoff gets re-run.
+
+    So callers that must distinguish the two cases use
+    `kickoff_comment_state` (tri-state) instead; this function is retained
+    as the thin bool wrapper with its historical fail-open contract intact.
+    """
+    return (
+        kickoff_comment_state(repo, issue_number, wave_num=wave_num, fetch_comments=fetch_comments)
+        == KICKOFF_PRESENT
+    )
+
+
+def kickoff_comment_state(
+    repo: str, issue_number: str, wave_num: int | None = None, fetch_comments=None
+) -> str:
+    """Tri-state idempotency probe (main#1145).
+
+    Returns:
+      `KICKOFF_PRESENT` — a kickoff comment for `wave_num` exists.
+      `KICKOFF_ABSENT`  — the comments were read and none matched.
+      `KICKOFF_UNKNOWN` — the comments could NOT be read (gh non-zero exit,
+                          15s timeout, JSON decode error). This is NOT
+                          "absent": a caller that treats it as absent posts
+                          on no evidence.
+
+    Keeping *unknown* as its own state is the whole point. Collapsing it
+    into *absent* is the same silent-wrong-zero class this hook's own #1141
+    fixes are about — a sweep that reports zero outstanding work because
+    every probe failed looks identical to one that has nothing to do.
     """
     if fetch_comments is None:
         fetch_comments = _gh_fetch_comments
 
     comments = fetch_comments(repo, issue_number)
     if comments is None:
-        return False
+        return KICKOFF_UNKNOWN
 
     heading_re = _kickoff_heading_re(wave_num)
     for c in comments:
         body = c.get("body", "") if isinstance(c, dict) else ""
         if heading_re.search(body):
-            return True
-    return False
+            return KICKOFF_PRESENT
+    return KICKOFF_ABSENT
 
 
 def _gh_fetch_comments(repo: str, issue_number: str) -> list[dict] | None:

--- a/.claude/hooks/post_wave_kickoff_comment.py
+++ b/.claude/hooks/post_wave_kickoff_comment.py
@@ -563,9 +563,14 @@ def _report_unresolved_label_applies(command: str) -> dict | None:
         "for these issues. Run the /wave-kickoff reconciliation sweep "
         "(.claude/lib/kickoff_sweep.py) to backfill from the labels that landed (#1141).",
     )
+    # `unresolved_edits` counts COMMAND SHAPES, not issues — one `for n in
+    # 1114 1116; do …; done` loop is a single unresolved edit that will touch
+    # two issues, and the issue count is unknowable from the command string
+    # (that is the whole defect). Named for what it counts so an operator does
+    # not read "1" as "one issue affected" (main#1141 review nit).
     return {
         "action": "skip_unresolved_issue_number",
-        "count": len(unresolved),
+        "unresolved_edits": len(unresolved),
         "labels": ",".join(labels),
     }
 

--- a/.claude/hooks/post_wave_kickoff_comment.py
+++ b/.claude/hooks/post_wave_kickoff_comment.py
@@ -443,9 +443,19 @@ def kickoff_already_posted(
       - For the HOOK, failing open is correct and bounded. The hook posts
         at most one comment per label-apply — an explicit operator action —
         and the failure it is guarding against is #286, a kickoff that
-        never gets posted. One possibly-duplicate comment beats a silently
-        missing assignment, and a real post failure still surfaces via
-        annunaki on the post call.
+        never gets posted.
+
+        The decisive argument is WHERE each error is visible. A duplicate
+        comment appears on the issue, in front of the implementer: it
+        self-reports. A missing comment is invisible at the artifact — the
+        only signal lives on some other surface. main#1141 is the proof
+        that a signal on another surface gets missed: 14 issues, several
+        days, found by an unrelated audit. For a mechanism whose entire
+        purpose is telling a person they own work, prefer the failure that
+        is visible where that person is already looking.
+
+        The post is still reported as `post_unverified`, not `post`, so the
+        possible duplicate has a trail (review round 3).
       - For the SWEEP, failing open is unbounded. `/wave-kickoff` Step 7b
         defines completion as "zero would_post", so under a sustained fetch
         failure every `--apply` pass appends another duplicate and reports
@@ -634,7 +644,11 @@ def check(
 
     Result shape (always returned as advisory, never blocking):
       None                                     — hook didn't apply
-      {"action": "post", "issue": "<n>", ...}  — comment posted
+      {"action": "post", "issue": "<n>", ...}  — verified absent, then posted
+      {"action": "post_unverified", ...}       — posted, but the existing
+                                                 comments could not be read
+                                                 first, so it may duplicate
+                                                 an earlier kickoff (#1145)
       {"action": "skip_meta_issue", ...}       — meta-issue skipped
       {"action": "skip_idempotent", ...}       — kickoff already posted
       {"action": "skip_no_scope", ...}         — wave_{M}_scope missing
@@ -790,9 +804,17 @@ def check(
     # Idempotency: don't double-post FOR THIS WAVE. Passing wave_num makes
     # the heading match wave-specific so a carry-forward issue's prior-wave
     # kickoff comment does not suppress the current wave's kickoff (#547).
-    if kickoff_already_posted(
+    #
+    # Tri-state (#1145 / review round 3): the hook still POSTS when the probe
+    # came back `unknown` — that fail-open decision stands, see
+    # `kickoff_already_posted` — but the result must not be reported as a
+    # verified post. An unverified post is exactly the state-collapse this PR
+    # exists to remove, so it gets its own action and its own log line, and
+    # the possible duplicate has a trail.
+    comment_state = kickoff_comment_state(
         repo, issue_number, wave_num=wave_num, fetch_comments=comment_fetcher
-    ):
+    )
+    if comment_state == KICKOFF_PRESENT:
         return {"action": "skip_idempotent", "repo": repo, "issue": issue_number}
 
     body = render_kickoff_comment(
@@ -811,8 +833,23 @@ def check(
         )
         return {"action": "skip_post_failed", "repo": repo, "issue": issue_number}
 
+    if comment_state == KICKOFF_UNKNOWN:
+        log_posttooluse_event(
+            "post_wave_kickoff_comment",
+            command,
+            f"post_unverified: posted a kickoff comment to {repo}#{issue_number} WITHOUT being "
+            "able to read the issue's existing comments (gh fetch failed), so it is unknown "
+            "whether this duplicates an earlier kickoff. Posting is the deliberate fail-open "
+            "for this surface — a duplicate is visible on the issue in front of the "
+            "implementer, whereas a missing kickoff is invisible there (#1141 is the proof: 14 "
+            "issues, several days, found by an unrelated audit). Check the issue if a duplicate "
+            "matters (#1145).",
+        )
+
     return {
-        "action": "post",
+        # `post` means "verified absent, then posted". `post_unverified` means
+        # "posted, but could not check first" — never collapsed into `post`.
+        "action": "post" if comment_state == KICKOFF_ABSENT else "post_unverified",
         "repo": repo,
         "issue": issue_number,
         "wave_label": wave_label,

--- a/.claude/hooks/tests/test__wave_label_parse.py
+++ b/.claude/hooks/tests/test__wave_label_parse.py
@@ -353,5 +353,146 @@ class NormalizeCommandSeparators(unittest.TestCase):
         self.assertEqual(self._segments("echo a \\\n  b"), [["echo", "a", "b"]])
 
 
+_REPO = "--repo noorinalabs/noorinalabs-main"
+
+
+class WrappedAndCompoundEditForms(unittest.TestCase):
+    """main#1141 — every row of the issue's verified repro table.
+
+    The two rows that already passed (redirect, `&&`) are pinned here too so
+    the wrapper fix cannot regress them.
+    """
+
+    def _first(self, command: str):
+        return p.parse_wave_label_change(command)
+
+    def test_plain(self) -> None:
+        c = self._first(f'gh issue edit 1114 {_REPO} --add-label "wave-29"')
+        self.assertIsNotNone(c)
+        self.assertEqual(
+            (c.repo, c.issue_number, c.add_label), ("noorinalabs-main", "1114", "wave-29")
+        )
+
+    def test_redirect_still_parses(self) -> None:
+        c = self._first(f'gh issue edit 1114 {_REPO} --add-label "wave-29" >/dev/null 2>&1')
+        self.assertIsNotNone(c)
+        self.assertEqual(c.issue_number, "1114")
+
+    def test_and_chain_still_parses(self) -> None:
+        c = self._first(f'gh issue edit 1114 {_REPO} --add-label "wave-29" && echo ok')
+        self.assertIsNotNone(c)
+        self.assertEqual(c.issue_number, "1114")
+
+    def test_timeout_prefix(self) -> None:
+        """A `timeout N gh …` prefix returned None before main#1141."""
+        c = self._first(f'timeout 45 gh issue edit 1114 {_REPO} --add-label "wave-29"')
+        self.assertIsNotNone(c)
+        self.assertEqual(
+            (c.repo, c.issue_number, c.add_label), ("noorinalabs-main", "1114", "wave-29")
+        )
+
+    def test_loop_with_literal_issue_number(self) -> None:
+        """THE row that disproves the variable-expansion theory.
+
+        An earlier revision of main#1141 blamed the unexpanded `"$n"`. A loop
+        carrying a fully LITERAL issue number failed identically, so the loop
+        CONSTRUCT was the defeater — `do` sat at token 0 of the segment. It
+        must parse now.
+        """
+        c = self._first(f'for x in a; do gh issue edit 1114 {_REPO} --add-label "wave-29"; done')
+        self.assertIsNotNone(c)
+        self.assertEqual(
+            (c.repo, c.issue_number, c.add_label), ("noorinalabs-main", "1114", "wave-29")
+        )
+
+    def test_loop_with_variable_stays_unparsed(self) -> None:
+        """The residual, and it must stay unparsed.
+
+        The issue number is genuinely absent from the command string; treating
+        `$n` as a ref would post to a nonexistent issue. It is surfaced via
+        `parse_unresolved_wave_label_edits` and fixed for real by the
+        state-based sweep, not by loosening this parser.
+        """
+        self.assertIsNone(
+            self._first(
+                f'for n in 1114 1116; do gh issue edit "$n" {_REPO} --add-label "wave-29"; done'
+            )
+        )
+
+    def test_loop_plus_timeout_both_stripped(self) -> None:
+        c = self._first(
+            f'for x in a; do timeout 45 gh issue edit 1114 {_REPO} --add-label "wave-29"; done'
+        )
+        self.assertIsNotNone(c)
+        self.assertEqual(c.issue_number, "1114")
+
+    def test_multi_iteration_loop_body_expanded(self) -> None:
+        """Two literal-number invocations in one loop body yield two changes."""
+        changes = p.parse_wave_label_changes(
+            f'for x in a; do gh issue edit 1114 {_REPO} --add-label "wave-29"; '
+            f'gh issue edit 1116 {_REPO} --add-label "wave-29"; done'
+        )
+        self.assertEqual([c.issue_number for c in changes], ["1114", "1116"])
+
+    def test_label_inside_echo_is_not_a_change(self) -> None:
+        """Data position stays data: the allowlist never strips `echo`."""
+        self.assertIsNone(self._first(f'echo gh issue edit 1114 {_REPO} --add-label "wave-29"'))
+
+
+class ParseUnresolvedWaveLabelEdits(unittest.TestCase):
+    """main#1141 — the hook must be able to say "I declined", not go silent."""
+
+    def test_loop_variable_is_reported(self) -> None:
+        found = p.parse_unresolved_wave_label_edits(
+            f'for n in 1114 1116; do gh issue edit "$n" {_REPO} --add-label "wave-29"; done'
+        )
+        self.assertEqual(len(found), 1)
+        self.assertEqual(found[0].add_label, "wave-29")
+        self.assertEqual(found[0].issue_token, "$n")
+        self.assertEqual(found[0].repo, "noorinalabs-main")
+
+    def test_timeout_wrapped_loop_variable_is_reported(self) -> None:
+        found = p.parse_unresolved_wave_label_edits(
+            f'for n in 1114; do timeout 45 gh issue edit "$n" {_REPO} --add-label "wave-29"; done'
+        )
+        self.assertEqual(len(found), 1)
+        self.assertEqual(found[0].issue_token, "$n")
+
+    def test_resolvable_command_is_not_reported(self) -> None:
+        self.assertEqual(
+            p.parse_unresolved_wave_label_edits(
+                f'gh issue edit 1114 {_REPO} --add-label "wave-29"'
+            ),
+            [],
+        )
+
+    def test_non_wave_label_is_not_reported(self) -> None:
+        self.assertEqual(
+            p.parse_unresolved_wave_label_edits(
+                f'for n in 1; do gh issue edit "$n" {_REPO} --add-label "bug"; done'
+            ),
+            [],
+        )
+
+    def test_unexpanded_repo_value_is_not_mistaken_for_the_issue_ref(self) -> None:
+        """`--repo "$R"` is a FLAG VALUE, never the issue positional."""
+        found = p.parse_unresolved_wave_label_edits(
+            'for n in 1; do gh issue edit --repo "$R" --add-label "wave-29"; done'
+        )
+        self.assertEqual(len(found), 1)
+        self.assertIsNone(found[0].issue_token)
+
+    def test_relabel_shape_is_reported_for_the_caller_to_filter(self) -> None:
+        found = p.parse_unresolved_wave_label_edits(
+            f'for n in 1; do gh issue edit "$n" {_REPO} --add-label "wave-29" '
+            '--remove-label "wave-28"; done'
+        )
+        self.assertEqual(len(found), 1)
+        self.assertEqual((found[0].add_label, found[0].remove_label), ("wave-29", "wave-28"))
+
+    def test_unparseable_command_yields_empty(self) -> None:
+        self.assertEqual(p.parse_unresolved_wave_label_edits('gh issue edit "unbalanced'), [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.claude/hooks/tests/test_post_wave_kickoff_comment.py
+++ b/.claude/hooks/tests/test_post_wave_kickoff_comment.py
@@ -1156,7 +1156,12 @@ class KickoffAlreadyPostedContractPreserved(unittest.TestCase):
         self.assertTrue(hook.kickoff_already_posted("r", "1", 29, fetch_comments=lambda r, n: body))
 
     def test_hook_still_posts_when_the_fetch_fails(self) -> None:
-        """End-to-end: the PostToolUse path keeps posting on a broken fetch."""
+        """End-to-end: the PostToolUse path keeps posting on a broken fetch.
+
+        But it reports `post_unverified`, not `post` — review round 3. The
+        fail-open decision stands; collapsing it into a verified post was the
+        last silent state-collapse in a PR about silent state-collapses.
+        """
         status = {
             "current_phase": 10,
             "wave_29_merge_model": "direct-to-main",
@@ -1170,7 +1175,52 @@ class KickoffAlreadyPostedContractPreserved(unittest.TestCase):
             body_writer=lambda b, r, n: Path("/dev/null"),
         )
         assert result is not None
+        self.assertEqual(result["action"], "post_unverified")
+
+    def test_unverified_post_is_logged(self) -> None:
+        logs: list = []
+        original = hook.log_posttooluse_event
+        hook.log_posttooluse_event = lambda *a: logs.append(a)
+        try:
+            hook.check(
+                _bash(f'gh issue edit 1114 {_EDIT_REPO} --add-label "wave-29"'),
+                status_loader=lambda: {
+                    "current_phase": 10,
+                    "wave_29_scope": {
+                        "tier_1": [{"id": "noorinalabs-main#1114", "implementer": "N"}]
+                    },
+                },
+                comment_fetcher=lambda r, n: None,
+                comment_poster=lambda r, n, p: True,
+                body_writer=lambda b, r, n: Path("/dev/null"),
+            )
+        finally:
+            hook.log_posttooluse_event = original
+        self.assertEqual(len(logs), 1)
+        self.assertIn("post_unverified", logs[0][2])
+
+    def test_verified_post_is_not_logged_as_unverified(self) -> None:
+        logs: list = []
+        original = hook.log_posttooluse_event
+        hook.log_posttooluse_event = lambda *a: logs.append(a)
+        try:
+            result = hook.check(
+                _bash(f'gh issue edit 1114 {_EDIT_REPO} --add-label "wave-29"'),
+                status_loader=lambda: {
+                    "current_phase": 10,
+                    "wave_29_scope": {
+                        "tier_1": [{"id": "noorinalabs-main#1114", "implementer": "N"}]
+                    },
+                },
+                comment_fetcher=lambda r, n: [],
+                comment_poster=lambda r, n, p: True,
+                body_writer=lambda b, r, n: Path("/dev/null"),
+            )
+        finally:
+            hook.log_posttooluse_event = original
+        assert result is not None
         self.assertEqual(result["action"], "post")
+        self.assertEqual(logs, [])
 
 
 if __name__ == "__main__":

--- a/.claude/hooks/tests/test_post_wave_kickoff_comment.py
+++ b/.claude/hooks/tests/test_post_wave_kickoff_comment.py
@@ -1059,6 +1059,10 @@ class SilentDeclineIsSurfaced(unittest.TestCase):
         )
         self.assertEqual(result["action"], "skip_unresolved_issue_number")
         self.assertEqual(result["labels"], "wave-29")
+        # Counts SHAPES, not issues: one loop == one unresolved edit, even
+        # though it will touch two issues (main#1141 review nit — the key is
+        # named for what it counts so the number cannot be misread).
+        self.assertEqual(result["unresolved_edits"], 1)
         self.assertEqual(len(logs), 1)
         self.assertIn("kickoff_sweep", logs[0][2])
 

--- a/.claude/hooks/tests/test_post_wave_kickoff_comment.py
+++ b/.claude/hooks/tests/test_post_wave_kickoff_comment.py
@@ -449,7 +449,12 @@ class RenderKickoffCommentTests(unittest.TestCase):
             "reviewer_2": "Santiago Ferreira",
             "priority": "tech-debt",
         }
-        body = hook.render_kickoff_comment(row, wave_num=9, phase_num=3, repo="noorinalabs-main")
+        # Explicit merge model: the wave-branch base is no longer the
+        # unconditional default (#1141), so the canonical render pins it by
+        # declaring the model the base belongs to.
+        body = hook.render_kickoff_comment(
+            row, wave_num=9, phase_num=3, repo="noorinalabs-main", merge_model="wave-branch"
+        )
         self.assertIn("Requestor: Fatima Okonkwo", body)
         self.assertIn("Requestee: Aino Virtanen", body)
         self.assertIn("RequestOrReplied: Request", body)
@@ -823,6 +828,270 @@ class PhaseAgnosticLabelForm(unittest.TestCase):
             status_loader=_status_no_phase,
         )
         self.assertEqual(result["action"], "skip_no_phase")
+
+
+_EDIT_REPO = "--repo noorinalabs/noorinalabs-main"
+
+
+class MergeModelAwareBranchBase(unittest.TestCase):
+    """main#1141 problem 1 — the branch base must follow the wave merge model.
+
+    `render_kickoff_comment` hardcoded `deployments/phase-{P}/wave-{M}`. Since
+    the 2026-06-09 every-wave-merges-to-main directive, `direct-to-main` is the
+    COMMON case, so every kickoff comment on waves 28 and 29 pointed the
+    implementer at a ref that will never exist.
+    """
+
+    ROW = {"implementer": "Nino Kavtaradze", "reviewer": "Aino Virtanen"}
+
+    def test_direct_to_main_renders_main_base(self) -> None:
+        body = hook.render_kickoff_comment(
+            self.ROW,
+            wave_num=29,
+            phase_num=10,
+            repo="noorinalabs-main",
+            merge_model="direct-to-main",
+        )
+        self.assertIn("- Branch from: `main`", body)
+        self.assertIn("- PR base: `main` (wave merge model: `direct-to-main`)", body)
+        self.assertNotIn("deployments/phase-10/wave-29", body)
+
+    def test_wave_branch_renders_wave_branch_base(self) -> None:
+        body = hook.render_kickoff_comment(
+            self.ROW,
+            wave_num=29,
+            phase_num=10,
+            repo="noorinalabs-main",
+            merge_model="wave-branch",
+        )
+        self.assertIn("- Branch from: `deployments/phase-10/wave-29`", body)
+        self.assertIn("wave merge model: `wave-branch`", body)
+
+    def test_absent_model_defaults_to_main(self) -> None:
+        """The recoverable failure is preferred to the hard block.
+
+        A nonexistent wave branch stops the implementer dead; branching from
+        `main` on a wave-branch wave is a PR-base retarget.
+        """
+        body = hook.render_kickoff_comment(
+            self.ROW, wave_num=29, phase_num=10, repo="noorinalabs-main", merge_model=None
+        )
+        self.assertIn("- Branch from: `main`", body)
+        self.assertIn("NOT declared", body)
+        self.assertNotIn("deployments/phase-10/wave-29", body)
+
+    def test_unknown_model_defaults_to_main(self) -> None:
+        body = hook.render_kickoff_comment(
+            self.ROW, wave_num=29, phase_num=10, repo="noorinalabs-main", merge_model="typo-model"
+        )
+        self.assertIn("- Branch from: `main`", body)
+
+    def test_default_argument_is_the_safe_base(self) -> None:
+        """A caller that never heard of merge models cannot emit a dead ref."""
+        body = hook.render_kickoff_comment(self.ROW, 29, 10, "noorinalabs-main")
+        self.assertIn("- Branch from: `main`", body)
+
+    def test_merge_model_constants_match_wave_merge_model(self) -> None:
+        """The duplicated enum must not drift from `.claude/lib/wave_merge_model.py`."""
+        sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "lib"))
+        import wave_merge_model  # noqa: PLC0415
+
+        self.assertEqual(hook.DIRECT_TO_MAIN, wave_merge_model.DIRECT_TO_MAIN)
+        self.assertEqual(hook.WAVE_BRANCH, wave_merge_model.WAVE_BRANCH)
+        self.assertEqual(
+            {hook.DIRECT_TO_MAIN, hook.WAVE_BRANCH}, set(wave_merge_model.MERGE_MODELS)
+        )
+
+
+class ReadMergeModel(unittest.TestCase):
+    """Both recorded locations, and a fail-safe on anything unrecognized."""
+
+    def test_top_level_key(self) -> None:
+        self.assertEqual(
+            hook.read_merge_model({"wave_29_merge_model": "direct-to-main"}, 29),
+            "direct-to-main",
+        )
+
+    def test_scope_key(self) -> None:
+        self.assertEqual(
+            hook.read_merge_model({"wave_29_scope": {"merge_model": "wave-branch"}}, 29),
+            "wave-branch",
+        )
+
+    def test_top_level_wins_over_scope(self) -> None:
+        status = {
+            "wave_29_merge_model": "direct-to-main",
+            "wave_29_scope": {"merge_model": "wave-branch"},
+        }
+        self.assertEqual(hook.read_merge_model(status, 29), "direct-to-main")
+
+    def test_scope_used_when_top_level_absent(self) -> None:
+        status = {"wave_29_scope": {"merge_model": "direct-to-main"}}
+        self.assertEqual(hook.read_merge_model(status, 29), "direct-to-main")
+
+    def test_absent_is_none(self) -> None:
+        self.assertIsNone(hook.read_merge_model({}, 29))
+
+    def test_invalid_value_is_none_not_passthrough(self) -> None:
+        self.assertIsNone(hook.read_merge_model({"wave_29_merge_model": "direct_to_main"}, 29))
+
+    def test_non_string_value_is_none(self) -> None:
+        self.assertIsNone(hook.read_merge_model({"wave_29_merge_model": 7}, 29))
+
+    def test_non_dict_scope_is_tolerated(self) -> None:
+        self.assertIsNone(hook.read_merge_model({"wave_29_scope": ["main#1"]}, 29))
+
+
+class CheckAppliesMergeModelEndToEnd(unittest.TestCase):
+    """The rendered body that actually gets POSTED must carry the right base."""
+
+    def _run(self, status: dict) -> str:
+        captured: dict = {}
+
+        def body_writer(body, repo, num):
+            captured["body"] = body
+            return Path("/dev/null")
+
+        result = hook.check(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": f'gh issue edit 1114 {_EDIT_REPO} --add-label "wave-29"'},
+            },
+            status_loader=lambda: status,
+            comment_fetcher=lambda r, n: [],
+            comment_poster=lambda r, n, p: True,
+            body_writer=body_writer,
+        )
+        assert result is not None
+        self.assertEqual(result["action"], "post")
+        return captured["body"]
+
+    def _status(self, **extra) -> dict:
+        status = {
+            "current_phase": 10,
+            "wave_29_scope": {
+                "tier_1": [{"id": "noorinalabs-main#1114", "implementer": "Nino Kavtaradze"}]
+            },
+        }
+        status.update(extra)
+        return status
+
+    def test_direct_to_main_wave(self) -> None:
+        body = self._run(self._status(wave_29_merge_model="direct-to-main"))
+        self.assertIn("- Branch from: `main`", body)
+
+    def test_wave_branch_wave(self) -> None:
+        body = self._run(self._status(wave_29_merge_model="wave-branch"))
+        self.assertIn("- Branch from: `deployments/phase-10/wave-29`", body)
+
+    def test_undeclared_wave(self) -> None:
+        body = self._run(self._status())
+        self.assertIn("- Branch from: `main`", body)
+
+
+class WrappedLabelApplyReachesTheHook(unittest.TestCase):
+    """main#1141 problem 2 — the full repro table, at the hook's own entry point."""
+
+    def test_repro_table(self) -> None:
+        rows = [
+            ("plain", f'gh issue edit 1114 {_EDIT_REPO} --add-label "wave-29"', True),
+            (
+                "redirect",
+                f'gh issue edit 1114 {_EDIT_REPO} --add-label "wave-29" >/dev/null 2>&1',
+                True,
+            ),
+            (
+                "and-chain",
+                f'gh issue edit 1114 {_EDIT_REPO} --add-label "wave-29" && echo ok',
+                True,
+            ),
+            (
+                "timeout-prefix",
+                f'timeout 45 gh issue edit 1114 {_EDIT_REPO} --add-label "wave-29"',
+                True,
+            ),
+            (
+                "loop-literal-number",
+                f'for x in a; do gh issue edit 1114 {_EDIT_REPO} --add-label "wave-29"; done',
+                True,
+            ),
+            (
+                # Unfixable at the command layer: the number is not in the
+                # string. Covered by the state-based sweep instead.
+                "loop-variable",
+                f'for n in 1114 1116; do gh issue edit "$n" {_EDIT_REPO} '
+                '--add-label "wave-29"; done',
+                False,
+            ),
+        ]
+        for name, command, should_parse in rows:
+            with self.subTest(row=name):
+                parsed = hook.parse_label_apply_command(command)
+                if should_parse:
+                    self.assertIsNotNone(parsed, f"{name} must parse after #1141")
+                    assert parsed is not None
+                    self.assertEqual(parsed[1], "1114")
+                    self.assertEqual(parsed[2], "wave-29")
+                else:
+                    self.assertIsNone(parsed)
+
+
+class SilentDeclineIsSurfaced(unittest.TestCase):
+    """A label lands, the hook cannot act — it must SAY SO (main#1141).
+
+    The primary bug class is the silent no-op, not the parse gap: 14 issues
+    labeled, 0 comments posted, caught days later by an unrelated audit.
+    """
+
+    def _check(self, command: str, logs: list):
+        original = hook.log_posttooluse_event
+        hook.log_posttooluse_event = lambda *a: logs.append(a)
+        try:
+            return hook.check({"tool_name": "Bash", "tool_input": {"command": command}})
+        finally:
+            hook.log_posttooluse_event = original
+
+    def test_loop_variable_apply_is_logged_and_reported(self) -> None:
+        logs: list = []
+        result = self._check(
+            f'for n in 1114 1116; do gh issue edit "$n" {_EDIT_REPO} --add-label "wave-29"; done',
+            logs,
+        )
+        self.assertEqual(result["action"], "skip_unresolved_issue_number")
+        self.assertEqual(result["labels"], "wave-29")
+        self.assertEqual(len(logs), 1)
+        self.assertIn("kickoff_sweep", logs[0][2])
+
+    def test_dispatcher_surfaces_the_decline(self) -> None:
+        """`EMIT_DISPATCH_SUMMARY` turns the action dict into an operator message."""
+        self.assertTrue(hook.EMIT_DISPATCH_SUMMARY)
+
+    def test_unrelated_command_stays_silent(self) -> None:
+        logs: list = []
+        self.assertIsNone(self._check("git status", logs))
+        self.assertEqual(logs, [])
+
+    def test_non_wave_label_stays_silent(self) -> None:
+        logs: list = []
+        self.assertIsNone(
+            self._check(
+                f'for n in 1; do gh issue edit "$n" {_EDIT_REPO} --add-label "bug"; done', logs
+            )
+        )
+        self.assertEqual(logs, [])
+
+    def test_relabel_shape_stays_silent(self) -> None:
+        """#467 carry-forward relabels are not kickoffs — logging them was a
+        36-event annunaki noise burst in P3W11."""
+        logs: list = []
+        self.assertIsNone(
+            self._check(
+                f'for n in 1; do gh issue edit "$n" {_EDIT_REPO} --add-label "wave-29" '
+                '--remove-label "wave-28"; done',
+                logs,
+            )
+        )
+        self.assertEqual(logs, [])
 
 
 if __name__ == "__main__":

--- a/.claude/hooks/tests/test_post_wave_kickoff_comment.py
+++ b/.claude/hooks/tests/test_post_wave_kickoff_comment.py
@@ -1098,5 +1098,80 @@ class SilentDeclineIsSurfaced(unittest.TestCase):
         self.assertEqual(logs, [])
 
 
+class KickoffCommentStateTriState(unittest.TestCase):
+    """main#1145 — `unknown` must be its own state, not folded into `absent`."""
+
+    HEADING = [{"body": "**Wave 29 Kickoff — Phase 10**\n\nbody"}]
+
+    def test_present(self) -> None:
+        self.assertEqual(
+            hook.kickoff_comment_state("r", "1", 29, fetch_comments=lambda r, n: self.HEADING),
+            hook.KICKOFF_PRESENT,
+        )
+
+    def test_absent(self) -> None:
+        self.assertEqual(
+            hook.kickoff_comment_state("r", "1", 29, fetch_comments=lambda r, n: []),
+            hook.KICKOFF_ABSENT,
+        )
+
+    def test_unknown_on_fetch_failure(self) -> None:
+        self.assertEqual(
+            hook.kickoff_comment_state("r", "1", 29, fetch_comments=lambda r, n: None),
+            hook.KICKOFF_UNKNOWN,
+        )
+
+    def test_three_states_are_distinct(self) -> None:
+        self.assertEqual(len({hook.KICKOFF_PRESENT, hook.KICKOFF_ABSENT, hook.KICKOFF_UNKNOWN}), 3)
+
+    def test_wave_specific_carry_forward_is_absent_not_present(self) -> None:
+        """#547 semantics survive the tri-state refactor."""
+        prior = [{"body": "**Wave 28 Kickoff — Phase 10**"}]
+        self.assertEqual(
+            hook.kickoff_comment_state("r", "1", 29, fetch_comments=lambda r, n: prior),
+            hook.KICKOFF_ABSENT,
+        )
+
+
+class KickoffAlreadyPostedContractPreserved(unittest.TestCase):
+    """The bool wrapper keeps its historical fail-open contract (main#1145).
+
+    Failing open is correct for the HOOK — it posts at most one comment per
+    label-apply, and the failure it guards against (#286) is a kickoff that
+    never gets posted at all. It is wrong for the SWEEP, which is why the
+    sweep uses the tri-state instead. Both behaviors are pinned so neither
+    drifts into the other.
+    """
+
+    def test_false_on_fetch_failure(self) -> None:
+        self.assertFalse(
+            hook.kickoff_already_posted("r", "1", 29, fetch_comments=lambda r, n: None)
+        )
+
+    def test_false_when_absent(self) -> None:
+        self.assertFalse(hook.kickoff_already_posted("r", "1", 29, fetch_comments=lambda r, n: []))
+
+    def test_true_when_present(self) -> None:
+        body = [{"body": "**Wave 29 Kickoff — Phase 10**"}]
+        self.assertTrue(hook.kickoff_already_posted("r", "1", 29, fetch_comments=lambda r, n: body))
+
+    def test_hook_still_posts_when_the_fetch_fails(self) -> None:
+        """End-to-end: the PostToolUse path keeps posting on a broken fetch."""
+        status = {
+            "current_phase": 10,
+            "wave_29_merge_model": "direct-to-main",
+            "wave_29_scope": {"tier_1": [{"id": "noorinalabs-main#1114", "implementer": "N"}]},
+        }
+        result = hook.check(
+            _bash(f'gh issue edit 1114 {_EDIT_REPO} --add-label "wave-29"'),
+            status_loader=lambda: status,
+            comment_fetcher=lambda r, n: None,
+            comment_poster=lambda r, n, p: True,
+            body_writer=lambda b, r, n: Path("/dev/null"),
+        )
+        assert result is not None
+        self.assertEqual(result["action"], "post")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.claude/hooks/tests/test_shell_parse.py
+++ b/.claude/hooks/tests/test_shell_parse.py
@@ -12,7 +12,10 @@ Run: ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/test_shell_parse.py 
 from __future__ import annotations
 
 import os
+import shutil
+import subprocess
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -939,57 +942,158 @@ class StripLockstepAcrossSegmentConsumers(unittest.TestCase):
         self.assertIsNone(sp.extract_leading_cd_target("cd relative && gh pr create"))
 
 
-class GuardedCdMustNotRoute(unittest.TestCase):
-    """main#1141 review round 3 — a guarded `cd` must not decide routing.
+class CdRoutingAgainstShellTruth(unittest.TestCase):
+    """`extract_leading_cd_target` vs what a REAL SHELL actually does.
 
-    The lockstep invariant is "apply the strip", NOT "apply it with the same
-    arguments". Applying it uniformly shipped a live misroute:
+    Method requirement from the main#1141 review, and it earned its keep
+    immediately. These tests do not compare the resolver against its own
+    expected output — each shape is run in a real `bash` with the `gh` node
+    replaced by `pwd`, and the printed directory is ground truth. Testing a
+    resolver against itself cannot find a resolver that is wrong, which is
+    how two families of this bug survived the previous suite.
 
-        if [ -f /nonexistent ] ; then cd /repo-b ; fi ; gh issue edit 5 …
+    It caught one of my own round-3 tests asserting a MISROUTE: I had pinned
+    `env FOO=1 cd /tmp && gh pr create` -> `/tmp`. The shell disagrees. `cd`
+    is a shell BUILTIN, so an exec-wrapper (`env`, `timeout`, `nice`,
+    `nohup`) runs a subprocess and the calling shell never moves — asserted
+    below. The resolver would have claimed a directory the command provably
+    never entered.
 
-    The shell never runs that `cd`. Stripping `then` made the resolver behave
-    as if it had, sending the kickoff comment to repo-b#5 instead of
-    repo-a#5 — the #981/#985 misrouting class.
+    THE SAFETY PROPERTY, and why it is not plain equality:
 
-    A **wrapper** always execs what follows, so stripping it is sound for any
-    caller. A **compound leader** guards a body that may not run: harmless for
-    a GATE that merely over-inspects, destructive for a RESOLVER that routes.
+        resolved is None  OR  resolved == shell_truth
+
+    Under-recovery (None when the shell did move) is ACCEPTED — the caller
+    falls back to the invocation cwd, which is the pre-main#1141 behaviour.
+    Over-recovery, naming a directory the command never entered, is the bug:
+    three hooks on this chain WRITE, so a misroute is an unrecoverable write
+    into the wrong repository.
     """
 
-    GUARDED = [
-        "if [ -f /nonexistent ] ; then cd /tmp ; fi ; gh issue edit 5 --add-label x",
-        "if false ; then cd /tmp ; fi ; gh pr create",
-        "git diff --quiet || { cd /tmp ; gh pr create ; }",
-        "for r in a ; do cd /tmp ; gh issue edit 1 --add-label x ; done",
+    MARKER = "gh issue edit 5 --add-label wave-29"
+
+    _start: str
+    _dest: str
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls._start = tempfile.mkdtemp(prefix="cdroute-start-")
+        cls._dest = tempfile.mkdtemp(prefix="cdroute-dest-")
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        for d in (cls._start, cls._dest):
+            shutil.rmtree(d, ignore_errors=True)
+
+    def _shell_truth(self, template: str) -> str | None:
+        """Directory the shell is actually in where the gh node sits.
+
+        None means the gh node never executes at all in that shape.
+        """
+        cmd = template.replace("DEST", self._dest).replace("MARKER", "pwd")
+        out = subprocess.run(
+            ["bash", "-c", cmd], cwd=self._start, capture_output=True, text=True, timeout=30
+        )
+        printed = out.stdout.strip().splitlines()
+        return printed[-1] if printed else None
+
+    def _resolved(self, template: str) -> str | None:
+        return sp.extract_leading_cd_target(
+            template.replace("DEST", self._dest).replace("MARKER", self.MARKER)
+        )
+
+    def _assert_never_misroutes(self, template: str) -> None:
+        truth = self._shell_truth(template)
+        resolved = self._resolved(template)
+        if resolved is None:
+            return  # under-recovery: caller falls back to the invocation cwd
+        self.assertEqual(
+            resolved,
+            truth,
+            f"resolver claims {resolved!r} but the shell runs the gh node in "
+            f"{truth!r} for: {template}",
+        )
+
+    # --- all seven leader shapes from the review, plus the brace group ---
+
+    LEADER_SHAPES = [
+        "if [ -f /nonexistent ] ; then cd DEST ; fi ; MARKER",
+        "if false ; then cd DEST ; fi ; MARKER",
+        "if false ; then true ; else cd DEST ; fi ; MARKER",
+        "for r in a ; do cd DEST ; done ; MARKER",
+        "for r in ; do cd DEST ; done ; MARKER",
+        "while false ; do cd DEST ; done ; MARKER",
+        "( cd DEST ) ; MARKER",
+        "true || { cd DEST ; } ; MARKER",
+        "false || { cd DEST ; } ; MARKER",
     ]
 
-    def test_guarded_cd_is_not_treated_as_taken(self) -> None:
-        for cmd in self.GUARDED:
-            with self.subTest(cmd=cmd):
-                self.assertIsNone(
-                    sp.extract_leading_cd_target(cmd),
-                    "a cd inside a guarded body must not resolve the routing target",
+    def test_leader_shapes_never_misroute(self) -> None:
+        for template in self.LEADER_SHAPES:
+            with self.subTest(shape=template):
+                self._assert_never_misroutes(template)
+
+    def test_subshell_cd_does_not_escape(self) -> None:
+        """`( cd DEST )` DOES run the cd — it just dies with the subshell."""
+        template = "( cd DEST ) ; MARKER"
+        self.assertEqual(self._shell_truth(template), self._start)
+        self.assertIsNone(self._resolved(template))
+
+    # --- wrappers: `cd` is a BUILTIN, so these never move the shell ---
+
+    WRAPPER_SHAPES = [
+        "env FOO=1 cd DEST ; MARKER",
+        "timeout 5 cd DEST ; MARKER",
+        "nice -n 5 cd DEST ; MARKER",
+        "nohup cd DEST ; MARKER",
+    ]
+
+    def test_wrapped_cd_never_misroutes(self) -> None:
+        for template in self.WRAPPER_SHAPES:
+            with self.subTest(shape=template):
+                self._assert_never_misroutes(template)
+
+    def test_exec_wrapper_provably_cannot_carry_cd(self) -> None:
+        """The fact the resolver must respect, asserted against the shell itself."""
+        for template in self.WRAPPER_SHAPES:
+            with self.subTest(shape=template):
+                self.assertEqual(
+                    self._shell_truth(template),
+                    self._start,
+                    "an exec-wrapper cannot carry the `cd` builtin — if this ever "
+                    "changes, the resolver's no-strip rule needs revisiting",
                 )
+                self.assertIsNone(self._resolved(template))
 
-    def test_unguarded_cd_still_resolves(self) -> None:
-        for cmd in (
-            "cd /tmp && gh pr create",
-            "cd /tmp ; gh pr create",
-            "cd /var && cd /tmp && gh pr create",  # last one wins
-        ):
-            with self.subTest(cmd=cmd):
-                self.assertEqual(sp.extract_leading_cd_target(cmd), "/tmp")
+    # --- the shapes that MUST still resolve ---
 
-    def test_wrapped_cd_still_resolves(self) -> None:
-        """A wrapper always execs what follows, so it stays strippable here."""
-        self.assertEqual(sp.extract_leading_cd_target("env FOO=1 cd /tmp && gh pr create"), "/tmp")
+    UNGUARDED_SHAPES = [
+        "cd DEST && MARKER",
+        "cd DEST ; MARKER",
+        "cd /var && cd DEST && MARKER",
+    ]
+
+    def test_unguarded_cd_resolves_exactly(self) -> None:
+        for template in self.UNGUARDED_SHAPES:
+            with self.subTest(shape=template):
+                self.assertEqual(self._resolved(template), self._shell_truth(template))
+                self.assertEqual(self._resolved(template), self._dest)
+
+    def test_relative_target_ignored(self) -> None:
+        """Relative targets would resolve against the (wrong) stdin cwd."""
+        self.assertIsNone(sp.extract_leading_cd_target("cd relative && gh pr create"))
+
+    # --- gates keep their conservative reach; only routing opts out ---
 
     def test_gates_still_see_guarded_bodies(self) -> None:
-        """The carve-out is routing-only — gates keep their conservative reach."""
         found = sp.find_gh_subcommand(["then", "gh", "pr", "review", "5"])
         self.assertEqual(found, ([], ["pr", "review", "5"]))
         self.assertEqual(
             sp.extract_dash_c_pairs(["do", "git", "-c", "user.name=A", "commit"]),
+            [("user.name", "A")],
+        )
+        self.assertEqual(
+            sp.extract_dash_c_pairs(["timeout", "60", "git", "-c", "user.name=A", "commit"]),
             [("user.name", "A")],
         )
 
@@ -998,10 +1102,34 @@ class GuardedCdMustNotRoute(unittest.TestCase):
         self.assertEqual(sp.strip_command_prefixes(seg), ["cd", "/tmp"])
         self.assertEqual(sp.strip_command_prefixes(seg, compound_leaders=False), seg)
 
-    def test_wrappers_strip_under_both_settings(self) -> None:
-        seg = ["timeout", "5", "cd", "/tmp"]
-        self.assertEqual(sp.strip_command_prefixes(seg), ["cd", "/tmp"])
-        self.assertEqual(sp.strip_command_prefixes(seg, compound_leaders=False), ["cd", "/tmp"])
+    # --- known, tracked, NOT closed here ---
+
+    KNOWN_GAP_SHAPES = [
+        "true || cd DEST ; MARKER",  # family A: no leader token to withhold
+        "MARKER ; cd DEST",  # family B: cd AFTER the gh node
+    ]
+
+    def test_known_gap_main_1151_still_misroutes(self) -> None:
+        """Characterization of the residual class — NOT a blessing of it.
+
+        Both shapes misroute on `95f375a` and on every head since; they
+        predate main#1141 and are untouched by it. Neither is fixable at this
+        layer: family A has no leader to withhold, and family B needs to know
+        whether the `cd` precedes the `gh` NODE, which `iter_command_segments`
+        has already discarded. main#1151 tracks the bashlex-AST fix.
+
+        This test exists so the gap is visible in the suite rather than only
+        in prose, and so closing #1151 forces someone to come back here.
+        """
+        for template in self.KNOWN_GAP_SHAPES:
+            with self.subTest(shape=template):
+                self.assertEqual(self._shell_truth(template), self._start)
+                self.assertEqual(
+                    self._resolved(template),
+                    self._dest,
+                    "if this now returns None, #1151 has been fixed — delete this "
+                    "test and fold the shape into test_leader_shapes_never_misroute",
+                )
 
 
 if __name__ == "__main__":

--- a/.claude/hooks/tests/test_shell_parse.py
+++ b/.claude/hooks/tests/test_shell_parse.py
@@ -6,6 +6,29 @@ find_git_subcommand, find_gh_subcommand, extract_dash_c_pairs,
 resolve_tool_cwd, is_shutdown_request_message) and the negative-match
 fixtures from the sibling-bug cluster (#226 #227 #223 #216 #188 #189 #144).
 
+Shell-truth tests, and their one known limit (main#1141 review)
+==============================================================
+
+`CdRoutingAgainstShellTruth` does not compare the resolver to an expected
+literal — it runs each shape in a REAL shell and takes the resulting cwd as
+ground truth. Everything else in this module asserts against expected output,
+which is fine for pure token functions but cannot catch a resolver whose model
+of the shell is simply wrong (it can only catch one that disagrees with
+someone's belief about it). Two families of main#1151 survived this suite for
+exactly that reason, and the method caught a round-3 test of mine that pinned a
+misroute as correct.
+
+**Limit — the oracle is `bash`, the harness shell is `zsh`.** Constructs are
+driven through `bash -c` for determinism and because CI runs bash. For every
+shape asserted here the two shells agree, and the load-bearing fact (an
+exec-wrapper cannot carry the `cd` BUILTIN, so `env FOO=1 cd /x` leaves the
+shell where it was) was checked in BOTH before the resolver was written to
+depend on it. One construct is known to differ and is therefore deliberately
+NOT relied on anywhere: `command cd /x` moves the shell in bash but not in
+zsh. If a future shape's behaviour is shell-dependent, verify it in both and
+either assert the common subset or leave it out — do not let a bash-only truth
+become a resolver invariant.
+
 Run: ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/test_shell_parse.py -v
 """
 
@@ -1064,6 +1087,17 @@ class CdRoutingAgainstShellTruth(unittest.TestCase):
                     "changes, the resolver's no-strip rule needs revisiting",
                 )
                 self.assertIsNone(self._resolved(template))
+
+    def test_shell_dependent_shape_is_not_relied_on(self) -> None:
+        """`command cd /x` moves the shell in bash but NOT in zsh.
+
+        The harness shell is zsh and the oracle here is bash, so this shape has
+        no single truth. The resolver must therefore claim nothing for it —
+        which it does for free, since it strips no prefixes at all. Pinned so a
+        future widening cannot quietly adopt a bash-only behaviour as an
+        invariant (module docstring § Shell-truth tests).
+        """
+        self.assertIsNone(self._resolved("command cd DEST ; MARKER"))
 
     # --- the shapes that MUST still resolve ---
 

--- a/.claude/hooks/tests/test_shell_parse.py
+++ b/.claude/hooks/tests/test_shell_parse.py
@@ -846,5 +846,84 @@ class FindSubcommandThroughPrefixes(unittest.TestCase):
         self.assertIsNone(sp.find_gh_subcommand(["echo", "gh", "issue", "edit", "1114"]))
 
 
+class StripLockstepAcrossSegmentConsumers(unittest.TestCase):
+    """main#1141 review MUST-FIX — every command-position keyer must strip.
+
+    `find_git_subcommand` stripped and `extract_dash_c_pairs` did not, while
+    `validate_commit_identity` calls BOTH on the SAME segment: the commit was
+    recognized but its `-c` pairs came back empty, so a fully compliant
+    `timeout 60 git -c user.name=… -c user.email=… commit` was BLOCKED for a
+    missing flag the operator had passed. The suite was green with and
+    without the fix, which is why 21/21 CI and a 25-shape adversarial pass
+    both missed it — hence these tests.
+    """
+
+    IDENTITY = ["-c", "user.name=Nino Kavtaradze", "-c", "user.email=n@example.com"]
+    EXPECTED = [("user.name", "Nino Kavtaradze"), ("user.email", "n@example.com")]
+
+    def test_dash_c_pairs_bare(self) -> None:
+        seg = ["git", *self.IDENTITY, "commit", "-m", "msg"]
+        self.assertEqual(sp.extract_dash_c_pairs(seg), self.EXPECTED)
+
+    def test_dash_c_pairs_behind_wrappers(self) -> None:
+        """Whole `_COMMAND_PREFIX_WRAPPERS` table, not just `timeout`."""
+        for prefix in (
+            ["timeout", "60"],
+            ["timeout", "-k", "5", "60"],
+            ["env", "FOO=1"],
+            ["nice", "-n", "5"],
+            ["nohup"],
+            ["command"],
+            ["sudo", "-u", "ci"],
+            ["do"],
+            ["do", "timeout", "60"],
+        ):
+            with self.subTest(prefix=" ".join(prefix)):
+                seg = [*prefix, "git", *self.IDENTITY, "commit", "-m", "msg"]
+                self.assertEqual(sp.extract_dash_c_pairs(seg), self.EXPECTED)
+
+    def test_dash_c_pairs_and_find_git_subcommand_agree(self) -> None:
+        """The invariant itself: both helpers see the same command, or neither.
+
+        A future segment-consuming helper that forgets the strip fails here.
+        """
+        for prefix in ([], ["timeout", "60"], ["env", "FOO=1"], ["do"], ["nice", "-n", "5"]):
+            with self.subTest(prefix=" ".join(prefix) or "(bare)"):
+                seg = [*prefix, "git", *self.IDENTITY, "commit", "-m", "msg"]
+                found = sp.find_git_subcommand(seg)
+                self.assertIsNotNone(found)
+                assert found is not None
+                self.assertEqual(found[1][0], "commit")
+                # Recognized as a commit => its identity flags MUST be readable.
+                self.assertEqual(sp.extract_dash_c_pairs(seg), self.EXPECTED)
+
+    def test_wrapped_commit_without_identity_still_yields_nothing(self) -> None:
+        """The strip must not invent pairs — an identity-less commit stays empty."""
+        for prefix in (["timeout", "60"], ["env", "FOO=1"], ["do"]):
+            with self.subTest(prefix=" ".join(prefix)):
+                self.assertEqual(
+                    sp.extract_dash_c_pairs([*prefix, "git", "commit", "-m", "msg"]), []
+                )
+
+    def test_non_wrapper_head_yields_no_pairs(self) -> None:
+        """`echo git -c user.name=X commit` is data, not a commit."""
+        self.assertEqual(sp.extract_dash_c_pairs(["echo", "git", *self.IDENTITY, "commit"]), [])
+
+    def test_cd_target_behind_compound_leader(self) -> None:
+        """`gh` inside a loop is visible now; the `cd` beside it must be too."""
+        self.assertEqual(
+            sp.extract_leading_cd_target(
+                "for r in a ; do cd /tmp ; gh issue edit 1 --add-label x ; done"
+            ),
+            "/tmp",
+        )
+
+    def test_cd_target_bare_still_works(self) -> None:
+        self.assertEqual(sp.extract_leading_cd_target("cd /tmp && gh pr create"), "/tmp")
+
+    def test_cd_target_relative_still_ignored(self) -> None:
+        self.assertIsNone(sp.extract_leading_cd_target("do cd relative && gh pr create"))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.claude/hooks/tests/test_shell_parse.py
+++ b/.claude/hooks/tests/test_shell_parse.py
@@ -909,20 +909,99 @@ class StripLockstepAcrossSegmentConsumers(unittest.TestCase):
         """`echo git -c user.name=X commit` is data, not a commit."""
         self.assertEqual(sp.extract_dash_c_pairs(["echo", "git", *self.IDENTITY, "commit"]), [])
 
-    def test_cd_target_behind_compound_leader(self) -> None:
-        """`gh` inside a loop is visible now; the `cd` beside it must be too."""
-        self.assertEqual(
+    def test_cd_target_behind_compound_leader_is_NOT_recovered(self) -> None:
+        """RETRACTED in review round 3 — this test asserted the wrong thing.
+
+        Round 2 argued that since `find_gh_subcommand` can see the `gh` inside
+        a loop, the `cd` beside it should be recovered too. That reasoning was
+        wrong: it treats a gate matcher and a routing resolver as the same
+        kind of consumer. Recovering a `cd` from ANY compound body also
+        recovers it from a never-taken `then` body, which misroutes — a live
+        bug, on the #981/#985 path, versus a speculative loop-cd shape with no
+        observed failure. `extract_leading_cd_target` strips wrappers only,
+        and the loop case staying unrecovered is the accepted cost (it needs
+        block-closure tracking to separate the two, which is not worth it).
+
+        Kept as an explicit non-goal rather than deleted, so the round-2
+        argument is not re-derived by the next reader. See `GuardedCdMustNotRoute`.
+        """
+        self.assertIsNone(
             sp.extract_leading_cd_target(
                 "for r in a ; do cd /tmp ; gh issue edit 1 --add-label x ; done"
-            ),
-            "/tmp",
+            )
         )
 
     def test_cd_target_bare_still_works(self) -> None:
         self.assertEqual(sp.extract_leading_cd_target("cd /tmp && gh pr create"), "/tmp")
 
     def test_cd_target_relative_still_ignored(self) -> None:
-        self.assertIsNone(sp.extract_leading_cd_target("do cd relative && gh pr create"))
+        """Relative targets are ambiguous (they'd resolve against the wrong cwd)."""
+        self.assertIsNone(sp.extract_leading_cd_target("cd relative && gh pr create"))
+
+
+class GuardedCdMustNotRoute(unittest.TestCase):
+    """main#1141 review round 3 — a guarded `cd` must not decide routing.
+
+    The lockstep invariant is "apply the strip", NOT "apply it with the same
+    arguments". Applying it uniformly shipped a live misroute:
+
+        if [ -f /nonexistent ] ; then cd /repo-b ; fi ; gh issue edit 5 …
+
+    The shell never runs that `cd`. Stripping `then` made the resolver behave
+    as if it had, sending the kickoff comment to repo-b#5 instead of
+    repo-a#5 — the #981/#985 misrouting class.
+
+    A **wrapper** always execs what follows, so stripping it is sound for any
+    caller. A **compound leader** guards a body that may not run: harmless for
+    a GATE that merely over-inspects, destructive for a RESOLVER that routes.
+    """
+
+    GUARDED = [
+        "if [ -f /nonexistent ] ; then cd /tmp ; fi ; gh issue edit 5 --add-label x",
+        "if false ; then cd /tmp ; fi ; gh pr create",
+        "git diff --quiet || { cd /tmp ; gh pr create ; }",
+        "for r in a ; do cd /tmp ; gh issue edit 1 --add-label x ; done",
+    ]
+
+    def test_guarded_cd_is_not_treated_as_taken(self) -> None:
+        for cmd in self.GUARDED:
+            with self.subTest(cmd=cmd):
+                self.assertIsNone(
+                    sp.extract_leading_cd_target(cmd),
+                    "a cd inside a guarded body must not resolve the routing target",
+                )
+
+    def test_unguarded_cd_still_resolves(self) -> None:
+        for cmd in (
+            "cd /tmp && gh pr create",
+            "cd /tmp ; gh pr create",
+            "cd /var && cd /tmp && gh pr create",  # last one wins
+        ):
+            with self.subTest(cmd=cmd):
+                self.assertEqual(sp.extract_leading_cd_target(cmd), "/tmp")
+
+    def test_wrapped_cd_still_resolves(self) -> None:
+        """A wrapper always execs what follows, so it stays strippable here."""
+        self.assertEqual(sp.extract_leading_cd_target("env FOO=1 cd /tmp && gh pr create"), "/tmp")
+
+    def test_gates_still_see_guarded_bodies(self) -> None:
+        """The carve-out is routing-only — gates keep their conservative reach."""
+        found = sp.find_gh_subcommand(["then", "gh", "pr", "review", "5"])
+        self.assertEqual(found, ([], ["pr", "review", "5"]))
+        self.assertEqual(
+            sp.extract_dash_c_pairs(["do", "git", "-c", "user.name=A", "commit"]),
+            [("user.name", "A")],
+        )
+
+    def test_compound_leaders_flag_is_honored(self) -> None:
+        seg = ["then", "cd", "/tmp"]
+        self.assertEqual(sp.strip_command_prefixes(seg), ["cd", "/tmp"])
+        self.assertEqual(sp.strip_command_prefixes(seg, compound_leaders=False), seg)
+
+    def test_wrappers_strip_under_both_settings(self) -> None:
+        seg = ["timeout", "5", "cd", "/tmp"]
+        self.assertEqual(sp.strip_command_prefixes(seg), ["cd", "/tmp"])
+        self.assertEqual(sp.strip_command_prefixes(seg, compound_leaders=False), ["cd", "/tmp"])
 
 
 if __name__ == "__main__":

--- a/.claude/hooks/tests/test_shell_parse.py
+++ b/.claude/hooks/tests/test_shell_parse.py
@@ -944,9 +944,16 @@ class StripLockstepAcrossSegmentConsumers(unittest.TestCase):
         kind of consumer. Recovering a `cd` from ANY compound body also
         recovers it from a never-taken `then` body, which misroutes — a live
         bug, on the #981/#985 path, versus a speculative loop-cd shape with no
-        observed failure. `extract_leading_cd_target` strips wrappers only,
-        and the loop case staying unrecovered is the accepted cost (it needs
-        block-closure tracking to separate the two, which is not worth it).
+        observed failure.
+
+        `extract_leading_cd_target` therefore strips NOTHING — `cd` must be
+        token 0 of its segment. Both prefix families are disqualified, for two
+        different reasons: a compound LEADER guards a body that may not run,
+        and a command-prefix WRAPPER cannot carry `cd` at all, because `cd` is
+        a shell builtin (`env FOO=1 cd /x` leaves the shell where it was, in
+        bash and zsh alike). The loop case staying unrecovered is the accepted
+        cost — separating a loop body that runs from a `then` body that does
+        not needs block-closure tracking, which is not worth it.
 
         Kept as an explicit non-goal rather than deleted, so the round-2
         argument is not re-derived by the next reader. See `GuardedCdMustNotRoute`.
@@ -1151,6 +1158,14 @@ class CdRoutingAgainstShellTruth(unittest.TestCase):
         layer: family A has no leader to withhold, and family B needs to know
         whether the `cd` precedes the `gh` NODE, which `iter_command_segments`
         has already discarded. main#1151 tracks the bashlex-AST fix.
+
+        Family A is narrower than it looks, and the difference is easy to
+        mistake for a fix: the BRACED variant `true || { cd DEST ; … }` does
+        NOT misroute, because the `{` makes that segment three tokens and the
+        `cd` is no longer at token 0 (it is covered by
+        `test_leader_shapes_never_misroute`). Only the BARE `true || cd DEST`
+        form gets through. So repairing the braced shape proves nothing about
+        family A — do not read it as evidence that #1151 is closed.
 
         This test exists so the gap is visible in the suite rather than only
         in prose, and so closing #1151 forces someone to come back here.

--- a/.claude/hooks/tests/test_shell_parse.py
+++ b/.claude/hooks/tests/test_shell_parse.py
@@ -742,5 +742,109 @@ class MemoizedParseMutationSafetyTests(unittest.TestCase):
         self.assertEqual(sp.iter_command_segments_ast(cmd), expected)
 
 
+class StripCommandPrefixes(unittest.TestCase):
+    """main#1141 — leading wrappers / compound keywords must not hide a command.
+
+    `find_git_subcommand` / `find_gh_subcommand` keyed on token 0 being
+    literally `git` / `gh`, so `timeout 45 gh …` and the `do`-prefixed body of
+    a `for … ; do … ; done` loop resolved to None and every consuming hook —
+    the kickoff-comment poster AND the blocking gates on the same primitive —
+    silently did nothing.
+    """
+
+    def test_bare_command_unchanged(self) -> None:
+        self.assertEqual(
+            sp.strip_command_prefixes(["gh", "issue", "edit"]), ["gh", "issue", "edit"]
+        )
+
+    def test_empty_segment(self) -> None:
+        self.assertEqual(sp.strip_command_prefixes([]), [])
+
+    def test_timeout_duration_positional(self) -> None:
+        self.assertEqual(
+            sp.strip_command_prefixes(["timeout", "45", "gh", "pr", "list"]), ["gh", "pr", "list"]
+        )
+
+    def test_timeout_with_flags(self) -> None:
+        self.assertEqual(
+            sp.strip_command_prefixes(["timeout", "-k", "5", "--foreground", "2m", "gh", "pr"]),
+            ["gh", "pr"],
+        )
+
+    def test_timeout_equals_form_flag(self) -> None:
+        self.assertEqual(
+            sp.strip_command_prefixes(["timeout", "--kill-after=5", "45", "gh", "pr"]),
+            ["gh", "pr"],
+        )
+
+    def test_compound_leaders(self) -> None:
+        for leader in ("do", "then", "else", "if", "elif", "while", "until", "!", "{", "("):
+            with self.subTest(leader=leader):
+                self.assertEqual(sp.strip_command_prefixes([leader, "gh", "pr"]), ["gh", "pr"])
+
+    def test_nested_wrappers(self) -> None:
+        self.assertEqual(
+            sp.strip_command_prefixes(["do", "timeout", "45", "nohup", "gh", "pr"]),
+            ["gh", "pr"],
+        )
+
+    def test_env_assignments_and_flags(self) -> None:
+        self.assertEqual(
+            sp.strip_command_prefixes(["env", "-u", "PAGER", "GH_PAGER=cat", "gh", "pr"]),
+            ["gh", "pr"],
+        )
+
+    def test_sudo_user_flag(self) -> None:
+        self.assertEqual(
+            sp.strip_command_prefixes(["sudo", "-u", "ci", "git", "commit"]), ["git", "commit"]
+        )
+
+    def test_double_dash_ends_wrapper_options(self) -> None:
+        self.assertEqual(sp.strip_command_prefixes(["env", "--", "gh", "pr"]), ["gh", "pr"])
+
+    def test_non_wrapper_head_is_not_stripped(self) -> None:
+        """The allowlist is the whole safety property.
+
+        A loose "find `gh` anywhere in the segment" scan would re-introduce the
+        data-position false-positive class this module exists to prevent — the
+        #118/#134/#144/#188/#189/#216/#223/#226/#227 bug trail. `echo`, `printf`
+        and friends take DATA, not a command, so they are never stripped.
+        """
+        for head in ("echo", "printf", "cat", "grep", "python3"):
+            with self.subTest(head=head):
+                seg = [head, "gh", "issue", "edit", "5"]
+                self.assertEqual(sp.strip_command_prefixes(seg), seg)
+
+    def test_for_keyword_is_not_a_leader(self) -> None:
+        """`for` is followed by a VARIABLE NAME, not a command."""
+        seg = ["for", "n", "in", "1114", "1116"]
+        self.assertEqual(sp.strip_command_prefixes(seg), seg)
+
+    def test_does_not_mutate_input(self) -> None:
+        seg = ["timeout", "45", "gh", "pr"]
+        sp.strip_command_prefixes(seg)
+        self.assertEqual(seg, ["timeout", "45", "gh", "pr"])
+
+
+class FindSubcommandThroughPrefixes(unittest.TestCase):
+    """The wrapper tolerance must reach the two public finders (main#1141)."""
+
+    def test_gh_behind_timeout(self) -> None:
+        found = sp.find_gh_subcommand(["timeout", "45", "gh", "issue", "edit", "1114"])
+        self.assertEqual(found, ([], ["issue", "edit", "1114"]))
+
+    def test_gh_in_loop_body(self) -> None:
+        found = sp.find_gh_subcommand(["do", "gh", "issue", "edit", "1114"])
+        self.assertEqual(found, ([], ["issue", "edit", "1114"]))
+
+    def test_git_behind_timeout_reaches_the_identity_gate(self) -> None:
+        """`timeout 60 git commit` previously walked past commit-identity validation."""
+        found = sp.find_git_subcommand(["timeout", "60", "git", "-c", "user.name=A", "commit"])
+        self.assertEqual(found, (["-c", "user.name=A"], ["commit"]))
+
+    def test_gh_as_data_still_not_found(self) -> None:
+        self.assertIsNone(sp.find_gh_subcommand(["echo", "gh", "issue", "edit", "1114"]))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.claude/hooks/tests/test_validate_commit_identity.py
+++ b/.claude/hooks/tests/test_validate_commit_identity.py
@@ -1312,5 +1312,63 @@ class CwdFallbackTests(unittest.TestCase):
             self.assertIsNone(result, f"expected allow, got block: {result}")
 
 
+class WrappedCommitIdentityRegression(unittest.TestCase):
+    """main#1141 review MUST-FIX — a wrapped COMPLIANT commit must be allowed.
+
+    main#1141 taught `_shell_parse` to see `git`/`gh` behind a command-prefix
+    wrapper, closing an evasion (`timeout 60 git commit` had bypassed this gate
+    entirely). But `extract_dash_c_pairs` was left un-stripped while
+    `find_git_subcommand` stripped, and this hook calls BOTH on the same
+    segment — so the wrapped commit became visible as a commit while its `-c`
+    identity flags read as absent, and the gate blocked it with
+    "missing `-c user.name=` flag", naming the exact flag that had been passed.
+
+    Trading an evasion for a false positive is a net loss: the evasion costs
+    one missed gate, the false positive blocks correct work for everyone with a
+    message that reads as a lie. Both directions are pinned below.
+    """
+
+    @staticmethod
+    def _input(command: str) -> dict:
+        return {"tool_name": "Bash", "tool_input": {"command": command}}
+
+    def _commit(self, prefix: str, *, identity: bool) -> str:
+        ident = (
+            '-c user.name="Nadia Khoury" -c user.email="parametrization+Nadia.Khoury@gmail.com" '
+            if identity
+            else ""
+        )
+        return f'{prefix}git {ident}commit -m "x"'
+
+    def test_wrapped_compliant_commit_is_allowed(self) -> None:
+        for prefix in (
+            "",
+            "timeout 60 ",
+            "timeout -k 5 60 ",
+            "env FOO=1 ",
+            "nice -n 5 ",
+            "nohup ",
+            "command ",
+        ):
+            with self.subTest(prefix=prefix or "(bare)"):
+                result = hook.check(self._input(self._commit(prefix, identity=True)))
+                self.assertIsNone(
+                    result,
+                    f"compliant commit behind {prefix!r} must be ALLOWED, got block: {result}",
+                )
+
+    def test_wrapped_identityless_commit_is_still_blocked(self) -> None:
+        """The evasion stays closed — the fix must not re-open it."""
+        for prefix in ("timeout 60 ", "env FOO=1 ", "nice -n 5 "):
+            with self.subTest(prefix=prefix):
+                result = hook.check(self._input(self._commit(prefix, identity=False)))
+                self.assertIsNotNone(
+                    result, f"identity-less commit behind {prefix!r} must be BLOCKED"
+                )
+
+    def test_bare_identityless_commit_is_still_blocked(self) -> None:
+        self.assertIsNotNone(hook.check(self._input(self._commit("", identity=False))))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.claude/lib/kickoff_sweep.py
+++ b/.claude/lib/kickoff_sweep.py
@@ -119,10 +119,12 @@ def list_labeled_issues(repo: str, labels: list[str], run_gh=None) -> list[str]:
 
     One `gh issue list` call per label (multiple `--label` flags on a single
     call are ANDed by gh, which is the opposite of what a form-union needs),
-    de-duplicated and returned in ascending numeric order. `--limit 500`
-    exceeds any plausible wave scope by an order of magnitude; a wave that
-    somehow exceeded it would silently under-sweep, so the limit is asserted
-    against the returned count by the caller's report (`len(candidates)`).
+    de-duplicated and returned in ascending numeric order.
+
+    `--limit 500` exceeds any plausible wave scope by an order of magnitude,
+    but there is NO assertion that the result stayed under it: a wave that
+    somehow exceeded 500 labeled issues in one repo would silently
+    under-sweep. Known gap, not a guarantee — tracked by main#1145.
     """
     run_gh = run_gh or _run_gh
     seen: set[str] = set()

--- a/.claude/lib/kickoff_sweep.py
+++ b/.claude/lib/kickoff_sweep.py
@@ -29,10 +29,20 @@ evidence than observing the resulting state") applied to the kickoff surface.
 Safety properties
 =================
 
-* **Idempotent.** Every candidate is screened through the hook's own
-  `kickoff_already_posted(repo, issue, wave_num=…)`, so re-running the sweep
-  posts nothing the second time. That check is wave-specific (#547), so a
-  carry-forward issue's PRIOR-wave kickoff does not suppress this wave's.
+* **Idempotent WHEN THE COMMENT FETCH SUCCEEDS.** Every candidate is screened
+  through the hook's own `kickoff_comment_state(repo, issue, wave_num=…)`, so
+  re-running the sweep posts nothing the second time. That check is
+  wave-specific (#547), so a carry-forward issue's PRIOR-wave kickoff does not
+  suppress this wave's.
+
+  The qualifier is load-bearing (main#1145). If the fetch itself fails, the
+  probe returns `unknown`, not `absent`, and the candidate resolves to
+  `skip_fetch_unknown` — no post, in either mode. Without that state a
+  sustained fetch failure appended a duplicate on every `--apply` pass and
+  reported `posted`, so the sweep never reached the zero-`would_post` that
+  Step 7b defines as done: an operator following the documented procedure into
+  an unbounded loop. A fetch is likeliest to fail during a GitHub incident,
+  which is exactly when kickoff gets re-run.
 * **One renderer.** The comment body comes from the hook's
   `render_kickoff_comment` with the hook's `read_merge_model` — the sweep can
   never drift from the hook's template or emit a different branch base.
@@ -48,9 +58,11 @@ CLI
   kickoff_sweep.py <phase> <wave> [--status PATH] [--repo NAME ...]
                                   [--apply] [--json]
 
-Exit codes: 0 = nothing to do / dry-run completed / all posts succeeded;
-1 = at least one post failed (a red signal for the operator, mirroring
-`wave_merge_model.py reachability`).
+Exit codes: 0 = the sweep saw every candidate and did its job; 1 = it did NOT
+(a post failed, or an issue could not be probed at all). Step 7b keys
+completion on exit 0, so an un-probeable issue blocks completion exactly like a
+failed post — the operator is never handed a quiet zero that means "I could not
+look". Mirrors `wave_merge_model.py reachability`.
 """
 
 from __future__ import annotations
@@ -73,11 +85,13 @@ _DEFAULT_STATUS = _REPO_ROOT / "cross-repo-status.json"
 # hook module).
 sys.path.insert(0, str(_HOOKS_DIR))
 from post_wave_kickoff_comment import (  # noqa: E402
+    KICKOFF_PRESENT,
+    KICKOFF_UNKNOWN,
     _gh_post_comment,
     _phase_from_status,
     _write_fresh_body_file,
     find_assignment_row,
-    kickoff_already_posted,
+    kickoff_comment_state,
     read_merge_model,
     render_kickoff_comment,
 )
@@ -91,6 +105,15 @@ SKIP_IDEMPOTENT = "skip_idempotent"
 SKIP_META_ISSUE = "skip_meta_issue"
 SKIP_NO_ROW = "skip_no_row"
 POST_FAILED = "post_failed"
+# main#1145: the comment fetch failed, so we CANNOT tell whether a kickoff
+# comment already exists. Never posts, in either mode.
+SKIP_FETCH_UNKNOWN = "skip_fetch_unknown"
+
+# Outcomes that mean the sweep did not finish its job. `/wave-kickoff` Step 7b
+# treats a non-zero exit as "Step 7 is NOT complete" — so an un-probeable issue
+# blocks completion exactly like a failed post does, rather than passing as a
+# quiet zero.
+_INCOMPLETE_ACTIONS = frozenset({POST_FAILED, SKIP_FETCH_UNKNOWN})
 
 
 def _run_gh(args: list[str]) -> str:
@@ -218,10 +241,21 @@ def sweep(
                 results.append({"repo": repo, "issue": issue_number, "action": SKIP_NO_ROW})
                 continue
 
-            if kickoff_already_posted(
+            state = kickoff_comment_state(
                 repo, issue_number, wave_num=wave_num, fetch_comments=fetch_comments
-            ):
+            )
+            if state == KICKOFF_PRESENT:
                 results.append({"repo": repo, "issue": issue_number, "action": SKIP_IDEMPOTENT})
+                continue
+            if state == KICKOFF_UNKNOWN:
+                # main#1145 fail-open guard. We could not read the comments, so
+                # "already posted?" is unanswered — and unanswered is not "no".
+                # Posting here is what made a sustained fetch failure append a
+                # duplicate on every `--apply` pass while reporting `posted`,
+                # so the sweep never converged to the zero-`would_post` that
+                # Step 7b defines as done. Report the uncertainty and post
+                # nothing; the operator re-runs once the fetch is healthy.
+                results.append({"repo": repo, "issue": issue_number, "action": SKIP_FETCH_UNKNOWN})
                 continue
 
             body = render_kickoff_comment(row, wave_num, phase_num, repo, merge_model=merge_model)
@@ -245,7 +279,12 @@ def sweep(
 
 
 def format_report(wave: str | int, results: list[dict], *, apply: bool) -> str:
-    """Human-readable sweep report — one line per candidate plus a summary."""
+    """Human-readable sweep report — one line per candidate plus a summary.
+
+    The `skip_fetch_unknown` count is called out separately rather than left to
+    be spotted in the summary line (main#1145): "nothing to do" and "could not
+    tell" must not look alike to an operator deciding whether Step 7 is done.
+    """
     counts: dict[str, int] = {}
     for r in results:
         counts[r["action"]] = counts.get(r["action"], 0) + 1
@@ -258,6 +297,18 @@ def format_report(wave: str | int, results: list[dict], *, apply: bool) -> str:
         lines.append(f"  (no open issue carries a wave-{wave} label in the swept repos)")
     summary = ", ".join(f"{k}={v}" for k, v in sorted(counts.items())) or "nothing to reconcile"
     lines.append(f"Summary: {summary}")
+
+    unknown = counts.get(SKIP_FETCH_UNKNOWN, 0)
+    if unknown:
+        lines.append(
+            f"INCOMPLETE: {unknown} issue(s) could not be checked — the comment fetch failed, "
+            "so it is unknown whether they already have a kickoff comment. NOTHING was posted "
+            "for them. Do NOT treat this sweep as complete; re-run once gh is healthy (#1145)."
+        )
+    if counts.get(POST_FAILED):
+        lines.append(
+            f"INCOMPLETE: {counts[POST_FAILED]} post(s) failed — re-run to retry (idempotent)."
+        )
     return "\n".join(lines)
 
 
@@ -277,7 +328,7 @@ def _cmd_sweep(args: argparse.Namespace) -> int:
         print(json.dumps({"wave": args.wave, "apply": args.apply, "results": results}, indent=2))
     else:
         print(format_report(args.wave, results, apply=args.apply))
-    return 1 if any(r["action"] == POST_FAILED for r in results) else 0
+    return 1 if any(r["action"] in _INCOMPLETE_ACTIONS for r in results) else 0
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/.claude/lib/kickoff_sweep.py
+++ b/.claude/lib/kickoff_sweep.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""State-based kickoff-comment reconciliation for `/wave-kickoff` (main#1141).
+
+Why a sweep exists at all
+=========================
+
+`post_wave_kickoff_comment.py` posts the charter-format kickoff comment as a
+PostToolUse reaction to the label-apply COMMAND. That is the right primary
+mechanism (it fires at the moment of the apply), but it inherits a structural
+limit: it can only act on what it can parse out of a shell string. main#1141
+found two ordinary shapes it could not — a `timeout 45 gh …` prefix and a
+`for … ; do gh issue edit … ; done` loop — and the consequence was silent in
+the unsafe direction: during `/wave-scope 10 29` on 2026-07-27, **14 issues
+were labeled and zero kickoff comments were posted**, undetected until an
+unrelated audit. The parser side of that is fixed (`_shell_parse.
+strip_command_prefixes`), but the loop-VARIABLE shape
+
+    for n in 1114 1116; do gh issue edit "$n" --add-label "wave-29"; done
+
+is genuinely unfixable at the command layer: the issue number never appears in
+the string. No parser closes that class.
+
+This module closes it from the other side. It reads the state that actually
+landed — the wave label on the issue — and posts a kickoff comment to every
+in-scope issue that carries the label but has no kickoff comment for that wave.
+It is the same discipline as main#981/#985 ("parsing a command string is weaker
+evidence than observing the resulting state") applied to the kickoff surface.
+
+Safety properties
+=================
+
+* **Idempotent.** Every candidate is screened through the hook's own
+  `kickoff_already_posted(repo, issue, wave_num=…)`, so re-running the sweep
+  posts nothing the second time. That check is wave-specific (#547), so a
+  carry-forward issue's PRIOR-wave kickoff does not suppress this wave's.
+* **One renderer.** The comment body comes from the hook's
+  `render_kickoff_comment` with the hook's `read_merge_model` — the sweep can
+  never drift from the hook's template or emit a different branch base.
+* **Dry-run by default.** Posting a comment is an outward-facing, effectively
+  irreversible action across up to ~20 issues, so `--apply` is required to
+  actually post. Without it the sweep prints exactly what it WOULD post.
+* **Open issues only.** A closed issue is not kicked off; posting there is
+  noise.
+
+CLI
+===
+
+  kickoff_sweep.py <phase> <wave> [--status PATH] [--repo NAME ...]
+                                  [--apply] [--json]
+
+Exit codes: 0 = nothing to do / dry-run completed / all posts succeeded;
+1 = at least one post failed (a red signal for the operator, mirroring
+`wave_merge_model.py reachability`).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+_LIB_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = _LIB_DIR.parents[1]
+_HOOKS_DIR = _REPO_ROOT / ".claude" / "hooks"
+_DEFAULT_STATUS = _REPO_ROOT / "cross-repo-status.json"
+
+# The kickoff hook is the single source of truth for the comment body, the
+# assignment-row lookup, the merge-model read and the idempotency check. The
+# sweep is a different TRIGGER for the same logic, never a second copy of it
+# (the `pr_ci_state.py` / `pr_review_state.py` precedent for lib importing a
+# hook module).
+sys.path.insert(0, str(_HOOKS_DIR))
+from post_wave_kickoff_comment import (  # noqa: E402
+    _gh_post_comment,
+    _phase_from_status,
+    _write_fresh_body_file,
+    find_assignment_row,
+    kickoff_already_posted,
+    read_merge_model,
+    render_kickoff_comment,
+)
+
+# Actions a candidate issue can resolve to. `posted` / `would_post` are the
+# reconciliation outcome; the rest are the reasons a candidate was skipped and
+# exist so a dry run explains itself rather than printing an empty list.
+POSTED = "posted"
+WOULD_POST = "would_post"
+SKIP_IDEMPOTENT = "skip_idempotent"
+SKIP_META_ISSUE = "skip_meta_issue"
+SKIP_NO_ROW = "skip_no_row"
+POST_FAILED = "post_failed"
+
+
+def _run_gh(args: list[str]) -> str:
+    """Run ``gh <args>`` with an explicit arg list and return stdout.
+
+    Never a shell string and never ``shell=True`` — no shell means no
+    word-splitting, the main#688 contract shared with wave_status.py /
+    wave_merge_model.py.
+    """
+    proc = subprocess.run(["gh", *args], capture_output=True, text=True, check=True)
+    return proc.stdout
+
+
+def wave_labels(phase: str | int, wave: str | int) -> list[str]:
+    """Return every label form that marks an issue as belonging to this wave.
+
+    Both the phase-agnostic global form (`wave-29`, the owner-preferred form
+    per #810) and the grandfathered legacy form (`p10-wave-29`) are swept —
+    an in-flight issue labeled either way still owns work in this wave.
+    """
+    return [f"wave-{wave}", f"p{phase}-wave-{wave}"]
+
+
+def list_labeled_issues(repo: str, labels: list[str], run_gh=None) -> list[str]:
+    """Return the OPEN issue numbers in `repo` carrying any of `labels`.
+
+    One `gh issue list` call per label (multiple `--label` flags on a single
+    call are ANDed by gh, which is the opposite of what a form-union needs),
+    de-duplicated and returned in ascending numeric order. `--limit 500`
+    exceeds any plausible wave scope by an order of magnitude; a wave that
+    somehow exceeded it would silently under-sweep, so the limit is asserted
+    against the returned count by the caller's report (`len(candidates)`).
+    """
+    run_gh = run_gh or _run_gh
+    seen: set[str] = set()
+    for label in labels:
+        raw = run_gh(
+            [
+                "issue",
+                "list",
+                "--repo",
+                f"noorinalabs/{repo}",
+                "--label",
+                label,
+                "--state",
+                "open",
+                "--limit",
+                "500",
+                "--json",
+                "number",
+            ]
+        )
+        for entry in json.loads(raw or "[]"):
+            number = entry.get("number")
+            if number is not None:
+                seen.add(str(number))
+    return sorted(seen, key=int)
+
+
+def _meta_issue_number(status: dict, wave: str | int) -> str | None:
+    """Return the wave meta-issue's bare number, tolerating both shapes.
+
+    `wave_{M}_meta_issue` is written either as a bare int (`1133`) or as a
+    qualified string (`"noorinalabs-main#821"`) — main#1053. Both carry the
+    number as their trailing digit run.
+    """
+    meta = status.get(f"wave_{wave}_meta_issue")
+    if meta is None:
+        return None
+    digits = "".join(ch for ch in str(meta) if ch.isdigit())
+    return digits or None
+
+
+def sweep(
+    phase: str | int,
+    wave: str | int,
+    status: dict,
+    repos: list[str],
+    *,
+    apply: bool = False,
+    list_issues=None,
+    fetch_comments=None,
+    post_comment=None,
+    body_writer=None,
+) -> list[dict]:
+    """Reconcile kickoff comments for every labeled, in-scope issue.
+
+    Returns one result dict per candidate issue: `{repo, issue, action}` plus
+    `body` for the post/would-post cases. All I/O is injectable so the whole
+    decision path is unit-testable without a network call, mirroring
+    `wave_merge_model.check_reachability`.
+
+    `apply=False` (the default) resolves every posting candidate to
+    `would_post` and performs NO write.
+    """
+    list_issues = list_issues or list_labeled_issues
+    post_comment = post_comment or _gh_post_comment
+    body_writer = body_writer or _write_fresh_body_file
+
+    wave_num = int(wave)
+    phase_num = _phase_from_status(status)
+    if phase_num is None:
+        phase_num = int(phase)
+    merge_model = read_merge_model(status, wave_num)
+    meta_issue = _meta_issue_number(status, wave)
+    labels = wave_labels(phase, wave)
+
+    results: list[dict] = []
+    for repo in repos:
+        for issue_number in list_issues(repo, labels):
+            if meta_issue is not None and issue_number == meta_issue and repo == "noorinalabs-main":
+                # The meta-issue gets the all-hands kickoff comment from
+                # /wave-kickoff Step 8, not the per-issue template.
+                results.append({"repo": repo, "issue": issue_number, "action": SKIP_META_ISSUE})
+                continue
+
+            row = find_assignment_row(status, repo, issue_number, wave_num)
+            if row is None:
+                # The issue carries the wave label but /wave-scope never wrote
+                # it into a tier. Surfacing it is the point: that is a scope
+                # bug, and it is exactly the drift a label-keyed sweep can see
+                # and a command-keyed hook cannot.
+                results.append({"repo": repo, "issue": issue_number, "action": SKIP_NO_ROW})
+                continue
+
+            if kickoff_already_posted(
+                repo, issue_number, wave_num=wave_num, fetch_comments=fetch_comments
+            ):
+                results.append({"repo": repo, "issue": issue_number, "action": SKIP_IDEMPOTENT})
+                continue
+
+            body = render_kickoff_comment(row, wave_num, phase_num, repo, merge_model=merge_model)
+            if not apply:
+                results.append(
+                    {"repo": repo, "issue": issue_number, "action": WOULD_POST, "body": body}
+                )
+                continue
+
+            body_path = body_writer(body, repo, issue_number)
+            ok = post_comment(repo, issue_number, body_path)
+            results.append(
+                {
+                    "repo": repo,
+                    "issue": issue_number,
+                    "action": POSTED if ok else POST_FAILED,
+                    "body": body,
+                }
+            )
+    return results
+
+
+def format_report(wave: str | int, results: list[dict], *, apply: bool) -> str:
+    """Human-readable sweep report — one line per candidate plus a summary."""
+    counts: dict[str, int] = {}
+    for r in results:
+        counts[r["action"]] = counts.get(r["action"], 0) + 1
+
+    mode = "APPLY" if apply else "DRY RUN (re-run with --apply to post)"
+    lines = [f"Kickoff sweep — wave {wave} [{mode}]"]
+    for r in results:
+        lines.append(f"  [{r['action']}] {r['repo']}#{r['issue']}")
+    if not results:
+        lines.append(f"  (no open issue carries a wave-{wave} label in the swept repos)")
+    summary = ", ".join(f"{k}={v}" for k, v in sorted(counts.items())) or "nothing to reconcile"
+    lines.append(f"Summary: {summary}")
+    return "\n".join(lines)
+
+
+def _cmd_sweep(args: argparse.Namespace) -> int:
+    status = json.loads(Path(args.status).read_text(encoding="utf-8"))
+    repos = args.repo or status.get(f"wave_{args.wave}_repos_in_scope")
+    if not repos:
+        print(
+            f"ERROR: no repos to sweep — wave_{args.wave}_repos_in_scope is missing from "
+            f"{args.status} and no --repo was given.",
+            file=sys.stderr,
+        )
+        return 1
+
+    results = sweep(args.phase, args.wave, status, list(repos), apply=args.apply)
+    if args.json:
+        print(json.dumps({"wave": args.wave, "apply": args.apply, "results": results}, indent=2))
+    else:
+        print(format_report(args.wave, results, apply=args.apply))
+    return 1 if any(r["action"] == POST_FAILED for r in results) else 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("phase", help="phase number (P)")
+    parser.add_argument("wave", help="wave number (M)")
+    parser.add_argument(
+        "--status",
+        type=Path,
+        default=_DEFAULT_STATUS,
+        help="path to cross-repo-status.json (default: repo-root copy)",
+    )
+    parser.add_argument(
+        "--repo",
+        action="append",
+        help="repo to sweep (repeatable); defaults to wave_{M}_repos_in_scope",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="actually post the missing kickoff comments (default: dry run)",
+    )
+    parser.add_argument("--json", action="store_true", help="emit results as JSON")
+    return parser
+
+
+def main(argv: list[str]) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        return _cmd_sweep(args)
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"ERROR: could not read status file {args.status}: {exc}", file=sys.stderr)
+        return 1
+    except subprocess.CalledProcessError as exc:
+        print(
+            f"ERROR: gh call failed (exit {exc.returncode}): {' '.join(exc.cmd)}\n{exc.stderr}",
+            file=sys.stderr,
+        )
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.claude/lib/tests/test_kickoff_sweep.py
+++ b/.claude/lib/tests/test_kickoff_sweep.py
@@ -233,5 +233,124 @@ class FormatReport(unittest.TestCase):
         self.assertIn("no open issue carries a wave-29 label", out)
 
 
+class FetchFailureNeverPosts(unittest.TestCase):
+    """main#1145 — a failed comment fetch must never be read as "no comment".
+
+    `kickoff_already_posted` returned False for BOTH "no kickoff comment" and
+    "could not fetch". In the sweep that fails open into a post, and because
+    SKILL.md Step 7b defined completion as "zero would_post", a sustained fetch
+    failure meant every `--apply` pass appended another duplicate and reported
+    `posted` — an operator following the documented procedure into a loop that
+    never converges. The fetch is likeliest to fail during a GitHub incident,
+    which is exactly when kickoff gets re-run.
+    """
+
+    def _sweep(self, rec: _Recorder, *, apply: bool):
+        return ks.sweep(
+            10,
+            29,
+            _status(),
+            ["noorinalabs-main"],
+            apply=apply,
+            list_issues=rec.list_issues,
+            fetch_comments=lambda repo, number: None,  # gh failed / timed out
+            post_comment=rec.post,
+            body_writer=rec.write_body,
+        )
+
+    def test_apply_posts_nothing_when_fetch_fails(self) -> None:
+        rec = _Recorder(["1114", "1116"])
+        results = self._sweep(rec, apply=True)
+        self.assertEqual([r["action"] for r in results], [ks.SKIP_FETCH_UNKNOWN] * 2)
+        self.assertEqual(rec.posted, [], "a failed probe must never produce a post")
+
+    def test_dry_run_reports_unknown_not_would_post(self) -> None:
+        rec = _Recorder(["1114"])
+        results = self._sweep(rec, apply=False)
+        self.assertEqual([r["action"] for r in results], [ks.SKIP_FETCH_UNKNOWN])
+        self.assertEqual(rec.posted, [])
+
+    def test_repeated_apply_passes_never_accumulate(self) -> None:
+        """The convergence property: N passes under sustained failure, 0 posts."""
+        rec = _Recorder(["1114", "1116"])
+        for _ in range(3):
+            self._sweep(rec, apply=True)
+        self.assertEqual(rec.posted, [])
+
+    def test_unknown_is_distinct_from_absent(self) -> None:
+        """Both are "no kickoff comment found" to the old bool; they are not the same."""
+        rec = _Recorder(["1114"])
+        absent = ks.sweep(
+            10,
+            29,
+            _status(),
+            ["noorinalabs-main"],
+            apply=True,
+            list_issues=rec.list_issues,
+            fetch_comments=lambda r, n: [],
+            post_comment=rec.post,
+            body_writer=rec.write_body,
+        )
+        self.assertEqual([r["action"] for r in absent], [ks.POSTED])
+
+        rec2 = _Recorder(["1114"])
+        unknown = self._sweep(rec2, apply=True)
+        self.assertEqual([r["action"] for r in unknown], [ks.SKIP_FETCH_UNKNOWN])
+
+    def test_partial_fetch_failure_still_posts_the_readable_ones(self) -> None:
+        """One bad probe must not stall the issues that WERE readable."""
+        rec = _Recorder(["1114", "1116"])
+        results = ks.sweep(
+            10,
+            29,
+            _status(),
+            ["noorinalabs-main"],
+            apply=True,
+            list_issues=rec.list_issues,
+            fetch_comments=lambda repo, number: None if number == "1114" else [],
+            post_comment=rec.post,
+            body_writer=rec.write_body,
+        )
+        self.assertEqual([r["action"] for r in results], [ks.SKIP_FETCH_UNKNOWN, ks.POSTED])
+        self.assertEqual(rec.posted, [("noorinalabs-main", "1116")])
+
+
+class IncompleteSweepIsLoudAndNonZero(unittest.TestCase):
+    """ "Could not tell" must not look like "nothing to do" (main#1145)."""
+
+    def test_report_calls_out_unknowns(self) -> None:
+        out = ks.format_report(
+            29,
+            [{"repo": "noorinalabs-main", "issue": "1114", "action": ks.SKIP_FETCH_UNKNOWN}],
+            apply=True,
+        )
+        self.assertIn("INCOMPLETE", out)
+        self.assertIn("could not be checked", out)
+        self.assertIn("NOTHING was posted", out)
+
+    def test_report_calls_out_failed_posts(self) -> None:
+        out = ks.format_report(
+            29,
+            [{"repo": "noorinalabs-main", "issue": "1114", "action": ks.POST_FAILED}],
+            apply=True,
+        )
+        self.assertIn("INCOMPLETE", out)
+
+    def test_clean_report_has_no_incomplete_banner(self) -> None:
+        out = ks.format_report(
+            29,
+            [{"repo": "noorinalabs-main", "issue": "1114", "action": ks.SKIP_IDEMPOTENT}],
+            apply=True,
+        )
+        self.assertNotIn("INCOMPLETE", out)
+
+    def test_unknown_counts_as_an_incomplete_action(self) -> None:
+        """Step 7b keys completion on exit 0, so unknown must block it."""
+        self.assertIn(ks.SKIP_FETCH_UNKNOWN, ks._INCOMPLETE_ACTIONS)
+        self.assertIn(ks.POST_FAILED, ks._INCOMPLETE_ACTIONS)
+        self.assertNotIn(ks.SKIP_IDEMPOTENT, ks._INCOMPLETE_ACTIONS)
+        self.assertNotIn(ks.WOULD_POST, ks._INCOMPLETE_ACTIONS)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.claude/lib/tests/test_kickoff_sweep.py
+++ b/.claude/lib/tests/test_kickoff_sweep.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Tests for `kickoff_sweep` — the state-based kickoff reconciliation (main#1141).
+
+The sweep is the layer that closes the class the command parser cannot: a
+`for n in …; do gh issue edit "$n" --add-label "wave-29"; done` loop carries no
+issue number in the command string, so no hook can react to it. The sweep keys
+on the label that LANDED instead.
+
+Every external interaction (issue list, comment fetch, comment post, body file
+write) is injected, so the whole decision path runs with no network.
+
+Run: python3 -m pytest .claude/lib/tests/test_kickoff_sweep.py -v
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+_LIB_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_LIB_DIR))
+
+import kickoff_sweep as ks  # noqa: E402
+
+
+def _status(**extra) -> dict:
+    status = {
+        "current_phase": 10,
+        "wave_29_meta_issue": 1133,
+        "wave_29_merge_model": "direct-to-main",
+        "wave_29_repos_in_scope": ["noorinalabs-main"],
+        "wave_29_scope": {
+            "tier_1_track_g": [
+                {
+                    "id": "noorinalabs-main#1114",
+                    "ref": "main#1114",
+                    "implementer": "Nino Kavtaradze",
+                    "reviewer": "Aino Virtanen",
+                },
+                {
+                    "id": "noorinalabs-main#1116",
+                    "ref": "main#1116",
+                    "implementer": "Lucas Ferreira",
+                    "reviewer": "Aino Virtanen",
+                },
+            ]
+        },
+    }
+    status.update(extra)
+    return status
+
+
+class _Recorder:
+    """Injectable I/O doubles + a record of what the sweep tried to do."""
+
+    def __init__(self, issues: list[str], commented: set[str] | None = None, ok: bool = True):
+        self.issues = issues
+        self.commented = commented or set()
+        self.ok = ok
+        self.posted: list[tuple[str, str]] = []
+        self.bodies: dict[str, str] = {}
+
+    def list_issues(self, repo, labels):
+        return list(self.issues)
+
+    def fetch_comments(self, repo, number):
+        if number in self.commented:
+            return [{"body": "**Wave 29 Kickoff — Phase 10**\n\nbody"}]
+        return []
+
+    def write_body(self, body, repo, number):
+        self.bodies[number] = body
+        return Path("/dev/null")
+
+    def post(self, repo, number, path):
+        self.posted.append((repo, number))
+        return self.ok
+
+
+class WaveLabels(unittest.TestCase):
+    def test_both_label_forms_are_swept(self) -> None:
+        """The global form AND the grandfathered phase-prefixed form (#810)."""
+        self.assertEqual(ks.wave_labels(10, 29), ["wave-29", "p10-wave-29"])
+
+
+class SweepReconciliation(unittest.TestCase):
+    def _sweep(self, rec: _Recorder, status: dict | None = None, apply: bool = True):
+        return ks.sweep(
+            10,
+            29,
+            status or _status(),
+            ["noorinalabs-main"],
+            apply=apply,
+            list_issues=rec.list_issues,
+            fetch_comments=rec.fetch_comments,
+            post_comment=rec.post,
+            body_writer=rec.write_body,
+        )
+
+    def test_posts_to_labeled_issue_missing_a_kickoff(self) -> None:
+        """The loop-applied label case: the label landed, no comment exists."""
+        rec = _Recorder(["1114", "1116"])
+        results = self._sweep(rec)
+        self.assertEqual([r["action"] for r in results], [ks.POSTED, ks.POSTED])
+        self.assertEqual(rec.posted, [("noorinalabs-main", "1114"), ("noorinalabs-main", "1116")])
+
+    def test_idempotent_second_run_posts_nothing(self) -> None:
+        """Safe to re-run — the hook's wave-specific idempotency check screens."""
+        rec = _Recorder(["1114", "1116"], commented={"1114", "1116"})
+        results = self._sweep(rec)
+        self.assertEqual([r["action"] for r in results], [ks.SKIP_IDEMPOTENT] * 2)
+        self.assertEqual(rec.posted, [])
+
+    def test_partial_backfill(self) -> None:
+        """Exactly the post-#1141 recovery shape: some got a comment, some didn't."""
+        rec = _Recorder(["1114", "1116"], commented={"1114"})
+        results = self._sweep(rec)
+        self.assertEqual([r["action"] for r in results], [ks.SKIP_IDEMPOTENT, ks.POSTED])
+        self.assertEqual(rec.posted, [("noorinalabs-main", "1116")])
+
+    def test_meta_issue_skipped(self) -> None:
+        """The meta-issue gets /wave-kickoff Step 8's all-hands comment instead."""
+        rec = _Recorder(["1133"])
+        results = self._sweep(rec)
+        self.assertEqual([r["action"] for r in results], [ks.SKIP_META_ISSUE])
+        self.assertEqual(rec.posted, [])
+
+    def test_labeled_but_unscoped_issue_is_surfaced_not_posted(self) -> None:
+        """A label with no tier row is /wave-scope drift — report, don't guess."""
+        rec = _Recorder(["9999"])
+        results = self._sweep(rec)
+        self.assertEqual([r["action"] for r in results], [ks.SKIP_NO_ROW])
+        self.assertEqual(rec.posted, [])
+
+    def test_dry_run_writes_nothing(self) -> None:
+        rec = _Recorder(["1114"])
+        results = self._sweep(rec, apply=False)
+        self.assertEqual([r["action"] for r in results], [ks.WOULD_POST])
+        self.assertEqual(rec.posted, [])
+        self.assertIn("Requestee: Nino Kavtaradze", results[0]["body"])
+
+    def test_failed_post_is_recorded(self) -> None:
+        rec = _Recorder(["1114"], ok=False)
+        results = self._sweep(rec)
+        self.assertEqual([r["action"] for r in results], [ks.POST_FAILED])
+
+    def test_body_follows_the_wave_merge_model(self) -> None:
+        """One renderer: the sweep can never drift from the hook's template."""
+        rec = _Recorder(["1114"])
+        self._sweep(rec)
+        self.assertIn("- Branch from: `main`", rec.bodies["1114"])
+
+        rec = _Recorder(["1114"])
+        self._sweep(rec, status=_status(wave_29_merge_model="wave-branch"))
+        self.assertIn("- Branch from: `deployments/phase-10/wave-29`", rec.bodies["1114"])
+
+    def test_phase_recovered_from_status(self) -> None:
+        rec = _Recorder(["1114"])
+        self._sweep(rec)
+        self.assertIn("**Wave 29 Kickoff — Phase 10**", rec.bodies["1114"])
+
+    def test_phase_argument_used_when_status_has_none(self) -> None:
+        status = _status()
+        del status["current_phase"]
+        rec = _Recorder(["1114"])
+        self._sweep(rec, status=status)
+        self.assertIn("**Wave 29 Kickoff — Phase 10**", rec.bodies["1114"])
+
+    def test_no_candidates_is_an_empty_report(self) -> None:
+        self.assertEqual(self._sweep(_Recorder([])), [])
+
+
+class MetaIssueNumber(unittest.TestCase):
+    def test_bare_int_form(self) -> None:
+        self.assertEqual(ks._meta_issue_number({"wave_29_meta_issue": 1133}, 29), "1133")
+
+    def test_qualified_string_form(self) -> None:
+        """main#1053: /wave-retro writes `noorinalabs-main#821`."""
+        self.assertEqual(
+            ks._meta_issue_number({"wave_29_meta_issue": "noorinalabs-main#821"}, 29), "821"
+        )
+
+    def test_absent(self) -> None:
+        self.assertIsNone(ks._meta_issue_number({}, 29))
+
+
+class ListLabeledIssues(unittest.TestCase):
+    def test_unions_both_label_forms_and_dedups(self) -> None:
+        calls: list[list[str]] = []
+
+        def run_gh(args):
+            calls.append(args)
+            label = args[args.index("--label") + 1]
+            if label == "wave-29":
+                return '[{"number": 1116}, {"number": 1114}]'
+            return '[{"number": 1114}, {"number": 1120}]'
+
+        self.assertEqual(
+            ks.list_labeled_issues("noorinalabs-main", ks.wave_labels(10, 29), run_gh=run_gh),
+            ["1114", "1116", "1120"],
+        )
+        self.assertEqual(len(calls), 2)
+
+    def test_only_open_issues_are_swept(self) -> None:
+        """A closed issue is not kicked off; a comment there is noise."""
+        seen: list[str] = []
+
+        def run_gh(args):
+            seen.append(args[args.index("--state") + 1])
+            return "[]"
+
+        ks.list_labeled_issues("noorinalabs-main", ["wave-29"], run_gh=run_gh)
+        self.assertEqual(seen, ["open"])
+
+    def test_empty_output_tolerated(self) -> None:
+        self.assertEqual(ks.list_labeled_issues("r", ["wave-29"], run_gh=lambda a: ""), [])
+
+
+class FormatReport(unittest.TestCase):
+    def test_dry_run_labels_itself(self) -> None:
+        out = ks.format_report(
+            29,
+            [{"repo": "noorinalabs-main", "issue": "1114", "action": ks.WOULD_POST}],
+            apply=False,
+        )
+        self.assertIn("DRY RUN", out)
+        self.assertIn("[would_post] noorinalabs-main#1114", out)
+        self.assertIn("would_post=1", out)
+
+    def test_empty_is_explicit(self) -> None:
+        out = ks.format_report(29, [], apply=True)
+        self.assertIn("no open issue carries a wave-29 label", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/skills/wave-kickoff/SKILL.md
+++ b/.claude/skills/wave-kickoff/SKILL.md
@@ -408,6 +408,10 @@ Hook behavior:
 - Failure-tolerant: if `wave_{M}_scope` is missing or the issue isn't in any tier, the hook logs to `.claude/annunaki/errors.jsonl` and lets the label-apply succeed. A missing scope row is a `/wave-scope` bug, not a label-apply bug.
 - Merge-model-aware branch base (main#1141): the comment instructs branching from `main` on a `direct-to-main` wave and from `deployments/phase-{P}/wave-{M}` on a `wave-branch` wave, read from `wave_{M}_merge_model` / `wave_{M}_scope.merge_model`. Declare the model (Step 1) BEFORE labeling, or the comment falls back to `main` with a "not declared" note.
 
+### 7a. Per-wave orchestration scripts (optional automation)
+
+For waves with many issues across many repos, the labeling + project-board adds in step 7 may be automated by a per-wave orchestration script. Write these scripts to `.claude/skills/wave-kickoff/_orchestration/` using the naming convention `w{N}-{purpose}.py` (e.g., `w5-kickoff.py`, `w5-project-add.py`). The directory is tracked for audit-trail visibility (see #247). Do NOT use `.claude/scratch/` — that location is gitignored and reserved for true ephemeral artifacts (commit messages, mid-task notes).
+
 ### 7b. Reconciliation sweep — MANDATORY after Step 7 (main#1141)
 
 **Do not treat Step 7 as complete until this sweep reports zero `would_post`.** The hook in § 7 reacts to the label-apply *command*, so it can only act on what it can parse out of a shell string. A `for n in 1114 1116; do gh issue edit "$n" …; done` loop carries no issue number in the command at all — nothing can react to it. That is not hypothetical: during `/wave-scope 10 29` on 2026-07-27, 14 issues were labeled and **zero** kickoff comments posted, undetected until an unrelated audit.
@@ -428,10 +432,6 @@ Read the dry-run output before applying:
 - `skip_no_row` — the issue carries the wave label but is in NO `wave_{M}_scope` tier. This is `/wave-scope` drift, not a kickoff bug — fix the scope, then re-run. The sweep never guesses an assignment.
 
 Repos default to `wave_{M}_repos_in_scope`; override with repeatable `--repo`. `--json` emits machine-readable results.
-
-### 7a. Per-wave orchestration scripts (optional automation)
-
-For waves with many issues across many repos, the labeling + project-board adds in step 7 may be automated by a per-wave orchestration script. Write these scripts to `.claude/skills/wave-kickoff/_orchestration/` using the naming convention `w{N}-{purpose}.py` (e.g., `w5-kickoff.py`, `w5-project-add.py`). The directory is tracked for audit-trail visibility (see #247). Do NOT use `.claude/scratch/` — that location is gitignored and reserved for true ephemeral artifacts (commit messages, mid-task notes).
 
 ### 8. Post the meta-issue all-hands kickoff comment
 

--- a/.claude/skills/wave-kickoff/SKILL.md
+++ b/.claude/skills/wave-kickoff/SKILL.md
@@ -406,6 +406,28 @@ Hook behavior:
 - Idempotent: re-applying the wave label after disposition correction does NOT double-post (the hook detects the charter heading `**Wave {M} Kickoff — Phase {N}**` in existing comments and skips).
 - Meta-issue skip: when the labeled issue is `wave_{M}_meta_issue`, the per-issue kickoff is skipped (the meta-issue gets its own all-hands kickoff comment — see § 8 below).
 - Failure-tolerant: if `wave_{M}_scope` is missing or the issue isn't in any tier, the hook logs to `.claude/annunaki/errors.jsonl` and lets the label-apply succeed. A missing scope row is a `/wave-scope` bug, not a label-apply bug.
+- Merge-model-aware branch base (main#1141): the comment instructs branching from `main` on a `direct-to-main` wave and from `deployments/phase-{P}/wave-{M}` on a `wave-branch` wave, read from `wave_{M}_merge_model` / `wave_{M}_scope.merge_model`. Declare the model (Step 1) BEFORE labeling, or the comment falls back to `main` with a "not declared" note.
+
+### 7b. Reconciliation sweep — MANDATORY after Step 7 (main#1141)
+
+**Do not treat Step 7 as complete until this sweep reports zero `would_post`.** The hook in § 7 reacts to the label-apply *command*, so it can only act on what it can parse out of a shell string. A `for n in 1114 1116; do gh issue edit "$n" …; done` loop carries no issue number in the command at all — nothing can react to it. That is not hypothetical: during `/wave-scope 10 29` on 2026-07-27, 14 issues were labeled and **zero** kickoff comments posted, undetected until an unrelated audit.
+
+The sweep keys on the labels that actually LANDED rather than on the command string, and is idempotent (it screens every candidate through the same `kickoff_already_posted` check the hook uses), so it is safe to run repeatedly:
+
+```bash
+# Dry run first — prints exactly what it would post.
+python3 .claude/lib/kickoff_sweep.py {PHASE} {WAVE}
+
+# Then post the missing comments.
+python3 .claude/lib/kickoff_sweep.py {PHASE} {WAVE} --apply
+```
+
+Read the dry-run output before applying:
+- `would_post` — the hook missed this issue; the sweep will backfill it.
+- `skip_idempotent` — the hook already posted. Expected for most issues.
+- `skip_no_row` — the issue carries the wave label but is in NO `wave_{M}_scope` tier. This is `/wave-scope` drift, not a kickoff bug — fix the scope, then re-run. The sweep never guesses an assignment.
+
+Repos default to `wave_{M}_repos_in_scope`; override with repeatable `--repo`. `--json` emits machine-readable results.
 
 ### 7a. Per-wave orchestration scripts (optional automation)
 

--- a/.claude/skills/wave-kickoff/SKILL.md
+++ b/.claude/skills/wave-kickoff/SKILL.md
@@ -414,7 +414,7 @@ For waves with many issues across many repos, the labeling + project-board adds 
 
 ### 7b. Reconciliation sweep — MANDATORY after Step 7 (main#1141)
 
-**Do not treat Step 7 as complete until this sweep reports zero `would_post`.** The hook in § 7 reacts to the label-apply *command*, so it can only act on what it can parse out of a shell string. A `for n in 1114 1116; do gh issue edit "$n" …; done` loop carries no issue number in the command at all — nothing can react to it. That is not hypothetical: during `/wave-scope 10 29` on 2026-07-27, 14 issues were labeled and **zero** kickoff comments posted, undetected until an unrelated audit.
+**Do not treat Step 7 as complete until this sweep exits 0** — that means zero `would_post` AND zero `skip_fetch_unknown`. Exit 0 is the criterion, not the `would_post` line alone: a sweep whose comment fetches all failed cannot tell you whether anything is outstanding, and must not be read as "nothing to do" (main#1145). The hook in § 7 reacts to the label-apply *command*, so it can only act on what it can parse out of a shell string. A `for n in 1114 1116; do gh issue edit "$n" …; done` loop carries no issue number in the command at all — nothing can react to it. That is not hypothetical: during `/wave-scope 10 29` on 2026-07-27, 14 issues were labeled and **zero** kickoff comments posted, undetected until an unrelated audit.
 
 The sweep keys on the labels that actually LANDED rather than on the command string, and is idempotent (it screens every candidate through the same `kickoff_already_posted` check the hook uses), so it is safe to run repeatedly:
 
@@ -430,6 +430,7 @@ Read the dry-run output before applying:
 - `would_post` — the hook missed this issue; the sweep will backfill it.
 - `skip_idempotent` — the hook already posted. Expected for most issues.
 - `skip_no_row` — the issue carries the wave label but is in NO `wave_{M}_scope` tier. This is `/wave-scope` drift, not a kickoff bug — fix the scope, then re-run. The sweep never guesses an assignment.
+- `skip_fetch_unknown` — the comment fetch failed, so whether a kickoff comment already exists is **unknown**. Nothing was posted for that issue and the sweep exits non-zero. Do not re-run `--apply` in a loop hoping it clears: fix the `gh` failure (usually a GitHub incident or auth), then re-run once. Re-running against a broken fetch is safe now — it posts nothing — but it also makes no progress.
 
 Repos default to `wave_{M}_repos_in_scope`; override with repeatable `--repo`. `--json` emits machine-readable results.
 

--- a/.claude/skills/wave-kickoff/SKILL.md
+++ b/.claude/skills/wave-kickoff/SKILL.md
@@ -416,7 +416,7 @@ For waves with many issues across many repos, the labeling + project-board adds 
 
 **Do not treat Step 7 as complete until this sweep exits 0** — that means zero `would_post` AND zero `skip_fetch_unknown`. Exit 0 is the criterion, not the `would_post` line alone: a sweep whose comment fetches all failed cannot tell you whether anything is outstanding, and must not be read as "nothing to do" (main#1145). The hook in § 7 reacts to the label-apply *command*, so it can only act on what it can parse out of a shell string. A `for n in 1114 1116; do gh issue edit "$n" …; done` loop carries no issue number in the command at all — nothing can react to it. That is not hypothetical: during `/wave-scope 10 29` on 2026-07-27, 14 issues were labeled and **zero** kickoff comments posted, undetected until an unrelated audit.
 
-The sweep keys on the labels that actually LANDED rather than on the command string, and is idempotent (it screens every candidate through the same `kickoff_already_posted` check the hook uses), so it is safe to run repeatedly:
+The sweep keys on the labels that actually LANDED rather than on the command string, and screens every candidate through `kickoff_comment_state` — the *tri-state* probe (`present` / `absent` / `unknown`). It is idempotent **whenever that probe can read the issue's comments**, so it is safe to run repeatedly. Note this is deliberately **stricter than the § 7 hook**, which shares the probe but fails open on `unknown` and posts anyway (reporting `post_unverified`): one comment per explicit label-apply is bounded, whereas a bulk sweep re-running under a broken fetch is not. Do not assume the two behave identically.
 
 ```bash
 # Dry run first — prints exactly what it would post.


### PR DESCRIPTION
Closes #1141. Closes #1145.

Two defects in `.claude/hooks/post_wave_kickoff_comment.py`, plus the durable third layer the issue asks for. Both defects failed **silently in the unsafe direction** — labels land, the wave looks kicked off, nobody is told they own anything — so the silent no-op is treated here as the primary bug class, not the parse gap.

## 1. The kickoff template ignored the wave's merge model

`render_kickoff_comment` hardcoded `deployments/phase-{P}/wave-{M}`; `merge_model` appeared nowhere in the hook. Since the 2026-06-09 every-wave-merges-to-main directive, `direct-to-main` is the common case, so this was the default-wrong path — waves 28 and 29 were both direct-to-main and every kickoff comment named a ref that will never exist.

- `read_merge_model(status, wave)` — top-level `wave_{M}_merge_model`, falling back to `wave_{M}_scope.merge_model`. An unrecognized value is treated as unreadable rather than passed through.
- `resolve_branch_base(model, wave, phase)` — `main` for `direct-to-main`, `deployments/phase-{P}/wave-{M}` for `wave-branch` (unchanged), `main` for absent/unreadable plus an explicit *"model NOT declared — confirm the base with the orchestrator before opening the PR"* note. Asymmetric on purpose: a nonexistent wave branch hard-blocks the implementer; a `main` base on a wave-branch wave is a recoverable retarget.
- The comment now also renders a `- PR base:` line naming the model, so the implementer knows which model is in force.
- `merge_model` defaults to `None` (i.e. `main`), so a caller that never heard of merge models cannot emit a dead ref.

Regression fixture per model: `merge_model_direct_to_main.json`, `merge_model_scope_key_wave_branch.json`, `merge_model_absent_defaults_to_main.json`. The pre-existing happy-path fixture now declares `wave-branch` explicitly, so its wave-branch base is asserted for the model it belongs to instead of as an unconditional hardcode.

## 2. Ordinary command wrappers defeated the parser

Root cause was one line, and it is not in this hook: `_shell_parse.find_gh_subcommand` required `gh` at `segment[0]`. `timeout 45 gh …` puts `timeout` there; a `for … ; do gh … ; done` loop puts `do` there. Same for the `git` twin.

Fixed in the shared primitive (`strip_command_prefixes`), which skips a leading run of compound-statement keywords (`do`, `then`, `if`, …) and transparent wrappers (`timeout N`, `env`, `nohup`, `sudo`, `nice`, …), each with its option grammar spelled out. It is an **allowlist**: a loose "find `gh` anywhere in the segment" scan would re-introduce the data-position false-positive class `_shell_parse` exists to prevent, so `echo gh issue edit 5 …` must not match — pinned by a test. `for` is not a leader (what follows is a variable name, not a command).

### Before / after — every row of the issue's table

| Command form | Before | After |
|---|---|---|
| `gh issue edit 1114 … --add-label "wave-29"` | parses | parses |
| `… --add-label "wave-29" >/dev/null 2>&1` | parses | parses |
| `… --add-label "wave-29" && echo ok` | parses | parses |
| `timeout 45 gh issue edit 1114 …` | **None** | **parses** |
| `for x in a; do gh issue edit 1114 …; done` (literal) | **None** | **parses** |
| `for n in 1114 1116; do gh issue edit "$n" …; done` | **None** | **None — by design** |

The last row is unfixable at the command layer: the issue number is not in the string. Accepting `$n` as a ref would post to a nonexistent issue. Instead it is now **surfaced**: `parse_unresolved_wave_label_edits` reports the shape, the hook annunaki-logs it and returns `skip_unresolved_issue_number`, which `EMIT_DISPATCH_SUMMARY` turns into an operator-visible message at the moment of the apply. #467 between-wave relabels stay silent so the P3W11 36-event noise burst does not return.

**Beyond the kickoff hook — scope of the closure, stated precisely.** The same primitive backs blocking gates: `block_gh_pr_review`, `block_squash_wave_merge`, `validate_wave_label_evidence`, `block_stale_tmp_message_file`, `warn_pipe_mask_rc`, and via `find_git_subcommand` the commit-identity family. What this PR closes for all of them is the **command-prefix wrapper** (`timeout`/`nice`/`env`/`nohup`/`sudo`/…) and the **space-padded** loop body.

What it does **not** close, correcting an earlier overclaim in this description: the **unspaced-`;` loop**. `normalize_command_separators` runs for only three callers, so `block_no_verify`, `block_git_config`, `block_gh_pr_review`, `block_squash_wave_merge`, `block_stale_tmp_message_file` and `warn_pipe_mask_rc` call `tokenize()` directly and still miss `for p in 1143; do gh pr review $p --approve; done` (verified ALLOWED; adding one space before the `;` blocks). Pre-existing, not introduced here — tracked as #1147.

Zero test breakage across the existing 2,879-test suite.

## 3. State-based reconciliation — `.claude/lib/kickoff_sweep.py`

Kept in this PR, not split: without it the loop-variable class stays open, and that class is 13 of the 14 issues that went uncommented. It lists issues carrying `wave-{M}` (both label forms) and posts to any lacking a kickoff comment for that wave — keying on the state that landed rather than on a command string, the same discipline as #981/#985.

- Reuses the hook's renderer, merge-model read, row lookup and wave-specific idempotency check, so it cannot drift from the hook and is safe to re-run.
- **Dry-run by default**; `--apply` posts. Open issues only. `skip_no_row` surfaces `/wave-scope` drift rather than guessing an assignment.
- Wired into `/wave-kickoff` as **Step 7b (mandatory)** — Step 7 is not complete until the sweep reports zero `would_post`.

Verified in dry-run against the live repo (no writes): 15 wave-29-labeled issues across `noorinalabs-main` and `noorinalabs-isnad-ingest-platform` have no kickoff comment, matching the issue's report.

## Tests

+79 tests; **2,879 → 2,958 passing**. Every row of the repro table is a test, including the two that already passed. Verified failing against pre-fix code: 63 failures / 2 subtest failures when the three source files are reverted to `origin/main` (the sweep's 20 tests fail at import).

Full gate set green locally: ruff-format, ruff-lint, actionlint, cspell, fixture-realism, skill-graphql-pagination, checksums-ascii, mypy, pytest, pytest-skills, memory-budget, headcount-budget, doc-freshness, office-drift, mermaid-render, `pre_commit_ci_sync`, and the CI smoke test (compile + empty-stdin exit 0).

## Review round 2 — regression found and fixed

Weronika Zielinska's review caught a **regression this PR introduced**, now fixed in `5f5ba62`.

`extract_dash_c_pairs` kept keying on a raw `segment[0] != "git"` while `find_git_subcommand` stripped, and `validate_commit_identity` calls **both on the same segment**. So a fully compliant `timeout 60 git -c user.name=… -c user.email=… commit` was recognized as a commit but read as having no identity flags, and was **BLOCKED** with "missing `-c user.name=` flag" — naming the exact flag the operator had passed. Pre-PR that shape never reached the gate at all, so I had closed an evasion and opened a false positive on the same path. That is the worse direction: an evasion costs one missed gate; a false positive blocks correct work for everyone with a message that reads as a lie.

Fixed by making the strip a **lockstep invariant** across every command-position keyer in `_shell_parse` — `extract_dash_c_pairs` and `extract_leading_cd_target` now strip too, and the module docstring states the invariant so a future helper cannot quietly opt out. `extract_leading_cd_target` is the same class, not a nicety: once the `gh` inside `for r in …; do cd /wt; gh …; done` is visible, a `cd` still invisible in that same loop resolves the repo from the wrong directory.

**Regression tests ship with it, and they are the point** — the suite was green with *and* without the fix, which is why 21/21 CI and a 25-shape adversarial pass both missed it. `WrappedCommitIdentityRegression` drives the real hook end-to-end across seven wrapper prefixes in the allow direction and three in the block direction; `StripLockstepAcrossSegmentConsumers` pins the invariant, including that the strip never *invents* pairs and that `echo git -c … commit` stays data. Verified failing against `95f375a`: 20 failed / 10 passed. Suite 2,958 → **2,969**.

Also in this round: SKILL.md read § 7 → 7b → 7a (reordered); the `kickoff_sweep` docstring claimed a `--limit 500` assertion that does not exist (now states the gap, points at #1145); the decline dict's `count` counted command *shapes*, not issues (renamed `unresolved_edits`).

**One finding for filing, not fixed here:** `no_worktree_self_delete.py` has its own private tokenizer and a bare `tokens[0] != "git"` check, so `timeout 5 git worktree remove <own-worktree>` is ALLOWED where the unwrapped form is BLOCKED (verified rc 0 vs rc 2). It never routed through `_shell_parse`, so it is independent of this PR — same family as #1147. I did not pull a third blocking hook into a PR that is already fixing a regression.

## Also closes #1145 — the sweep's fail-open probe (owner decision: fold in)

`kickoff_already_posted` returned `False` for **both** "no kickoff comment" and "could not fetch the comments" (gh non-zero exit, 15s timeout, decode error), so the sweep could not tell them apart and failed open into a post.

The reason this moved from non-blocking to blocking is Weronika's reframing, not the duplicate itself: § 7b defined Step 7 completion as **"zero `would_post`"**, so under a *sustained* fetch failure the sweep never converges — every `--apply` pass appends another duplicate and reports `posted`. That is an operator following the documented procedure into an unbounded loop, and the fetch is likeliest to fail during a GitHub incident, i.e. exactly when kickoff gets re-run.

- `kickoff_comment_state()` — tri-state probe: present / absent / **unknown**. Unknown is never collapsed into absent.
- `sweep()` resolves an unknown probe to `skip_fetch_unknown`, which posts nothing under `--apply` *and* under dry-run.
- The report prints an explicit `INCOMPLETE:` banner, and unknown exits non-zero exactly like a failed post — because a quiet zero that means "I could not look" is the same silent-wrong-zero class this whole PR is about.
- **§ 7b now defines completion as exit 0** (zero `would_post` AND zero `skip_fetch_unknown`), closing the definition that made the loop unbounded, plus an operator row telling them to fix `gh` rather than re-run in a loop.

`kickoff_already_posted` keeps its bool signature and fail-open contract on purpose: the **hook** posts at most one comment per label-apply — an explicit operator action — and the failure it guards against (#286) is a kickoff that never gets posted at all, so one possibly-duplicate comment beats a silently missing assignment. That is bounded; the sweep's repeated bulk pass is not. Both behaviors are pinned by tests so neither drifts into the other.

Tests to the same standard as the MUST-FIX: fetch-returns-`None` under both modes asserting zero posts and a distinct unknown state; three consecutive `--apply` passes under sustained failure posting nothing (the convergence property); unknown proven distinct from absent; a partial failure still posting the readable issues; the banner and the exit classification; and the hook's fail-open path pinned end-to-end. Verified failing against `5f5ba62`: 13 failed / 1 passed. Suite **2,969 → 2,987**.

## Review round 3 — the generalisation went one function too far

Weronika caught a **live misroute** my round-2 change introduced. `if [ -f /nonexistent ] ; then cd …/noorinalabs-deploy ; fi ; gh issue edit 5 …` resolved to `noorinalabs-deploy` on `2b4fabb` and `noorinalabs-main` (correct) on `95f375a`. The condition is false — the shell never runs that `cd` — so a kickoff comment would have gone to `deploy#5`. Three hooks on that resolver chain **write**, so a misroute is an unrecoverable write into the wrong repository.

The distinction the round-2 invariant was missing:

| | Behavior | Safe for a gate? | Safe for routing? |
|---|---|---|---|
| **Wrapper** (`timeout`, `env`, `nice`) | always execs what follows | yes | **no** — see below |
| **Compound leader** (`then`, `do`, `{`, `(`) | guards a body that may not run | yes | no |

Over-matching is *conservative* for a **gate matcher** (worst case: inspect a command that would not have run) and *destructive* for a **routing resolver** (output goes where the command never went). `find_git_subcommand` / `find_gh_subcommand` / `extract_dash_c_pairs` are gates and are unchanged — they still strip everything. `extract_leading_cd_target` is the only routing resolver in `_shell_parse`.

### The mandated test method changed the answer

I was briefed to implement a **wrappers-only** carve-out. Writing the tests against shell truth — run each shape in a real `bash`, replace the `gh` node with `pwd`, take the printed directory as ground truth — showed wrappers-only was *still* too permissive, and caught **one of my own round-3 tests asserting a misroute**:

```
env FOO=1 cd DEST ; pwd    -> prints the ORIGINAL directory   (bash AND zsh)
timeout 5 cd DEST ; pwd    -> prints the ORIGINAL directory
nice -n 5 / nohup cd DEST  -> same
```

`cd` is a shell **builtin**. An exec-wrapper runs a subprocess and the calling shell never moves, so stripping a wrapper claims a `cd` that provably never happened. I had pinned `env FOO=1 cd /tmp && gh pr create` → `/tmp` as *correct*. It is not. (`command cd` is worse than useless as a signal: bash honours it, zsh does not.)

So the resolver strips **nothing** — `cd` must be token 0 of its segment, which is exactly the pre-#1141 behavior. All seven leader shapes are verified against a real shell (if/then, bare `then`, bare `do`, empty `for r in ;`, `while false`, `else`, and the `( cd … )` subshell where the cd runs but dies with the subshell), plus the brace group taken and not taken. None misroute.

The assertion is the **safety property**, not equality:

```
resolved is None  OR  resolved == shell_truth
```

Under-recovery is accepted and is the pre-#1141 behavior — a `cd` in a body that *does* run is not recovered, and the caller falls back to the invocation cwd. Claiming no knowledge is recoverable; claiming the wrong directory is not. Plain equality would have failed those shapes and pushed back toward the over-recovery that started this.

### #1151 pinned, not closed

Per the brief I did **not** generalise again. The two residual families now have a characterization test asserting the misroute they still produce — `true || cd DEST` (no leader token to withhold) and `gh … ; cd DEST` (cd after the gh node) — both present on `95f375a` and every head since. The test comment says that closing #1151 must delete it, so the gap is visible in the suite rather than only in prose and cannot be mistaken for desired behavior.

`compound_leaders` survives as a parameter with no caller passing `False`, keeping the two prefix families separable rather than welded together.

**SHOULD-FIX 1** — `check()` returned `{"action": "post"}` on an `unknown` probe, byte-identical to a verified post: the last silent state-collapse in a PR about silent state-collapses. Now returns `post_unverified` and logs it. Posting still happens; Weronika's argument for that is folded into the docstring — a duplicate appears on the issue in front of the implementer and self-reports, whereas a missing comment is invisible at the artifact, and #1141 is the proof that a signal on another surface gets missed.

**SHOULD-FIX 2** — SKILL.md § 7b claimed the sweep uses "the same `kickoff_already_posted` check the hook uses". Both halves were wrong after round 2, and it told the operator the two behave identically when the point of #1145 is that they deliberately do not. Corrected.

Suite **2,987 → 2,998**.

## Note on the issue's diagnosis

The issue is accurate on every point I could check, including its correction note. One addition it does not make: the two defeaters are **the same root cause**, not two — `timeout` and `do` both fail by occupying `segment[0]`, so one fix in `_shell_parse` closes both. And the blast radius is wider than the kickoff hook: the same bypass reached four blocking gates.

No `wave-*` label was applied to any issue in this work, including #1141.




