### PR TITLE
fix(hooks): route `cd` from the Bash AST, not the flattened segment list

### DIFF
--- a/.claude/hooks/_shell_parse.py
+++ b/.claude/hooks/_shell_parse.py
@@ -1113,6 +1113,25 @@ def resolve_tool_cwd(input_data: dict) -> str:
 # disqualifying, in either position.
 _UNCONDITIONAL_LEADING_OPS = frozenset({";", "&&"})
 
+# Commands that move (or replace) the CURRENT shell WITHOUT being spelled `cd`.
+# A leading `cd` is only evidence of where the work runs if nothing between it
+# and the work moves the shell again — and `pushd`/`popd`/`eval`/`source`/`.`
+# all do, invisibly to a scan that keys on the literal token `cd`.
+#
+# ONE list, consumed by BOTH mechanisms. It started life inline in the degraded
+# token set only, and the AST path keyed on `words[0] == "cd"` alone — so
+# `cd /a && pushd /b && gh …` returned `/a` on the AST path while the degraded
+# path correctly returned None, making the primary strictly weaker than the
+# co-primary it is declared equal to (found at the #1156 merge gate, Aino
+# Virtanen). Two mechanisms with independently maintained lists WILL drift
+# again; deriving both from this frozenset is what makes that impossible, and
+# is a stronger fix than patching the AST branch to match.
+#
+# `exec` is included for the same parity even though it cannot carry a `cd`
+# (`exec cd /x` fails — exec needs an external command): it REPLACES the shell,
+# so the routed command never runs at all. Refusing costs only recovery.
+_CWD_MOVING_COMMANDS = frozenset({"pushd", "popd", "eval", "source", ".", "exec"})
+
 # Fail-closed scan (bashlex absent, OR the command did not parse — most often
 # a quoted-delimiter heredoc): any of these appearing as its OWN shlex token
 # means the command carries control flow, a subshell, a pipeline or an opaque
@@ -1121,38 +1140,34 @@ _UNCONDITIONAL_LEADING_OPS = frozenset({";", "&&"})
 # ABSENT: they are the separators of the leading `cd` run itself, and dropping
 # `cd /worktree && gh pr create` would destroy the #521 recovery signal this
 # resolver exists for.
