### PR TITLE
fix(wave-scope): resolve review-class slots against the org-union manifest (#1162)

### DIFF
--- a/.claude/skills/wave-scope/SKILL.md
+++ b/.claude/skills/wave-scope/SKILL.md
@@ -536,7 +536,7 @@ Validate every declared name against the relevant roster BEFORE `/wave-kickoff` 
 
 | # | Check | Applies to | Failure |
 |---|---|---|---|
-| #319 | **Name resolution** — does the name exist at all? | every slot | unresolved name + fuzzy suggestions |
+| #319 | **Name resolution** — does the name exist at all? | every slot, but the candidate set differs by slot class (#1162 — see Resolution rules) | unresolved name + fuzzy suggestions |
 | #1134 | **Repo membership** — is the implementer on the TARGET repo's roster? | `implementer` on a child repo | cross-repo implementer with no recorded override |
 
 **#319 (name resolution).** Pre-#319 a stale alias like "Anya Volkov" (canonical: "Anya Kowalczyk") would propagate through scope and only surface at first-spawn time — P3W7 retro recorded TWO such substitutions in `wave_7_decisions.implementer_substitutions`.
@@ -544,8 +544,11 @@ Validate every declared name against the relevant roster BEFORE `/wave-kickoff` 
 **#1134 (repo membership).** Name resolution alone is not enough: a **parent-org persona scoped as the implementer of a child-repo story** resolves fine (they are a real persona) but is not on the repo whose files they must commit to. This recurred W27 → W28 → W29 — Nurul Hakim on `user-service#204`, and (found by running this gate retroactively over `wave_28_scope`) Weronika Zielinska on `isnad-graph#1191`. The wrap-time repair is a mechanical merge-commit re-attribution that severs the "who implemented" audit trail.
 
 **Resolution rules:**
-- Name resolution: child-repo roster (`<repo>/.claude/team/roster/*.md`) UNION parent roster. This lets org-level coordinators (Aino, Nadia, Wanjiku, Santiago) fill child-repo slots without duplicating roster entries.
-- Repo membership: the **target repo's roster only**, and **only for the `implementer` slot**. Reviewers keep the union — cross-team reviewers are explicitly permitted by `charter/agents/spawn-discipline.md` § Child-Repo Implementer Rule step 5. The implementer is the only role that must produce a commit in the target repo.
+- Name resolution — **the candidate set depends on the slot class (#1162):**
+  - **Review-class slots** (`reviewer`, `reviewer_2`, `merge_gate_reviewer`): child-repo roster (`<repo>/.claude/team/roster/*.md`) UNION parent roster UNION the **org-union manifest** `.claude/team/roster.json`. The manifest is what makes a reviewer drawn from a **third child repo** valid — e.g. a `noorinalabs-data-acquisition` persona reviewing an `isnad-ingest-platform` story. **A third-child reviewer is a correct assignment, not drift: do not "fix" one by reassigning it.** Before #1162 the parent side was the parent's *card directory* only (9 names, not the manifest's 78), so such a reviewer resolved against neither roster and hard-blocked this step and `/wave-kickoff` § 0b.
+  - **`implementer`**: child-repo roster UNION parent roster only — **the manifest is deliberately excluded.** Including it would loosen the #1134 membership check in the `unverified` case below: when the target roster is unreadable, membership fails open, so a manifest-only implementer would resolve, be reported `unverified`, and pass. Keeping the set narrow means that slot only passes on a name the target repo (or the parent) can vouch for.
+  - Both sets let org-level coordinators (Aino, Nadia, Wanjiku, Santiago) fill child-repo slots without duplicating roster entries.
+- Repo membership: the **target repo's roster only**, and **only for the `implementer` slot**. Reviewers keep the wider resolution set above and are never membership-gated — cross-team reviewers are explicitly permitted by `charter/agents/spawn-discipline.md` § Child-Repo Implementer Rule step 5. The implementer is the only role that must produce a commit in the target repo.
 - Parent entries (`noorinalabs-main` or empty repo key) → parent-only roster; membership is vacuous there and never fires.
 - Match is case-insensitive; trailing parenthetical role suffix (`Aino Virtanen (Standards & Quality Lead)`) is stripped before comparison.
 - On a name miss: fuzzy-match via difflib SequenceMatcher; surface the top-3 closest matches to the operator.

--- a/.claude/skills/wave-scope/tests/test_validate_matrix_names.py
+++ b/.claude/skills/wave-scope/tests/test_validate_matrix_names.py
@@ -11,6 +11,7 @@ org-dir state (which changes wave-to-wave).
 
 from __future__ import annotations
 
+import json
 import sys
 import tempfile
 import unittest
@@ -19,6 +20,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from validate_matrix_names import (  # noqa: E402
+    _load_org_manifest_names,
     _override_rationale,
     _print_report_to_stderr,
     repo_of_row,
@@ -559,6 +561,215 @@ class ScopeModeTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             org = _build_fake_org_dir(Path(tmpdir))
             self.assertEqual(validate_scope({"theme": "x"}, org), {})
+
+
+class OrgUnionManifestTests(unittest.TestCase):
+    """#1162: a reviewer drawn from a THIRD child repo must resolve.
+
+    The parent side of the #319 union is the parent's CARD DIRECTORY (9 names),
+    not the org-union MANIFEST (78 names). A reviewer who is a real persona in
+    some other child repo is on neither the parent's cards nor the target
+    repo's, so it was reported UNRESOLVED "(no close matches)" — hard-blocking
+    /wave-scope § 12.5 and /wave-kickoff § 0b on an assignment the charter
+    explicitly permits (spawn-discipline.md § Child-Repo Implementer Rule
+    step 5). Live W28 instance: Nikolaos Papadopoulos / Oyunbileg Batbayar
+    (cards in noorinalabs-data-acquisition) reviewing isnad-ingest-platform.
+
+    Every test here that turns on the reviewer half FAILS against the
+    pre-#1162 validator. The implementer-half guards additionally pin that the
+    OBVIOUS over-broad fix — unioning the manifest into every slot — is not
+    what landed: they go red under that mutation.
+    """
+
+    THIRD_CHILD_REVIEWER = "Nikolaos Papadopoulos"
+
+    def _build_org(self, tmp: Path, *, manifest: object | None = None) -> Path:
+        """Fake org dir + a third child repo + the target repo + a manifest.
+
+        `manifest=None` writes the realistic manifest (parent cards + both
+        children + the third-child reviewer). Pass an explicit value to write
+        something else, or `_build_org(..., manifest=False)` for no file.
+        """
+        org = _build_fake_org_dir(tmp)
+        # Third child repo — where the reviewer's card actually lives.
+        _write_roster_card(
+            org / "noorinalabs-data-acquisition" / ".claude" / "team" / "roster",
+            "data_engineer_nikolaos",
+            self.THIRD_CHILD_REVIEWER,
+        )
+        # Target child repo — cloned, so membership is decidable.
+        _write_roster_card(
+            org / "noorinalabs-isnad-ingest-platform" / ".claude" / "team" / "roster",
+            "eng_farhan",
+            "Farhan Malik",
+        )
+        if manifest is None:
+            manifest = {
+                name: f"parametrization+{name.replace(' ', '.')}@gmail.com"
+                for name in (
+                    "Nadia Khoury",
+                    "Wanjiku Mwangi",
+                    "Aino Virtanen",
+                    "Anya Kowalczyk",
+                    "Farhan Malik",
+                    self.THIRD_CHILD_REVIEWER,
+                )
+            }
+        if manifest is not False:
+            path = org / ".claude" / "team" / "roster.json"
+            path.write_text(json.dumps(manifest, indent=2))
+        return org
+
+    def test_third_child_reviewer_resolves_and_implementer_stays_gated(self):
+        """The live reproducer, both halves — this is the #1162 acceptance test.
+
+        Half 1 (the fix): the third-child reviewer resolves and is NOT
+        membership-gated. Half 2 (the carve-out): the same name in the
+        `implementer` slot still does not resolve, because the manifest
+        deliberately does not widen the commit-capable resolution set.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = self._build_org(Path(tmpdir))
+            reviewed = {
+                "noorinalabs-isnad-ingest-platform": {
+                    "implementer": "Farhan Malik",  # target-repo member
+                    "reviewer": self.THIRD_CHILD_REVIEWER,
+                    "merge_gate_reviewer": self.THIRD_CHILD_REVIEWER,
+                }
+            }
+            report = validate(reviewed, org)
+            findings = report["noorinalabs-isnad-ingest-platform"]
+            for f in findings:
+                self.assertTrue(f["resolved"], f"{f['declared']} should resolve")
+            by_role = {f["role"]: f for f in findings}
+            self.assertEqual(by_role["reviewer"]["membership"], "n/a")
+            self.assertEqual(by_role["merge_gate_reviewer"]["membership"], "n/a")
+            self.assertEqual(by_role["implementer"]["membership"], "member")
+            self.assertEqual(_print_report_to_stderr(report), 0)
+
+            # Half 2 — same org, same name, commit-capable slot.
+            implemented = {
+                "noorinalabs-isnad-ingest-platform": {
+                    "implementer": self.THIRD_CHILD_REVIEWER,
+                }
+            }
+            impl_report = validate(implemented, org)
+            impl = impl_report["noorinalabs-isnad-ingest-platform"][0]
+            self.assertFalse(impl["resolved"], "manifest must not widen the implementer slot")
+            self.assertEqual(impl["membership"], "n/a")
+            self.assertEqual(_print_report_to_stderr(impl_report), 1)
+
+    def test_manifest_does_not_pass_implementer_on_uncloned_repo(self):
+        """The precise loosening the carve-out prevents.
+
+        Membership fails OPEN when the target repo's roster is unreadable (the
+        CI case). If the manifest widened the implementer resolution set too, a
+        manifest-only implementer on a not-cloned repo would resolve, be marked
+        `unverified`, and exit 0 — silently passing exactly the assignment
+        class #1134 exists to stop. It must stay an unresolved name (exit 1).
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = self._build_org(Path(tmpdir))
+            # noorinalabs-design-system has no roster dir in the fixture.
+            report = validate(
+                {"noorinalabs-design-system": {"implementer": self.THIRD_CHILD_REVIEWER}}, org
+            )
+            finding = report["noorinalabs-design-system"][0]
+            self.assertFalse(finding["resolved"])
+            self.assertNotEqual(finding["membership"], "unverified")
+            self.assertEqual(_print_report_to_stderr(report), 1)
+
+    def test_manifest_widening_does_not_excuse_a_parent_only_implementer(self):
+        """#1134's headline finding survives: a parent persona is still cross-repo.
+
+        Nadia Khoury is on the parent cards AND the manifest; neither makes her
+        a member of the target repo. This is the wave-28 `Nurul Hakim` /
+        `Weronika Zielinska` shape, which must keep failing after #1162.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = self._build_org(Path(tmpdir))
+            report = validate(
+                {"noorinalabs-isnad-ingest-platform": {"implementer": "Nadia Khoury"}}, org
+            )
+            finding = report["noorinalabs-isnad-ingest-platform"][0]
+            self.assertTrue(finding["resolved"])
+            self.assertEqual(finding["membership"], "cross-repo")
+            self.assertEqual(_print_report_to_stderr(report), 1)
+
+    def test_scope_mode_third_child_reviewer_row_passes(self):
+        """End-to-end through the path /wave-scope § 12.5 and /wave-kickoff § 0b run."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = self._build_org(Path(tmpdir))
+            scope = {
+                "tier_1_core": [
+                    {
+                        "id": "noorinalabs-isnad-ingest-platform#140",
+                        "ref": "isnad-ingest-platform#140",
+                        "implementer": "Farhan Malik",
+                        "reviewer": self.THIRD_CHILD_REVIEWER,
+                        "merge_gate_reviewer": self.THIRD_CHILD_REVIEWER,
+                    }
+                ]
+            }
+            report = validate_scope(scope, org)
+            findings = report["noorinalabs-isnad-ingest-platform (isnad-ingest-platform#140)"]
+            self.assertTrue(all(f["resolved"] for f in findings))
+            self.assertEqual(_print_report_to_stderr(report), 0)
+
+    def test_unresolved_reviewer_gets_manifest_sourced_suggestion(self):
+        """A typo'd reviewer name now suggests against the manifest, not "(no close matches)"."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = self._build_org(Path(tmpdir))
+            report = validate(
+                {"noorinalabs-isnad-ingest-platform": {"reviewer": "Nikolas Papadopolous"}}, org
+            )
+            finding = report["noorinalabs-isnad-ingest-platform"][0]
+            self.assertFalse(finding["resolved"])
+            self.assertIn(self.THIRD_CHILD_REVIEWER, finding["suggestions"])
+
+    def test_missing_manifest_degrades_to_the_card_union(self):
+        """Fail OPEN, never closed: the manifest only ever WIDENS the review set.
+
+        With no roster.json the validator must behave exactly as pre-#1162 —
+        parent-card reviewers still resolve, the third-child reviewer does not.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = self._build_org(Path(tmpdir), manifest=False)
+            self.assertEqual(_load_org_manifest_names(org), set())
+            report = validate(
+                {
+                    "noorinalabs-isnad-ingest-platform": {
+                        "reviewer": "Aino Virtanen",  # parent card
+                        "reviewer_2": self.THIRD_CHILD_REVIEWER,  # third child only
+                    }
+                },
+                org,
+            )
+            by_role = {f["role"]: f for f in report["noorinalabs-isnad-ingest-platform"]}
+            self.assertTrue(by_role["reviewer"]["resolved"])
+            self.assertFalse(by_role["reviewer_2"]["resolved"])
+
+    def test_malformed_manifest_is_ignored_not_fatal(self):
+        """A truncated or wrong-shaped roster.json must not crash or fail closed."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = _build_fake_org_dir(Path(tmpdir))
+            manifest_path = org / ".claude" / "team" / "roster.json"
+            for bad in ('{"Nadia Khoury": ', '["Nadia Khoury"]', "null"):
+                manifest_path.write_text(bad)
+                self.assertEqual(_load_org_manifest_names(org), set(), f"for {bad!r}")
+                report = validate({"noorinalabs-isnad-graph": {"reviewer": "Aino Virtanen"}}, org)
+                self.assertTrue(report["noorinalabs-isnad-graph"][0]["resolved"])
+
+    def test_manifest_names_are_trimmed_and_non_strings_skipped(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = self._build_org(
+                Path(tmpdir), manifest={"  Padded Persona  ": "p@example.com", "": "x@example.com"}
+            )
+            self.assertEqual(_load_org_manifest_names(org), {"Padded Persona"})
+            report = validate(
+                {"noorinalabs-isnad-ingest-platform": {"reviewer": "padded persona"}}, org
+            )
+            self.assertTrue(report["noorinalabs-isnad-ingest-platform"][0]["resolved"])
 
 
 if __name__ == "__main__":

--- a/.claude/skills/wave-scope/validate_matrix_names.py
+++ b/.claude/skills/wave-scope/validate_matrix_names.py
@@ -32,6 +32,18 @@ Pre-existing since #319, but #1134 made § 12.5 mandatory over every canonical
 `tier_*` row and added a hard `exit 1` at `/wave-kickoff` § 0b, turning a latent
 gap into a STOP on a charter-permitted assignment.
 
+Why the manifest is acceptable HERE and not everywhere. It is the LOOSER of the
+two authorities, not the more authoritative one: a card directory is the thing a
+repo actually vouches for, while `roster.json` is a flat union manifest that can
+carry a name whose card has been removed. It is trusted for review-class slots
+because of the CONSEQUENCE asymmetry, not because it is a better source — a
+review slot never commits, and a wrong reviewer name fails LOUDLY and later
+(the merge gate blocks on a missing approval; cf. #1179, where a third-child
+reviewer's approval is not yet counted at all). A wrong IMPLEMENTER name fails
+silently and expensively — the W28 mechanical merge-commit re-attribution. Match
+the authority to the blast radius; do not read this as licence to widen the
+manifest's use to any slot whose failure mode is quiet.
+
 The manifest is deliberately NOT unioned into the `implementer` resolution set.
 Doing so would loosen check 2 in the `unverified` case: when the target repo's
 roster is unreadable (not cloned — the CI case), membership fails OPEN, so a

--- a/.claude/skills/wave-scope/validate_matrix_names.py
+++ b/.claude/skills/wave-scope/validate_matrix_names.py
@@ -11,11 +11,33 @@ Two orthogonal checks (#319 + #1134)
 ====================================
 1. **Name resolution (#319)** — does the declared name exist at all? Resolved
    against the parent roster UNION the target repo's roster, because org-level
-   coordinators legitimately fill child-repo *review* slots.
+   coordinators legitimately fill child-repo *review* slots. For **review-class**
+   slots the org-union manifest is unioned in as well (#1162 — see below).
 2. **Repo membership (#1134)** — for the `implementer` slot on a CHILD repo,
    is the name on *that repo's own* roster? A name can resolve (check 1) and
    still fail this, which is exactly the recurring bug: a parent-org persona
    scoped as the implementer of a child-repo story.
+
+Review-class slots resolve against the org-union manifest too (#1162)
+=====================================================================
+The parent side of the check-1 union is the parent's **card directory**
+(`.claude/team/roster/*.md`, 9 names), not the org-union **manifest**
+(`.claude/team/roster.json`, 78 names). A reviewer legitimately drawn from a
+THIRD child repo — permitted by `charter/agents/spawn-discipline.md`
+§ Child-Repo Implementer Rule step 5 — is on neither the parent's cards nor the
+target repo's, so it was reported UNRESOLVED with "(no close matches)". Live
+instance: `Nikolaos Papadopoulos` / `Oyunbileg Batbayar` (cards in
+`noorinalabs-data-acquisition`) reviewing `isnad-ingest-platform` stories in W28.
+Pre-existing since #319, but #1134 made § 12.5 mandatory over every canonical
+`tier_*` row and added a hard `exit 1` at `/wave-kickoff` § 0b, turning a latent
+gap into a STOP on a charter-permitted assignment.
+
+The manifest is deliberately NOT unioned into the `implementer` resolution set.
+Doing so would loosen check 2 in the `unverified` case: when the target repo's
+roster is unreadable (not cloned — the CI case), membership fails OPEN, so a
+third-child implementer that newly *resolved* would exit 0 where today it exits
+1 as an unresolved name. Keeping the commit-capable resolution set narrow means
+the only way that slot passes is a name the target repo can actually vouch for.
 
 Why check 2 is implementer-only. The implementer is the only role that must
 produce a **commit in the target repo**, where `validate_commit_identity`
@@ -106,6 +128,8 @@ Resolution:
       and extract the member name (both card formats — see _load_roster_names).
     - For parent-repo entries (repo == "noorinalabs-main" or no repo), fall
       back to the parent's own `.claude/team/roster/`.
+    - Review-class slots additionally resolve against the parent's org-union
+      manifest `.claude/team/roster.json` (#1162).
     - Case-insensitive exact match wins.
     - On miss: fuzzy-match (difflib SequenceMatcher) and print the top-3
       closest matches as suggestions.
@@ -200,6 +224,28 @@ def _load_roster_names(roster_dir: Path) -> set[str]:
             if name:
                 names.add(name)
     return names
+
+
+def _load_org_manifest_names(org_dir: Path) -> set[str]:
+    """Parse names from the parent's org-union manifest `.claude/team/roster.json`.
+
+    The manifest is a flat `{"<name>": "<email>"}` object covering every persona
+    across the org (78 at time of writing) — a strict superset of the parent's
+    own card directory, and the only place a persona from a repo that is not the
+    target repo can be recognised without cloning that repo.
+
+    Fails OPEN (empty set) when the file is missing or malformed: the manifest
+    only ever WIDENS the review-class resolution set, so an unreadable manifest
+    degrades to exactly the pre-#1162 behaviour rather than blocking a run.
+    """
+    path = org_dir / ".claude" / "team" / "roster.json"
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return set()
+    if not isinstance(data, dict):
+        return set()
+    return {name.strip() for name in data if isinstance(name, str) and name.strip()}
 
 
 def _load_repo_roster(org_dir: Path, repo: str) -> set[str]:
@@ -302,6 +348,8 @@ def validate(
     # Wanjiku, Aino, Santiago) can appear in per-repo matrix slots when
     # reviewing parent-flavored work.
     parent_roster = _load_repo_roster(org_dir, "noorinalabs-main")
+    # #1162: the org-union manifest widens the REVIEW-class resolution set only.
+    org_manifest = _load_org_manifest_names(org_dir)
     for repo, slots in matrix.items():
         repo_roster = _load_repo_roster(org_dir, repo)
         is_parent_repo = repo in PARENT_REPO_KEYS
@@ -313,7 +361,10 @@ def validate(
             if fetched:
                 repo_roster = fetched
         membership_decidable = is_parent_repo or bool(repo_roster)
+        # Commit-capable slots keep the narrow #319 union (see module docstring
+        # § Review-class slots for why the manifest must not widen this one).
         combined = parent_roster | repo_roster
+        review_combined = combined | org_manifest
         override = _override_rationale(slots.get("roster_union_override"))
         repo_findings: list[dict[str, object]] = []
         for role, raw in slots.items():
@@ -323,7 +374,8 @@ def validate(
                 continue
             declared = raw
             declared_clean = re.sub(r"\s*\(.*?\)\s*$", "", declared).strip()
-            resolved = any(declared_clean.lower() == known.lower() for known in combined)
+            candidates = combined if role in COMMIT_CAPABLE_ROLES else review_combined
+            resolved = any(declared_clean.lower() == known.lower() for known in candidates)
             entry: dict[str, object] = {
                 "role": role,
                 "declared": declared,
@@ -331,7 +383,7 @@ def validate(
                 "membership": "n/a",
             }
             if not resolved:
-                entry["suggestions"] = _suggest(declared_clean, combined)
+                entry["suggestions"] = _suggest(declared_clean, candidates)
                 repo_findings.append(entry)
                 continue
             # #1134: commit-capable slots on a child repo must be repo members.


### PR DESCRIPTION
Closes #1162. Refs #1134, #319.

## Problem

`.claude/skills/wave-scope/validate_matrix_names.py` resolved **every** assignment slot against `parent_cards ∪ target_repo_cards`, where the parent side is the parent's **card directory** (`.claude/team/roster/*.md`, 9 names) — not the org-union **manifest** (`.claude/team/roster.json`, 78 names). A reviewer legitimately drawn from a **third child repo** is on neither set, so a charter-permitted cross-team review assignment (`charter/agents/spawn-discipline.md` § Child-Repo Implementer Rule step 5) was reported `UNRESOLVED … (no close matches)` and exited 1.

Latent since #319. #1134 (merged as `fbb528e8`) made it **blocking**: § 12.5 became mandatory over every canonical `tier_*` row, and `/wave-kickoff` § 0b gained a new hard `exit 1` running the same check.

The live instance is `Nikolaos Papadopoulos` and `Oyunbileg Batbayar` reviewing `isnad-ingest-platform` stories in wave-28. Both are real personas with cards in `noorinalabs-data-acquisition/.claude/team/roster/` **and** entries in the parent's 78-name `roster.json`.

> Correction to the record: #1154's description characterised these two as having "no persona card in any roster directory". That is wrong — the cards exist. The defect is in the resolution set, not roster drift.

## Fix

Review-class slots (`reviewer`, `reviewer_2`, `merge_gate_reviewer`) union the org manifest into their resolution set. Commit-capable slots do not.

```python
combined = parent_roster | repo_roster            # commit-capable resolution set
review_combined = combined | org_manifest         # review-class (#1162)
...
candidates = combined if role in COMMIT_CAPABLE_ROLES else review_combined
```

**Why `implementer` is deliberately excluded.** Widening it would *loosen* the #1134 membership check in the `unverified` case. Membership fails OPEN when the target repo's roster is unreadable (not cloned — the CI case), so a manifest-only implementer on such a repo would newly *resolve*, be marked `unverified`, and **exit 0** — silently passing exactly the assignment class #1134 exists to stop. Today it exits 1 as an unknown name, and it still does. `test_manifest_does_not_pass_implementer_on_uncloned_repo` pins this.

Manifest load fails OPEN (missing / malformed / non-object → empty set), degrading to precisely the pre-#1162 behaviour, since the manifest only ever *widens*.

## Measurement — `cross-repo-status.json` at `999dfae`

| Run | Before | After |
|---|---|---|
| `--wave 28` | `4/30 names UNRESOLVED across 10 entries` + `2/30 CROSS-REPO IMPLEMENTER`, **exit 1** | **0 unresolved names**; `2/30 CROSS-REPO IMPLEMENTER` unchanged, **exit 1** |
| `--wave 29` | `all 85 names resolved across 28 entries`, exit 0 | `all 85 names resolved across 28 entries`, **exit 0** |

Wave-28 **must** stay exit 1. The two surviving findings are correct #1134 behaviour and are untouched:

```
noorinalabs-user-service (user-service#204):
  - implementer: 'Nurul Hakim' is NOT on this repo's roster.
noorinalabs-isnad-graph (isnad-graph#1191):
  - implementer: 'Weronika Zielinska' is NOT on this repo's roster.
```

## Tests

8 new cases in `OrgUnionManifestTests`; 41 pass total. `test_reviewer_slots_keep_parent_union` is **unmodified** and green (existing fixtures write no `roster.json`, so every pre-existing test sees an empty manifest and unchanged behaviour).

Non-inertness verified by mutation, not by assertion:

| Mutation | Result |
|---|---|
| `review_combined = combined` (pre-#1162 behaviour, helper retained) | **4 of 8 red**, including the acceptance test |
| `candidates = review_combined` for all roles (the obvious over-broad fix) | **2 red** — both implementer carve-out guards |
| unfixed file wholesale (`git show main:…`) | collection `ImportError` — hence the two surgical mutations above |

## Gates

`pre-commit run --hook-stage pre-push --all-files` → all 16 hooks pass (ruff-format, ruff-lint, actionlint, cspell, fixture-realism, skill-graphql-pagination, checksums-ascii, mypy, pytest, pytest-skills, memory-budget, headcount-budget, doc-freshness, office-drift, mermaid-render). `pre_commit_ci_sync.py .` → `OK: pre-commit config mirrors all CI-enforced checks.`

## Reviewers

Aino Virtanen (Standards & Quality Lead — found the defect and set the fix direction), Wanjiku Mwangi (TPM).

Do not merge — merges are owner-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
