### PR TITLE
fix(commit-identity): scope indirect-exec matchers by heredoc TARGET (#1152)

### DIFF
--- a/.claude/hooks/_shell_parse.py
+++ b/.claude/hooks/_shell_parse.py
@@ -562,18 +562,40 @@ def _segment_head_command(seg_text: str) -> str | None:
     return head.rsplit("/", 1)[-1] if "/" in head else head
 
 
-def _scan_command_line(line: str) -> tuple[list[tuple[int, int, str]], list[tuple[int, bool, str]]]:
+class _LineScan(NamedTuple):
+    """Result of one quote-aware pass over a physical line."""
+
+    segments: list[tuple[int, int, str]]  # (start, end, separator_before)
+    openers: list[tuple[int, bool, str]]  # (position, is_dash_form, delimiter)
+    procsubs: list[int]  # positions of unquoted `<(` / `>(`
+
+
+def _scan_command_line(line: str) -> _LineScan:
     """Quote-aware single pass over one physical line.
 
-    Returns `(segments, openers)` where each segment is
-    `(start, end, separator_that_preceded_it)` and each opener is
-    `(position, is_dash_form, delimiter)`. Separators (`;`, `|`, `&`, `&&`,
-    `||`) and heredoc openers inside single/double quotes or behind a backslash
-    are DATA and are skipped, so `echo "a | b"` is one segment and
-    `echo "<<EOF"` holds no opener.
+    Separators (`;`, `|`, `&`, `&&`, `||`), heredoc openers and process
+    substitutions inside single/double quotes or behind a backslash are DATA and
+    are skipped, so `echo "a | b"` is one segment and `echo "<<EOF"` holds no
+    opener.
+
+    Two shapes must NOT be mistaken for control operators (main#1155 review, M2):
+
+      - `2>&1`, `>&2`, `<&0` — the `&` is part of a redirect, not a separator.
+        Splitting there resolved `cat 2>&1 > n.md <<'EOF'` to a head command of
+        `1`, so #1152's own false positive survived for every redirect-carrying
+        opener, and `cat <<'EOF' 2>&1 | bash` evaded the pipe-follow entirely.
+      - `&>file`, `&>>file` — the same `&`, on the other side.
+
+    Process-substitution positions are reported because `>(bash)` is a SECOND
+    sink hanging off the same segment: `tee >(bash) <<'EOF'` executes the body
+    even though the segment head is the inert `tee`. Recording them here (rather
+    than substring-searching the segment text later) keeps the quote-awareness —
+    a literal `>(` inside `cat > "weird>(name).md"` is not a process
+    substitution and must not be treated as one.
     """
     segments: list[tuple[int, int, str]] = []
     openers: list[tuple[int, bool, str]] = []
+    procsubs: list[int] = []
     quote: str | None = None
     seg_start = 0
     sep_before = ""
@@ -609,11 +631,19 @@ def _scan_command_line(line: str) -> tuple[list[tuple[int, int, str]], list[tupl
             i += 2
             continue
         two = line[i : i + 2]
+        if two in ("<(", ">("):
+            procsubs.append(i)
+            i += 2
+            continue
         if two in ("&&", "||"):
             segments.append((seg_start, i, sep_before))
             sep_before = two
             i += 2
             seg_start = i
+            continue
+        if c == "&" and (line[i - 1 : i] in ("<", ">") or line[i + 1 : i + 2] == ">"):
+            # `2>&1` / `>&2` / `&>log` — a redirect, not a control operator.
+            i += 1
             continue
         if c in (";", "|", "&"):
             segments.append((seg_start, i, sep_before))
@@ -623,32 +653,62 @@ def _scan_command_line(line: str) -> tuple[list[tuple[int, int, str]], list[tupl
             continue
         i += 1
     segments.append((seg_start, n, sep_before))
-    return segments, openers
+    return _LineScan(segments, openers, procsubs)
 
 
-def _opener_feeds_interpreter(line: str, pos: int, segments: list[tuple[int, int, str]]) -> bool:
+def _opener_feeds_interpreter(line: str, pos: int, scan: _LineScan) -> bool:
     """True if the heredoc opened at `pos` on `line` is consumed as shell code.
 
     A heredoc belongs to the pipeline segment it appears in. It is DATA only if
-    that segment's command is a known inert sink AND no segment downstream of it
-    *in the same pipeline* is a shell interpreter — `cat <<EOF | bash` feeds the
-    body to `bash` just as surely as `bash <<EOF` does. `&&`, `||`, `;` and `&`
-    break the pipeline: what follows them does not receive this stdin.
+    EVERY sink that can reach its bytes is inert:
+
+      1. the segment's head command is a known inert sink (`cat`, `tee`), AND
+      2. that segment carries no process substitution, AND
+      3. no segment downstream of it *in the same pipeline* is a shell
+         interpreter or itself carries a process substitution.
+
+    Condition 2 is the one that is easy to miss, and missing it is a live
+    bypass (main#1155 review, M1):
+
+        tee >(bash) <<'DELIM'
+        git -c user.name=X -c user.email=Y commit -m z
+        DELIM
+
+    The head word is the inert `tee`, but `>(bash)` is a SECOND sink hanging off
+    the same segment, and the body really is executed — confirmed under both
+    bash and zsh. Following only `|` never sees it, so the body was classified
+    as data, stripped, and the commit sailed through. A process substitution
+    anywhere in a reachable segment therefore forces CODE without trying to
+    resolve what is inside it: an unresolvable sink resolves toward CODE, which
+    is the rule the rest of this classifier already follows.
+
+    `&&`, `||`, `;` and `&` break the pipeline: what follows them does not
+    receive this stdin. A `&` that is part of a redirect (`2>&1`) is not a
+    separator at all — see `_scan_command_line`.
     """
+    segments = scan.segments
     idx = next(
         (k for k, (start, end, _sep) in enumerate(segments) if start <= pos < end),
         None,
     )
     if idx is None:
         return True
-    start, end, _sep = segments[idx]
-    if _segment_head_command(line[start:end]) not in HEREDOC_DATA_SINKS:
+
+    def _reachable_sink_is_code(k: int, *, head_must_be_inert_sink: bool) -> bool:
+        start, end, _sep = segments[k]
+        if any(start <= p < end for p in scan.procsubs):
+            return True
+        head = _segment_head_command(line[start:end])
+        if head_must_be_inert_sink:
+            return head not in HEREDOC_DATA_SINKS
+        return head in SHELL_INTERPRETERS
+
+    if _reachable_sink_is_code(idx, head_must_be_inert_sink=True):
         return True
     for k in range(idx + 1, len(segments)):
         if segments[k][2] != "|":
             break
-        nxt_start, nxt_end, _nxt_sep = segments[k]
-        if _segment_head_command(line[nxt_start:nxt_end]) in SHELL_INTERPRETERS:
+        if _reachable_sink_is_code(k, head_must_be_inert_sink=False):
             return True
     return False
 
@@ -674,9 +734,9 @@ def _classify_heredocs_cached(cmd: str) -> tuple[HeredocSpan, ...]:
     while i < len(lines):
         line = lines[i]
         i += 1
-        segments, openers = _scan_command_line(line)
-        for pos, dash_form, delim in openers:
-            is_code = _opener_feeds_interpreter(line, pos, segments)
+        scan = _scan_command_line(line)
+        for pos, dash_form, delim in scan.openers:
+            is_code = _opener_feeds_interpreter(line, pos, scan)
             body: list[str] = []
             term = None
             j = i
@@ -719,9 +779,9 @@ def strip_data_heredocs(cmd: str) -> str:
         line = lines[i]
         out.append(line)
         i += 1
-        segments, openers = _scan_command_line(line)
-        for pos, dash_form, delim in openers:
-            is_code = _opener_feeds_interpreter(line, pos, segments)
+        scan = _scan_command_line(line)
+        for pos, dash_form, delim in scan.openers:
+            is_code = _opener_feeds_interpreter(line, pos, scan)
             term = None
             j = i
             while j < len(lines):

--- a/.claude/hooks/_shell_parse.py
+++ b/.claude/hooks/_shell_parse.py
@@ -578,6 +578,14 @@ def _scan_command_line(line: str) -> _LineScan:
     are skipped, so `echo "a | b"` is one segment and `echo "<<EOF"` holds no
     opener.
 
+    `|&` is ONE operator — bash/zsh shorthand for `2>&1 |` — and must be
+    consumed as a pipe (main#1155 review round 2). Falling through to the
+    single-character cases split it into `|` then `&`, leaving an empty segment
+    between them and breaking the downstream walk on the `&`, so
+    `cat <<'D' |& bash` walked around the pipe-to-shell block. That was strictly
+    worse than either reading of the operator: treating it as a pipe catches the
+    shape, treating it as backgrounding would at least be consistent.
+
     Two shapes must NOT be mistaken for control operators (main#1155 review, M2):
 
       - `2>&1`, `>&2`, `<&0` — the `&` is part of a redirect, not a separator.
@@ -634,6 +642,19 @@ def _scan_command_line(line: str) -> _LineScan:
         if two in ("<(", ">("):
             procsubs.append(i)
             i += 2
+            continue
+        if two == "|&":
+            # bash/zsh shorthand for `2>&1 |` — ONE pipe operator, not `|`
+            # followed by a backgrounding `&`. Splitting it in two left an empty
+            # segment between them, and the downstream walk then broke on the
+            # `&` before ever reaching the interpreter, so `cat <<'D' |& bash`
+            # walked around the pipe-to-shell block this module adds. Emitting
+            # it as a `|` is both correct and the conservative reading: it keeps
+            # the pipeline connected, so the walk keeps looking for a sink.
+            segments.append((seg_start, i, sep_before))
+            sep_before = "|"
+            i += 2
+            seg_start = i
             continue
         if two in ("&&", "||"):
             segments.append((seg_start, i, sep_before))

--- a/.claude/hooks/_shell_parse.py
+++ b/.claude/hooks/_shell_parse.py
@@ -33,6 +33,21 @@ Public API
         word). Handles repeated/nested heredocs by iterating until the regex
         is fixed.
 
+    classify_heredocs(cmd) -> tuple[HeredocSpan, ...]
+        Every heredoc in `cmd` with the verdict on what CONSUMES it: a body fed
+        to `bash`/`sh`/`zsh`/`dash`/`ksh` (directly, or piped out of the opening
+        command) is `is_code=True`; a body fed to `cat`/`tee`, with or without a
+        file redirect, is `is_code=False` — inert text. Every ambiguity resolves
+        to `is_code=True`, so a misparse preserves a caller's blocking behaviour
+        rather than opening a hole (main#1152).
+
+    strip_data_heredocs(cmd) -> str
+        The complement of `strip_heredocs`: drops ONLY the `is_code=False`
+        bodies, keeping the ones a shell will execute. This is what a
+        bypass/gate matcher wants — scanning a `cat > notes.md <<'EOF' … EOF`
+        body for shell-injection shapes finds only documentation, while a
+        `bash <<'EOF' … EOF` body is genuinely executable and must stay visible.
+
     iter_command_segments(tokens) -> Iterator[list[str]]
         Splits a token list on the shell-control tokens `;`, `&&`, `||`, `|`
         (these survive shlex.split as their own tokens because they're not
@@ -244,7 +259,7 @@ import re
 import shlex
 import subprocess
 from functools import lru_cache
-from typing import Iterator
+from typing import Iterator, NamedTuple
 
 # Optional structural dependency (#748 D3b). bashlex gives a real Bash-AST
 # parse for the commit-identity matcher. It is imported defensively so a
@@ -441,6 +456,286 @@ def strip_heredocs(cmd: str) -> str:
         prev = cur
         cur = _HEREDOC_RE.sub("", cur)
     return cur
+
+
+# ---------------------------------------------------------------------------
+# Heredoc target classification (main#1152)
+# ---------------------------------------------------------------------------
+#
+# `strip_heredocs` answers "where are the heredoc bodies?" but not "who eats
+# them?", and every consumer that needs the second question has so far guessed.
+# `validate_commit_identity._detect_indirect_commit` ran its indirect-exec
+# matchers over the RAW command, so a heredoc body was scanned for bypass
+# shapes regardless of what the heredoc was attached to — documenting the shape
+#
+#     cat > notes.md <<'EOF'
+#     the bypass looks like: bash -c 'git commit …'
+#     EOF
+#
+# was blocked as if it WERE that invocation, while the identical bytes written
+# through the `Write` tool sailed through (main#1152).
+#
+# The distinction the matchers need is a property of the heredoc's TARGET:
+#
+#   - fed to `bash`/`sh`/`zsh`/`dash`/`ksh` (directly, or via a pipe out of the
+#     opening command) -> the body is CODE the shell will execute. A real
+#     bypass surface; must stay scannable.
+#   - fed to `cat`/`tee`, with or without a `>`/`>>` file redirect -> the body
+#     is DATA. Inert text; scanning it produces false positives only.
+#
+# Why not bashlex here, despite it being the structurally "right" tool and
+# already a dependency of this module: **bashlex cannot parse a quoted-delimiter
+# heredoc at all**. `bashlex.parse("cat <<'EOF'\nx\nEOF")` raises
+# `ParsingError: here-document ... delimited by end-of-file (wanted "'EOF'")`,
+# and the same for `<<"EOF"`. Only the bare `<<EOF` / `<<-EOF` forms parse.
+# `<<'EOF'` is the dominant form in practice (it is the form in the #1152
+# reproduction), so an AST-only classifier would not answer the question in the
+# very case that motivated it. This is a measured property of the installed
+# parser, not a style preference — see the regression test
+# `test_bashlex_cannot_parse_quoted_delimiter_heredoc`, which pins it so that a
+# future bashlex upgrade that fixes it will fail loudly and invite this comment
+# to be revisited.
+#
+# The classifier is therefore a quote-aware line scanner. Every ambiguity
+# resolves toward CODE (scan the body) so a misparse can only ever preserve
+# today's blocking behaviour, never open a hole:
+#
+#   - owner command not recognised, or unresolvable  -> CODE
+#   - heredoc never terminated                       -> CODE (and everything
+#                                                       after it is left alone)
+#   - delimiter not a bare `\w+` word                -> opener not recognised,
+#                                                       body treated as ordinary
+#                                                       command text (unstripped)
+
+# The POSIX shells whose heredoc body is executed as shell code. Single source
+# of truth: `validate_commit_identity` builds its `_INTERPRETERS` regex
+# alternation from this set, so the "which heredocs are code?" answer used by
+# the strip pass can never drift from the one used by the block pass. `mksh` /
+# `pdksh` stay out for the same conservative reason as #482.
+SHELL_INTERPRETERS = frozenset({"bash", "sh", "zsh", "dash", "ksh"})
+
+# Commands whose heredoc body is inert data: they copy stdin to stdout and/or a
+# file and never interpret it. Deliberately a tiny ALLOWLIST rather than a
+# denylist of interpreters — an unknown command keeps today's scan-the-body
+# behaviour, so growing this set is the only way to unblock anything and each
+# addition is an explicit, reviewable decision.
+HEREDOC_DATA_SINKS = frozenset({"cat", "tee"})
+
+# A heredoc opener: `<<EOF`, `<<'EOF'`, `<<"EOF"`, `<<-EOF`. Matched with
+# `.match(line, i)` from a scanner that has already excluded `<<<` (here-string)
+# and quoted regions, so no lookbehind is needed here.
+_HEREDOC_OPENER_RE = re.compile(r"<<(?P<dash>-?)[ \t]*(?P<q>['\"]?)(?P<delim>\w+)(?P=q)")
+
+
+class HeredocSpan(NamedTuple):
+    """One heredoc found in a command, with the verdict on what consumes it.
+
+    `body` excludes both the opener line and the terminator line. `is_code` is
+    True when the body is fed to a shell interpreter (directly or through a
+    pipe) — i.e. when scanning it for bypass shapes is correct. `terminated` is
+    False when no delimiter line was found before end-of-input.
+    """
+
+    delim: str
+    body: str
+    is_code: bool
+    terminated: bool
+
+
+def _segment_head_command(seg_text: str) -> str | None:
+    """Return the command name at the head of one pipeline segment, or None.
+
+    Heredoc openers are removed first (they are redirects, not words), then the
+    segment is tokenized and stripped of `KEY=value` prefixes and transparent
+    wrappers (`env`, `timeout 30`, `sudo`, …) via the shared helpers, so
+    `FOO=1 timeout 30 /bin/bash` resolves to `bash`. A leading path is reduced
+    to its basename. Returns None when the segment does not tokenize or holds no
+    word — callers must treat None as "unknown", never as "safe".
+    """
+    tokens = tokenize(_HEREDOC_OPENER_RE.sub(" ", seg_text))
+    if tokens is None:
+        return None
+    tokens = strip_command_prefixes(_strip_leading_env_assignments(tokens))
+    if not tokens:
+        return None
+    head = tokens[0]
+    return head.rsplit("/", 1)[-1] if "/" in head else head
+
+
+def _scan_command_line(line: str) -> tuple[list[tuple[int, int, str]], list[tuple[int, bool, str]]]:
+    """Quote-aware single pass over one physical line.
+
+    Returns `(segments, openers)` where each segment is
+    `(start, end, separator_that_preceded_it)` and each opener is
+    `(position, is_dash_form, delimiter)`. Separators (`;`, `|`, `&`, `&&`,
+    `||`) and heredoc openers inside single/double quotes or behind a backslash
+    are DATA and are skipped, so `echo "a | b"` is one segment and
+    `echo "<<EOF"` holds no opener.
+    """
+    segments: list[tuple[int, int, str]] = []
+    openers: list[tuple[int, bool, str]] = []
+    quote: str | None = None
+    seg_start = 0
+    sep_before = ""
+    i = 0
+    n = len(line)
+    while i < n:
+        c = line[i]
+        if quote is not None:
+            if c == "\\" and quote == '"' and i + 1 < n:
+                i += 2
+                continue
+            if c == quote:
+                quote = None
+            i += 1
+            continue
+        if c in ("'", '"'):
+            quote = c
+            i += 1
+            continue
+        if c == "\\" and i + 1 < n:
+            i += 2
+            continue
+        if line.startswith("<<<", i):
+            # Here-string, not a heredoc: consumed inline, opens no body.
+            i += 3
+            continue
+        if line.startswith("<<", i):
+            m = _HEREDOC_OPENER_RE.match(line, i)
+            if m is not None:
+                openers.append((i, bool(m.group("dash")), m.group("delim")))
+                i = m.end()
+                continue
+            i += 2
+            continue
+        two = line[i : i + 2]
+        if two in ("&&", "||"):
+            segments.append((seg_start, i, sep_before))
+            sep_before = two
+            i += 2
+            seg_start = i
+            continue
+        if c in (";", "|", "&"):
+            segments.append((seg_start, i, sep_before))
+            sep_before = c
+            i += 1
+            seg_start = i
+            continue
+        i += 1
+    segments.append((seg_start, n, sep_before))
+    return segments, openers
+
+
+def _opener_feeds_interpreter(line: str, pos: int, segments: list[tuple[int, int, str]]) -> bool:
+    """True if the heredoc opened at `pos` on `line` is consumed as shell code.
+
+    A heredoc belongs to the pipeline segment it appears in. It is DATA only if
+    that segment's command is a known inert sink AND no segment downstream of it
+    *in the same pipeline* is a shell interpreter — `cat <<EOF | bash` feeds the
+    body to `bash` just as surely as `bash <<EOF` does. `&&`, `||`, `;` and `&`
+    break the pipeline: what follows them does not receive this stdin.
+    """
+    idx = next(
+        (k for k, (start, end, _sep) in enumerate(segments) if start <= pos < end),
+        None,
+    )
+    if idx is None:
+        return True
+    start, end, _sep = segments[idx]
+    if _segment_head_command(line[start:end]) not in HEREDOC_DATA_SINKS:
+        return True
+    for k in range(idx + 1, len(segments)):
+        if segments[k][2] != "|":
+            break
+        nxt_start, nxt_end, _nxt_sep = segments[k]
+        if _segment_head_command(line[nxt_start:nxt_end]) in SHELL_INTERPRETERS:
+            return True
+    return False
+
+
+def classify_heredocs(cmd: str) -> tuple[HeredocSpan, ...]:
+    """Find every heredoc in `cmd` and say whether its body is code or data.
+
+    Bodies are located line-wise (the shell's own rule: openers are collected
+    across the command line, bodies follow in opener order). Returns an empty
+    tuple when the command holds no recognised heredoc.
+
+    Memoized (#1113 discipline): pure in `cmd` and the result is a tuple of
+    immutable NamedTuples, so the cached value is returned directly.
+    """
+    return _classify_heredocs_cached(cmd)
+
+
+@lru_cache(maxsize=256)
+def _classify_heredocs_cached(cmd: str) -> tuple[HeredocSpan, ...]:
+    lines = cmd.split("\n")
+    found: list[HeredocSpan] = []
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        i += 1
+        segments, openers = _scan_command_line(line)
+        for pos, dash_form, delim in openers:
+            is_code = _opener_feeds_interpreter(line, pos, segments)
+            body: list[str] = []
+            term = None
+            j = i
+            while j < len(lines):
+                candidate = lines[j].rstrip("\r")
+                if (candidate.lstrip("\t") if dash_form else candidate) == delim:
+                    term = j
+                    break
+                body.append(lines[j])
+                j += 1
+            if term is None:
+                found.append(HeredocSpan(delim, "\n".join(body), True, False))
+                return tuple(found)
+            found.append(HeredocSpan(delim, "\n".join(body), is_code, True))
+            i = term + 1
+    return tuple(found)
+
+
+@lru_cache(maxsize=256)
+def strip_data_heredocs(cmd: str) -> str:
+    """Remove the bodies of heredocs that are fed to a non-interpreter.
+
+    The complement of `strip_heredocs`, which removes EVERY heredoc body: this
+    keeps the bodies a shell will execute (so a bypass matcher still sees them)
+    and drops only the ones that are inert text. Opener and terminator lines are
+    left in place, so the surrounding command is unchanged and matchers anchored
+    on `<interpreter> … <<DELIM` still work.
+
+    Fails toward keeping the body: an unterminated heredoc, an unresolvable
+    owner, or an unrecognised delimiter shape all leave the text untouched.
+
+    Memoized (#1113): pure in `cmd`, returns an immutable `str`.
+    """
+    if "<<" not in cmd:
+        return cmd
+    lines = cmd.split("\n")
+    out: list[str] = []
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        out.append(line)
+        i += 1
+        segments, openers = _scan_command_line(line)
+        for pos, dash_form, delim in openers:
+            is_code = _opener_feeds_interpreter(line, pos, segments)
+            term = None
+            j = i
+            while j < len(lines):
+                candidate = lines[j].rstrip("\r")
+                if (candidate.lstrip("\t") if dash_form else candidate) == delim:
+                    term = j
+                    break
+                j += 1
+            if term is None:
+                out.extend(lines[i:])
+                return "\n".join(out)
+            out.extend(lines[i : term + 1] if is_code else [lines[term]])
+            i = term + 1
+    return "\n".join(out)
 
 
 def iter_command_segments(tokens: list[str]) -> Iterator[list[str]]:

--- a/.claude/hooks/tests/test_heredoc_target_scope.py
+++ b/.claude/hooks/tests/test_heredoc_target_scope.py
@@ -42,6 +42,7 @@ import validate_commit_identity as hook  # noqa: E402
 from _shell_parse import (  # noqa: E402
     HEREDOC_DATA_SINKS,
     SHELL_INTERPRETERS,
+    _scan_command_line,
     classify_heredocs,
     strip_data_heredocs,
 )
@@ -374,6 +375,137 @@ class CatPipedToShellTests(unittest.TestCase):
         self.assertIsNone(hook.check(_bash(f"cat > /tmp/n.md <<'EOF'\n{DOC_LINE}\nEOF\nls")))
 
 
+class ProcessSubstitutionSinkTests(unittest.TestCase):
+    """A process substitution is a SECOND sink on the heredoc's own segment.
+
+    Regression for the merge-gate finding on PR #1155 (Aino Virtanen). The
+    first version of this classifier resolved the segment head to `tee`, found
+    it in `HEREDOC_DATA_SINKS`, and then followed only `|` downstream. A
+    process substitution hangs off the SAME segment, so the walk never saw it:
+
+        tee >(bash) <<'DELIM'
+        git -c user.name=X -c user.email=Y commit -m z
+        DELIM
+
+    BLOCK at `fea0dca` -> ALLOW at `e163320`. A genuine block -> allow
+    regression on an identity-carrying commit, verified to really execute under
+    both bash and zsh:
+
+        $ bash procsub.sh  ->  PROCSUB-BODY-EXECUTED
+        $ zsh  procsub.sh  ->  PROCSUB-BODY-EXECUTED
+
+    The stated guarantee ("unknown owner -> CODE") held for the HEAD WORD only.
+    A known-inert head carrying an unrecognised second sink fell through it.
+    The classifier now forces CODE on any reachable segment carrying `>(`/`<(`,
+    without trying to resolve what is inside — an unresolvable sink resolves
+    toward CODE, the rule the rest of the classifier already follows.
+    """
+
+    def _assert_blocked(self, cmd: str) -> None:
+        result = hook.check(_bash(cmd))
+        self.assertIsNotNone(result, f"process-substitution sink must block: {cmd!r}")
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+
+    def test_tee_procsub_bash(self):
+        self._assert_blocked(f"tee >(bash) <<'EOF'\n{REAL_COMMIT}\nEOF")
+
+    def test_tee_procsub_sh(self):
+        self._assert_blocked(f"tee >(sh) <<'EOF'\n{REAL_COMMIT}\nEOF")
+
+    def test_tee_procsub_with_additional_redirect(self):
+        self._assert_blocked(f"tee >(bash) > /dev/null <<'EOF'\n{REAL_COMMIT}\nEOF")
+
+    def test_cat_redirected_into_procsub(self):
+        self._assert_blocked(f"cat > >(bash) <<'EOF'\n{REAL_COMMIT}\nEOF")
+
+    def test_input_form_procsub_also_forces_code(self):
+        """`<(...)` too. We do not try to decide whether the substitution's
+        contents are inert — an unresolvable sink is CODE."""
+        self._assert_blocked(f"tee <(cat /etc/hosts) <<'EOF'\n{REAL_COMMIT}\nEOF")
+
+    def test_procsub_downstream_of_a_pipe(self):
+        """The pipe-follow must apply the same rule to downstream segments —
+        `| tee >(bash)` reaches the body just as `tee >(bash)` does."""
+        self._assert_blocked(f"cat <<'EOF' | tee >(bash)\n{REAL_COMMIT}\nEOF")
+
+    def test_procsub_containing_a_pipeline(self):
+        """A `|` INSIDE the substitution splits the scanner's segments, but the
+        `>(` position still falls in the owning segment, so the rule fires."""
+        self._assert_blocked(f"tee >(grep x | bash) <<'EOF'\n{REAL_COMMIT}\nEOF")
+
+    def test_quoted_procsub_is_not_a_procsub(self):
+        """The detection is quote-aware: a literal `>(` inside a quoted filename
+        is not a process substitution and must not re-introduce #1152's false
+        positive by the back door."""
+        cmd = f"cat > 'weird>(name).md' <<'EOF'\n{DOC_LINE}\nEOF"
+        self.assertIsNone(hook.check(_bash(cmd)))
+
+    def test_classifier_marks_procsub_segment_as_code(self):
+        """Pinned at the primitive too, so a failure localises to the
+        classifier rather than only to the hook's verdict."""
+        (span,) = classify_heredocs("tee >(bash) <<'EOF'\nbody\nEOF")
+        self.assertTrue(span.is_code)
+
+
+class RedirectAmpersandTests(unittest.TestCase):
+    """`2>&1` is a redirect, not a control operator.
+
+    Second merge-gate finding on PR #1155. `_scan_command_line` split the
+    segment on the `&` in `2>&1`, with two measured consequences:
+
+      * `cat <<'DELIM' 2>&1 | bash` — the downstream walk broke on a non-`|`
+        separator, so the new pipe-to-shell block was evaded by three
+        characters. (ALLOW at base and at the first head; not a regression, but
+        it made the new protection trivially bypassable.)
+      * `cat 2>&1 > notes.md <<'DELIM'` — the head command resolved to `1`
+        rather than `cat`, so #1152's own false positive survived for every
+        redirect-carrying opener. The bug this PR closes was not fully closed.
+
+    `&>file` is the same `&` from the other side. A genuine backgrounding `&`
+    must still separate.
+    """
+
+    def test_stderr_redirect_does_not_evade_the_pipe_block(self):
+        result = hook.check(_bash(f"cat <<'EOF' 2>&1 | bash\n{REAL_COMMIT}\nEOF"))
+        self.assertIsNotNone(result, "`2>&1` must not break the pipe-follow")
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+
+    def test_stdout_to_stderr_form(self):
+        result = hook.check(_bash(f"cat <<'EOF' >&2 | bash\n{REAL_COMMIT}\nEOF"))
+        self.assertIsNotNone(result)
+
+    def test_ampersand_redirect_both_form(self):
+        result = hook.check(_bash(f"cat <<'EOF' &> /tmp/l | bash\n{REAL_COMMIT}\nEOF"))
+        self.assertIsNotNone(result)
+
+    def test_false_positive_fixed_for_leading_redirect(self):
+        """The #1152 fix must reach redirect-carrying openers too."""
+        self.assertIsNone(hook.check(_bash(f"cat 2>&1 > /tmp/n.md <<'EOF'\n{DOC_LINE}\nEOF")))
+
+    def test_false_positive_fixed_for_trailing_redirect(self):
+        self.assertIsNone(hook.check(_bash(f"cat > /tmp/n.md 2>&1 <<'EOF'\n{DOC_LINE}\nEOF")))
+
+    def test_false_positive_fixed_for_stderr_to_devnull(self):
+        self.assertIsNone(hook.check(_bash(f"tee /tmp/n.md 2>/dev/null <<'EOF'\n{DOC_LINE}\nEOF")))
+
+    def test_backgrounding_ampersand_still_separates(self):
+        """Only a `&` adjacent to a redirect is exempt — a real control `&`
+        must keep its meaning."""
+        segments = _scan_command_line("sleep 1 & wait").segments
+        self.assertEqual(len(segments), 2)
+        self.assertEqual(segments[1][2], "&")
+
+    def test_redirect_ampersand_does_not_split(self):
+        segments = _scan_command_line("cat <<'EOF' 2>&1 | bash").segments
+        self.assertEqual([s[2] for s in segments], ["", "|"])
+
+    def test_and_operator_still_splits(self):
+        segments = _scan_command_line("mkdir -p /a && cat <<'EOF'").segments
+        self.assertEqual([s[2] for s in segments], ["", "&&"])
+
+
 class BashlexHeredocLimitationTests(unittest.TestCase):
     """Why the classifier is a scanner and not a bashlex AST walk.
 
@@ -387,13 +519,19 @@ class BashlexHeredocLimitationTests(unittest.TestCase):
     """
 
     def test_bashlex_cannot_parse_quoted_delimiter_heredoc(self):
+        """Pinned to `ParsingError` specifically, not bare `Exception` — a
+        broad `assertRaises` would also be satisfied by an unrelated failure
+        (an import error, a TypeError from a signature change) and would keep
+        passing while the measurement it encodes had quietly stopped being
+        true."""
         try:
             import bashlex
+            import bashlex.errors
         except ImportError:  # pragma: no cover - degraded mode
             self.skipTest("bashlex not installed")
         for cmd in ("cat <<'EOF'\nx\nEOF\n", 'cat <<"EOF"\nx\nEOF\n'):
             with self.subTest(command=cmd):
-                with self.assertRaises(Exception):
+                with self.assertRaises(bashlex.errors.ParsingError):
                     bashlex.parse(cmd)
 
     def test_bashlex_does_parse_the_bare_delimiter_form(self):

--- a/.claude/hooks/tests/test_heredoc_target_scope.py
+++ b/.claude/hooks/tests/test_heredoc_target_scope.py
@@ -1,0 +1,530 @@
+#!/usr/bin/env python3
+"""Regression tests for main#1152 — heredoc TARGET scoping in the commit-identity gate.
+
+`validate_commit_identity._detect_indirect_commit` ran its indirect-exec
+matchers over the raw command string. None of those matchers asks what a
+heredoc is fed to, so a heredoc body was scanned for bypass shapes regardless
+of whether a shell would ever execute it: documenting the shape
+
+    cat > notes.md <<'EOF'
+    the bypass looks like: bash -c 'git commit -m x'
+    EOF
+
+was blocked as if it *were* that invocation, while the identical bytes written
+through the `Write` tool were allowed.
+
+The fix classifies each heredoc by its target — interpreter-fed bodies are code
+and stay scannable, `cat`/`tee`-fed bodies are data and are stripped before the
+matchers run — and these tests pin BOTH directions:
+
+  * `FiveRowReproductionTests` is the table from the issue, verbatim, including
+    the `Write`-vs-heredoc consistency pair.
+  * `GenuineBypassStillBlocksTests` re-asserts every shape the gate is supposed
+    to catch, because the only way to "fix" a false positive wrongly is to stop
+    blocking something real.
+  * `HeredocClassifierTests` / `StripDataHeredocsTests` pin the `_shell_parse`
+    primitive, including its fail-toward-CODE behaviour on every ambiguity.
+
+Run: python3 -m pytest .claude/hooks/tests/test_heredoc_target_scope.py -v
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_HOOKS_DIR = _HERE.parent
+sys.path.insert(0, str(_HOOKS_DIR))
+
+import validate_commit_identity as hook  # noqa: E402
+from _shell_parse import (  # noqa: E402
+    HEREDOC_DATA_SINKS,
+    SHELL_INTERPRETERS,
+    classify_heredocs,
+    strip_data_heredocs,
+)
+
+# The payload used throughout: a line of PROSE that names an interpreter `-c`
+# invocation carrying a commit. Inert as data, executable as code — which is
+# exactly the distinction under test.
+DOC_LINE = "the bypass shape looks like: bash -c 'git commit -m x'"
+
+# A real commit invocation, for the heredoc bodies that a shell will execute.
+REAL_COMMIT = 'git -c user.name="X" -c user.email="Y" commit -m z'
+
+
+def _bash(command: str) -> dict:
+    return {"tool_name": "Bash", "tool_input": {"command": command}}
+
+
+def _write(content: str) -> dict:
+    return {
+        "tool_name": "Write",
+        "tool_input": {"file_path": "/tmp/notes.md", "content": content},
+    }
+
+
+class FiveRowReproductionTests(unittest.TestCase):
+    """The reproduction table from main#1152, row for row.
+
+    Rows 1, 2, 4 and 5 already held before the fix; row 3 is the defect. They
+    are all kept because the value of the table is the CONTRAST — row 3 differs
+    from row 2 only in whether the documented invocation mentions a commit, and
+    from row 4 only in what the heredoc is fed to. A future change that fixes
+    row 3 by loosening rows 1/2/4 would pass a row-3-only test.
+    """
+
+    def test_row1_heredoc_body_with_bare_commit_phrase_allowed(self):
+        """Row 1: prose naming `git commit`, fed to `cat` → data. Allowed."""
+        cmd = "cat > /tmp/notes.md <<'EOF'\nrun git commit with identity flags\nEOF"
+        self.assertIsNone(hook.check(_bash(cmd)))
+
+    def test_row2_heredoc_body_with_interpreter_dash_c_no_commit_allowed(self):
+        """Row 2: prose naming `bash -c` with no commit in it → data. Allowed."""
+        cmd = "cat > /tmp/notes.md <<'EOF'\nshape: bash -c 'ls -la'\nEOF"
+        self.assertIsNone(hook.check(_bash(cmd)))
+
+    def test_row3_heredoc_body_documenting_dash_c_commit_via_cat_allowed(self):
+        """Row 3 — THE DEFECT. Prose naming `bash -c '…git commit…'`, fed to
+        `cat` and redirected to a file. `cat` does not execute its stdin, so the
+        body is inert text; before the fix `_DASH_C_RE` matched it in the raw
+        string and the command was blocked."""
+        cmd = f"cat > /tmp/notes.md <<'EOF'\n{DOC_LINE}\nEOF"
+        result = hook.check(_bash(cmd))
+        self.assertIsNone(
+            result,
+            "a heredoc fed to `cat` is data, not code — must not block "
+            f"(got: {result['reason'].splitlines()[0] if result else ''})",
+        )
+
+    def test_row4_heredoc_fed_directly_to_interpreter_blocks(self):
+        """Row 4: the same class of body, but fed to `bash`. A genuine bypass —
+        the shell executes it — and it must stay blocked."""
+        cmd = f"bash <<'EOF'\n{REAL_COMMIT}\nEOF"
+        result = hook.check(_bash(cmd))
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+        self.assertIn("heredoc", result["reason"])
+
+    def test_row5_write_tool_and_cat_heredoc_agree(self):
+        """Row 5 — the consistency pair. The SAME bytes, delivered through the
+        `Write` tool and through a `cat` heredoc, must reach the same verdict.
+        Before the fix `Write` was allowed and the heredoc was blocked, which is
+        what made the false positive visible: the workaround was to stop using
+        the shell."""
+        content = DOC_LINE + "\n"
+        via_write = hook.check(_write(content))
+        via_heredoc = hook.check(_bash(f"cat > /tmp/notes.md <<'EOF'\n{DOC_LINE}\nEOF"))
+        self.assertIsNone(via_write, "Write of inert content must be allowed")
+        self.assertIsNone(via_heredoc, "the identical bytes via heredoc must also be allowed")
+        self.assertEqual(
+            via_write is None,
+            via_heredoc is None,
+            "Write and `cat` heredoc must agree on identical content",
+        )
+
+
+class DataHeredocVariantsTests(unittest.TestCase):
+    """Row 3 generalised across delimiter forms, sinks and payload shapes.
+
+    Row 3 used `<<'EOF'`; the other opener forms and the other four bypass
+    matchers reach the same body through different code, so each is pinned.
+    """
+
+    def _assert_allowed(self, cmd: str) -> None:
+        result = hook.check(_bash(cmd))
+        self.assertIsNone(
+            result,
+            f"data heredoc must not block: {cmd!r} "
+            f"(got: {result['reason'].splitlines()[0] if result else ''})",
+        )
+
+    def test_unquoted_delimiter(self):
+        self._assert_allowed(f"cat > /tmp/n.md <<EOF\n{DOC_LINE}\nEOF")
+
+    def test_double_quoted_delimiter(self):
+        self._assert_allowed(f'cat > /tmp/n.md <<"EOF"\n{DOC_LINE}\nEOF')
+
+    def test_dash_form_delimiter(self):
+        self._assert_allowed(f"cat > /tmp/n.md <<-EOF\n\t{DOC_LINE}\nEOF")
+
+    def test_append_redirect(self):
+        self._assert_allowed(f"cat >> /tmp/n.md <<'EOF'\n{DOC_LINE}\nEOF")
+
+    def test_no_redirect_at_all(self):
+        self._assert_allowed(f"cat <<'EOF'\n{DOC_LINE}\nEOF")
+
+    def test_tee_sink(self):
+        self._assert_allowed(f"tee /tmp/n.md <<'EOF'\n{DOC_LINE}\nEOF")
+
+    def test_tee_append_sink(self):
+        self._assert_allowed(f"tee -a /tmp/n.md <<'EOF'\n{DOC_LINE}\nEOF")
+
+    def test_body_documents_pipe_to_shell(self):
+        self._assert_allowed("cat > /tmp/n.md <<'EOF'\nprintf 'git commit -m x' | bash\nEOF")
+
+    def test_body_documents_process_substitution(self):
+        self._assert_allowed("cat > /tmp/n.md <<'EOF'\nbash <(printf 'git commit -m x')\nEOF")
+
+    def test_body_documents_eval(self):
+        self._assert_allowed("cat > /tmp/n.md <<'EOF'\neval 'git commit -m x'\nEOF")
+
+    def test_body_documents_here_string(self):
+        self._assert_allowed("cat > /tmp/n.md <<'EOF'\nbash <<<'git commit -m x'\nEOF")
+
+    def test_body_documents_script_invocation(self):
+        """The `bash <script>` matcher reads from DISK and is not gated on the
+        word `commit`, so it too must scan the stripped text — otherwise merely
+        writing `bash deploy.sh` into a file could trigger a disk read and a
+        block on that script's contents."""
+        self._assert_allowed("cat > /tmp/n.md <<'EOF'\nbash deploy.sh\nEOF")
+
+    def test_body_documents_a_nested_interpreter_heredoc(self):
+        """A `bash <<'INNER'` shown INSIDE a `cat` heredoc is still just text —
+        the outer `cat` consumes the whole thing."""
+        self._assert_allowed(
+            "cat > /tmp/n.md <<'OUTER'\nbash <<'INNER'\ngit commit -m x\nINNER\nOUTER"
+        )
+
+    def test_data_heredoc_after_a_leading_command(self):
+        self._assert_allowed(f"mkdir -p /tmp/d && cat > /tmp/d/n.md <<'EOF'\n{DOC_LINE}\nEOF")
+
+    def test_data_heredoc_after_a_cd(self):
+        self._assert_allowed(f"cd /tmp && cat > n.md <<'EOF'\n{DOC_LINE}\nEOF")
+
+    def test_two_data_heredocs_in_one_command(self):
+        self._assert_allowed(
+            "cat > /tmp/a <<'E1'\nbash -c 'git commit'\nE1\n"
+            "cat > /tmp/b <<'E2'\neval 'git commit'\nE2"
+        )
+
+    def test_data_heredoc_followed_by_innocent_command(self):
+        """Body-consumption must resume correctly after the terminator: the
+        trailing `ls -la` is a real command line, not more body."""
+        self._assert_allowed(f"cat > /tmp/n.md <<'EOF'\n{DOC_LINE}\nEOF\nls -la")
+
+
+class GenuineBypassStillBlocksTests(unittest.TestCase):
+    """Every shape the gate exists to catch, re-asserted after the change.
+
+    A false-positive fix is only correct if it is provably one-directional.
+    These are the negative-space tests: if a future narrowing of the classifier
+    starts treating an interpreter-fed body as data, one of these fails.
+    """
+
+    def _assert_blocked(self, cmd: str, shape: str) -> None:
+        result = hook.check(_bash(cmd))
+        self.assertIsNotNone(result, f"genuine bypass must block: {cmd!r}")
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+        self.assertIn("indirect-exec", result["reason"])
+        self.assertIn(shape, result["reason"])
+
+    def test_interpreter_heredoc_quoted_delimiter(self):
+        self._assert_blocked(f"bash <<'EOF'\n{REAL_COMMIT}\nEOF", "heredoc")
+
+    def test_interpreter_heredoc_unquoted_delimiter(self):
+        self._assert_blocked(f"bash <<EOF\n{REAL_COMMIT}\nEOF", "heredoc")
+
+    def test_interpreter_heredoc_dash_form(self):
+        self._assert_blocked(f"bash <<-EOF\n\t{REAL_COMMIT}\nEOF", "heredoc")
+
+    def test_every_interpreter_name_blocks(self):
+        """The classifier's `SHELL_INTERPRETERS` and the matcher's
+        `_INTERPRETERS` regex are now built from one set; this walks the whole
+        set so adding a name to it can never silently reach only one side."""
+        for interp in sorted(SHELL_INTERPRETERS):
+            with self.subTest(interpreter=interp):
+                self._assert_blocked(f"{interp} <<'EOF'\n{REAL_COMMIT}\nEOF", "heredoc")
+
+    def test_interpreter_regex_matches_exactly_the_shared_set(self):
+        """Pin the derived alternation against the shared set — a drift here is
+        the failure mode the derivation exists to prevent."""
+        import re
+
+        pattern = re.compile(r"^\(\?:(.+)\)$")
+        m = pattern.match(hook._INTERPRETERS)
+        self.assertIsNotNone(m, f"unexpected _INTERPRETERS shape: {hook._INTERPRETERS!r}")
+        assert m is not None
+        self.assertEqual(set(m.group(1).split("|")), set(SHELL_INTERPRETERS))
+
+    def test_interpreter_heredoc_body_containing_dash_c(self):
+        """Label is `shell -c`, not `heredoc`: the matchers run in a fixed
+        order and `_DASH_C_RE` reaches the surviving body first. Which matcher
+        claims it is not the contract — that it BLOCKS is. Asserted against the
+        measured label rather than the expected one."""
+        self._assert_blocked(f"bash <<'EOF'\nbash -c '{REAL_COMMIT}'\nEOF", "shell -c")
+
+    def test_interpreter_heredoc_with_output_redirect(self):
+        """`bash <<'EOF' > /tmp/out.log` — a redirect on the interpreter line
+        must not be mistaken for a `cat > file` data sink."""
+        self._assert_blocked(f"bash <<'EOF' > /tmp/out.log\n{REAL_COMMIT}\nEOF", "heredoc")
+
+    def test_absolute_path_interpreter(self):
+        self._assert_blocked(f"/bin/bash <<'EOF'\n{REAL_COMMIT}\nEOF", "heredoc")
+
+    def test_env_prefixed_interpreter(self):
+        self._assert_blocked(f"env bash <<'EOF'\n{REAL_COMMIT}\nEOF", "heredoc")
+
+    def test_timeout_prefixed_interpreter(self):
+        self._assert_blocked(f"timeout 30 bash <<'EOF'\n{REAL_COMMIT}\nEOF", "heredoc")
+
+    def test_sudo_prefixed_interpreter(self):
+        self._assert_blocked(f"sudo bash <<'EOF'\n{REAL_COMMIT}\nEOF", "heredoc")
+
+    def test_env_assignment_prefixed_interpreter(self):
+        self._assert_blocked(f"FOO=1 bash <<'EOF'\n{REAL_COMMIT}\nEOF", "heredoc")
+
+    def test_data_heredoc_does_not_shadow_a_later_real_bypass(self):
+        """The stripped body must not swallow the command lines that follow it.
+        A `cat` heredoc first, a real `bash` heredoc second."""
+        self._assert_blocked(
+            f"cat > /tmp/a <<'E1'\njust prose\nE1\nbash <<'E2'\n{REAL_COMMIT}\nE2",
+            "heredoc",
+        )
+
+    def test_data_heredoc_does_not_shadow_a_later_dash_c(self):
+        self._assert_blocked(
+            f"cat > /tmp/a <<'E1'\njust prose\nE1\nbash -c '{REAL_COMMIT}'",
+            "shell -c",
+        )
+
+    def test_real_bypass_before_a_data_heredoc(self):
+        self._assert_blocked(
+            f"bash -c '{REAL_COMMIT}'\ncat > /tmp/a <<'E1'\njust prose\nE1",
+            "shell -c",
+        )
+
+    def test_pipe_to_shell(self):
+        self._assert_blocked(
+            f"printf '%s\\n' \"{REAL_COMMIT}\" | bash", "printf/echo piped to shell"
+        )
+
+    def test_dash_c(self):
+        self._assert_blocked(f"bash -c '{REAL_COMMIT}'", "shell -c")
+
+    def test_process_substitution(self):
+        self._assert_blocked(f"bash <(printf '{REAL_COMMIT}')", "process substitution")
+
+    def test_here_string(self):
+        self._assert_blocked(f"bash <<<'{REAL_COMMIT}'", "here-string")
+
+    def test_eval(self):
+        self._assert_blocked(f"eval '{REAL_COMMIT}'", "eval")
+
+    def test_unterminated_data_heredoc_still_scanned(self):
+        """No terminator → the classifier cannot tell where the body ends, so it
+        keeps everything. Fail-closed: this stays blocked."""
+        self._assert_blocked(f"cat > /tmp/n.md <<'EOF'\nbash -c '{REAL_COMMIT}'", "shell -c")
+
+    def test_unrecognised_sink_still_scanned(self):
+        """`myrunner` is not in the data-sink allowlist, so its body keeps
+        today's scan-the-body behaviour. The allowlist is the only thing that
+        can unblock anything."""
+        self._assert_blocked(f"myrunner <<'EOF'\nbash -c '{REAL_COMMIT}'\nEOF", "shell -c")
+
+    def test_non_shell_interpreter_sink_still_scanned(self):
+        """`python3` is neither a shell interpreter nor a data sink. It keeps
+        the pre-existing (conservative) behaviour rather than being quietly
+        unblocked by this change."""
+        self._assert_blocked(
+            f"python3 <<'EOF'\nsubprocess.run(\"bash -c '{REAL_COMMIT}'\", shell=True)\nEOF",
+            "shell -c",
+        )
+
+
+class CatPipedToShellTests(unittest.TestCase):
+    """`cat <<'EOF' | bash` — a hole this change CLOSES.
+
+    `_HEREDOC_RE` requires the interpreter to appear textually BEFORE the `<<`,
+    so it never matched this shape, and no other matcher covers it either: a
+    heredoc body piped into a shell was measurably ALLOWED before this change,
+    despite being executed verbatim. The classifier already has to answer "is
+    this body fed to an interpreter?" — including through a pipe — to decide
+    what to strip, so the answer is used to block as well as to allow.
+    """
+
+    def _assert_blocked(self, cmd: str) -> None:
+        result = hook.check(_bash(cmd))
+        self.assertIsNotNone(result, f"heredoc piped into a shell must block: {cmd!r}")
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+        self.assertIn("heredoc", result["reason"])
+
+    def test_cat_heredoc_piped_to_bash(self):
+        self._assert_blocked(f"cat <<'EOF' | bash\n{REAL_COMMIT}\nEOF")
+
+    def test_cat_heredoc_piped_to_sh_with_spacing(self):
+        self._assert_blocked(f"cat <<'EOF'   |   sh\n{REAL_COMMIT}\nEOF")
+
+    def test_cat_heredoc_piped_through_tee_into_bash(self):
+        self._assert_blocked(f"cat <<'EOF' | tee /tmp/a.sh | bash\n{REAL_COMMIT}\nEOF")
+
+    def test_cat_heredoc_piped_only_to_tee_is_still_data(self):
+        """The pipeline walk must stop at non-interpreters, not treat any pipe
+        as executable."""
+        self.assertIsNone(hook.check(_bash(f"cat <<'EOF' | tee /tmp/a.md\n{DOC_LINE}\nEOF")))
+
+    def test_semicolon_does_not_make_a_following_shell_the_target(self):
+        """`;` is not a pipe — the following `bash` does not receive this stdin,
+        so the body stays data."""
+        self.assertIsNone(hook.check(_bash(f"cat > /tmp/n.md <<'EOF'\n{DOC_LINE}\nEOF\nls")))
+
+
+class BashlexHeredocLimitationTests(unittest.TestCase):
+    """Why the classifier is a scanner and not a bashlex AST walk.
+
+    The structurally obvious tool is `iter_command_segments_ast` — the AST
+    carries redirect nodes, and `validate_commit_identity` already depends on
+    it. It cannot be used here: the installed bashlex FAILS TO PARSE a
+    quoted-delimiter heredoc at all, and `<<'EOF'` is the dominant form (it is
+    the form in the #1152 reproduction). This test pins that measurement so a
+    future bashlex that fixes it fails loudly and invites the classifier to be
+    revisited, rather than the limitation being re-derived from scratch.
+    """
+
+    def test_bashlex_cannot_parse_quoted_delimiter_heredoc(self):
+        try:
+            import bashlex
+        except ImportError:  # pragma: no cover - degraded mode
+            self.skipTest("bashlex not installed")
+        for cmd in ("cat <<'EOF'\nx\nEOF\n", 'cat <<"EOF"\nx\nEOF\n'):
+            with self.subTest(command=cmd):
+                with self.assertRaises(Exception):
+                    bashlex.parse(cmd)
+
+    def test_bashlex_does_parse_the_bare_delimiter_form(self):
+        """The contrast that makes the point precise: it is the QUOTING of the
+        delimiter that defeats the parser, not heredocs in general."""
+        try:
+            import bashlex
+        except ImportError:  # pragma: no cover - degraded mode
+            self.skipTest("bashlex not installed")
+        self.assertTrue(bashlex.parse("cat <<EOF\nx\nEOF\n"))
+
+    def test_classifier_handles_what_bashlex_cannot(self):
+        spans = classify_heredocs("cat > /tmp/n.md <<'EOF'\nbody\nEOF")
+        self.assertEqual(len(spans), 1)
+        self.assertEqual(spans[0].delim, "EOF")
+        self.assertEqual(spans[0].body, "body")
+        self.assertFalse(spans[0].is_code)
+        self.assertTrue(spans[0].terminated)
+
+
+class HeredocClassifierTests(unittest.TestCase):
+    """`classify_heredocs` — the primitive, tested directly."""
+
+    def test_no_heredoc_returns_empty(self):
+        self.assertEqual(classify_heredocs("ls -la"), ())
+
+    def test_here_string_is_not_a_heredoc(self):
+        self.assertEqual(classify_heredocs("bash <<<'git commit -m x'"), ())
+
+    def test_interpreter_body_is_code(self):
+        (span,) = classify_heredocs("bash <<'EOF'\ngit commit\nEOF")
+        self.assertTrue(span.is_code)
+        self.assertEqual(span.body, "git commit")
+
+    def test_data_sink_body_is_not_code(self):
+        (span,) = classify_heredocs("tee /tmp/a <<'EOF'\ngit commit\nEOF")
+        self.assertFalse(span.is_code)
+
+    def test_unterminated_marks_terminated_false_and_code_true(self):
+        (span,) = classify_heredocs("cat <<'EOF'\ngit commit")
+        self.assertFalse(span.terminated)
+        self.assertTrue(span.is_code, "an unterminated heredoc must fail toward CODE")
+
+    def test_two_heredocs_classified_independently(self):
+        first, second = classify_heredocs(
+            "cat > /tmp/a <<'E1'\nprose\nE1\nbash <<'E2'\ngit commit\nE2"
+        )
+        self.assertFalse(first.is_code)
+        self.assertTrue(second.is_code)
+        self.assertEqual(second.body, "git commit")
+
+    def test_multiline_body_preserved(self):
+        (span,) = classify_heredocs("cat <<'EOF'\nline one\nline two\nEOF")
+        self.assertEqual(span.body, "line one\nline two")
+
+    def test_dash_form_terminator_may_be_tab_indented(self):
+        (span,) = classify_heredocs("cat <<-EOF\n\tbody\n\tEOF")
+        self.assertTrue(span.terminated)
+        self.assertEqual(span.body, "\tbody")
+
+    def test_plain_form_terminator_may_not_be_tab_indented(self):
+        """Without `-`, a tab-indented delimiter does NOT terminate the heredoc
+        (real shell behaviour). The result is an unterminated heredoc, which
+        fails toward CODE."""
+        (span,) = classify_heredocs("cat <<EOF\nbody\n\tEOF")
+        self.assertFalse(span.terminated)
+
+    def test_opener_inside_quotes_is_not_an_opener(self):
+        self.assertEqual(classify_heredocs('echo "<<EOF" > /tmp/a'), ())
+
+    def test_non_word_delimiter_is_not_recognised(self):
+        """`<<'END-OF-FILE'` has a non-`\\w` delimiter; the opener is not
+        recognised at all, so nothing is stripped — the conservative outcome."""
+        self.assertEqual(classify_heredocs("cat <<'END-OF-FILE'\nx\nEND-OF-FILE"), ())
+
+    def test_cached_result_is_a_stable_immutable_tuple(self):
+        cmd = "cat <<'EOF'\nbody\nEOF"
+        first = classify_heredocs(cmd)
+        second = classify_heredocs(cmd)
+        self.assertEqual(first, second)
+        self.assertIsInstance(first, tuple)
+
+
+class StripDataHeredocsTests(unittest.TestCase):
+    """`strip_data_heredocs` — the complement of `strip_heredocs`."""
+
+    def test_no_heredoc_is_returned_unchanged(self):
+        cmd = "git -c user.name=X commit -m z"
+        self.assertEqual(strip_data_heredocs(cmd), cmd)
+
+    def test_interpreter_body_survives_verbatim(self):
+        cmd = "bash <<'EOF'\ngit commit -m x\nEOF"
+        self.assertEqual(strip_data_heredocs(cmd), cmd)
+
+    def test_data_body_is_removed_but_the_command_line_is_kept(self):
+        cmd = "cat > /tmp/n.md <<'EOF'\ngit commit -m x\nEOF"
+        out = strip_data_heredocs(cmd)
+        self.assertNotIn("git commit", out)
+        self.assertIn("cat > /tmp/n.md <<'EOF'", out)
+        self.assertIn("EOF", out)
+
+    def test_mixed_command_keeps_only_the_code_body(self):
+        cmd = "cat > /tmp/a <<'E1'\ndata line\nE1\nbash <<'E2'\ncode line\nE2"
+        out = strip_data_heredocs(cmd)
+        self.assertNotIn("data line", out)
+        self.assertIn("code line", out)
+
+    def test_trailing_command_line_survives(self):
+        out = strip_data_heredocs("cat <<'EOF'\ndata line\nEOF\nls -la")
+        self.assertNotIn("data line", out)
+        self.assertIn("ls -la", out)
+
+    def test_unterminated_heredoc_is_left_untouched(self):
+        cmd = "cat <<'EOF'\ngit commit -m x"
+        self.assertEqual(strip_data_heredocs(cmd), cmd)
+
+    def test_piped_to_interpreter_body_survives(self):
+        cmd = "cat <<'EOF' | bash\ngit commit -m x\nEOF"
+        self.assertEqual(strip_data_heredocs(cmd), cmd)
+
+    def test_data_sink_allowlist_is_the_only_unblocking_lever(self):
+        """Anything outside `HEREDOC_DATA_SINKS` keeps its body. Pinned so that
+        growing the allowlist stays an explicit, reviewable act."""
+        self.assertEqual(HEREDOC_DATA_SINKS, frozenset({"cat", "tee"}))
+        cmd = "sponge /tmp/n.md <<'EOF'\ngit commit -m x\nEOF"
+        self.assertEqual(strip_data_heredocs(cmd), cmd)
+
+    def test_repeated_calls_are_stable(self):
+        cmd = "cat <<'EOF'\ndata\nEOF"
+        self.assertEqual(strip_data_heredocs(cmd), strip_data_heredocs(cmd))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/.claude/hooks/tests/test_heredoc_target_scope.py
+++ b/.claude/hooks/tests/test_heredoc_target_scope.py
@@ -506,6 +506,79 @@ class RedirectAmpersandTests(unittest.TestCase):
         self.assertEqual([s[2] for s in segments], ["", "&&"])
 
 
+class PipeAmpersandOperatorTests(unittest.TestCase):
+    """`|&` is ONE operator — bash/zsh shorthand for `2>&1 |`.
+
+    Second-slot merge-gate finding on PR #1155 (Nino Kavtaradze, security lens).
+    Falling through to the single-character cases split it into `|` then `&`,
+    which is strictly worse than either reading of the operator:
+
+        sep=''  seg="cat <<'D' "   head='cat'
+        sep='|' seg=''             head=None    <- empty segment
+        sep='&' seg=' bash'        head='bash'  <- never reached: walk broke on `&`
+
+    So `cat <<'D' |& bash` walked around the pipe-to-shell block that this PR
+    itself introduces — the gate is real and was evaded by one character. Not a
+    regression (base allowed it too), but a gap in new protection, and the same
+    class as the `2>&1` finding from round 1.
+
+    Body execution confirmed in both shells with a marker assembled AT RUNTIME,
+    so a shell that merely PRINTS the body cannot forge it:
+
+        cat <<'D' |& bash
+        printf 'WZ-%s-MARKER\\n' EXEC
+        D
+
+        $ bash -> WZ-EXEC-MARKER      $ zsh -> WZ-EXEC-MARKER
+    """
+
+    def _assert_blocked(self, cmd: str) -> None:
+        result = hook.check(_bash(cmd))
+        self.assertIsNotNone(result, f"`|&` feeds a shell — must block: {cmd!r}")
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+
+    def test_cat_pipe_ampersand_bash(self):
+        self._assert_blocked(f"cat <<'EOF' |& bash\n{REAL_COMMIT}\nEOF")
+
+    def test_tee_pipe_ampersand_sh(self):
+        self._assert_blocked(f"tee /dev/null <<'EOF' |& sh\n{REAL_COMMIT}\nEOF")
+
+    def test_pipe_ampersand_unspaced(self):
+        self._assert_blocked(f"cat <<'EOF' |&bash\n{REAL_COMMIT}\nEOF")
+
+    def test_pipe_ampersand_then_further_pipe(self):
+        """The walk must keep going past a `|&` relay, not just handle it in
+        terminal position."""
+        self._assert_blocked(f"cat <<'EOF' |& tee /tmp/a | bash\n{REAL_COMMIT}\nEOF")
+
+    def test_pipe_ampersand_to_a_data_sink_stays_data(self):
+        """`|&` connects the pipeline; it does not by itself mean `code`. A
+        `|& tee` relay with no interpreter anywhere must stay ALLOW, or the fix
+        would have re-introduced #1152's false positive for this shape."""
+        self.assertIsNone(hook.check(_bash(f"cat <<'EOF' |& tee /tmp/a\n{DOC_LINE}\nEOF")))
+
+    def test_scanner_emits_one_pipe_separator(self):
+        """Pinned at the scanner, so a failure localises here rather than only
+        in the hook verdict. Two segments, one `|` — not three with an empty."""
+        segments = _scan_command_line("cat <<'D' |& bash").segments
+        self.assertEqual([s[2] for s in segments], ["", "|"])
+        self.assertEqual(len(segments), 2)
+
+    def test_backgrounding_ampersand_is_untouched_by_the_pipe_amp_case(self):
+        """A bare `&` still backgrounds and still breaks the pipeline."""
+        segments = _scan_command_line("sleep 1 & bash").segments
+        self.assertEqual([s[2] for s in segments], ["", "&"])
+
+    def test_or_operator_is_untouched_by_the_pipe_amp_case(self):
+        """`||` must not be mis-consumed as `|` + `|`, and is not `|&`."""
+        segments = _scan_command_line("false || bash").segments
+        self.assertEqual([s[2] for s in segments], ["", "||"])
+
+    def test_or_still_breaks_the_pipeline(self):
+        self.assertIsNone(hook.check(_bash(f"cat > /tmp/n <<'EOF'\n{DOC_LINE}\nEOF\nfalse || ls")))
+
+
 class BashlexHeredocLimitationTests(unittest.TestCase):
     """Why the classifier is a scanner and not a bashlex AST walk.
 

--- a/.claude/hooks/validate_commit_identity.py
+++ b/.claude/hooks/validate_commit_identity.py
@@ -99,12 +99,15 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _shell_parse import (  # noqa: E402
+    SHELL_INTERPRETERS,
     bashlex_available,
+    classify_heredocs,
     extract_dash_c_pairs,
     find_git_subcommand,
     iter_command_segments,
     iter_command_segments_ast,
     resolve_tool_cwd,
+    strip_data_heredocs,
     strip_heredocs,
     tokenize,
 )
@@ -252,7 +255,14 @@ def _detect_target_roster(command: str, *, cwd: str | None = None) -> dict[str, 
 # `mksh` and `pdksh` are deliberately excluded as a conservative bound;
 # they're rare in modern installs and can be added later if observed in
 # any bypass surface (see #482 acceptance bullet).
-_INTERPRETERS = r"(?:bash|sh|zsh|dash|ksh)"
+#
+# Built from `_shell_parse.SHELL_INTERPRETERS` rather than spelled out twice
+# (main#1152): the same set decides which heredoc bodies `strip_data_heredocs`
+# KEEPS for scanning and which shapes the matchers below BLOCK. If the two
+# drifted, a body could be stripped as data by one definition and would then
+# never be offered to the matcher that considers it code — a silent hole. Sorted
+# longest-first so no alternative can shadow a longer one it prefixes.
+_INTERPRETERS = "(?:" + "|".join(sorted(SHELL_INTERPRETERS, key=lambda s: (-len(s), s))) + ")"
 
 # printf/echo … | <interpreter>. Captures the printf/echo argument body.
 # Anchor on `printf` or `echo` at word boundary, allow any chars up to the
@@ -427,36 +437,60 @@ def _detect_indirect_commit(command: str, *, cwd: str | None = None) -> str | No
     `commit` (e.g. `bash deploy.sh`), so gating it on `"commit" in command`
     would reintroduce the #482 `bash <script>` bypass. It therefore always
     runs, exactly as before.
+
+    Scan scope (main#1152): every shape above is matched against
+    `strip_data_heredocs(command)`, NOT the raw string. All seven matchers scan
+    the whole text and none of them asks what a heredoc is attached to, so on
+    the raw string a heredoc body was searched for bypass shapes no matter what
+    consumed it — `cat > notes.md <<'EOF' … bash -c 'git commit …' … EOF` was
+    blocked as if it WERE that invocation, while the identical bytes through the
+    `Write` tool were allowed. Stripping first removes only the bodies that a
+    shell will never execute; interpreter-fed bodies survive untouched and stay
+    fully scannable, and `strip_data_heredocs` resolves every ambiguity toward
+    "keep", so this can only narrow false positives, never open a bypass.
+
+    Shape 4 additionally consults `classify_heredocs` directly. `_HEREDOC_RE`
+    requires the interpreter to appear textually BEFORE the `<<`, which misses
+    `cat <<'EOF' | bash` — the body is piped into a shell and executed, and that
+    shape was measurably ALLOWED before this change. The classifier already
+    computes "is this body fed to an interpreter?" including through a pipe, so
+    the check is added here rather than left as a known hole.
     """
-    if "commit" in command:
-        for m in _PIPE_TO_SHELL_RE.finditer(command):
+    scanned = strip_data_heredocs(command)
+
+    if "commit" in scanned:
+        for m in _PIPE_TO_SHELL_RE.finditer(scanned):
             if _payload_looks_like_commit(m.group("payload")):
                 return "printf/echo piped to shell"
 
-        for m in _DASH_C_RE.finditer(command):
+        for m in _DASH_C_RE.finditer(scanned):
             payload = _strip_outer_quotes(m.group("payload"))
             if _payload_looks_like_commit(payload):
                 return "shell -c"
 
-        for m in _PROCESS_SUB_RE.finditer(command):
+        for m in _PROCESS_SUB_RE.finditer(scanned):
             if _payload_looks_like_commit(m.group("payload")):
                 return "process substitution"
 
-        for m in _HEREDOC_RE.finditer(command):
+        for m in _HEREDOC_RE.finditer(scanned):
             if _payload_looks_like_commit(m.group("payload")):
                 return "heredoc"
 
-        for m in _HERESTRING_RE.finditer(command):
+        for span in classify_heredocs(command):
+            if span.is_code and _payload_looks_like_commit(span.body):
+                return "heredoc"
+
+        for m in _HERESTRING_RE.finditer(scanned):
             payload = _strip_outer_quotes(m.group("payload"))
             if _payload_looks_like_commit(payload):
                 return "here-string"
 
-        for m in _EVAL_RE.finditer(command):
+        for m in _EVAL_RE.finditer(scanned):
             payload = _strip_outer_quotes(m.group("payload"))
             if _payload_looks_like_commit(payload):
                 return "eval"
 
-    for m in _SCRIPT_INVOKE_RE.finditer(command):
+    for m in _SCRIPT_INVOKE_RE.finditer(scanned):
         content = _read_script_if_safe(m.group("path"), cwd)
         if content and _payload_looks_like_commit(content):
             return f"shell script ({m.group('path')})"


### PR DESCRIPTION
Closes #1152

## The defect

`_detect_indirect_commit` runs its seven matchers over the **raw** command string. None of them asks what a heredoc is fed to, so a heredoc body was scanned for bypass shapes regardless of whether a shell would ever execute it. `_find_commit_segment` *does* call `strip_heredocs`, but it runs after and is never reached once the indirect-exec detector has blocked.

## Five-row reproduction table, before and after

Run through the real `check()`; row 3 is the defect.

| # | shape | before | after |
|---|---|---|---|
| 1 | heredoc body with a bare `git commit` phrase, fed to `cat` | allow | allow |
| 2 | heredoc body naming an interpreter `-c` with no commit in it | allow | allow |
| 3 | heredoc body naming an interpreter `-c` **that mentions a commit**, fed to `cat` > file | **block** | **allow** |
| 4 | heredoc fed directly to an interpreter | block | block |
| 5 | the identical bytes via the `Write` tool | allow | allow |

Rows 3 and 5 are the pair that makes it visible: the same bytes were inert through `Write` and blocking through a `cat` heredoc. Confirmed at the hook's CLI entry point, not just in-process — row 3 goes `exit 2` -> `exit 0`, row 4 stays `exit 2`.

## The fix

The distinction the matchers need is a property of the heredoc's **target**: a body fed to `bash`/`sh`/`zsh`/`dash`/`ksh` is code and must stay scannable; a body fed to `cat`/`tee`, with or without a file redirect, is inert data.

`_shell_parse.classify_heredocs()` / `strip_data_heredocs()` — a quote-aware line scanner that pairs each heredoc opener with the pipeline segment that owns it, resolves the owner through `KEY=val` prefixes, transparent wrappers (`env`, `timeout 30`, `sudo`) and a leading path (`/bin/bash`), and follows `|` downstream. `_detect_indirect_commit` then matches against the stripped text instead of the raw string.

**Not weakened — the two guarantees:**

1. **Every ambiguity resolves toward CODE.** Unknown owner, unterminated heredoc, non-`\w` delimiter, untokenizable segment — all leave the body in place. A misparse can only preserve today's blocking behaviour, never open a hole.
2. **Data sinks are a two-entry ALLOWLIST** (`cat`, `tee`), not a denylist of interpreters. Growing it is the only way to unblock anything, and each addition is an explicit reviewable diff. `python3`, `sponge`, an unrecognised runner — all keep today's scan-the-body behaviour.

## Why not bashlex — measured, not asserted

The issue proposed `iter_command_segments_ast`, and it is the structurally right instinct: the AST carries redirect nodes and the hook already depends on it. **It cannot be used here.** The installed bashlex fails to parse a quoted-delimiter heredoc at all:

```
>>> bashlex.parse("cat <<'EOF'\nx\nEOF\n")
ParsingError: here-document at line 0 delimited by end-of-file (wanted "'EOF'")
```

Same for `<<"EOF"`. Only the bare `<<EOF` / `<<-EOF` forms parse. `<<'EOF'` is the dominant form in practice and is the form in the #1152 reproduction, so an AST-only classifier would not answer the question in the very case that motivated the issue. `BashlexHeredocLimitationTests` pins this measurement (including the `<<EOF`-parses-fine contrast that isolates *quoting* as the cause) so a future bashlex that fixes it fails loudly and invites this decision to be revisited, rather than the limitation being silently re-derived.

## A hole this also closes

The instrument surfaced a second, pre-existing defect in the opposite direction:

```
cat <<'EOF' | bash
git -c user.name=X -c user.email=Y commit -m z
EOF
```

was measurably **ALLOWED** before this change. `_HEREDOC_RE` requires the interpreter to appear textually *before* the `<<`, so it never matched; `_PIPE_TO_SHELL_RE` requires `printf`/`echo`. The body is piped into a shell and executed verbatim. The classifier already has to answer "is this body fed to an interpreter, including through a pipe?" in order to decide what to strip, so leaving the hole open would have meant the new code knows the answer and declines to use it. `CatPipedToShellTests` covers it, including the `| tee | bash` chain and the `| tee` -only case that must stay data.

## Shared interpreter set

`_INTERPRETERS` is now derived from `_shell_parse.SHELL_INTERPRETERS` rather than spelled out twice. This is a correctness requirement rather than tidying: if the set that decides which bodies get **stripped** drifted from the set that decides which shapes get **blocked**, a body could be dropped as data and then never offered to the matcher that considers it code. `test_interpreter_regex_matches_exactly_the_shared_set` and `test_every_interpreter_name_blocks` pin both halves.

## Verification

- **49-shape corpus** driven through the real `check()`: **19 wrong before** (17 false positives + 2 missed bypasses), **0 wrong after**.
- **74 new tests**; suite **3,073 passing** (2,999 baseline), no changes to existing tests.
- One test was written asserting the label `heredoc` for an interpreter heredoc whose body contains `bash -c`; running it showed the real label is `shell -c` (the `-c` matcher reaches the surviving body first). The test now asserts the measured label — blocking is the contract, which matcher claims it is not.
- ruff-format, ruff-lint, mypy, cspell, actionlint, the CI-sync drift gate, and both pre-commit hook stages: green locally.

## Coordination

Scoped to stay clear of #1151 (Lucas Ferreira), which edits `extract_leading_cd_target` / `resolve_invocation_cwd` in the same file. This change adds a new block adjacent to `strip_heredocs` (~line 450) and touches nothing in the `cd`-resolution chain; all new tests are in a **new** file, so there is no shared-test-file conflict surface either.

**#1149 is unblocked** — its regression tests can now carry interpreter `-c` invocation literals inside heredoc bodies without the `Write`-tool workaround.

## Review

Merge-gate reviewer: @Aino-Virtanen (Standards & Quality Lead). Owner-gated — not merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011hEQbrJGwa2kQ6dbEjyHQ6