-_DEGRADED_CONTROL_FLOW_TOKENS = frozenset(
-    {
-        "if",
-        "then",
-        "else",
-        "elif",
-        "fi",
-        "while",
-        "until",
-        "for",
-        "do",
-        "done",
-        "case",
-        "esac",
-        "select",
-        "function",
-        "{",
-        "}",
-        "(",
-        ")",
-        "!",
-        "|",
-        "||",
-        "&",
-        # Commands that can move the shell in ways this scan cannot follow.
-        "eval",
-        "exec",
-        "source",
-        ".",
-        "pushd",
-        "popd",
-    }
+_DEGRADED_CONTROL_FLOW_TOKENS = (
+    frozenset(
+        {
+            "if",
+            "then",
+            "else",
+            "elif",
+            "fi",
+            "while",
+            "until",
+            "for",
+            "do",
+            "done",
+            "case",
+            "esac",
+            "select",
+            "function",
+            "{",
+            "}",
+            "(",
+            ")",
+            "!",
+            "|",
+            "||",
+            "&",
+        }
+    )
+    | _CWD_MOVING_COMMANDS
 )
 
 
@@ -1192,10 +1207,16 @@ def _ast_top_level_elements(tree) -> list[tuple[object, str | None, str | None]]
     return elements
 
 
-def _ast_subtree_contains_cd(node) -> bool:
-    """True if any command-position `cd` appears anywhere under `node`.
+def _ast_subtree_moves_cwd(node) -> bool:
+    """True if anything under `node` can move the shell's cwd.
 
-    Used on everything AFTER the leading `cd` run. A `cd` there makes the
+    That means a command-position `cd` OR any of `_CWD_MOVING_COMMANDS`
+    (`pushd`, `popd`, `eval`, `source`, `.`, `exec`) — the second half is the
+    part a `words[0] == "cd"` check misses, and missing it left
+    `cd /a && pushd /b && gh …` resolving to `/a` while both shells run the gh
+    in `/b` (#1156 merge gate).
+
+    Used on everything AFTER the leading `cd` run. A cwd move there makes the
     resolver's single answer ambiguous with respect to the command a consumer
     actually cares about (`gh issue edit 5 …; cd /elsewhere` — main#1151
     family B), or is a group whose `cd` applies to a later command in the same
@@ -1206,15 +1227,15 @@ def _ast_subtree_contains_cd(node) -> bool:
     """
     found = False
 
-    class _CdFinder(bashlex_ast.nodevisitor):
+    class _CwdMoveFinder(bashlex_ast.nodevisitor):
         def visitcommand(self, n, parts):
             nonlocal found
             words = [p.word for p in parts if getattr(p, "kind", None) == "word"]
-            if words and words[0] == "cd":
+            if words and (words[0] == "cd" or words[0] in _CWD_MOVING_COMMANDS):
                 found = True
             return True
 
-    _CdFinder().visit(node)
+    _CwdMoveFinder().visit(node)
     return found
 
 
@@ -1279,9 +1300,11 @@ def _ast_leading_cd_target_cached(command: str) -> tuple[bool, str | None]:
         target = words[1]
         index += 1
 
-    # Phase 2 — nothing after the leading run may contain a `cd` at all.
+    # Phase 2 — nothing after the leading run may move the cwd again. Starts AT
+    # the breaking element, so a `pushd`/`eval`/`source` that ended phase 1 is
+    # itself inspected; phase 1 needs no matching check of its own.
     for node, _prev_op, _next_op in elements[index:]:
-        if _ast_subtree_contains_cd(node):
+        if _ast_subtree_moves_cwd(node):
             return (True, None)
     return (True, target)
 
@@ -1399,10 +1422,21 @@ def extract_leading_cd_target(command: str) -> str | None:
     `mkdir -p /a && cd /a && gh …` (the run is no longer leading), for a
     RELATIVE `cd` (`cd /parent && cd child-repo` — refused outright now,
     because keeping `/parent` was itself a cross-repo misroute in a tree of
-    nested child repos), and for a pipeline sitting after the run. Each of
-    those falls back to the invocation cwd, which is the recoverable #650
-    behaviour. Claiming no knowledge is recoverable; claiming the wrong
-    directory is not.
+    nested child repos), for a pipeline sitting after the run, and for anything
+    in `_CWD_MOVING_COMMANDS` after the run (`cd /a && pushd /b && gh …`,
+    `… && eval 'cd /b' && …`, `… && source s.sh && …`) — including `exec`,
+    which does not move the shell but replaces it, so the routed command never
+    runs at all. Each of those falls back to the invocation cwd, which is the
+    recoverable #650 behaviour. Claiming no knowledge is recoverable; claiming
+    the wrong directory is not.
+
+    That last group is NOT a frontier the design leaves open — it is a case
+    where the two mechanisms had drifted. The degraded scan already refused
+    `pushd`/`eval`/`source`, so the AST path keying on the literal token `cd`
+    was strictly weaker than its own fallback (#1156 merge gate). Both now read
+    the same `_CWD_MOVING_COMMANDS` frozenset. A shape whose cwd this function
+    cannot compute must resolve to None on BOTH paths, and any new entry
+    belongs in that one set, never in a per-path list.
     """
     parsed, target = _ast_leading_cd_target(command)
     if parsed:

--- a/.claude/hooks/_shell_parse.py
+++ b/.claude/hooks/_shell_parse.py
@@ -193,8 +193,10 @@ Public API
         unconditional, (2) executed by the current shell, and (3) positioned
         before the work. Reads the bashlex AST (not the flattened segment
         list, which has already discarded the control flow that decides
-        whether a `cd` runs) and falls back to a fail-closed token scan when
-        bashlex is unavailable. main#1151.
+        whether a `cd` runs), with a fail-closed token scan as a CO-PRIMARY
+        for the commands bashlex cannot parse — notably any quoted-delimiter
+        heredoc (`<<'EOF'`), which raises rather than yielding an AST.
+        main#1151.
 
     resolve_invocation_cwd(input_data) -> str
         Like resolve_tool_cwd, but FIRST tries to recover the directory the
@@ -1073,9 +1075,30 @@ def resolve_tool_cwd(input_data: dict) -> str:
 # Segment-level analysis provably cannot answer any of these: by the time
 # `iter_command_segments` has split on `;`/`&&`/`||`/`|` the control flow that
 # decides whether a `cd` runs is already gone, and a guarded `cd` lands at token
-# 0 of its own segment with no leader left to withhold. So the check moves up to
-# the bashlex AST, where all three are directly readable, and falls back to a
-# fail-closed token scan when bashlex is absent.
+# 0 of its own segment with no leader left to withhold.
+#
+# TWO CO-PRIMARY MECHANISMS, not a primary and a safety net:
+#
+#   1. `_ast_leading_cd_target`  — the bashlex AST, where all three properties
+#                                  are directly readable.
+#   2. `_degraded_leading_cd_target` — a token scan that FAILS CLOSED on any
+#                                  control flow, used whenever (1) cannot see
+#                                  the command.
+#
+# (2) is NOT a rare degraded path. main#1152 established, against the installed
+# bashlex, that a QUOTED-delimiter heredoc does not parse AT ALL:
+#
+#     bashlex.parse("cat <<'EOF'\nx\nEOF\n")  -> ParsingError
+#
+# `<<'EOF'` / `<<"EOF"` raise; only bare `<<EOF` / `<<-EOF` parse. The quoted
+# form is the DOMINANT one in this repo (`python3 - <<'PY'`, `gh issue comment
+# --body-file - <<'EOF'`), so the commands most likely to carry a `cd` are
+# exactly the ones the AST cannot see. And the failure is SILENT: bashlex_available()
+# stays True (it reports import success, not per-command success) and
+# `iter_command_segments_ast` returns the same None it uses for "bashlex
+# absent". An AST-ONLY fix here would therefore have reported success and
+# changed nothing on precisely those commands — which is why (2) must close, on
+# its own, every family (1) closes. Pinned by `CdRoutingWhenBashlexCannotParse`.
 #
 # The asymmetry is deliberate and is the same call main#1141 made: UNDER-
 # detecting a `cd` degrades to the recoverable #650 invocation-cwd fallback;
@@ -1263,12 +1286,25 @@ def _ast_leading_cd_target_cached(command: str) -> tuple[bool, str | None]:
 
 
 def _degraded_leading_cd_target(command: str) -> str | None:
-    """Fail-closed token-scan fallback for when bashlex is unavailable.
+    """Fail-closed token scan — the issue's fix direction 2, as a CO-PRIMARY.
+
+    Runs whenever the AST cannot see the command: bashlex absent, or (far more
+    often) a command carrying a quoted-delimiter heredoc, which the installed
+    bashlex cannot parse at all. `python3 - <<'PY'` and `gh issue comment
+    --body-file - <<'EOF'` are the repo's dominant heredoc forms, so this path
+    is ordinary traffic, not an edge case, and it must close every family the
+    AST path closes rather than relaxing to the old last-`cd`-wins scan.
 
     Mirrors the AST phase model with the only tool left: reject outright any
     command whose shlex token stream shows control flow, a subshell, a pipeline
     or an opaque cwd change (`_DEGRADED_CONTROL_FLOW_TOKENS`), then accept only
     a leading run of `cd /abs` segments with no `cd` anywhere after it.
+
+    Heredoc BODIES are deliberately not stripped here (`strip_heredocs` is not
+    called): a body always follows its command, so its tokens can never occupy
+    the leading position, and any `cd` they contribute lands in the non-leading
+    phase and forces None. Unstripped bodies can therefore only cost recovery,
+    never buy a route — verified in `test_heredoc_body_cannot_inject_a_route`.
 
     Deliberately does NOT call `normalize_command_separators` — see the
     main#1151 ordering constraint recorded in `wave_29_scope`. Without it an
@@ -1328,8 +1364,13 @@ def extract_leading_cd_target(command: str) -> str | None:
     cannot answer them: `iter_command_segments` has already discarded the
     control flow, and a guarded `cd` sits at token 0 of its own segment with no
     leader left to withhold — which is why patching leader-by-leader kept
-    producing new families. When bashlex is unavailable the degraded scan fails
-    closed on any control-flow token instead.
+    producing new families.
+
+    The AST is NOT the sole mechanism. A quoted-delimiter heredoc (`<<'EOF'`,
+    the repo's dominant form) does not parse at all, so
+    `_degraded_leading_cd_target` — a token scan that fails closed on any
+    control flow — is a CO-PRIMARY that must close the same families on its
+    own. See the module-level § Unconditional-leading-`cd` routing resolution.
 
     Strips NOTHING — `cd` must be word 0 of a top-level simple command
     (main#1141 review round 3). Both prefix families are unsafe here:

--- a/.claude/hooks/_shell_parse.py
+++ b/.claude/hooks/_shell_parse.py
@@ -94,7 +94,10 @@ Public API
             the command never went, and three hooks downstream WRITE.
             `extract_leading_cd_target` is the only one in this module, and it
             opts out entirely (a leader may not run; and an exec-wrapper
-            cannot carry `cd` at all, since `cd` is a shell builtin).
+            cannot carry `cd` at all, since `cd` is a shell builtin). As of
+            main#1151 it does not consume segments at all — it reads the AST,
+            because the three properties that make a `cd` honourable are not
+            recoverable from a flattened segment list at any strip setting.
 
         `compound_leaders=False` exists for a caller that wants wrappers but
         not leaders. Nothing needs it today — the one routing caller wants
@@ -182,20 +185,29 @@ Public API
         want to operate on the *user's* cwd (not the hook's parent process
         cwd) should use this to anchor `subprocess.run(..., cwd=...)`.
 
+    extract_leading_cd_target(command) -> str | None
+        The ROUTING resolver: the directory the shell is in when the
+        command's first real work runs, or None when that cannot be
+        established with certainty. Honours only the UNCONDITIONAL LEADING
+        RUN of `cd <absolute-dir>` commands — a `cd` must be (1)
+        unconditional, (2) executed by the current shell, and (3) positioned
+        before the work. Reads the bashlex AST (not the flattened segment
+        list, which has already discarded the control flow that decides
+        whether a `cd` runs) and falls back to a fail-closed token scan when
+        bashlex is unavailable. main#1151.
+
     resolve_invocation_cwd(input_data) -> str
         Like resolve_tool_cwd, but FIRST tries to recover the directory the
-        command actually runs in by extracting a leading `cd <dir>` segment
-        from the Bash command string. This closes the #521 residual: for a
-        worktree subagent the harness `cwd` field is captured at agent-spawn
-        time (the orchestrator's dir), NOT the subagent's dir after it has
-        `cd`'d into its worktree, and subsequent `cd` calls do not propagate
-        back to the hook's view of `cwd`. When the triggering command is
-        `cd /path/to/worktree && gh pr create ...`, the cd target is the
-        only in-band signal that recovers the real repo. Falls back to
-        resolve_tool_cwd (stdin cwd → os.getcwd()) when no leading `cd`
-        is present. Only absolute existing directories are honored; relative
-        cd targets are ambiguous (they'd be relative to the already-wrong
-        stdin cwd) so they are ignored.
+        command actually runs in via `extract_leading_cd_target`. This closes
+        the #521 residual: for a worktree subagent the harness `cwd` field is
+        captured at agent-spawn time (the orchestrator's dir), NOT the
+        subagent's dir after it has `cd`'d into its worktree, and subsequent
+        `cd` calls do not propagate back to the hook's view of `cwd`. When the
+        triggering command is `cd /path/to/worktree && gh pr create ...`, the
+        cd target is the only in-band signal that recovers the real repo.
+        Falls back to resolve_tool_cwd (stdin cwd → os.getcwd()) when no
+        honourable leading `cd` is present. Only absolute existing directories
+        are honored.
 
     resolve_repo_short_name(input_data, *, git_runner=None) -> str | None
         Resolve the GitHub repository NAME (e.g. `noorinalabs-main`) from the
@@ -1043,31 +1055,284 @@ def resolve_tool_cwd(input_data: dict) -> str:
     return os.getcwd()
 
 
+# ---------------------------------------------------------------------------
+# Unconditional-leading-`cd` routing resolution (main#1151)
+# ---------------------------------------------------------------------------
+#
+# `extract_leading_cd_target` ROUTES — it decides which GitHub repo eight hooks
+# read and three hooks WRITE to. Its old implementation took the LAST `cd /abs`
+# pair anywhere in the flat segment list, which checks none of the three
+# properties that actually make a `cd` honourable. A `cd` may only be honoured
+# when it is
+#
+#   (1) UNCONDITIONAL      — not guarded by `||`, not inside if/while/for/case,
+#   (2) IN THE CURRENT SHELL — not in a subshell, pipeline, `&` background job
+#                              or command substitution, and
+#   (3) BEFORE the work    — positioned ahead of the command being routed.
+#
+# Segment-level analysis provably cannot answer any of these: by the time
+# `iter_command_segments` has split on `;`/`&&`/`||`/`|` the control flow that
+# decides whether a `cd` runs is already gone, and a guarded `cd` lands at token
+# 0 of its own segment with no leader left to withhold. So the check moves up to
+# the bashlex AST, where all three are directly readable, and falls back to a
+# fail-closed token scan when bashlex is absent.
+#
+# The asymmetry is deliberate and is the same call main#1141 made: UNDER-
+# detecting a `cd` degrades to the recoverable #650 invocation-cwd fallback;
+# OVER-detecting writes into the wrong repository, which no retry undoes.
+
+# Operators that may PRECEDE a `cd` in the leading run without making it
+# conditional on something other than the run itself. `;` is plain sequencing.
+# `&&` is admitted ONLY because the scan stops at the first non-`cd` element:
+# every earlier element of the run is itself a `cd`, so if this `cd` executes at
+# all it executes from the directory already recorded. `||` (runs only when the
+# left side FAILED) and `&` (backgrounds the left side into a subshell) are both
+# disqualifying, in either position.
+_UNCONDITIONAL_LEADING_OPS = frozenset({";", "&&"})
+
+# Degraded mode (no bashlex): any of these appearing as its OWN shlex token
+# means the command carries control flow, a subshell, a pipeline or an opaque
+# cwd change that the flat token stream cannot reason about -> return None and
+# let the caller fall back to the invocation cwd. `&&` and `;` are deliberately
+# ABSENT: they are the separators of the leading `cd` run itself, and dropping
+# `cd /worktree && gh pr create` would destroy the #521 recovery signal this
+# resolver exists for.
+_DEGRADED_CONTROL_FLOW_TOKENS = frozenset(
+    {
+        "if",
+        "then",
+        "else",
+        "elif",
+        "fi",
+        "while",
+        "until",
+        "for",
+        "do",
+        "done",
+        "case",
+        "esac",
+        "select",
+        "function",
+        "{",
+        "}",
+        "(",
+        ")",
+        "!",
+        "|",
+        "||",
+        "&",
+        # Commands that can move the shell in ways this scan cannot follow.
+        "eval",
+        "exec",
+        "source",
+        ".",
+        "pushd",
+        "popd",
+    }
+)
+
+
+def _ast_command_words(node) -> list[str]:
+    """Word-kind tokens of a bashlex CommandNode, in source order.
+
+    `KEY=value` prefixes arrive as AssignmentNodes and redirections as
+    RedirectNodes; neither is word-kind, so both drop out naturally. That is
+    correct for routing: `FOO=1 cd /dest` and `cd /dest > /dev/null` both move
+    the calling shell (verified in bash and zsh — `cd` is a builtin, and a
+    one-shot assignment prefix does not spawn a subprocess for a builtin).
+    """
+    return [p.word for p in node.parts if getattr(p, "kind", None) == "word"]
+
+
+def _ast_top_level_elements(tree) -> list[tuple[object, str | None, str | None]]:
+    """Flatten one parse tree's TOP-LEVEL list into (node, prev_op, next_op).
+
+    Only the outermost list is flattened — nothing nested is descended into.
+    That is the point: a node that is not a plain top-level CommandNode (an
+    `if`, a `for`, a `{ }` group, a subshell, a pipeline) is exactly the case
+    the caller must refuse to reason about.
+    """
+    if getattr(tree, "kind", None) != "list":
+        return [(tree, None, None)]
+    elements: list[tuple[object, str | None, str | None]] = []
+    pending_prev: str | None = None
+    for part in tree.parts:
+        if getattr(part, "kind", None) == "operator":
+            if elements:
+                node, prev_op, _ = elements[-1]
+                elements[-1] = (node, prev_op, part.op)
+            pending_prev = part.op
+            continue
+        elements.append((part, pending_prev, None))
+        pending_prev = None
+    return elements
+
+
+def _ast_subtree_contains_cd(node) -> bool:
+    """True if any command-position `cd` appears anywhere under `node`.
+
+    Used on everything AFTER the leading `cd` run. A `cd` there makes the
+    resolver's single answer ambiguous with respect to the command a consumer
+    actually cares about (`gh issue edit 5 …; cd /elsewhere` — main#1151
+    family B), or is a group whose `cd` applies to a later command in the same
+    group (`cd /a && { cd /b ; gh x ; }`). Either way: refuse to answer.
+
+    Only CommandNodes are inspected, so `gh pr create --body "cd /ghost"` —
+    where the text is a WordNode value, not a command — does not trip it.
+    """
+    found = False
+
+    class _CdFinder(bashlex_ast.nodevisitor):
+        def visitcommand(self, n, parts):
+            nonlocal found
+            words = [p.word for p in parts if getattr(p, "kind", None) == "word"]
+            if words and words[0] == "cd":
+                found = True
+            return True
+
+    _CdFinder().visit(node)
+    return found
+
+
+def _ast_leading_cd_target(command: str) -> tuple[bool, str | None]:
+    """AST answer to "which directory is the shell in when the work starts?".
+
+    Returns `(parsed, target)`. `parsed is False` means bashlex is unavailable
+    or the command did not parse, and the caller MUST fall back to the degraded
+    token scan — it is never "no cd". `parsed is True` with `target is None`
+    means the AST was read and the command has no honourable leading `cd`.
+
+    The `_BASHLEX_AVAILABLE` gate lives HERE, outside the cache, for the same
+    reason `iter_command_segments_ast` keeps it outside
+    `_iter_command_segments_ast_cached`: a test monkeypatching the flag to
+    simulate a bare checkout must never be served a stale cached AST answer.
+    """
+    if not _BASHLEX_AVAILABLE:
+        return (False, None)
+    return _ast_leading_cd_target_cached(command)
+
+
+@lru_cache(maxsize=256)
+def _ast_leading_cd_target_cached(command: str) -> tuple[bool, str | None]:
+    """Memoized core of `_ast_leading_cd_target`. Assumes bashlex is available.
+
+    Memoized (#1113): pure in `command`, and returns an immutable tuple of
+    immutable values, so the cached object can be handed out directly — no
+    copy needed, no mutation hazard.
+    """
+    try:
+        trees = bashlex.parse(command)
+    except Exception:
+        # Same resilience posture as `_iter_command_segments_ast_cached`: any
+        # bashlex failure signals the caller to fall back, never a crash.
+        return (False, None)
+
+    elements: list[tuple[object, str | None, str | None]] = []
+    for tree in trees:
+        elements.extend(_ast_top_level_elements(tree))
+
+    target: str | None = None
+    index = 0
+    # Phase 1 — the unconditional leading run of simple `cd` commands.
+    while index < len(elements):
+        node, prev_op, next_op = elements[index]
+        if getattr(node, "kind", None) != "command":
+            break  # compound / pipeline / control flow: phase 2 decides
+        words = _ast_command_words(node)
+        if not words or words[0] != "cd":
+            break  # first real work — the cwd is fixed from here
+        if prev_op is not None and prev_op not in _UNCONDITIONAL_LEADING_OPS:
+            return (True, None)  # `||`-guarded or `&`-preceded
+        if next_op == "&":
+            return (True, None)  # backgrounded: the calling shell never moves
+        if len(words) != 2 or not words[1].startswith("/"):
+            # Anything we cannot pin to one absolute directory — `cd` (HOME),
+            # `cd -`, `cd -P /x`, `cd sub`, `cd "$(git rev-parse …)"`. A
+            # RELATIVE target is the sharpest of these: `cd /parent && cd
+            # child-repo` really does land in a DIFFERENT repository, so
+            # silently keeping `/parent` was itself a misroute. Refuse.
+            return (True, None)
+        target = words[1]
+        index += 1
+
+    # Phase 2 — nothing after the leading run may contain a `cd` at all.
+    for node, _prev_op, _next_op in elements[index:]:
+        if _ast_subtree_contains_cd(node):
+            return (True, None)
+    return (True, target)
+
+
+def _degraded_leading_cd_target(command: str) -> str | None:
+    """Fail-closed token-scan fallback for when bashlex is unavailable.
+
+    Mirrors the AST phase model with the only tool left: reject outright any
+    command whose shlex token stream shows control flow, a subshell, a pipeline
+    or an opaque cwd change (`_DEGRADED_CONTROL_FLOW_TOKENS`), then accept only
+    a leading run of `cd /abs` segments with no `cd` anywhere after it.
+
+    Deliberately does NOT call `normalize_command_separators` — see the
+    main#1151 ordering constraint recorded in `wave_29_scope`. Without it an
+    unspaced `cd /a;gh …` glues into one 3-token segment and is refused, which
+    is the safe direction; adding normalization here would widen this path
+    without the AST's control-flow knowledge behind it.
+    """
+    tokens = tokenize(command)
+    if tokens is None:
+        return None
+    if any(tok in _DEGRADED_CONTROL_FLOW_TOKENS for tok in tokens):
+        return None
+    target: str | None = None
+    leading = True
+    for segment in iter_command_segments(tokens):
+        is_cd = segment[0] == "cd"
+        if not is_cd:
+            leading = False
+            continue
+        if not leading:
+            return None  # a `cd` after real work — ambiguous, refuse
+        if len(segment) != 2 or not segment[1].startswith("/"):
+            return None
+        target = segment[1]
+    return target
+
+
 def extract_leading_cd_target(command: str) -> str | None:
-    """Return the directory of the last `cd <dir>` that precedes other work.
+    """Directory the shell is in when the command's first real work runs.
 
-    Walks the command's pipeline segments (see iter_command_segments) and
-    records the target of every `cd <dir>` segment, returning the last one.
-    Only honors a single-argument absolute `cd` target — relative targets
-    are ambiguous because they'd resolve against the (wrong) stdin cwd, and
-    multi-arg `cd` (e.g. `cd -P x`) is rare enough to skip rather than
-    mis-parse.
-
-    Returns None when the command does not tokenize, has no `cd`, or the
-    cd target is not an absolute path. The caller is responsible for
-    checking the path actually exists.
+    Returns the target of the last `cd <absolute-dir>` in the command's
+    UNCONDITIONAL LEADING RUN of `cd` commands, or None when there is no such
+    run or the answer cannot be established with certainty. The caller is
+    responsible for checking the path actually exists.
 
     This is the in-band recovery signal for the worktree-subagent cwd-anchor
     bug (#521): `cd /worktree && gh pr create` carries the real cwd in the
     command itself even though the harness `cwd` field points at the
     orchestrator's spawn-time directory.
 
-    Strips NOTHING — `cd` must be token 0 of its segment (main#1141 review
-    round 3). This function ROUTES: it decides which repo an action targets,
-    and three hooks on its chain WRITE (`post_wave_kickoff_comment`,
-    `auto_add_issue_to_board`, `post_label_change_wave_field_sync`), so a
-    wrong answer is an unrecoverable write into the wrong repository. Both
-    prefix families are unsafe here, for two different reasons:
+    Why the contract is this narrow
+    -------------------------------
+    This function ROUTES: it decides which repo an action targets, and three
+    hooks on its chain WRITE (`post_wave_kickoff_comment`,
+    `auto_add_issue_to_board`, `post_label_change_wave_field_sync`), so a wrong
+    answer is an unrecoverable write into the wrong repository. A `cd` is only
+    evidence of where the work runs when it is (1) unconditional, (2) executed
+    by the CURRENT shell, and (3) positioned before that work. main#1151 found
+    two families where the old last-`cd`-wins scan honoured a `cd` that was
+    none of those:
+
+      A. `true || cd /sibling ; gh issue edit 5 …` — the `cd` never runs.
+      B. `gh issue edit 5 … ; cd /sibling`        — the `cd` runs AFTER the gh.
+
+    Both are answered structurally by `_ast_leading_cd_target`, which reads the
+    bashlex AST rather than the flattened segment list. Segment-level analysis
+    cannot answer them: `iter_command_segments` has already discarded the
+    control flow, and a guarded `cd` sits at token 0 of its own segment with no
+    leader left to withhold — which is why patching leader-by-leader kept
+    producing new families. When bashlex is unavailable the degraded scan fails
+    closed on any control-flow token instead.
+
+    Strips NOTHING — `cd` must be word 0 of a top-level simple command
+    (main#1141 review round 3). Both prefix families are unsafe here:
 
     1. **Compound leaders** (`then`, `do`, `else`, `{`, `(`) guard a body that
        may not run. `if [ -f /nonexistent ]; then cd /repo-b; fi; gh issue
@@ -1087,30 +1352,20 @@ def extract_leading_cd_target(command: str) -> str | None:
     went). So `find_git_subcommand` / `find_gh_subcommand` /
     `extract_dash_c_pairs` strip everything and this function strips nothing.
 
-    Accepted cost — UNDER-recovery. A `cd` in a body that DOES run (a taken
-    `else`, a real loop iteration) is not recovered, so the caller falls back
-    to the invocation cwd. That is the pre-#1141 behaviour and it is the safe
-    direction: claiming no knowledge is recoverable, claiming the wrong
+    Accepted cost — UNDER-recovery, in every direction. None is returned for a
+    `cd` in a taken `else` or a real loop iteration, for a `cd` reached through
+    `mkdir -p /a && cd /a && gh …` (the run is no longer leading), for a
+    RELATIVE `cd` (`cd /parent && cd child-repo` — refused outright now,
+    because keeping `/parent` was itself a cross-repo misroute in a tree of
+    nested child repos), and for a pipeline sitting after the run. Each of
+    those falls back to the invocation cwd, which is the recoverable #650
+    behaviour. Claiming no knowledge is recoverable; claiming the wrong
     directory is not.
-
-    Known residual, tracked by main#1151 — NOT closed here, and not closable
-    at this layer: (a) a short-circuit `true || cd /elsewhere` puts `cd` at
-    token 0 of its own segment with no leader to withhold, and (b) this
-    function returns the LAST `cd` anywhere in the command with no positional
-    relation to the `gh` node, so `gh issue edit 5 …; cd /elsewhere`
-    misroutes. Both predate main#1141 and both need the bashlex AST
-    (`iter_command_segments_ast`) to answer "is this `cd` unconditional, and
-    does it precede the gh node?" — `iter_command_segments` has already
-    discarded the control flow by the time this loop runs.
     """
-    tokens = tokenize(command)
-    if tokens is None:
-        return None
-    target: str | None = None
-    for segment in iter_command_segments(tokens):
-        if len(segment) == 2 and segment[0] == "cd" and segment[1].startswith("/"):
-            target = segment[1]
-    return target
+    parsed, target = _ast_leading_cd_target(command)
+    if parsed:
+        return target
+    return _degraded_leading_cd_target(command)
 
 
 def resolve_invocation_cwd(input_data: dict) -> str:

--- a/.claude/hooks/_shell_parse.py
+++ b/.claude/hooks/_shell_parse.py
@@ -1113,7 +1113,8 @@ def resolve_tool_cwd(input_data: dict) -> str:
 # disqualifying, in either position.
 _UNCONDITIONAL_LEADING_OPS = frozenset({";", "&&"})
 
-# Degraded mode (no bashlex): any of these appearing as its OWN shlex token
+# Fail-closed scan (bashlex absent, OR the command did not parse — most often
+# a quoted-delimiter heredoc): any of these appearing as its OWN shlex token
 # means the command carries control flow, a subshell, a pipeline or an opaque
 # cwd change that the flat token stream cannot reason about -> return None and
 # let the caller fall back to the invocation cwd. `&&` and `;` are deliberately

--- a/.claude/hooks/no_worktree_self_delete.py
+++ b/.claude/hooks/no_worktree_self_delete.py
@@ -27,13 +27,18 @@ Matches (one or more segments in the command, split on &&, ||, ;, |):
     - `<path>` is the first non-flag argument after `remove`.
     - A leading `cd <dir>` IS honored when it names an absolute directory
       that exists on disk (#535): the cwd used for the ancestry check is the
-      last such `cd` target (last-cd-wins via `resolve_invocation_cwd`),
-      because that is where the shell will be when `git worktree remove`
-      actually runs. `cd /safe && git worktree remove <wt>` therefore ALLOWS
-      (shell moves out first) while `cd <wt> && git worktree remove <wt>`
-      BLOCKS (the self-delete). A `cd <nonexistent>` is ignored — recovery
-      falls back to the stdin `cwd`, so the guard never relaxes on a path
-      that isn't there.
+      last `cd` target of the command's UNCONDITIONAL LEADING RUN of `cd`s
+      (via `resolve_invocation_cwd`), because that is where the shell will be
+      when `git worktree remove` actually runs. `cd /safe && git worktree
+      remove <wt>` therefore ALLOWS (shell moves out first) while
+      `cd <wt> && git worktree remove <wt>` BLOCKS (the self-delete). A
+      `cd <nonexistent>` is ignored — recovery falls back to the stdin `cwd`,
+      so the guard never relaxes on a path that isn't there. A `cd` that is
+      guarded, backgrounded, nested in control flow, or positioned after the
+      `git worktree remove` is NOT honored at all (main#1151) — the resolver
+      returns None and the guard falls back to the stdin `cwd`, which is the
+      conservative direction for this hook too: it can only ever fail to
+      relax the guard, never relax it on a `cd` that did not run.
 
 Does NOT match:
     git worktree list            (no `remove` subcommand)
@@ -270,9 +275,10 @@ def check(input_data: dict) -> dict | None:
             return None
 
         # Recover the cwd the shell will actually be in when `git worktree
-        # remove` runs (#535). resolve_invocation_cwd applies last-cd-wins
-        # recovery: it returns the target of the last `cd <absolute-existing
-        # -dir>` in the command, else the stdin `cwd`, else os.getcwd().
+        # remove` runs (#535). resolve_invocation_cwd returns the target of the
+        # last `cd <absolute-existing-dir>` in the command's UNCONDITIONAL
+        # LEADING run of `cd`s (main#1151 — a guarded, backgrounded, nested or
+        # trailing `cd` is refused), else the stdin `cwd`, else os.getcwd().
         #
         # Unlike the gh-pr-create hooks — which adopt recovery to fix repo
         # IDENTITY — here recovery fixes the block/allow SAFETY verdict, and it

--- a/.claude/hooks/tests/test_no_worktree_self_delete.py
+++ b/.claude/hooks/tests/test_no_worktree_self_delete.py
@@ -233,7 +233,7 @@ class CdRecoverySafetyMatrix(unittest.TestCase):
             result = hook.check(_bash(cmd, cwd=str(f.wt_a)))
             self.assertIsNone(result)
 
-    # --- last-cd-wins ordering ---
+    # --- last-cd-wins ordering (within the UNCONDITIONAL LEADING run) ---
 
     def test_last_cd_wins_safe_then_unsafe_blocks(self) -> None:
         """POS: `cd <safe> && cd <wt_a> && remove <wt_a>` — the LAST cd lands
@@ -251,6 +251,37 @@ class CdRecoverySafetyMatrix(unittest.TestCase):
             cmd = f"cd {f.wt_a} && cd {f.parent} && git worktree remove {f.wt_a}"
             result = hook.check(_bash(cmd, cwd=str(f.wt_a)))
             self.assertIsNone(result)
+
+    # --- main#1151: a `cd` the shell does not reach before the remove ---
+
+    def test_trailing_cd_out_does_not_relax_the_guard(self) -> None:
+        """POS: `remove <wt_a> ; cd <safe>` with stdin cwd at <wt_a>.
+
+        The `cd` is positioned AFTER the remove, so the shell is still INSIDE
+        <wt_a> when `git worktree remove` runs — a real self-delete. The
+        pre-main#1151 resolver took the last `cd` anywhere in the command,
+        resolved to <safe>, and FAILED OPEN on it. This is the same defect
+        family as the gh misroutes, landing on the safety verdict instead of
+        on repo identity.
+        """
+        with _WorktreeFixture() as f:
+            cmd = f"git worktree remove {f.wt_a} ; cd {f.parent}"
+            result = hook.check(_bash(cmd, cwd=str(f.wt_a)))
+            assert result is not None, "a trailing cd must not relax the self-delete guard"
+            self.assertEqual(result["decision"], "block")
+
+    def test_short_circuit_guarded_cd_out_does_not_relax_the_guard(self) -> None:
+        """POS: `true || cd <safe> ; remove <wt_a>` with stdin cwd at <wt_a>.
+
+        `true` succeeds, so the guarded `cd` never runs and the shell is still
+        inside <wt_a>. The old scan honoured it (the `||` split put `cd` at
+        token 0 of its own segment) and allowed the self-delete.
+        """
+        with _WorktreeFixture() as f:
+            cmd = f"true || cd {f.parent} ; git worktree remove {f.wt_a}"
+            result = hook.check(_bash(cmd, cwd=str(f.wt_a)))
+            assert result is not None, "a guarded cd must not relax the self-delete guard"
+            self.assertEqual(result["decision"], "block")
 
     # --- recovery must not RELAX the guard on a path that isn't there ---
 

--- a/.claude/hooks/tests/test_shell_parse.py
+++ b/.claude/hooks/tests/test_shell_parse.py
@@ -6,8 +6,8 @@ find_git_subcommand, find_gh_subcommand, extract_dash_c_pairs,
 resolve_tool_cwd, is_shutdown_request_message) and the negative-match
 fixtures from the sibling-bug cluster (#226 #227 #223 #216 #188 #189 #144).
 
-Shell-truth tests, and their one known limit (main#1141 review)
-==============================================================
+Shell-truth tests (main#1141 review; oracle widened to both shells in #1151)
+===========================================================================
 
 `CdRoutingAgainstShellTruth` does not compare the resolver to an expected
 literal — it runs each shape in a REAL shell and takes the resulting cwd as
@@ -18,16 +18,19 @@ someone's belief about it). Two families of main#1151 survived this suite for
 exactly that reason, and the method caught a round-3 test of mine that pinned a
 misroute as correct.
 
-**Limit — the oracle is `bash`, the harness shell is `zsh`.** Constructs are
-driven through `bash -c` for determinism and because CI runs bash. For every
-shape asserted here the two shells agree, and the load-bearing fact (an
-exec-wrapper cannot carry the `cd` BUILTIN, so `env FOO=1 cd /x` leaves the
-shell where it was) was checked in BOTH before the resolver was written to
-depend on it. One construct is known to differ and is therefore deliberately
-NOT relied on anywhere: `command cd /x` moves the shell in bash but not in
-zsh. If a future shape's behaviour is shell-dependent, verify it in both and
-either assert the common subset or leave it out — do not let a bash-only truth
-become a resolver invariant.
+**The oracle is BOTH `bash` and `zsh` (`SHELLS`).** main#1141 ran bash only —
+CI's shell — and documented the gap in prose. main#1151 closes it: every shape
+is executed under both, and the safety property is
+
+    resolved is None  OR  resolved == truth(bash) == truth(zsh)
+
+so a shape whose behaviour is shell-DEPENDENT can no longer be adopted as a
+resolver invariant by passing under bash alone. `command cd /x` is the known
+divergence (bash moves the shell, zsh does not); the resolver claims nothing
+for it, pinned by `test_shell_dependent_shape_is_not_relied_on`. The other
+load-bearing facts — an exec-wrapper cannot carry the `cd` BUILTIN, and a
+one-shot `FOO=1` prefix does NOT stop `cd` from moving the shell — are
+asserted in both shells rather than trusted.
 
 Run: ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/test_shell_parse.py -v
 """
@@ -1002,47 +1005,79 @@ class CdRoutingAgainstShellTruth(unittest.TestCase):
 
     MARKER = "gh issue edit 5 --add-label wave-29"
 
+    # Both shells are exercised for every shape (main#1151). `bash` is what CI
+    # runs; `zsh` is the actual harness shell the hooks see commands from. A
+    # shape whose truth DIFFERS between them has no single answer and the
+    # resolver must claim nothing for it — see
+    # `test_shell_dependent_shape_is_not_relied_on`.
+    #
+    # `zsh` is INSTALLED by the CI pytest job so both halves really run there;
+    # the `which` filter exists only so a bare checkout without zsh degrades to
+    # the bash-only oracle instead of erroring. It must never be the reason CI
+    # is green — if the CI install step is dropped, this silently narrows.
+    SHELLS = tuple(s for s in ("bash", "zsh") if shutil.which(s))
+
     _start: str
     _dest: str
+    _nested: str
 
     @classmethod
     def setUpClass(cls) -> None:
         cls._start = tempfile.mkdtemp(prefix="cdroute-start-")
         cls._dest = tempfile.mkdtemp(prefix="cdroute-dest-")
+        # A real subdirectory of _start, standing in for the org's nested
+        # child repos (`noorinalabs-main/noorinalabs-deploy/`): `cd START &&
+        # cd NESTED` lands in a DIFFERENT repository than START.
+        cls._nested = os.path.join(cls._start, "child-repo")
+        os.makedirs(cls._nested, exist_ok=True)
 
     @classmethod
     def tearDownClass(cls) -> None:
         for d in (cls._start, cls._dest):
             shutil.rmtree(d, ignore_errors=True)
 
-    def _shell_truth(self, template: str) -> str | None:
+    def _expand(self, template: str, marker: str) -> str:
+        return (
+            template.replace("DEST", self._dest)
+            .replace("START", self._start)
+            .replace("NESTED", "child-repo")
+            .replace("MARKER", marker)
+        )
+
+    def _shell_truth(self, template: str, shell: str = "bash") -> str | None:
         """Directory the shell is actually in where the gh node sits.
 
         None means the gh node never executes at all in that shape.
         """
-        cmd = template.replace("DEST", self._dest).replace("MARKER", "pwd")
+        cmd = self._expand(template, "pwd")
         out = subprocess.run(
-            ["bash", "-c", cmd], cwd=self._start, capture_output=True, text=True, timeout=30
+            [shell, "-c", cmd], cwd=self._start, capture_output=True, text=True, timeout=30
         )
         printed = out.stdout.strip().splitlines()
         return printed[-1] if printed else None
 
     def _resolved(self, template: str) -> str | None:
-        return sp.extract_leading_cd_target(
-            template.replace("DEST", self._dest).replace("MARKER", self.MARKER)
-        )
+        return sp.extract_leading_cd_target(self._expand(template, self.MARKER))
 
     def _assert_never_misroutes(self, template: str) -> None:
-        truth = self._shell_truth(template)
+        """THE safety property, checked against BOTH shells.
+
+            resolved is None  OR  resolved == shell_truth(bash) == shell_truth(zsh)
+
+        Under-recovery is accepted; naming a directory the command never
+        entered — in EITHER shell — is the bug.
+        """
         resolved = self._resolved(template)
         if resolved is None:
             return  # under-recovery: caller falls back to the invocation cwd
-        self.assertEqual(
-            resolved,
-            truth,
-            f"resolver claims {resolved!r} but the shell runs the gh node in "
-            f"{truth!r} for: {template}",
-        )
+        for shell in self.SHELLS:
+            truth = self._shell_truth(template, shell)
+            self.assertEqual(
+                resolved,
+                truth,
+                f"resolver claims {resolved!r} but {shell} runs the gh node in "
+                f"{truth!r} for: {template}",
+            )
 
     # --- all seven leader shapes from the review, plus the brace group ---
 
@@ -1098,13 +1133,21 @@ class CdRoutingAgainstShellTruth(unittest.TestCase):
     def test_shell_dependent_shape_is_not_relied_on(self) -> None:
         """`command cd /x` moves the shell in bash but NOT in zsh.
 
-        The harness shell is zsh and the oracle here is bash, so this shape has
-        no single truth. The resolver must therefore claim nothing for it —
-        which it does for free, since it strips no prefixes at all. Pinned so a
-        future widening cannot quietly adopt a bash-only behaviour as an
-        invariant (module docstring § Shell-truth tests).
+        The harness shell is zsh, so this shape has no single truth. The
+        resolver must therefore claim nothing for it — which it does for free,
+        since it strips no prefixes at all. Pinned so a future widening cannot
+        quietly adopt a bash-only behaviour as an invariant (module docstring
+        § Shell-truth tests).
+
+        main#1151 asserts the DIVERGENCE itself rather than only asserting the
+        resolver's silence: if the two shells ever converge, the reason this
+        shape is excluded has changed and someone should re-decide it here.
         """
-        self.assertIsNone(self._resolved("command cd DEST ; MARKER"))
+        template = "command cd DEST ; MARKER"
+        self.assertIsNone(self._resolved(template))
+        if "zsh" in self.SHELLS:
+            self.assertEqual(self._shell_truth(template, "bash"), self._dest)
+            self.assertEqual(self._shell_truth(template, "zsh"), self._start)
 
     # --- the shapes that MUST still resolve ---
 
@@ -1143,42 +1186,155 @@ class CdRoutingAgainstShellTruth(unittest.TestCase):
         self.assertEqual(sp.strip_command_prefixes(seg), ["cd", "/tmp"])
         self.assertEqual(sp.strip_command_prefixes(seg, compound_leaders=False), seg)
 
-    # --- known, tracked, NOT closed here ---
+    # --- main#1151: the two families, now CLOSED by the bashlex-AST scan ---
+    #
+    # These were `KNOWN_GAP_SHAPES` / `test_known_gap_main_1151_still_misroutes`,
+    # a characterization test that PINNED the misroute so the gap stayed visible
+    # in the suite. Its own instruction on closure was "delete this test and fold
+    # the shape into test_leader_shapes_never_misroute" — done, with the
+    # explicit-None assertions below kept so a regression names the family it
+    # reopened rather than surfacing as a generic misroute.
 
-    KNOWN_GAP_SHAPES = [
-        "true || cd DEST ; MARKER",  # family A: no leader token to withhold
-        "MARKER ; cd DEST",  # family B: cd AFTER the gh node
+    FAMILY_A_SHAPES = [
+        # A `cd` guarded by a short-circuit operator. `iter_command_segments`
+        # splits on `||`, so the `cd` is at token 0 of its own segment and NO
+        # leader-stripping rule could ever reach it — the reason this needed the
+        # AST rather than another entry in `_COMPOUND_LEADERS`.
+        "true || cd DEST ; MARKER",
+        "true || cd DEST && MARKER",
+        # The braced variant never misrouted (the `{` made it a 3-token
+        # segment). Kept adjacent so the two are not confused again: repairing
+        # the braced shape proves nothing about family A.
+        "true || { cd DEST ; } ; MARKER",
+        # `&&` after a FAILING command is the same class in the other polarity.
+        "false && cd DEST ; MARKER",
     ]
 
-    def test_known_gap_main_1151_still_misroutes(self) -> None:
-        """Characterization of the residual class — NOT a blessing of it.
+    FAMILY_B_SHAPES = [
+        # A `cd` positioned AFTER the gh node. Despite the resolver's name the
+        # old scan took the LAST match with no positional relation to the work.
+        "MARKER ; cd DEST",
+        "MARKER && cd DEST",
+        "cd START ; MARKER ; cd DEST",
+        # A `cd` inside a brace GROUP after the run — not a subshell, so it
+        # genuinely applies to the gh node beside it.
+        "cd DEST && { cd START ; MARKER ; }",
+    ]
 
-        Both shapes misroute on `95f375a` and on every head since; they
-        predate main#1141 and are untouched by it. Neither is fixable at this
-        layer: family A has no leader to withhold, and family B needs to know
-        whether the `cd` precedes the `gh` NODE, which `iter_command_segments`
-        has already discarded. main#1151 tracks the bashlex-AST fix.
-
-        Family A is narrower than it looks, and the difference is easy to
-        mistake for a fix: the BRACED variant `true || { cd DEST ; … }` does
-        NOT misroute, because the `{` makes that segment three tokens and the
-        `cd` is no longer at token 0 (it is covered by
-        `test_leader_shapes_never_misroute`). Only the BARE `true || cd DEST`
-        form gets through. So repairing the braced shape proves nothing about
-        family A — do not read it as evidence that #1151 is closed.
-
-        This test exists so the gap is visible in the suite rather than only
-        in prose, and so closing #1151 forces someone to come back here.
-        """
-        for template in self.KNOWN_GAP_SHAPES:
+    def test_family_a_short_circuit_cd_never_misroutes(self) -> None:
+        for template in self.FAMILY_A_SHAPES:
             with self.subTest(shape=template):
-                self.assertEqual(self._shell_truth(template), self._start)
-                self.assertEqual(
+                self._assert_never_misroutes(template)
+                self.assertIsNone(
                     self._resolved(template),
-                    self._dest,
-                    "if this now returns None, #1151 has been fixed — delete this "
-                    "test and fold the shape into test_leader_shapes_never_misroute",
+                    "main#1151 family A: a short-circuit-guarded `cd` must never route",
                 )
+
+    def test_family_b_trailing_cd_never_misroutes(self) -> None:
+        for template in self.FAMILY_B_SHAPES:
+            with self.subTest(shape=template):
+                self._assert_never_misroutes(template)
+                self.assertIsNone(
+                    self._resolved(template),
+                    "main#1151 family B: a `cd` at/after the routed command must never route",
+                )
+
+    def test_family_a_and_b_shell_truth_is_the_start_dir(self) -> None:
+        """The fact the fix rests on, asserted against BOTH shells directly.
+
+        For every family-A shape the guarded `cd` does not run; for every
+        family-B shape the `cd` runs only after the gh node. Either way the gh
+        node executes in the ORIGINAL directory — so the old resolver's answer
+        (`DEST`) named a directory the command had not entered.
+        """
+        for template in self.FAMILY_A_SHAPES + self.FAMILY_B_SHAPES:
+            if template.startswith("cd START") or template.startswith("cd DEST"):
+                continue  # these two legitimately move first; covered above
+            for shell in self.SHELLS:
+                with self.subTest(shape=template, shell=shell):
+                    self.assertEqual(self._shell_truth(template, shell), self._start)
+
+    # --- main#1151 family C: a RELATIVE `cd` into a nested child repo ---
+
+    def test_relative_cd_into_nested_repo_never_misroutes(self) -> None:
+        """`cd /parent && cd child-repo` lands in a DIFFERENT repository.
+
+        The old scan skipped the relative leg and kept `/parent`, which in this
+        org's tree (child repos cloned beneath `noorinalabs-main/`) resolves
+        `origin` to the PARENT repo — a cross-repo misroute on a shape that
+        looks entirely innocent. The resolver now refuses the whole run rather
+        than keeping a stale absolute prefix.
+        """
+        template = "cd START && cd NESTED && MARKER"
+        for shell in self.SHELLS:
+            with self.subTest(shell=shell):
+                self.assertEqual(self._shell_truth(template, shell), self._nested)
+        self._assert_never_misroutes(template)
+        self.assertIsNone(self._resolved(template))
+
+    # --- backgrounded / pipelined `cd` cannot move the calling shell ---
+
+    SUBSHELL_SHAPES = [
+        "cd DEST & MARKER",
+        "cd DEST | cat ; MARKER",
+    ]
+
+    def test_backgrounded_or_pipelined_cd_never_misroutes(self) -> None:
+        for template in self.SUBSHELL_SHAPES:
+            with self.subTest(shape=template):
+                self._assert_never_misroutes(template)
+                self.assertIsNone(self._resolved(template))
+
+    # --- shapes that MUST keep resolving, verified against both shells ---
+
+    STILL_RESOLVING_SHAPES = [
+        "cd DEST && MARKER",
+        "cd DEST ; MARKER",
+        "cd /var && cd DEST && MARKER",
+        "cd DEST ; MARKER ; true",  # trailing work with no `cd` is harmless
+        "cd DEST > /dev/null && MARKER",  # a redirect is not a wrapper
+        "FOO=1 cd DEST && MARKER",  # one-shot assignment; `cd` is still a builtin
+        "cd DEST && MARKER | cat",  # a pipeline cannot move the calling shell
+    ]
+
+    def test_unconditional_leading_cd_still_resolves_to_shell_truth(self) -> None:
+        for template in self.STILL_RESOLVING_SHAPES:
+            with self.subTest(shape=template):
+                resolved = self._resolved(template)
+                self.assertEqual(resolved, self._dest, f"lost the #521 recovery for: {template}")
+                for shell in self.SHELLS:
+                    self.assertEqual(resolved, self._shell_truth(template, shell))
+
+    # --- degraded mode: no bashlex, so fail closed on control flow ---
+
+    def _resolved_degraded(self, template: str) -> str | None:
+        original = sp._BASHLEX_AVAILABLE
+        sp._BASHLEX_AVAILABLE = False
+        try:
+            return sp.extract_leading_cd_target(self._expand(template, self.MARKER))
+        finally:
+            sp._BASHLEX_AVAILABLE = original
+
+    def test_degraded_mode_fails_closed_on_both_families(self) -> None:
+        """Without bashlex the fallback refuses anything carrying control flow.
+
+        The availability gate sits OUTSIDE the memo, so monkeypatching it here
+        cannot be served a cached AST answer.
+        """
+        for template in self.FAMILY_A_SHAPES + self.FAMILY_B_SHAPES + self.SUBSHELL_SHAPES:
+            with self.subTest(shape=template):
+                self.assertIsNone(self._resolved_degraded(template))
+
+    def test_degraded_mode_keeps_the_521_recovery(self) -> None:
+        """`&&`/`;` are the separators of the leading run itself, not control flow.
+
+        Fail-closed must not mean "refuse every command with an `&&`" — that
+        would delete `cd /worktree && gh pr create`, the shape this resolver
+        exists for.
+        """
+        for template in ("cd DEST && MARKER", "cd DEST ; MARKER", "cd /var && cd DEST && MARKER"):
+            with self.subTest(shape=template):
+                self.assertEqual(self._resolved_degraded(template), self._dest)
 
 
 if __name__ == "__main__":

--- a/.claude/hooks/tests/test_shell_parse.py
+++ b/.claude/hooks/tests/test_shell_parse.py
@@ -1337,5 +1337,159 @@ class CdRoutingAgainstShellTruth(unittest.TestCase):
                 self.assertEqual(self._resolved_degraded(template), self._dest)
 
 
+class CdRoutingWhenBashlexCannotParse(unittest.TestCase):
+    """The AST is NOT the sole mechanism — `<<'EOF'` does not parse at all.
+
+    main#1152 (Weronika Zielinska) established, against the INSTALLED bashlex,
+    that a QUOTED-delimiter heredoc raises `ParsingError`:
+
+        bashlex.parse("cat <<'EOF'\\nx\\nEOF\\n")
+        -> ParsingError: here-document ... delimited by end-of-file
+
+    `<<'EOF'` / `<<"EOF"` fail; only the bare `<<EOF` / `<<-EOF` forms parse.
+    That matters here more than anywhere else in the module, because the quoted
+    form is the DOMINANT one in this repo (`python3 - <<'PY'`, `gh issue
+    comment --body-file - <<'EOF'`) — so the commands most likely to carry a
+    `cd` are exactly the ones the AST cannot see. `bashlex_available()` stays
+    True (it only reports import success), and `iter_command_segments_ast`
+    returns the same `None` it uses for "bashlex absent", so a caller that
+    treats `None` as "fall back to the old shlex scan" degrades SILENTLY — an
+    AST-only fix would have reported success and changed nothing on precisely
+    these commands.
+
+    It does not, and this class is the evidence. The fallback is not the old
+    last-`cd`-wins scan; it is the issue's fix direction 2 (fail closed on
+    control flow), which makes the two mechanisms CO-PRIMARY rather than
+    primary-and-safety-net. Every shape below forces the ParsingError and is
+    checked against real bash and zsh.
+    """
+
+    GH = "gh issue comment 5 --body-file -"
+    SHELLS = tuple(s for s in ("bash", "zsh") if shutil.which(s))
+
+    _start: str
+    _dest: str
+    _nested: str
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls._start = tempfile.mkdtemp(prefix="cdhd-start-")
+        cls._dest = tempfile.mkdtemp(prefix="cdhd-dest-")
+        cls._nested = os.path.join(cls._start, "child-repo")
+        os.makedirs(cls._nested, exist_ok=True)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        for d in (cls._start, cls._dest):
+            shutil.rmtree(d, ignore_errors=True)
+
+    def _expand(self, template: str) -> str:
+        return (
+            template.replace("DEST", self._dest)
+            .replace("START", self._start)
+            .replace("NESTED", "child-repo")
+            .replace("GH", self.GH)
+        )
+
+    def _assert_does_not_parse(self, template: str) -> None:
+        """Every shape here must really exercise the fallback, not the AST."""
+        parsed, _ = sp._ast_leading_cd_target(self._expand(template))
+        self.assertFalse(
+            parsed,
+            f"shape no longer forces the bashlex ParsingError, so it stops "
+            f"testing the fallback path: {template}",
+        )
+
+    def _resolved(self, template: str) -> str | None:
+        return sp.extract_leading_cd_target(self._expand(template))
+
+    def _shell_truth(self, template: str, shell: str) -> str | None:
+        """cwd where the gh node sits. `pwd` goes to stderr so the heredoc
+        body (which `cat` sends to stdout) cannot be mistaken for it."""
+        cmd = self._expand(template).replace(self.GH, "pwd >&2 ; cat")
+        out = subprocess.run(
+            [shell, "-c", cmd], cwd=self._start, capture_output=True, text=True, timeout=30
+        )
+        printed = out.stderr.strip().splitlines()
+        return printed[-1] if printed else None
+
+    def _assert_never_misroutes(self, template: str) -> None:
+        self._assert_does_not_parse(template)
+        resolved = self._resolved(template)
+        if resolved is None:
+            return
+        for shell in self.SHELLS:
+            self.assertEqual(resolved, self._shell_truth(template, shell), f"for: {template}")
+
+    def test_quoted_delimiter_heredoc_really_does_not_parse(self) -> None:
+        """The premise, asserted against the installed bashlex, not from docs."""
+        if not sp.bashlex_available():
+            self.skipTest("bashlex not installed")
+        for body in ("cat <<'EOF'\nx\nEOF\n", 'cat <<"EOF"\nx\nEOF\n'):
+            with self.subTest(form=body.splitlines()[0]):
+                with self.assertRaises(Exception):
+                    sp.bashlex.parse(body)
+        for body in ("cat <<EOF\nx\nEOF\n", "cat <<-EOF\nx\nEOF\n"):
+            with self.subTest(form=body.splitlines()[0]):
+                sp.bashlex.parse(body)  # bare forms DO parse
+
+    def test_bashlex_available_is_not_evidence_the_command_parsed(self) -> None:
+        """The trap: the flag reports IMPORT success, not per-command success."""
+        if not sp.bashlex_available():
+            self.skipTest("bashlex not installed")
+        cmd = "cat <<'EOF'\nx\nEOF\n"
+        self.assertTrue(sp.bashlex_available())
+        self.assertIsNone(sp.iter_command_segments_ast(cmd))
+        self.assertEqual(sp._ast_leading_cd_target(cmd), (False, None))
+
+    FAMILY_SHAPES = [
+        # A — short-circuit-guarded `cd`, alongside a quoted heredoc.
+        "true || cd DEST ; GH <<'EOF'\nhello\nEOF\n",
+        # B — `cd` positioned after the gh node.
+        "GH <<'EOF'\nhello\nEOF\ncd DEST\n",
+        # C — relative leg into a nested child repo.
+        "cd START && cd NESTED && GH <<'EOF'\nhi\nEOF\n",
+    ]
+
+    def test_families_stay_closed_on_the_fallback_path(self) -> None:
+        for template in self.FAMILY_SHAPES:
+            with self.subTest(shape=template):
+                self._assert_never_misroutes(template)
+                self.assertIsNone(
+                    self._resolved(template),
+                    "a family shape must not route just because bashlex could "
+                    "not parse the heredoc that came with it",
+                )
+
+    ADVERSARIAL_BODY_SHAPES = [
+        # Can an UNSTRIPPED heredoc BODY inject a `cd` the token scan mistakes
+        # for a leading, unconditional one? It cannot: a body always follows
+        # its command, so its tokens are never in the leading position.
+        "cat <<'EOF'\n; cd DEST\nEOF\nGH",
+        "cd /var && cat <<'EOF'\n; cd DEST\nEOF\nGH",
+        "GH <<'EOF'\ncd DEST\nEOF\n",
+        "GH <<'EOF'\ntrue || cd DEST\nEOF\n",
+        "cd DEST && GH <<'EOF'\n; cd /var\nEOF\n",
+    ]
+
+    def test_heredoc_body_cannot_inject_a_route(self) -> None:
+        for template in self.ADVERSARIAL_BODY_SHAPES:
+            with self.subTest(shape=template):
+                self._assert_never_misroutes(template)
+
+    def test_genuine_recovery_survives_the_fallback(self) -> None:
+        """Fail-closed must not mean "refuse every command with a heredoc".
+
+        `cd /worktree && gh issue comment … <<'EOF'` is an ordinary shape and
+        still resolves — the fallback keeps `;`/`&&` as leading-run separators.
+        """
+        template = "cd DEST && GH <<'EOF'\nhello\nEOF\n"
+        self._assert_does_not_parse(template)
+        resolved = self._resolved(template)
+        self.assertEqual(resolved, self._dest)
+        for shell in self.SHELLS:
+            self.assertEqual(resolved, self._shell_truth(template, shell))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.claude/hooks/tests/test_shell_parse.py
+++ b/.claude/hooks/tests/test_shell_parse.py
@@ -1020,26 +1020,36 @@ class CdRoutingAgainstShellTruth(unittest.TestCase):
     _start: str
     _dest: str
     _nested: str
+    _other: str
+    _script: str
 
     @classmethod
     def setUpClass(cls) -> None:
         cls._start = tempfile.mkdtemp(prefix="cdroute-start-")
         cls._dest = tempfile.mkdtemp(prefix="cdroute-dest-")
+        cls._other = tempfile.mkdtemp(prefix="cdroute-other-")
         # A real subdirectory of _start, standing in for the org's nested
         # child repos (`noorinalabs-main/noorinalabs-deploy/`): `cd START &&
         # cd NESTED` lands in a DIFFERENT repository than START.
         cls._nested = os.path.join(cls._start, "child-repo")
         os.makedirs(cls._nested, exist_ok=True)
+        # A sourceable script that moves the shell without the command line
+        # ever containing the token `cd`.
+        cls._script = os.path.join(cls._start, "goto.sh")
+        with open(cls._script, "w", encoding="utf-8") as fh:
+            fh.write(f"cd {cls._other}\n")
 
     @classmethod
     def tearDownClass(cls) -> None:
-        for d in (cls._start, cls._dest):
+        for d in (cls._start, cls._dest, cls._other):
             shutil.rmtree(d, ignore_errors=True)
 
     def _expand(self, template: str, marker: str) -> str:
         return (
             template.replace("DEST", self._dest)
             .replace("START", self._start)
+            .replace("OTHER", self._other)
+            .replace("SCRIPT", self._script)
             .replace("NESTED", "child-repo")
             .replace("MARKER", marker)
         )
@@ -1208,6 +1218,14 @@ class CdRoutingAgainstShellTruth(unittest.TestCase):
         "true || { cd DEST ; } ; MARKER",
         # `&&` after a FAILING command is the same class in the other polarity.
         "false && cd DEST ; MARKER",
+        # LEADING element is itself a `cd`, so phase 1's `prev_op` guard — not
+        # phase 2 — is what closes these. Without such a shape that guard is
+        # INERT: every other family-A fixture breaks out of phase 1 at `true`
+        # before the guard is reached, so deleting it left the suite green
+        # while `cd A || cd B && gh` reopened a real misroute to B (#1156
+        # merge gate). `cd START` succeeds, so `cd DEST` never runs.
+        "cd START || cd DEST && MARKER",
+        "cd START || cd DEST ; MARKER",
     ]
 
     FAMILY_B_SHAPES = [
@@ -1246,10 +1264,12 @@ class CdRoutingAgainstShellTruth(unittest.TestCase):
         family-B shape the `cd` runs only after the gh node. Either way the gh
         node executes in the ORIGINAL directory — so the old resolver's answer
         (`DEST`) named a directory the command had not entered.
+
+        Every shape is asserted, with no skip list: the shapes whose leading
+        element really is a `cd` all `cd START`, which IS the original
+        directory, so they belong here rather than in an exemption.
         """
         for template in self.FAMILY_A_SHAPES + self.FAMILY_B_SHAPES:
-            if template.startswith("cd START") or template.startswith("cd DEST"):
-                continue  # these two legitimately move first; covered above
             for shell in self.SHELLS:
                 with self.subTest(shape=template, shell=shell):
                     self.assertEqual(self._shell_truth(template, shell), self._start)
@@ -1271,6 +1291,75 @@ class CdRoutingAgainstShellTruth(unittest.TestCase):
                 self.assertEqual(self._shell_truth(template, shell), self._nested)
         self._assert_never_misroutes(template)
         self.assertIsNone(self._resolved(template))
+
+    # --- a cwd move that is not spelled `cd`, AFTER the leading run ---
+
+    CWD_MOVING_BUILTIN_SHAPES = [
+        "cd DEST && pushd OTHER > /dev/null && MARKER",
+        "cd DEST ; pushd OTHER > /dev/null ; MARKER",
+        "cd DEST && eval 'cd OTHER' && MARKER",
+        "cd DEST && . SCRIPT && MARKER",
+        "cd DEST && source SCRIPT && MARKER",
+    ]
+
+    def test_cwd_moving_builtin_after_the_run_never_misroutes(self) -> None:
+        """`pushd`/`eval`/`source`/`.` move the shell without the token `cd`.
+
+        Found at the #1156 merge gate. A leading `cd` is only evidence of where
+        the work runs if nothing between it and the work moves the shell again;
+        keying phase 2 on `words[0] == "cd"` alone missed every one of these and
+        returned the stale leading target. `OTHER` is a real directory, so
+        `resolve_invocation_cwd`'s `isdir` guard does not catch it either.
+
+        This was not an open frontier — it was DRIFT. The degraded token scan
+        already refused all of them, so the AST path was strictly weaker than
+        its own co-primary fallback. `test_both_paths_agree_on_cwd_moving_builtins`
+        is what stops that recurring.
+        """
+        for template in self.CWD_MOVING_BUILTIN_SHAPES:
+            with self.subTest(shape=template):
+                for shell in self.SHELLS:
+                    self.assertEqual(
+                        self._shell_truth(template, shell),
+                        self._other,
+                        f"{shell} should end up in OTHER for: {template}",
+                    )
+                self._assert_never_misroutes(template)
+                self.assertIsNone(self._resolved(template))
+
+    def test_popd_after_the_run_never_misroutes(self) -> None:
+        """`popd` returns to DEST, so the truth here happens to match the stale
+        answer — which is exactly why it must not be trusted. Refused anyway."""
+        template = "cd DEST && pushd OTHER > /dev/null && popd > /dev/null && MARKER"
+        for shell in self.SHELLS:
+            self.assertEqual(self._shell_truth(template, shell), self._dest)
+        self.assertIsNone(self._resolved(template))
+
+    def test_exec_after_the_run_never_misroutes(self) -> None:
+        """`exec` cannot carry a `cd`, but it REPLACES the shell — the routed
+        command never runs at all, so claiming a directory for it is meaningless."""
+        self.assertIsNone(self._resolved("cd DEST && exec -a x true ; MARKER"))
+
+    def test_both_paths_agree_on_cwd_moving_builtins(self) -> None:
+        """The anti-drift check: AST and degraded must refuse the SAME shapes.
+
+        The #1156 defect was two mechanisms with independently maintained
+        lists. Both now derive from `_CWD_MOVING_COMMANDS`, and this asserts
+        the property rather than the shared constant, so a future split that
+        re-introduces per-path lists fails here.
+        """
+        for template in self.CWD_MOVING_BUILTIN_SHAPES:
+            with self.subTest(shape=template):
+                self.assertEqual(
+                    self._resolved(template),
+                    self._resolved_degraded(template),
+                    "the AST path must never be weaker than its own fallback",
+                )
+
+    def test_cwd_moving_commands_feeds_the_degraded_token_set(self) -> None:
+        """One source of truth, asserted structurally as well as behaviourally."""
+        self.assertTrue(sp._CWD_MOVING_COMMANDS <= sp._DEGRADED_CONTROL_FLOW_TOKENS)
+        self.assertNotIn("cd", sp._DEGRADED_CONTROL_FLOW_TOKENS)
 
     # --- backgrounded / pipelined `cd` cannot move the calling shell ---
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,16 @@ jobs:
       # ENFORCED structural Bash-AST parse path (the bashlex-specific cases
       # skip when it is absent; this install makes CI run them, not skip them).
       - run: pip install pytest pyyaml bashlex
+      # zsh (main#1151): `CdRoutingAgainstShellTruth` runs every `cd`-routing
+      # shape in a REAL shell and takes the resulting cwd as ground truth. The
+      # org's harness shell is zsh, not bash, and at least one construct
+      # (`command cd /x`) genuinely differs between them — so a bash-only
+      # oracle can adopt a bash-only behaviour as a resolver invariant. The
+      # runner image ships bash but not zsh; install it so the zsh half of the
+      # oracle RUNS in CI rather than skipping (the tests skip gracefully on a
+      # bare checkout without it).
+      - name: Install zsh (second shell-truth oracle)
+        run: sudo apt-get update && sudo apt-get install -y zsh
       - name: Run hook and lib tests
         run: pytest .claude/hooks/tests/ .claude/lib/tests/ -q
       # .claude/skills/*/tests/ added per #326. Run PER-SKILL (each from its own


### PR DESCRIPTION
Closes #1151.

## What was wrong

`extract_leading_cd_target` decides which GitHub repo eight hooks read and **three hooks write** to. It took the **last `cd /abs` pair anywhere in the flat segment list**, which checks none of the three properties that actually make a `cd` honourable:

1. **unconditional** — not guarded by `||`, not inside `if`/`while`/`for`/`case`
2. **in the current shell** — not in a subshell, pipeline, `&` job, or command substitution
3. **before the work** — positioned ahead of the command being routed

## Families closed

| # | Shape | Old result | New result | Shell truth (bash + zsh) |
|---|---|---|---|---|
| **A** | `true \|\| cd <sibling> ; gh issue edit 5 …` | `<sibling>` | `None` | start dir |
| **A** | `false && cd <sibling> ; gh issue edit 5 …` | `<sibling>` | `None` | start dir |
| **B** | `gh issue edit 5 … ; cd <sibling>` | `<sibling>` | `None` | start dir |
| **B** | `gh issue edit 5 … && cd <sibling>` | `<sibling>` | `None` | start dir |
| **B** | `cd /a && { cd <sibling> ; gh x ; }` | `<sibling>` | `None` | `<sibling>` (ambiguous → refused) |
| **C** | `cd /parent && cd child-repo && gh …` | `/parent` | `None` | `/parent/child-repo` |

**Family C was not in the issue.** It fell out of the same rule and is the sharpest of the three for this org specifically: the old scan silently skipped the relative leg and kept the stale absolute prefix, so `cd /noorinalabs-main && cd noorinalabs-deploy && gh issue create` resolved `origin` to the **parent** repo. Child repos are cloned beneath `noorinalabs-main/`, so the `os.path.isdir` guard does not catch it. Relative legs are now refused outright.

## How — two CO-PRIMARY mechanisms, not one

**Fix direction 1, the AST**, is the main vehicle: `_ast_leading_cd_target` walks only the **top-level** command list of the bashlex parse and honours a `cd` solely inside the unconditional leading run; anything after that run containing a `cd` at all makes the answer ambiguous and returns `None`. Segment-level analysis provably cannot answer this — `iter_command_segments` has already discarded the control flow, and a guarded `cd` sits at token 0 of its own segment with no leader left to withhold, which is exactly why patching leader-by-leader kept producing new families.

**But the AST cannot be the SOLE mechanism**, and that is a change from the brief. Weronika's #1152 found — and I re-verified against the installed bashlex, not from docs — that a quoted-delimiter heredoc does not parse at all:

```
bashlex.parse("cat <<'EOF'\nx\nEOF\n")  -> ParsingError: here-document ... delimited by end-of-file
bashlex.parse('cat <<"EOF"\nx\nEOF\n')  -> ParsingError
bashlex.parse("cat <<EOF\nx\nEOF\n")    -> OK       (bare and <<- forms parse)
```

`<<'EOF'` is this repo's dominant heredoc form (`python3 - <<'PY'`, `gh issue comment --body-file - <<'EOF'`), so **the commands most likely to carry a `cd` are exactly the ones the AST cannot see.** And the failure is silent: `bashlex_available()` reports *import* success, not per-command success, and `iter_command_segments_ast` returns the same `None` it uses for "bashlex absent". A caller treating that `None` as "fall back to the old shlex scan" would report success and change nothing on precisely those commands.

**This resolver does not do that.** Its fallback is the issue's **fix direction 2** — fail closed on any control-flow token — so the families stay closed with no AST at all. Measured:

| shape (with `<<'EOF'` attached) | bashlex | old scan | this PR | bash | zsh |
|---|---|---|---|---|---|
| `true \|\| cd <dest> ; gh … <<'EOF'…EOF` | **ParsingError** | `<dest>` | `None` | start | start |
| `gh … <<'EOF'…EOF` + `cd <dest>` | **ParsingError** | `None`\* | `None` | start | start |
| `cd <start> && cd child-repo && gh … <<'EOF'…EOF` | **ParsingError** | `<start>` | `None` | `<start>/child-repo` | `<start>/child-repo` |
| `cd <dest> && gh … <<'EOF'…EOF` (genuine) | **ParsingError** | `<dest>` | `<dest>` | `<dest>` | `<dest>` |

\* only by accident — the missing `normalize_command_separators()` glues the trailing `;`, the same accident the ordering constraint warns about.

`;` and `&&` are deliberately **not** in the fail-closed token set — they are the separators of the leading run itself, and dropping them would delete `cd /worktree && gh pr create`, the #521 recovery this resolver exists for. Heredoc **bodies** are deliberately not stripped either: a body always follows its command, so its tokens can never occupy the leading position, and any `cd` they contribute lands in the non-leading phase and forces `None`. Unstripped bodies can only cost recovery, never buy a route — five adversarial shapes pin that.

The asymmetry is #1141's, restated: **under-detecting degrades to the recoverable #650 invocation-cwd fallback; over-detecting writes into the wrong repository, which no retry undoes.**

## Ordering constraint honoured

This does **not** add `normalize_command_separators()` to the routing path — see `wave_29_scope.cross_wave_dependencies` (#1151 before/with #1150, never after). The AST does now read an unspaced `cd /a;gh …` correctly, but that widening is *toward shell truth* and only after Families A/B are closed structurally; it is not the "normalize everywhere" change the constraint warns about.

## Second-order fix: `no_worktree_self_delete`

Same defect, landing on a **safety verdict** rather than repo identity. `git worktree remove <wt> ; cd /safe` run from inside `<wt>` previously resolved to `/safe` and **failed open on a real self-delete** — the shell is still inside `<wt>` when the remove executes. Now blocks. Same for the `||`-guarded variant. Both pinned.

## Tests — shell truth, in BOTH shells

Both families survived the previous suite because the tests encoded the implementation. Every `cd`-routing shape is now executed in a **real shell** with the `gh` node replaced by `pwd`, and the printed directory is ground truth:

```
resolved is None  OR  resolved == truth(bash) == truth(zsh)
```

- **The oracle is widened from bash-only to bash AND zsh.** #1141 ran bash — CI's shell — and documented the gap in prose. zsh is the actual harness shell, and `command cd /x` genuinely differs between them, so a bash-only oracle can adopt a bash-only behaviour as a resolver invariant. That divergence is now **asserted** (bash moves, zsh does not) rather than described.
- `.github/workflows/ci.yml` installs `zsh` in the pytest job so both halves really run in CI. The tests degrade to the bash-only oracle on a bare checkout without zsh, with a comment saying that must never be why CI is green.
- The `test_known_gap_main_1151_still_misroutes` characterization test — which *pinned* the misroute so the gap stayed visible — is replaced exactly as its own docstring instructed on closure.
- `CdRoutingWhenBashlexCannotParse` covers the **fallback as ordinary traffic**, not an edge case: the premise itself (quoted forms raise, bare forms parse), the trap (`bashlex_available()` True while the command did not parse), families A/B/C with a heredoc attached, five adversarial heredoc-body injection shapes, and the genuine recovery surviving. Every shape is first asserted to actually force the `ParsingError`, so it cannot silently stop testing the fallback.
- Degraded mode (bashlex monkeypatched off) is covered both ways: fails closed on every family shape, and still recovers the three canonical #521 shapes. The `_BASHLEX_AVAILABLE` gate is placed **outside** the memo (matching `iter_command_segments_ast`) so a monkeypatching test is never served a stale cached AST answer.

## Correction — a claim in this PR was false, and Aino falsified it

An earlier revision of this section said *"No shape I could construct returns a directory the shell does not enter, under either shell."* **That was wrong**, and the merge-gate review produced the counterexample:

```
cd DEST && pushd OTHER && gh …    ->  resolved DEST;  both shells run the gh in OTHER
```

Same for `eval 'cd …'`, `source SCRIPT`, and `. SCRIPT`. `_ast_subtree_contains_cd` refused only commands whose `words[0] == "cd"`, so a builtin that moves the shell *without being spelled* `cd` passed phase 2 untouched. `OTHER` is a real directory, so the `isdir` guard did not catch it either.

Not a regression — the old scan returns `DEST` too — but the unrecoverable direction, which is the whole asymmetry #1151 turns on. **Fixed** at `1b77424`.

The root cause matters more than the symptom: this was **drift, not an open frontier**. `_DEGRADED_CONTROL_FLOW_TOKENS` already listed `eval`/`exec`/`source`/`.`/`pushd`/`popd` under *"Commands that can move the shell in ways this scan cannot follow"*, so the degraded scan returned `None` on all five while the AST path returned `DEST` — **the primary was strictly weaker than the co-primary I declared it equal to, on a class I had already enumerated.** So rather than patch the AST branch to match, both mechanisms now derive from one `_CWD_MOVING_COMMANDS` frozenset, and `test_both_paths_agree_on_cwd_moving_builtins` asserts the two paths return the *same answer* rather than asserting the shared constant. `_ast_subtree_contains_cd` is renamed `_ast_subtree_moves_cwd`.

Also fixed: the phase-1 `prev_op` guard was **inert**. Every family-A fixture was `true || cd …`, where phase 1 breaks at `true` and phase 2 closes the shape before the guard is reached — so deleting a load-bearing guard left the suite green while `cd A || cd B && gh` reopened a real misroute to `B`. Two fixtures with a `cd` in the leading position now cover it. The `test_family_a_and_b_shell_truth_is_the_start_dir` skip list is gone too — every shape in both families really does have the start dir as its truth, so the prefix-matching exemption was hiding coverage rather than earning it.

Mutation-checked, because "the guard is now covered" is exactly the claim that needs an instrument:

| mutation | failures |
|---|---|
| delete the phase-1 `prev_op` guard | **2** (was 0 — inert) |
| phase 2 keys on `"cd"` only (pre-fix) | **12** |
| drop `_CWD_MOVING_COMMANDS` from the degraded token set | **6** |

## Residual — honestly scoped

Families A, B and C are closed. What remains is **under-recovery**, in every case falling back to the recoverable invocation cwd:

- a `cd` in a taken `else` or a real loop iteration (unchanged from #1141)
- `mkdir -p /a && cd /a && gh …` — the run is no longer *leading*, so `None`
- any relative `cd` (family C's safe direction)
- `cd "$(git rev-parse --show-toplevel)"` — not statically resolvable (unchanged)
- a `cd` inside a group/pipeline after the leading run — refused as ambiguous
- **anything in `_CWD_MOVING_COMMANDS` after the run** — `pushd`/`popd`/`eval`/`source`/`.`, and `exec`, which does not move the shell but *replaces* it, so the routed command never runs at all (`cd DEST && exec -a x true ; gh …` previously returned `DEST` for a `gh` that never executes)

I am not restating the "no shape I could construct" claim. What I will state is narrower and checkable: **every shape below returns `None` on the AST path AND the degraded path, and the two paths agree on all of them** — which is the property whose violation produced M1.

## Verification

- `ENVIRONMENT=test python3 -m pytest .claude/hooks/tests .claude/lib/tests -q` → **3018 passed, 243 subtests** (baseline ~2999)
- `pre-commit run --all-files` and `--hook-stage pre-push` → **all 16 hooks pass** (ruff-format, ruff-lint, actionlint, cspell, checksums-ascii, mypy, pytest, pytest-skills, memory-budget, headcount-budget, doc-freshness, office-drift, mermaid-render, + the file-scoped linters)
- `python3 .claude/lib/pre_commit_ci_sync.py .` → OK
- `actionlint .github/workflows/ci.yml` → clean
- CI-only smoke test (py_compile over changed files) → clean

## File-overlap note

Scoped to the `cd`-resolution functions. **No heredoc helper is touched** — `strip_heredocs` is not called on this path and the reason is now recorded rather than incidental — per the coordination note with #1152 (Weronika Zielinska). Her `_shell_parse.py` change sits next to `strip_heredocs` (~line 450) with its tests in a new file, so the two diffs do not overlap. This PR and #1155 agree on what bashlex can do; the finding is credited in the code comments and the commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011hEQbrJGwa2kQ6dbEjyHQ6

