### PR TITLE
fix(#1134): enforce child-repo implementer roster membership at wave-scope time

### DIFF
--- a/.claude/skills/wave-kickoff/SKILL.md
+++ b/.claude/skills/wave-kickoff/SKILL.md
@@ -54,6 +54,25 @@ This check is a deterministic JSON read — no GitHub API calls, no side effects
 
 **Permissive fallback (intentional).** When neither `wave_{M-1}_retro_completed_at` nor `wave_{M-1}_completed_at` exists in `cross-repo-status.json` — e.g., the first wave of a phase, or a fresh project — the staleness comparison is silently skipped and only the absent-scope check fires. This keeps the precondition usable for Phase-N-Wave-1 cases without requiring a synthetic zero-timestamp. The trade-off: a `wave_{M}_scope_reconciled_at` written years ago with no surrounding context will pass. If that becomes a real failure mode, tighten to fail-closed and require an explicit `WAVE_KICKOFF_ALLOW_NO_PRIOR_RETRO=1` override.
 
+### 0b. Verify child-repo implementers are repo-roster members (Mandatory precondition — main#1134)
+
+A child-repo story whose `implementer` is not on that child repo's roster cannot be implemented as scoped: the assignee cannot author the commit under their own identity, and the wrap-time repair is a mechanical merge-commit re-attribution that severs the "who implemented" audit trail. `/wave-scope` § 12.5 is where this is normally caught; this step is the **backstop** for a wave scoped before the rule existed, or scoped off-path.
+
+```bash
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+python3 "$REPO_ROOT/.claude/skills/wave-scope/validate_matrix_names.py" \
+    --scope "$REPO_ROOT/cross-repo-status.json" --wave {M}
+RC=$?
+if [ "$RC" -ne 0 ]; then
+  echo "ERROR: wave_{M}_scope has unresolved names or cross-repo implementer(s)."
+  echo "  Fix the scope rows (reassign, onboard, or record a roster_union_override"
+  echo "  with a rationale) and re-run. See /wave-scope SKILL.md § 12.5."
+  exit 1
+fi
+```
+
+Deterministic and hermetic by default — reads only local rosters and `cross-repo-status.json`, no GitHub API calls. A child repo not cloned locally is reported `unverified` and does not block; add `--fetch-missing` to resolve those over the network. Charter rule: `charter/skills.md` § Wave Scoping — Child-Repo Implementer Must Be a Repo-Roster Member.
+
 ### 0. Derive wave repos in scope (Mandatory first step)
 
 The canonical source for the wave's repo list is `cross-repo-status.json` key `wave_{M}_repos_in_scope` (array of `noorinalabs-*` strings). All subsequent steps iterate this list.

--- a/.claude/skills/wave-scope/SKILL.md
+++ b/.claude/skills/wave-scope/SKILL.md
@@ -530,25 +530,44 @@ Do NOT delete the original body — copy it (or post the pre-update version as a
 
 If any step surfaced a process gap (stale memory, missing meta-issue, vague reference), include a `**Process gaps surfaced**` section so the next retro can address them.
 
-### 12.5. Validate implementer/reviewer names against per-repo rosters (#319)
+### 12.5. Validate implementer/reviewer names + child-repo membership (#319, #1134) — MANDATORY
 
-If the wave-scope output includes an implementer/reviewer matrix (a per-repo mapping of `implementer` / `reviewer` / `reviewer_2` to team-member names), validate every declared name against the relevant roster BEFORE `/wave-kickoff` fan-out. Pre-#319 a stale alias like "Anya Volkov" (canonical: "Anya Kowalczyk") would propagate through scope and only surface at first-spawn time — P3W7 retro recorded TWO such substitutions in `wave_7_decisions.implementer_substitutions`.
+Validate every declared name against the relevant roster BEFORE `/wave-kickoff` fan-out. The validator runs **two independent checks**:
+
+| # | Check | Applies to | Failure |
+|---|---|---|---|
+| #319 | **Name resolution** — does the name exist at all? | every slot | unresolved name + fuzzy suggestions |
+| #1134 | **Repo membership** — is the implementer on the TARGET repo's roster? | `implementer` on a child repo | cross-repo implementer with no recorded override |
+
+**#319 (name resolution).** Pre-#319 a stale alias like "Anya Volkov" (canonical: "Anya Kowalczyk") would propagate through scope and only surface at first-spawn time — P3W7 retro recorded TWO such substitutions in `wave_7_decisions.implementer_substitutions`.
+
+**#1134 (repo membership).** Name resolution alone is not enough: a **parent-org persona scoped as the implementer of a child-repo story** resolves fine (they are a real persona) but is not on the repo whose files they must commit to. This recurred W27 → W28 → W29 — Nurul Hakim on `user-service#204`, and (found by running this gate retroactively over `wave_28_scope`) Weronika Zielinska on `isnad-graph#1191`. The wrap-time repair is a mechanical merge-commit re-attribution that severs the "who implemented" audit trail.
 
 **Resolution rules:**
-- Per-repo entries (`noorinalabs-deploy`, `noorinalabs-isnad-graph`, …) → child-repo roster (`<repo>/.claude/team/roster/*.md`) UNION parent roster. This lets org-level coordinators (Aino, Nadia, Wanjiku, Santiago) fill child-repo slots without duplicating roster entries.
-- Parent entries (`noorinalabs-main` or empty repo key) → parent-only roster (`.claude/team/roster/*.md`).
+- Name resolution: child-repo roster (`<repo>/.claude/team/roster/*.md`) UNION parent roster. This lets org-level coordinators (Aino, Nadia, Wanjiku, Santiago) fill child-repo slots without duplicating roster entries.
+- Repo membership: the **target repo's roster only**, and **only for the `implementer` slot**. Reviewers keep the union — cross-team reviewers are explicitly permitted by `charter/agents/spawn-discipline.md` § Child-Repo Implementer Rule step 5. The implementer is the only role that must produce a commit in the target repo.
+- Parent entries (`noorinalabs-main` or empty repo key) → parent-only roster; membership is vacuous there and never fires.
 - Match is case-insensitive; trailing parenthetical role suffix (`Aino Virtanen (Standards & Quality Lead)`) is stripped before comparison.
-- On miss: fuzzy-match via difflib SequenceMatcher; surface the top-3 closest matches to the operator.
+- On a name miss: fuzzy-match via difflib SequenceMatcher; surface the top-3 closest matches to the operator.
+- **Unverifiable repos fail OPEN.** A child repo that is not cloned beside the parent has no readable roster, so membership cannot be decided — reported `unverified`, not a failure. Add `--fetch-missing` to resolve those over the network (reuses `.claude/lib/roster_union_sync.py::fetch_child_roster`).
 
-**Invocation:**
+**Invocation — prefer scope mode.** It reads the canonical `wave_{M}_scope.tier_*[]` rows straight out of `cross-repo-status.json`, so a row cannot escape the gate by being left out of a hand-transcribed matrix. Run it **after** Step 13 writes `wave_{M}_scope`:
 
 ```bash
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 VALIDATOR="$REPO_ROOT/.claude/skills/wave-scope/validate_matrix_names.py"
 
-# The matrix JSON shape is {repo: {role: name, ...}, ...}. Build it from
-# the scope file you composed (or extract from cross-repo-status.json's
-# wave_{M}_scope tier_* entries if those have been written).
+python3 "$VALIDATOR" --scope "$REPO_ROOT/cross-repo-status.json" --wave {M}
+RC=$?
+if [ $RC -ne 0 ]; then
+    echo "STOP: fix the scope rows before /wave-kickoff fan-out (see output above)."
+    exit 1
+fi
+```
+
+Matrix mode remains supported for a slate not yet written to `cross-repo-status.json`:
+
+```bash
 cat > /tmp/wave-{M}-matrix.json <<'EOF'
 {
     "noorinalabs-isnad-graph": {
@@ -563,22 +582,36 @@ cat > /tmp/wave-{M}-matrix.json <<'EOF'
     }
 }
 EOF
-
-python3 "$VALIDATOR" /tmp/wave-{M}-matrix.json
-RC=$?
-if [ $RC -ne 0 ]; then
-    echo "STOP: resolve unresolved names before /wave-kickoff fan-out."
-    echo "  If a substitution is intentional, document it in"
-    echo "  cross-repo-status.json wave_{M}_decisions.implementer_substitutions"
-    echo "  with rationale; then update the matrix and re-run /wave-scope."
-    exit 1
-fi
+python3 "$VALIDATOR" /tmp/wave-{M}-matrix.json || exit 1
 ```
 
+**Resolving a #1134 cross-repo implementer failure** — pick one, in preference order:
+
+1. **Reassign** to a member of the target repo's roster (preferred — this is the charter default).
+2. **Onboard** the persona into `<repo>/.claude/team/roster/` + `<repo>/.claude/team/roster.json`, making the assignment genuinely in-roster. Keep `.claude/lib/roster_union_sync.py` green by folding the name into the parent union manifest too.
+3. **Record an explicit override** on the scope row, when the cross-repo assignment is genuinely intended:
+
+```json
+{
+  "id": "noorinalabs-user-service#204",
+  "ref": "user-service#204",
+  "implementer": "Nurul Hakim",
+  "reviewer": "Nadia Boukhari",
+  "roster_union_override": {
+    "rationale": "Parent-owned hook wired into us CI; Nurul authors as himself and is onboarded to the us roster in the same PR.",
+    "approved_by": "owner",
+    "approved_at": "2026-07-27T00:00:00Z"
+  }
+}
+```
+
+A bare `"roster_union_override": true` is **rejected** — an override with no stated reason is indistinguishable from the silent workaround this gate exists to prevent. Only `rationale` is load-bearing; `approved_by` / `approved_at` are conventional and unvalidated.
+
 **Acceptance:**
-- Every implementer / reviewer / reviewer_2 name in the scope matrix resolves to a canonical roster entry.
+- Every implementer / reviewer / reviewer_2 / merge_gate_reviewer name resolves to a canonical roster entry.
+- Every child-repo `implementer` is on that repo's roster, or the row carries a `roster_union_override` with a non-empty rationale.
 - Unresolved names are surfaced with suggested matches.
-- Approved overrides are recorded under `wave_{M}_decisions.implementer_substitutions` in `cross-repo-status.json` with this shape:
+- A wrap-time substitution that was NOT pre-recorded here is a process failure to raise at retro, not a routine repair. Post-hoc substitutions still get logged under `wave_{M}_decisions.implementer_substitutions`:
 
 ```json
 {
@@ -591,7 +624,9 @@ fi
 }
 ```
 
-**Why this lives in `/wave-scope` not `/wave-kickoff`:** Step 0 of kickoff is a pre-flight CHECKLIST that the orchestrator confirms manually. By the time kickoff runs, scope is supposed to be settled. Validating names at scope-time means the matrix shape is already correct when kickoff reads it — the orchestrator never sees a "name not in roster" surface at fan-out time, only at scope-time review.
+**Why this lives in `/wave-scope` not `/wave-kickoff`:** Step 0 of kickoff is a pre-flight CHECKLIST that the orchestrator confirms manually. By the time kickoff runs, scope is supposed to be settled. Validating at scope-time means the matrix shape is already correct when kickoff reads it — the orchestrator never sees a "name not in roster" surface at fan-out time, only at scope-time review.
+
+**Why this is not merely an earlier warning.** The `validate_commit_identity` hook resolves a child-repo author against `_load_merged_roster(<child>)`, which merges the **parent** `roster.json` (the 78-name org union) over the child's — so from a child repo root every parent persona already resolves, and neither `noorinalabs-user-service` nor `noorinalabs-isnad-graph` ships its own identity hook or CI identity job. Measured 2026-07-27; see #1134 for the transcript. This gate is therefore the **only** place child-repo implementer membership is actually enforced, which is why it is a hard fail rather than an advisory.
 
 ### 13. Write reconciliation timestamp + structured bookkeeping keys to `cross-repo-status.json`
 

--- a/.claude/skills/wave-scope/tests/test_validate_matrix_names.py
+++ b/.claude/skills/wave-scope/tests/test_validate_matrix_names.py
@@ -18,7 +18,13 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from validate_matrix_names import validate  # noqa: E402
+from validate_matrix_names import (  # noqa: E402
+    _override_rationale,
+    _print_report_to_stderr,
+    repo_of_row,
+    validate,
+    validate_scope,
+)
 
 
 def _write_roster_card(roster_dir: Path, role_slug: str, name: str) -> None:
@@ -268,6 +274,291 @@ class MissingRosterTests(unittest.TestCase):
             # Bereket only exists in deploy roster — design-system lookup
             # combines parent + design-system rosters, not deploy.
             self.assertFalse(report["noorinalabs-design-system"][0]["resolved"])
+
+
+class CrossRepoImplementerTests(unittest.TestCase):
+    """#1134: a child-repo story's implementer must be on THAT repo's roster.
+
+    Every test here FAILS against the pre-#1134 validator, which unioned the
+    parent roster into every child lookup and so reported the live W27/W28
+    Nurul-on-user-service pairing as fully resolved (exit 0).
+    """
+
+    def test_parent_persona_as_child_implementer_is_flagged(self):
+        """The live reproducer: parent-org persona scoped to implement child work."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = _build_fake_org_dir(Path(tmpdir))
+            # "Nadia Khoury" is parent-roster-only, mirroring Nurul Hakim's
+            # relationship to the user-service roster in W27/W28.
+            matrix = {"noorinalabs-isnad-graph": {"implementer": "Nadia Khoury"}}
+            report = validate(matrix, org)
+            finding = report["noorinalabs-isnad-graph"][0]
+            # Name RESOLVES (she is a real persona) — that is why the #319
+            # check alone shipped this green for three waves.
+            self.assertTrue(finding["resolved"])
+            self.assertEqual(finding["membership"], "cross-repo")
+            self.assertEqual(_print_report_to_stderr(report), 1)
+
+    def test_repo_member_implementer_passes(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = _build_fake_org_dir(Path(tmpdir))
+            matrix = {"noorinalabs-isnad-graph": {"implementer": "Anya Kowalczyk"}}
+            report = validate(matrix, org)
+            finding = report["noorinalabs-isnad-graph"][0]
+            self.assertEqual(finding["membership"], "member")
+            self.assertEqual(_print_report_to_stderr(report), 0)
+
+    def test_reviewer_slots_keep_parent_union(self):
+        """Charter § Child-Repo Implementer Rule step 5: reviewers may be cross-team.
+
+        Regression guard against over-applying the membership check — if this
+        starts failing, the gate has broken a rule the org deliberately holds.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = _build_fake_org_dir(Path(tmpdir))
+            matrix = {
+                "noorinalabs-isnad-graph": {
+                    "implementer": "Anya Kowalczyk",
+                    "reviewer": "Aino Virtanen",  # parent-only
+                    "reviewer_2": "Nadia Khoury",  # parent-only
+                    "merge_gate_reviewer": "Wanjiku Mwangi",  # parent-only
+                }
+            }
+            report = validate(matrix, org)
+            for f in report["noorinalabs-isnad-graph"]:
+                self.assertTrue(f["resolved"])
+                if f["role"] != "implementer":
+                    self.assertEqual(f["membership"], "n/a", f"{f['role']} must not be gated")
+            self.assertEqual(_print_report_to_stderr(report), 0)
+
+    def test_parent_repo_implementer_not_gated(self):
+        """A noorinalabs-main story's implementer is a parent persona by definition."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = _build_fake_org_dir(Path(tmpdir))
+            report = validate({"noorinalabs-main": {"implementer": "Nadia Khoury"}}, org)
+            self.assertEqual(report["noorinalabs-main"][0]["membership"], "n/a")
+            self.assertEqual(_print_report_to_stderr(report), 0)
+
+    def test_unresolved_name_is_not_also_reported_cross_repo(self):
+        """An unknown name is a #319 failure only — not double-counted as #1134."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = _build_fake_org_dir(Path(tmpdir))
+            report = validate({"noorinalabs-isnad-graph": {"implementer": "Ghost Person"}}, org)
+            finding = report["noorinalabs-isnad-graph"][0]
+            self.assertFalse(finding["resolved"])
+            self.assertEqual(finding["membership"], "n/a")
+
+
+class UnverifiableRepoTests(unittest.TestCase):
+    """A repo whose roster cannot be read must FAIL OPEN, never fail closed.
+
+    An absent roster dir means "not cloned" (the CI case), not "nobody is a
+    member". Failing closed here would red-flag every child-repo implementer
+    in any environment without sibling checkouts.
+    """
+
+    def test_missing_child_roster_marks_implementer_unverified(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = _build_fake_org_dir(Path(tmpdir))
+            # noorinalabs-design-system has no roster dir in the fixture.
+            report = validate({"noorinalabs-design-system": {"implementer": "Aino Virtanen"}}, org)
+            finding = report["noorinalabs-design-system"][0]
+            self.assertTrue(finding["resolved"])
+            self.assertEqual(finding["membership"], "unverified")
+            self.assertEqual(_print_report_to_stderr(report), 0)
+
+
+class OverrideTests(unittest.TestCase):
+    """The escape hatch: an explicit, RECORDED roster-union override."""
+
+    def test_override_with_rationale_passes(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = _build_fake_org_dir(Path(tmpdir))
+            matrix = {
+                "noorinalabs-isnad-graph": {
+                    "implementer": "Nadia Khoury",
+                    "roster_union_override": {
+                        "rationale": "Parent-owned drift gate wired into ig CI; "
+                        "Nadia is onboarded to the ig roster in the same PR."
+                    },
+                }
+            }
+            report = validate(matrix, org)
+            finding = report["noorinalabs-isnad-graph"][0]
+            self.assertEqual(finding["membership"], "overridden")
+            self.assertIn("drift gate", str(finding["override_rationale"]))
+            self.assertEqual(_print_report_to_stderr(report), 0)
+
+    def test_bare_true_override_is_rejected(self):
+        """`true` records no reason — indistinguishable from the silent workaround."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = _build_fake_org_dir(Path(tmpdir))
+            matrix = {
+                "noorinalabs-isnad-graph": {
+                    "implementer": "Nadia Khoury",
+                    "roster_union_override": True,
+                }
+            }
+            report = validate(matrix, org)
+            self.assertEqual(report["noorinalabs-isnad-graph"][0]["membership"], "cross-repo")
+            self.assertEqual(_print_report_to_stderr(report), 1)
+
+    def test_empty_rationale_is_rejected(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = _build_fake_org_dir(Path(tmpdir))
+            matrix = {
+                "noorinalabs-isnad-graph": {
+                    "implementer": "Nadia Khoury",
+                    "roster_union_override": {"rationale": "   "},
+                }
+            }
+            report = validate(matrix, org)
+            self.assertEqual(report["noorinalabs-isnad-graph"][0]["membership"], "cross-repo")
+
+    def test_override_does_not_leak_into_name_findings(self):
+        """The override key must not be validated as if it were a person's name."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = _build_fake_org_dir(Path(tmpdir))
+            matrix = {
+                "noorinalabs-isnad-graph": {
+                    "implementer": "Anya Kowalczyk",
+                    "roster_union_override": {"rationale": "n/a"},
+                }
+            }
+            report = validate(matrix, org)
+            roles = [f["role"] for f in report["noorinalabs-isnad-graph"]]
+            self.assertEqual(roles, ["implementer"])
+
+    def test_bare_string_override_accepted_as_rationale(self):
+        self.assertEqual(_override_rationale("intended cross-repo"), "intended cross-repo")
+        self.assertIsNone(_override_rationale(True))
+        self.assertIsNone(_override_rationale(None))
+        self.assertIsNone(_override_rationale({"approved_by": "owner"}))
+
+
+class RepoOfRowTests(unittest.TestCase):
+    """Scope rows carry `id` (authoritative) and a short `ref`."""
+
+    def test_full_id_wins(self):
+        self.assertEqual(
+            repo_of_row({"id": "noorinalabs-user-service#204", "ref": "user-service#204"}),
+            "noorinalabs-user-service",
+        )
+
+    def test_short_ref_is_expanded(self):
+        self.assertEqual(repo_of_row({"ref": "user-service#204"}), "noorinalabs-user-service")
+
+    def test_bare_main_maps_to_parent_repo(self):
+        self.assertEqual(repo_of_row({"ref": "main#1134"}), "noorinalabs-main")
+        self.assertEqual(repo_of_row({"id": "noorinalabs-main#1134"}), "noorinalabs-main")
+
+    def test_unparsable_row_returns_empty(self):
+        self.assertEqual(repo_of_row({"id": "not-a-ref"}), "")
+        self.assertEqual(repo_of_row({}), "")
+
+
+class ScopeModeTests(unittest.TestCase):
+    """#1134 scope mode — read wave_{M}_scope.tier_*[] rows directly.
+
+    Scope mode exists because the matrix is hand-transcribed: a row omitted
+    from the matrix is a row the gate never sees. Reading the canonical rows
+    removes that bypass.
+    """
+
+    def test_cross_repo_implementer_in_tier_row_fails(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = _build_fake_org_dir(Path(tmpdir))
+            scope = {
+                "theme": "irrelevant",
+                "tier_1_core": [
+                    {
+                        "id": "noorinalabs-isnad-graph#1191",
+                        "ref": "isnad-graph#1191",
+                        "implementer": "Nadia Khoury",  # parent-only
+                        "reviewer": "Aino Virtanen",
+                    }
+                ],
+            }
+            report = validate_scope(scope, org)
+            findings = report["noorinalabs-isnad-graph (isnad-graph#1191)"]
+            impl = next(f for f in findings if f["role"] == "implementer")
+            self.assertEqual(impl["membership"], "cross-repo")
+            self.assertEqual(_print_report_to_stderr(report), 1)
+
+    def test_per_row_override_is_scoped_to_its_own_row(self):
+        """Two rows in the SAME repo: only the row carrying the override passes."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = _build_fake_org_dir(Path(tmpdir))
+            scope = {
+                "tier_1_core": [
+                    {
+                        "id": "noorinalabs-isnad-graph#1",
+                        "ref": "isnad-graph#1",
+                        "implementer": "Nadia Khoury",
+                        "roster_union_override": {"rationale": "intended, owner-approved"},
+                    },
+                    {
+                        "id": "noorinalabs-isnad-graph#2",
+                        "ref": "isnad-graph#2",
+                        "implementer": "Wanjiku Mwangi",  # no override
+                    },
+                ]
+            }
+            report = validate_scope(scope, org)
+            overridden = report["noorinalabs-isnad-graph (isnad-graph#1)"][0]
+            bare = report["noorinalabs-isnad-graph (isnad-graph#2)"][0]
+            self.assertEqual(overridden["membership"], "overridden")
+            self.assertEqual(bare["membership"], "cross-repo")
+            self.assertEqual(_print_report_to_stderr(report), 1)
+
+    def test_all_tier_arrays_are_walked(self):
+        """A story hidden in tier_3 must be checked exactly like tier_1."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = _build_fake_org_dir(Path(tmpdir))
+            scope = {
+                "tier_1_core": [
+                    {"id": "noorinalabs-main#1", "ref": "main#1", "implementer": "Nadia Khoury"}
+                ],
+                "tier_3_tech_debt": [
+                    {
+                        "id": "noorinalabs-deploy#9",
+                        "ref": "deploy#9",
+                        "implementer": "Wanjiku Mwangi",  # parent-only, deploy story
+                    }
+                ],
+            }
+            report = validate_scope(scope, org)
+            self.assertIn("noorinalabs-deploy (deploy#9)", report)
+            self.assertEqual(report["noorinalabs-deploy (deploy#9)"][0]["membership"], "cross-repo")
+            self.assertEqual(_print_report_to_stderr(report), 1)
+
+    def test_non_tier_keys_and_null_slots_ignored(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = _build_fake_org_dir(Path(tmpdir))
+            scope = {
+                "theme": "a string, not a tier",
+                "phase": 10,
+                "repos_in_scope": ["noorinalabs-main"],
+                "tier_1_core": [
+                    {
+                        "id": "noorinalabs-deploy#9",
+                        "ref": "deploy#9",
+                        "implementer": "Bereket Tadesse",  # deploy roster member
+                        "reviewer_2": None,
+                    }
+                ],
+            }
+            report = validate_scope(scope, org)
+            self.assertEqual(len(report), 1)
+            findings = report["noorinalabs-deploy (deploy#9)"]
+            self.assertEqual([f["role"] for f in findings], ["implementer"])
+            self.assertEqual(findings[0]["membership"], "member")
+            self.assertEqual(_print_report_to_stderr(report), 0)
+
+    def test_empty_scope_produces_empty_report(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = _build_fake_org_dir(Path(tmpdir))
+            self.assertEqual(validate_scope({"theme": "x"}, org), {})
 
 
 if __name__ == "__main__":

--- a/.claude/skills/wave-scope/validate_matrix_names.py
+++ b/.claude/skills/wave-scope/validate_matrix_names.py
@@ -7,10 +7,74 @@ and only surfaced at first-spawn time. P3W7 logged both substitutions in
 `wave_7_decisions.implementer_substitutions`. This script runs at scope
 time and surfaces unknown names BEFORE `/wave-kickoff` fan-out.
 
-Usage:
-    validate_matrix_names.py <scope-json-path>
+Two orthogonal checks (#319 + #1134)
+====================================
+1. **Name resolution (#319)** — does the declared name exist at all? Resolved
+   against the parent roster UNION the target repo's roster, because org-level
+   coordinators legitimately fill child-repo *review* slots.
+2. **Repo membership (#1134)** — for the `implementer` slot on a CHILD repo,
+   is the name on *that repo's own* roster? A name can resolve (check 1) and
+   still fail this, which is exactly the recurring bug: a parent-org persona
+   scoped as the implementer of a child-repo story.
 
-Where `<scope-json-path>` is a JSON file with the shape:
+Why check 2 is implementer-only. The implementer is the only role that must
+produce a **commit in the target repo**, where `validate_commit_identity`
+(Hook 5) resolves the author against that repo's roster. Reviewers never
+commit there, and the charter explicitly permits cross-team reviewers
+(`charter/agents/spawn-discipline.md` § Child-Repo Implementer Rule, step 5:
+"Reviewer assignment is a separate decision"). Applying membership to review
+slots would break that rule and produce noise.
+
+Live instance this closes (#1134): Nurul Hakim (parent roster, NOT on the
+user-service roster) was scoped as implementer of `user-service#204` in W27
+and again in W28. Check 1 passed — Nurul is a real persona — so scope shipped
+green, and at wrap time PR us#212's merge commit was mechanically re-attributed
+to Nadia Boukhari while the implementor label still said Nurul
+(`wave_28_decisions.implementer_substitutions`). Running check 2 retroactively
+over `wave_28_scope` finds a SECOND, never-recorded instance: Weronika
+Zielinska on `isnad-graph#1191`.
+
+This gate is the only enforcement point, not merely an earlier one
+==================================================================
+The issue framed the runtime identity gate as a correct backstop that "fires
+too late". Measured 2026-07-27, it does not fire at all for this class:
+`validate_commit_identity._load_merged_roster(<child>)` merges the PARENT
+`roster.json` — the 78-name org union manifest — over the child's, so from a
+child repo root every parent persona resolves; and neither
+`noorinalabs-user-service` nor `noorinalabs-isnad-graph` ships its own identity
+hook or a CI identity job. That is consistent with the observed W28 split:
+Weronika's isnad-graph commits went through unblocked. Closing that runtime gap
+is tracked separately; until it lands, scope time is where this rule lives,
+which is why the failure below is a hard exit-1 rather than a warning.
+
+Hard fail, with an explicit RECORDED override
+=============================================
+A cross-repo implementer assignment fails (exit 1) unless the scope row carries
+a `roster_union_override` object with a non-empty `rationale`. It is deliberately
+NOT a warning and deliberately NOT an unconditional block:
+
+- A bare warning is what already existed — the pre-#1134 validator printed
+  "all N names resolved" for the Nurul/user-service pairing. Three waves of
+  recurrence (W27 → W28 → W29) is the evidence that advisory output does not
+  hold this line.
+- An unconditional block with no escape hatch would be worked around, because
+  a genuinely-intended cross-repo assignment does occur (parent-flavored work
+  landing inside a child repo). A gate operators route around decays, and the
+  W28 mechanical-merge re-attribution is precisely that kind of workaround.
+
+The override therefore lives in the scope DATA (`cross-repo-status.json`), so it
+is a committed, reviewable diff rather than a verbal decision — which is what
+makes "no wave reaches wrap-time with a *silent* substitution" true.
+
+Usage
+=====
+    # Matrix mode (back-compatible, repo → role-slots)
+    validate_matrix_names.py <matrix-json-path>
+
+    # Scope mode (#1134) — reads wave_{M}_scope.tier_*[] rows directly
+    validate_matrix_names.py --scope <cross-repo-status.json> --wave 29
+
+Matrix-mode input shape:
 
     {
         "noorinalabs-isnad-graph": {
@@ -25,31 +89,63 @@ Where `<scope-json-path>` is a JSON file with the shape:
         }
     }
 
+Scope-mode reads the canonical wave-scope rows instead of a hand-transcribed
+matrix — the repo is derived from each row's `id` (`noorinalabs-user-service#204`
+→ `noorinalabs-user-service`), so the check cannot be defeated by forgetting to
+copy a row into the matrix.
+
 Exit codes:
-    0 — all names resolve to a canonical roster entry
-    1 — one or more names don't resolve; suggested matches printed to stderr
+    0 — all names resolve, and every child-repo implementer is a repo member
+        (or carries a recorded override)
+    1 — one or more names don't resolve, OR a child-repo implementer is not on
+        that repo's roster and has no recorded override
     2 — invalid input
 
 Resolution:
     - For each per-repo entry, read `<parent>/<repo>/.claude/team/roster/*.md`
-      and extract the `**Name:**` field.
+      and extract the member name (both card formats — see _load_roster_names).
     - For parent-repo entries (repo == "noorinalabs-main" or no repo), fall
       back to the parent's own `.claude/team/roster/`.
     - Case-insensitive exact match wins.
     - On miss: fuzzy-match (difflib SequenceMatcher) and print the top-3
       closest matches as suggestions.
 
-The script is read-only — it never modifies the matrix or rosters. The
-operator makes the substitution decision and re-runs.
+Unverifiable repos fail OPEN. If the target child repo is not cloned beside the
+parent (the CI case, and the normal case for a repo an operator has not pulled),
+its roster dir is absent and membership CANNOT be decided. Such a row is
+reported `membership: "unverified"` and does NOT fail the run — the same posture
+`roster_union_sync.fetch_child_roster` and `premise_check`'s WARN verdict take
+for cross-repo reads. `--fetch-missing` opts into resolving those repos over the
+network by reusing `roster_union_sync.fetch_child_roster`, rather than growing a
+second GitHub-fetch implementation here.
+
+Relationship to `.claude/lib/roster_union_sync.py`: that gate answers a
+DIFFERENT question — "does the committed parent union manifest cover every child
+persona?" (manifest coverage, network-backed, advisory/continue-on-error). This
+one answers "is this specific implementer a member of the repo they were scoped
+into?" Neither subsumes the other; do not merge them.
+
+The script is read-only — it never modifies the matrix, the scope file, or
+rosters. The operator makes the substitution decision and re-runs.
 """
 
 from __future__ import annotations
 
+import argparse
 import difflib
 import json
 import re
 import sys
 from pathlib import Path
+
+# Role slots that must be able to COMMIT in the target repo. Only these are
+# subject to the #1134 repo-membership check; every other slot is review-class
+# and keeps the parent-union resolution (#319 semantics).
+COMMIT_CAPABLE_ROLES: frozenset[str] = frozenset({"implementer"})
+
+# Repo keys that mean "the parent repo itself" — membership is vacuous there
+# (the parent roster IS the repo roster), so #1134 never fires on them.
+PARENT_REPO_KEYS: frozenset[str] = frozenset({"", "noorinalabs-main", "main"})
 
 
 def _find_org_dir() -> Path:
@@ -125,94 +221,386 @@ def _suggest(name: str, candidates: set[str], top: int = 3) -> list[str]:
     return difflib.get_close_matches(name, sorted(candidates), n=top, cutoff=0.5)
 
 
+def _fetch_repo_roster_names(repo: str, owner: str = "noorinalabs") -> set[str] | None:
+    """Fetch a child repo's roster names over the network, or None if unavailable.
+
+    Delegates to `.claude/lib/roster_union_sync.fetch_child_roster` rather than
+    growing a second `gh api` implementation in this skill (#1134 review point —
+    the org is actively paying down hand-rolled narrower duplicates). Returns
+    None on any failure, which the caller treats as `unverified` (fail-open).
+    """
+    lib_dir = Path(__file__).resolve().parents[2] / "lib"
+    if str(lib_dir) not in sys.path:
+        sys.path.insert(0, str(lib_dir))
+    try:
+        from roster_union_sync import fetch_child_roster  # noqa: PLC0415
+    except ImportError:
+        return None
+    roster = fetch_child_roster(owner, repo)
+    return set(roster) if roster else None
+
+
+def _override_rationale(override: object) -> str | None:
+    """Extract a non-empty rationale from a `roster_union_override` value.
+
+    Accepted shapes — a dict carrying a rationale, or a bare non-empty string
+    used AS the rationale:
+
+        "roster_union_override": {"rationale": "…", "approved_by": "owner"}
+        "roster_union_override": "…"
+
+    A bare `true` / `1` is deliberately REJECTED (returns None). An override
+    with no stated reason is indistinguishable from the silent workaround this
+    gate exists to prevent — the recorded rationale is the whole point.
+    """
+    if isinstance(override, str):
+        return override.strip() or None
+    if isinstance(override, dict):
+        rationale = override.get("rationale")
+        if isinstance(rationale, str) and rationale.strip():
+            return rationale.strip()
+    return None
+
+
 def validate(
-    matrix: dict[str, dict[str, str]],
+    matrix: dict[str, dict[str, object]],
     org_dir: Path,
+    *,
+    fetch_missing: bool = False,
+    owner: str = "noorinalabs",
 ) -> dict[str, list[dict[str, object]]]:
     """Return a per-repo report of name → resolution status.
 
-    Result shape:
+    Result shape (the `membership` / `override_rationale` keys are #1134
+    additions; `role` / `declared` / `resolved` / `suggestions` are unchanged
+    from #319 so existing callers keep working):
+
         {
             "noorinalabs-isnad-graph": [
                 {"role": "implementer", "declared": "Anya Volkov",
-                 "resolved": False, "suggestions": ["Anya Kowalczyk"]},
+                 "resolved": False, "membership": "n/a",
+                 "suggestions": ["Anya Kowalczyk"]},
                 ...
             ],
             ...
         }
+
+    `membership` is one of:
+      - ``"member"``     — commit-capable slot; name is on the target repo roster
+      - ``"cross-repo"`` — commit-capable slot; name resolves only via the parent
+                           union. FAILS unless the row records an override.
+      - ``"overridden"`` — ``"cross-repo"`` plus a recorded override rationale
+      - ``"unverified"`` — target repo roster unreadable (not cloned / no dir);
+                           cannot decide, so does not fail
+      - ``"n/a"``        — review-class slot, parent-repo row, or unresolved name
+
+    A per-repo `roster_union_override` may be supplied as a slot key alongside
+    the role names; scope mode maps each row's own override onto its repo.
     """
     report: dict[str, list[dict[str, object]]] = {}
+    # Parent rosters are always loaded — org-level coordinators (Nadia,
+    # Wanjiku, Aino, Santiago) can appear in per-repo matrix slots when
+    # reviewing parent-flavored work.
+    parent_roster = _load_repo_roster(org_dir, "noorinalabs-main")
     for repo, slots in matrix.items():
-        # Parent rosters are always loaded — org-level coordinators
-        # (Nadia, Wanjiku, Aino, Santiago) can appear in per-repo matrix
-        # slots when reviewing parent-flavored work.
-        parent_roster = _load_repo_roster(org_dir, "noorinalabs-main")
         repo_roster = _load_repo_roster(org_dir, repo)
+        is_parent_repo = repo in PARENT_REPO_KEYS
+        # Membership is only decidable when we could actually read the target
+        # repo's roster. An empty set from a child repo means "not cloned /
+        # no roster dir", NOT "nobody is a member" — fail open (see docstring).
+        if not repo_roster and not is_parent_repo and fetch_missing:
+            fetched = _fetch_repo_roster_names(repo, owner)
+            if fetched:
+                repo_roster = fetched
+        membership_decidable = is_parent_repo or bool(repo_roster)
         combined = parent_roster | repo_roster
+        override = _override_rationale(slots.get("roster_union_override"))
         repo_findings: list[dict[str, object]] = []
-        for role, declared in slots.items():
-            if not declared:
+        for role, raw in slots.items():
+            if role == "roster_union_override":
                 continue
+            if not raw or not isinstance(raw, str):
+                continue
+            declared = raw
             declared_clean = re.sub(r"\s*\(.*?\)\s*$", "", declared).strip()
             resolved = any(declared_clean.lower() == known.lower() for known in combined)
             entry: dict[str, object] = {
                 "role": role,
                 "declared": declared,
                 "resolved": resolved,
+                "membership": "n/a",
             }
             if not resolved:
                 entry["suggestions"] = _suggest(declared_clean, combined)
+                repo_findings.append(entry)
+                continue
+            # #1134: commit-capable slots on a child repo must be repo members.
+            if role in COMMIT_CAPABLE_ROLES and not is_parent_repo:
+                if not membership_decidable:
+                    entry["membership"] = "unverified"
+                elif any(declared_clean.lower() == known.lower() for known in repo_roster):
+                    entry["membership"] = "member"
+                elif override:
+                    entry["membership"] = "overridden"
+                    entry["override_rationale"] = override
+                else:
+                    entry["membership"] = "cross-repo"
+                    entry["repo_roster"] = sorted(repo_roster)
             repo_findings.append(entry)
         report[repo] = repo_findings
     return report
 
 
+def repo_of_row(row: dict[str, object]) -> str:
+    """Derive the target repo from a wave-scope assignment row (#1134).
+
+    Rows carry `id` (`noorinalabs-user-service#204`) and usually a short `ref`
+    (`user-service#204`). `id` is authoritative; the short form is expanded with
+    the `noorinalabs-` prefix (and bare `main` → `noorinalabs-main`) so both
+    shapes resolve to the same roster. Returns "" when neither parses, which the
+    caller treats as a parent-repo row.
+    """
+    for key in ("id", "ref"):
+        raw = row.get(key)
+        if not isinstance(raw, str) or "#" not in raw:
+            continue
+        repo = raw.split("#", 1)[0].strip()
+        if not repo:
+            continue
+        if repo == "main":
+            return "noorinalabs-main"
+        return repo if repo.startswith("noorinalabs-") else f"noorinalabs-{repo}"
+    return ""
+
+
+def _iter_tier_rows(scope: dict[str, object]) -> list[dict[str, object]]:
+    """Yield every assignment-row dict across the scope object's `tier_*` arrays."""
+    rows: list[dict[str, object]] = []
+    for key, value in scope.items():
+        if not key.startswith("tier_") or not isinstance(value, list):
+            continue
+        rows.extend(row for row in value if isinstance(row, dict))
+    return rows
+
+
+def validate_scope(
+    scope: dict[str, object],
+    org_dir: Path,
+    *,
+    fetch_missing: bool = False,
+    owner: str = "noorinalabs",
+) -> dict[str, list[dict[str, object]]]:
+    """Validate a `wave_{M}_scope` object row-by-row (#1134).
+
+    Each row becomes its own report key (`"<repo> (<ref>)"`) so a repo with
+    several stories reports — and overrides — each story independently. Rows
+    with no parsable repo are treated as parent-repo rows, matching the
+    `/wave-scope` convention that a bare `main#N` lives in `noorinalabs-main`.
+    """
+    report: dict[str, list[dict[str, object]]] = {}
+    for row in _iter_tier_rows(scope):
+        repo = repo_of_row(row) or "noorinalabs-main"
+        slots: dict[str, object] = {}
+        for role in ("implementer", "reviewer", "reviewer_2", "merge_gate_reviewer"):
+            value = row.get(role)
+            if isinstance(value, str) and value:
+                slots[role] = value
+        if "roster_union_override" in row:
+            slots["roster_union_override"] = row["roster_union_override"]
+        if not slots:
+            continue
+        ref = row.get("ref") or row.get("id") or "?"
+        row_report = validate({repo: slots}, org_dir, fetch_missing=fetch_missing, owner=owner)
+        report[f"{repo} ({ref})"] = row_report[repo]
+    return report
+
+
 def _print_report_to_stderr(report: dict[str, list[dict[str, object]]]) -> int:
-    """Pretty-print the report to stderr; return exit code."""
+    """Pretty-print the report to stderr; return exit code.
+
+    Two independent failure classes (#319 name resolution, #1134 repo
+    membership). Either one alone returns 1.
+    """
     total = 0
     unresolved = 0
-    for repo, findings in report.items():
+    cross_repo = 0
+    overridden = 0
+    unverified = 0
+    for findings in report.values():
         for f in findings:
             total += 1
             if not f["resolved"]:
                 unresolved += 1
-    if unresolved == 0:
+            membership = f.get("membership")
+            if membership == "cross-repo":
+                cross_repo += 1
+            elif membership == "overridden":
+                overridden += 1
+            elif membership == "unverified":
+                unverified += 1
+
+    if unresolved:
         print(
-            f"validate_matrix_names: all {total} names resolved across {len(report)} repos.",
+            f"validate_matrix_names: {unresolved}/{total} names UNRESOLVED "
+            f"across {len(report)} entries.",
             file=sys.stderr,
         )
-        return 0
+        for repo, findings in report.items():
+            bad = [f for f in findings if not f["resolved"]]
+            if not bad:
+                continue
+            print(f"\n  {repo}:", file=sys.stderr)
+            for f in bad:
+                raw_suggestions = f.get("suggestions")
+                suggestions = raw_suggestions if isinstance(raw_suggestions, list) else []
+                sug_str = ", ".join(suggestions) if suggestions else "(no close matches)"
+                print(
+                    f"    - {f['role']}: {f['declared']!r}  →  suggestions: {sug_str}",
+                    file=sys.stderr,
+                )
+        print(
+            "\n  Resolve each unknown name before /wave-kickoff fan-out.\n"
+            "  Approved substitutions: record under wave_{M}_decisions.implementer_substitutions"
+            " in cross-repo-status.json with rationale.",
+            file=sys.stderr,
+        )
+
+    if cross_repo:
+        print(
+            f"\nvalidate_matrix_names: {cross_repo}/{total} CROSS-REPO IMPLEMENTER "
+            "assignment(s) with no recorded override (#1134).",
+            file=sys.stderr,
+        )
+        for repo, findings in report.items():
+            bad = [f for f in findings if f.get("membership") == "cross-repo"]
+            if not bad:
+                continue
+            print(f"\n  {repo}:", file=sys.stderr)
+            for f in bad:
+                raw_roster = f.get("repo_roster")
+                roster = raw_roster if isinstance(raw_roster, list) else []
+                roster_str = ", ".join(roster) if roster else "(empty)"
+                print(
+                    f"    - {f['role']}: {f['declared']!r} is NOT on this repo's roster.\n"
+                    f"      repo roster: {roster_str}",
+                    file=sys.stderr,
+                )
+        print(
+            "\n  The implementer is the only role that must COMMIT in the target repo,\n"
+            "  where validate_commit_identity (Hook 5) resolves the author against that\n"
+            "  repo's roster. Shipping this assignment means the commit is blocked at\n"
+            "  wrap time and gets mechanically re-attributed — the #1134 failure.\n"
+            "\n  Pick one:\n"
+            "    (a) reassign to a member of the target repo's roster (preferred), or\n"
+            "    (b) onboard the persona into <repo>/.claude/team/roster/ + roster.json, or\n"
+            "    (c) record an explicit override on the scope row and re-run:\n"
+            '          "roster_union_override": {"rationale": "<why this cross-repo\n'
+            '            assignment is intended and how the commit will be authored>"}\n'
+            "\n  A bare `true` is not accepted — the rationale is the audit trail.",
+            file=sys.stderr,
+        )
+
+    if unresolved or cross_repo:
+        return 1
+
+    detail = []
+    if overridden:
+        detail.append(f"{overridden} cross-repo implementer(s) with recorded override")
+    if unverified:
+        detail.append(f"{unverified} implementer(s) unverified (repo roster unreadable)")
+    suffix = f" [{'; '.join(detail)}]" if detail else ""
     print(
-        f"validate_matrix_names: {unresolved}/{total} names UNRESOLVED across {len(report)} repos.",
+        f"validate_matrix_names: all {total} names resolved across {len(report)} entries.{suffix}",
         file=sys.stderr,
     )
     for repo, findings in report.items():
-        bad = [f for f in findings if not f["resolved"]]
-        if not bad:
-            continue
-        print(f"\n  {repo}:", file=sys.stderr)
-        for f in bad:
-            raw_suggestions = f.get("suggestions")
-            suggestions = raw_suggestions if isinstance(raw_suggestions, list) else []
-            sug_str = ", ".join(suggestions) if suggestions else "(no close matches)"
-            print(
-                f"    - {f['role']}: {f['declared']!r}  →  suggestions: {sug_str}",
-                file=sys.stderr,
-            )
-    print(
-        "\n  Resolve each unknown name before /wave-kickoff fan-out.\n"
-        "  Approved substitutions: record under wave_{M}_decisions.implementer_substitutions"
-        " in cross-repo-status.json with rationale.",
-        file=sys.stderr,
+        for f in findings:
+            if f.get("membership") == "overridden":
+                print(
+                    f"  OVERRIDE {repo} {f['role']}={f['declared']!r}: "
+                    f"{f.get('override_rationale')}",
+                    file=sys.stderr,
+                )
+            elif f.get("membership") == "unverified":
+                print(
+                    f"  UNVERIFIED {repo} {f['role']}={f['declared']!r}: "
+                    "target repo roster unreadable (not cloned?) — membership not checked. "
+                    "Re-run with --fetch-missing to resolve over the network.",
+                    file=sys.stderr,
+                )
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Validate wave-scope implementer/reviewer names against per-repo rosters."
     )
-    return 1
+    parser.add_argument(
+        "matrix",
+        nargs="?",
+        help="path to a matrix JSON file ({repo: {role: name}}). Omit when using --scope.",
+    )
+    parser.add_argument(
+        "--scope",
+        metavar="STATUS_JSON",
+        help="path to cross-repo-status.json; validates wave_{M}_scope.tier_*[] rows (#1134)",
+    )
+    parser.add_argument(
+        "--wave",
+        type=int,
+        help="wave id {M} to read from --scope (required with --scope)",
+    )
+    parser.add_argument(
+        "--fetch-missing",
+        action="store_true",
+        help=(
+            "resolve a not-cloned child repo's roster over the network via "
+            "roster_union_sync.fetch_child_roster instead of reporting it unverified"
+        ),
+    )
+    parser.add_argument(
+        "--owner",
+        default="noorinalabs",
+        help="GitHub org/owner used by --fetch-missing (default: noorinalabs)",
+    )
+    return parser
 
 
 def main(argv: list[str]) -> int:
-    if len(argv) != 2:
-        print(__doc__, file=sys.stderr)
+    args = _build_parser().parse_args(argv[1:])
+    if bool(args.scope) == bool(args.matrix):
+        print("ERROR: pass exactly one of <matrix-json-path> or --scope", file=sys.stderr)
         return 2
-    path = Path(argv[1])
+    org_dir = _find_org_dir()
+
+    if args.scope:
+        if args.wave is None:
+            print("ERROR: --scope requires --wave {M}", file=sys.stderr)
+            return 2
+        path = Path(args.scope)
+        try:
+            status = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError) as exc:
+            print(f"ERROR reading {path}: {exc}", file=sys.stderr)
+            return 2
+        if not isinstance(status, dict):
+            print("ERROR: --scope file must contain a JSON object", file=sys.stderr)
+            return 2
+        key = f"wave_{args.wave}_scope"
+        scope = status.get(key)
+        if not isinstance(scope, dict):
+            print(f"ERROR: {path} has no object at key {key!r}", file=sys.stderr)
+            return 2
+        report = validate_scope(scope, org_dir, fetch_missing=args.fetch_missing, owner=args.owner)
+        if not report:
+            print(
+                f"validate_matrix_names: {key} has no tier_* assignment rows to check.",
+                file=sys.stderr,
+            )
+            return 0
+        return _print_report_to_stderr(report)
+
+    path = Path(args.matrix)
     try:
         matrix = json.loads(path.read_text())
     except (OSError, json.JSONDecodeError) as exc:
@@ -221,8 +609,7 @@ def main(argv: list[str]) -> int:
     if not isinstance(matrix, dict):
         print("ERROR: top-level must be an object mapping repo → role-slots", file=sys.stderr)
         return 2
-    org_dir = _find_org_dir()
-    report = validate(matrix, org_dir)
+    report = validate(matrix, org_dir, fetch_missing=args.fetch_missing, owner=args.owner)
     return _print_report_to_stderr(report)
 
 

--- a/.claude/team/charter/agents/spawn-discipline.md
+++ b/.claude/team/charter/agents/spawn-discipline.md
@@ -192,6 +192,12 @@ Before authoring an implementer spawn brief for a child-repo issue:
 
 The verbatim canonical roster lives in each child repo's `.claude/team/roster.json` — read that at spawn time, not this snapshot.
 
+### Scope-time twin (main#1134)
+
+This rule binds at **spawn** time. Its **scope**-time twin — the wave cannot be *scoped* in violation of it in the first place — is `charter/skills.md` § Wave Scoping — Child-Repo Implementer Must Be a Repo-Roster Member, enforced by `/wave-scope` § 12.5 (`validate_matrix_names.py --scope`). Read that section before assigning implementers in a wave-scope matrix.
+
+Note also, per the measurement recorded there: Hook 5 does **not** currently block a parent-org persona from committing in a child repo (`_load_merged_roster` merges the parent union manifest over the child's roster). The "Why" paragraph above describes the intended design; the scope-time gate is what actually enforces it today.
+
 ### Exceptions
 
 - **User explicitly directs otherwise** in a given session ("have Lucas do the landing-page work" overrides). Hook would still block; user would need to register the agent in the target roster first or accept the block.

--- a/.claude/team/charter/skills.md
+++ b/.claude/team/charter/skills.md
@@ -42,6 +42,49 @@ Derived from Phase 2 Wave 9 retrospective, 2026-04-22.
 
 This rule is proposed for promotion to a hook-enforced check (hook > skill > charter per the enforcement-hierarchy principle). A wave-audit hook would scan handoff/retro/wrapup skill outputs for "concluded"/"done"/"complete" phrasing and block the skill's completion unless the open-item count is zero or an explicit carry-forward list is present. Tracked as a followup issue.
 
+## Wave Scoping — Child-Repo Implementer Must Be a Repo-Roster Member <!-- promotion-target: hook -->
+
+A wave-scope row whose story lives in a **child repo** MUST name an `implementer` who is on **that child repo's** roster (`<repo>/.claude/team/roster/`). Scope-time enforcement is `/wave-scope` § 12.5 via `.claude/skills/wave-scope/validate_matrix_names.py`; a violation is a **hard STOP** before `/wave-kickoff` fan-out, not a warning.
+
+This is the scope-time twin of `charter/agents/spawn-discipline.md` § Child-Repo Implementer Rule, which governs the same constraint at spawn time. That section says which roster an implementer must come from; this one says the wave cannot be *scoped* in violation of it in the first place.
+
+### Scope
+
+- Applies to the **`implementer` slot only**. Reviewer / `reviewer_2` / `merge_gate_reviewer` slots keep the parent-union resolution — cross-team reviewers are explicitly permitted (spawn-discipline § step 5). The implementer is the only role that must produce a commit in the target repo.
+- Does not apply to `noorinalabs-main` rows (membership is vacuous — the parent roster *is* the repo roster).
+- A child repo whose roster cannot be read (not cloned locally) is reported `unverified` and does **not** fail the run. Fail-open on unverifiable, never fail-closed.
+
+### The override — explicit and recorded, never silent
+
+A genuinely-intended cross-repo assignment is permitted, but only when the scope row records it:
+
+```json
+"roster_union_override": {
+  "rationale": "<why this cross-repo assignment is intended and how the commit will be authored>",
+  "approved_by": "owner"
+}
+```
+
+A bare `true` is rejected — only a non-empty `rationale` satisfies the gate. Because the override lives in `cross-repo-status.json`, it ships as a **reviewable diff** rather than a verbal decision, which is what makes "no wave reaches wrap-time with a *silent* implementer substitution" enforceable.
+
+### Why hard-fail-with-override rather than either extreme
+
+- **A warning was already the status quo and it failed.** The pre-#1134 validator reported the offending pairing as fully resolved. The mismatch recurred across three consecutive waves (W27 → W28 → W29).
+- **An unconditional block with no escape hatch would be routed around.** The W28 repair — assign anyway, then mechanically re-attribute the merge commit — is exactly that failure mode, and a gate operators route around decays (`feedback_enforcement_hierarchy`). Giving the exception a cheap, honest, auditable path is what keeps the default path honest.
+
+### Why this gate is load-bearing rather than redundant
+
+The runtime backstop does **not** currently enforce this. `validate_commit_identity._load_merged_roster(<child>)` merges the parent `roster.json` — the org-wide union manifest kept green by `.claude/lib/roster_union_sync.py` — over the child's, so from a child repo root every parent persona already resolves; and neither `noorinalabs-user-service` nor `noorinalabs-isnad-graph` ships its own identity hook or a CI identity job. Measured 2026-07-27 (main#1134). Until that gap closes, scope time is the **only** enforcement point, which is why the STOP is hard.
+
+### Evidence
+
+- `user-service#204` — Nurul Hakim (parent roster; not on the 4-person user-service roster) scoped as implementer in W27 and again in W28. PR us#212's merge commit was re-attributed to Nadia Boukhari while the implementor label still read Nurul (`wave_28_decisions.implementer_substitutions`).
+- `isnad-graph#1191` — Weronika Zielinska (parent roster; not on the isnad-graph roster) scoped as implementer in W28. Found by running the new gate retroactively over `wave_28_scope`; it was never recorded as a substitution at all, so the W28 retro undercounted the problem.
+
+### Promotion provenance
+
+main#1134, carried W27 → W28 → W29; owner-chosen fix direction 2026-07-27 (enforce at scope/kickoff time, keep the identity gate as the runtime backstop).
+
 ## Cross-repo-status.json upsert pattern <!-- promotion-target: hook -->
 
 Any skill that writes top-level `wave_{N}_*` keys to `cross-repo-status.json` MUST use the shared upsert helper at `.claude/lib/upsert_status_keys.py`. Raw `jq ... > tmp && mv` (and equivalent full-file rewrites — `jq | sponge`, `python -c 'json.dump(...)'` round-trips, etc.) are **banned** for top-level `wave_{N}_*` key writes.


### PR DESCRIPTION
Closes #1134

## What this does

Wave scoping repeatedly assigned a **parent-org persona as implementer of a child-repo story** whose roster does not include them. This adds the scope-time gate the owner chose on 2026-07-27, by **extending the existing scope-time validator** rather than adding a second one.

`.claude/skills/wave-scope/validate_matrix_names.py` now runs two orthogonal checks:

| # | Check | Roster used | Applies to |
|---|---|---|---|
| #319 | Name resolution — does the name exist? | parent **UNION** target repo | every slot |
| #1134 | Repo membership — is the implementer on the target repo's roster? | **target repo only** | `implementer` on a child repo |

Reviewer / `reviewer_2` / `merge_gate_reviewer` slots deliberately keep the union — cross-team reviewers are explicitly permitted by `charter/agents/spawn-discipline.md` § Child-Repo Implementer Rule step 5. The implementer is the only role that must produce a **commit** in the target repo.

Also adds `--scope cross-repo-status.json --wave M`, which reads the canonical `wave_{M}_scope.tier_*[]` rows directly, so a row cannot escape the gate by being omitted from a hand-transcribed matrix.

## Reuse, not duplication

Per the #1150 "hand-rolled narrower duplicate" anti-pattern the org is paying down:

- The membership check extends the **existing** `validate_matrix_names.py` (the skill that already owns scope-time roster validation) — no new gate module.
- `--fetch-missing` resolves a not-cloned child's roster by importing `.claude/lib/roster_union_sync.py::fetch_child_roster` rather than growing a second `gh api` implementation.
- `roster_union_sync.py` is **not** duplicated and not merged into this. It answers a different question: "does the committed parent union manifest cover every child persona?" (manifest coverage, network-backed, `continue-on-error`). This answers "is this implementer a member of the repo they were scoped into?" The module docstring states the distinction so a future reader doesn't conflate them.

## The design judgement: hard fail *with* an explicit recorded override

**Chosen: hard fail (exit 1) unless the scope row carries a `roster_union_override` with a non-empty `rationale`.** A bare `"roster_union_override": true` is rejected.

```json
"roster_union_override": {
  "rationale": "why this cross-repo assignment is intended and how the commit will be authored",
  "approved_by": "owner"
}
```

Why not the two extremes:

- **A soft warning is what already existed, and it failed.** The pre-change validator printed `all 2 names resolved` for the exact Nurul/user-service pairing (reproduced below). The mismatch recurred W27 → W28 → W29. Advisory output demonstrably does not hold this line.
- **A block with no escape hatch would be routed around.** A genuinely-intended cross-repo assignment does occur, and the W28 repair — assign anyway, then mechanically re-attribute the merge commit — is exactly that workaround. A gate operators route around decays (`feedback_enforcement_hierarchy`). Giving the exception a cheap, honest, auditable path is what keeps the default path honest.

The override lives in the scope **data**, so it ships as a reviewable diff rather than a verbal decision — which is what makes acceptance criterion 2 ("no wave reaches wrap-time with a *silent* implementer substitution") actually enforceable.

**Unverifiable repos fail OPEN.** A child repo not cloned beside the parent has no readable roster, so membership cannot be decided — reported `unverified`, never a false block. Failing closed here would red-flag every child-repo implementer in any environment without sibling checkouts.

## Evidence — instruments run, not reasoning

**1. The gap reproduces on the pre-change code.** Matrix `{"noorinalabs-user-service": {"implementer": "Nurul Hakim", "reviewer": "Nadia Boukhari"}}`:

```
$ python3 .claude/skills/wave-scope/validate_matrix_names.py m.json   # BEFORE
validate_matrix_names: all 2 names resolved across 1 repos.
EXIT=0
```

**2. The same input on the new code:**

```
$ python3 .claude/skills/wave-scope/validate_matrix_names.py m.json   # AFTER
validate_matrix_names: 1/2 CROSS-REPO IMPLEMENTER assignment(s) with no recorded override (#1134).

  noorinalabs-user-service:
    - implementer: 'Nurul Hakim' is NOT on this repo's roster.
      repo roster: Anya Kowalczyk, Idris Yusuf, Mateo Salazar, Nadia Boukhari
EXIT=1
```

Reviewer `Nadia Boukhari` is correctly not flagged.

**3. Retroactive run over the real `wave_28_scope` found a SECOND, never-recorded instance.**

```
$ python3 .claude/skills/wave-scope/validate_matrix_names.py --scope cross-repo-status.json --wave 28
  noorinalabs-user-service (user-service#204):
    - implementer: 'Nurul Hakim' is NOT on this repo's roster.
  noorinalabs-isnad-graph (isnad-graph#1191):
    - implementer: 'Weronika Zielinska' is NOT on this repo's roster.
EXIT=1
```

`isnad-graph#1191` was never logged in `wave_28_decisions.implementer_substitutions` — the W28 retro undercounted the problem by half.

**4. No false positive on the live wave.**

```
$ python3 .claude/skills/wave-scope/validate_matrix_names.py --scope cross-repo-status.json --wave 29
validate_matrix_names: all 60 names resolved across 20 entries.
EXIT=0
```

**5. The new tests are genuinely red against the old code.** An `ImportError` would be weak evidence, so I ran the behavioural assertion against the pre-change `validate()` using only symbols it already exported:

```
>           self.assertEqual(finding.get("membership"), "cross-repo")
E           AssertionError: None != 'cross-repo'
1 failed
```

## Correction to the issue's stated premise

The issue says the child's `validate_commit_identity` gate "correctly blocks" the assigned implementer, and treats it as a working runtime backstop that merely fires late. **Measured 2026-07-27, it does not fire at all for this class:**

```
$ python3 -c "... v._load_merged_roster(<path>) ..."
child repo ROOT       | roster size= 78 | Weronika: True | Nurul: True
child WORKTREE subdir | roster size=  0 | Weronika: False | Nurul: False
us repo ROOT          | roster size= 78 | Weronika: True | Nurul: True
```

`_load_merged_roster` merges the **parent** `roster.json` — the 78-name org union manifest — over the child's, so from a child repo root every parent persona resolves. And neither `noorinalabs-user-service` nor `noorinalabs-isnad-graph` ships its own `validate_commit_identity.py` copy, a `verify_commit_identity.py`, or a CI identity job (all four checked; all absent). Consistent with the observed W28 split: Weronika's two isnad-graph commits on PR ig#1203 went through **unblocked** under exactly the configuration that allegedly blocked Nurul.

I did **not** substitute a different design — the owner's chosen direction is correct and this evidence *strengthens* it: scope time is the **only** place this rule is enforced today, which is why the failure is a hard exit-1 rather than an advisory. The runtime-gate gap is reported below as out-of-scope.

## Acceptance criteria

- [x] Scope/kickoff rejects (or flags for explicit override) a child-repo story assigned to a non-roster implementer — `/wave-scope` § 12.5 (primary) + `/wave-kickoff` § 0b (backstop for a wave scoped off-path).
- [x] No wave can reach wrap-time with a silent implementer-substitution caused by a roster mismatch — the only non-failing path for a cross-repo assignment is a committed `roster_union_override` with a rationale.
- [x] Rule documented in the wave-scoping charter section — `charter/skills.md` § Wave Scoping — Child-Repo Implementer Must Be a Repo-Roster Member, cross-referenced from `charter/agents/spawn-discipline.md`.

## Gates

| Gate | Result |
|---|---|
| `pytest .claude/hooks/tests/ .claude/lib/tests/` | **2999 passed**, 167 subtests — baseline held exactly |
| per-skill pytest (CI shape) | wave-scope **33 passed** (13 pre-existing + 20 new), promotion-audit 102, wave-kickoff 8, wave-wrapup 15 |
| ruff-format / ruff-lint | Passed |
| mypy (CI flags) | Passed |
| cspell / actionlint / checksums-ascii | Passed |
| markdownlint-cli2 | 0 issues in 162 files |
| `pre_commit_ci_sync.py` | `OK: pre-commit config mirrors all CI-enforced checks` |
| full pre-push suite | all 16 hooks Passed |

20 new tests. No `--no-verify`. No known-failing check.

## Out of scope — worth filing separately

1. **The runtime identity gate does not enforce child-repo membership** (evidence above). The charter asserts Hook 5 enforces per-repo rosters; the parent-union merge means it does not, and child repos ship no identity gate of their own. This is the backstop #1134 assumed already worked.
2. **`/wave-kickoff` SKILL.md:40 silently fails open under zsh.** The scope-staleness check uses `[ "$SCOPE_TS" \< "$PRIOR_RETRO_TS" ]`; verified: `zsh:1: condition expected: <` then takes the FALSE branch with `rc=0`. So a stale scope timestamp never blocks kickoff. Pre-existing, not touched here.
3. **Parent `roster.json` ⇄ roster-card drift.** `Nikolaos Papadopoulos` and `Oyunbileg Batbayar` are in the 78-name parent `roster.json` but have **no persona card in any roster directory** (checked parent + all 7 children). They surface as unresolved W28 reviewer names. `roster_consistency_check.py` territory.
4. **`pytest .claude/skills/` flat collection fails** on duplicate test-module basenames in wave-wrapup (pre-existing; CI sidesteps it with a per-skill-dir loop).

---

**Reviewer:** @noorinalabs — Aino Virtanen (Standards & Quality Lead), also the Opus merge gate.
**Merge model:** wave-29 is direct-to-main; this PR bases on `main`.
**Not merging** — merges are owner-gated in this org.
