### PR TITLE
fix(wave-status): canonical-scope merged-PR discovery for direct-to-main waves

### DIFF
--- a/.claude/lib/tests/test_wave_status.py
+++ b/.claude/lib/tests/test_wave_status.py
@@ -367,5 +367,449 @@ class Digest(unittest.TestCase):
             self.assertEqual(parsed["current_wave"], "wave-25")
 
 
+# --------------------------------------------------------------------------- #
+# direct-to-main (main#1131): merged_prs()/compute_counters() silently
+# returned 0/{} on a direct-to-main wave because the base was hardcoded to a
+# wave branch that never exists under that model. The fix routes through the
+# wave's canonical scope set (wave_{M}_scope's tier_* rows) rather than
+# base+timestamp alone, per the wave-28 retro finding that base+timestamp
+# over-counts (the recorded false positive: `us#213` was in-window but
+# out-of-scope).
+# --------------------------------------------------------------------------- #
+
+
+def _kv_flags(cmd: list[str]) -> dict[str, str]:
+    """Extract every ``-f``/``-F key=value`` pair from a gh argv list."""
+    out: dict[str, str] = {}
+    i = 0
+    while i < len(cmd):
+        if cmd[i] in ("-f", "-F") and i + 1 < len(cmd):
+            k, _, v = cmd[i + 1].partition("=")
+            out[k] = v
+        i += 1
+    return out
+
+
+class _FakeGhDirectToMain:
+    """subprocess.run side_effect for the direct-to-main path.
+
+    Each PR fixture dict carries: repo, number, sha, mergedAt, login,
+    commit_author, closes (the issue numbers GitHub records this PR as
+    closing — NOT assumed to equal the PR number, mirroring main#1172 being
+    delivered by PR #1173).
+    """
+
+    def __init__(self, prs: list[dict]) -> None:
+        self.prs = prs
+        self.calls: list[list[str]] = []
+
+    def __call__(self, cmd, *args, **kwargs):  # noqa: ANN001
+        assert isinstance(cmd, list), f"gh called with non-list cmd: {cmd!r}"
+        assert cmd[0] == "gh"
+        assert kwargs.get("shell") is not True
+        self.calls.append(cmd)
+
+        if cmd[1:3] == ["pr", "list"]:
+            repo = cmd[cmd.index("--repo") + 1].removeprefix("noorinalabs/")
+            # direct-to-main must query base=main -- never a wave branch.
+            self_base = cmd[cmd.index("--base") + 1]
+            assert self_base == "main", f"expected --base main, got {self_base!r}"
+            listed = [
+                {
+                    "number": p["number"],
+                    "headRefOid": p["sha"],
+                    "mergedAt": p["mergedAt"],
+                    "author": {"login": p["login"]},
+                }
+                for p in self.prs
+                if p["repo"] == repo
+            ]
+            return SimpleNamespace(stdout=json.dumps(listed), returncode=0, stderr="")
+
+        if cmd[1:3] == ["api", "graphql"]:
+            flags = _kv_flags(cmd)
+            repo = flags["name"]
+            number = int(flags["number"])
+            closes = next(
+                p["closes"] for p in self.prs if p["repo"] == repo and p["number"] == number
+            )
+            return SimpleNamespace(stdout=json.dumps(closes), returncode=0, stderr="")
+
+        if cmd[1] == "api":
+            path = cmd[2]
+            parts = path.split("/")
+            if "/commits/" in path:
+                sha = parts[4]
+                name = next(p["commit_author"] for p in self.prs if p["sha"] == sha)
+                return SimpleNamespace(stdout=name + "\n", returncode=0, stderr="")
+            if path.endswith("/comments"):
+                number = int(parts[4])
+                cr = next((p.get("cr", 0) for p in self.prs if p["number"] == number), 0)
+                return SimpleNamespace(stdout=f"{cr}\n", returncode=0, stderr="")
+
+        raise AssertionError(f"unexpected gh call: {cmd!r}")
+
+
+def _scope_row(issue_number: int) -> dict:
+    return {"id": f"noorinalabs-main#{issue_number}", "ref": f"main#{issue_number}"}
+
+
+def _write_direct_to_main_status(
+    path: Path,
+    *,
+    wave: str,
+    repos: list[str],
+    kickoff: str,
+    tiers: dict[str, list[int]],
+) -> None:
+    """Write a cross-repo-status.json shaped like wave-29's real record:
+    `wave_{M}_merge_model="direct-to-main"` + a `wave_{M}_scope` dict whose
+    tier keys are NOT the fixed set from any prior wave (arbitrary tier names
+    below prove the `tier_*` iteration is generic, per main#1131)."""
+    scope: dict = {"theme": "test fixture", "merge_model": "direct-to-main"}
+    for tier_name, issue_numbers in tiers.items():
+        scope[tier_name] = [_scope_row(n) for n in issue_numbers]
+    data = {
+        "current_wave": int(wave),
+        f"wave_{wave}_repos_in_scope": repos,
+        f"wave_{wave}_kicked_off_at": kickoff,
+        f"wave_{wave}_merge_model": "direct-to-main",
+        f"wave_{wave}_scope": scope,
+    }
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+class CanonicalIssueNumbers(unittest.TestCase):
+    def test_generic_tier_iteration_not_hardcoded(self) -> None:
+        """Tier names are wave-specific (main#1131: wave-29 introduced
+        `tier_4_in_wave_findings`, absent from earlier waves) -- the helper
+        must not hardcode any tier name."""
+        with TemporaryDirectory() as td:
+            status = Path(td) / "cross-repo-status.json"
+            _write_direct_to_main_status(
+                status,
+                wave="29",
+                repos=["noorinalabs-main"],
+                kickoff="2026-07-27T22:56:17Z",
+                tiers={
+                    "tier_1_track_g": [1114],
+                    "tier_4_in_wave_findings": [1160, 1162],
+                    "tier_99_never_seen_before": [9999],
+                },
+            )
+            by_repo = wave_status._canonical_issue_numbers_by_repo("29", status)
+        self.assertEqual(by_repo["noorinalabs-main"], {1114, 1160, 1162, 9999})
+
+    def test_legacy_string_tier_rows_skipped_not_raised(self) -> None:
+        with TemporaryDirectory() as td:
+            status = Path(td) / "cross-repo-status.json"
+            data = {
+                "wave_29_scope": {
+                    "tier_1_backlog": ["main#322", {"id": "noorinalabs-main#1114"}],
+                }
+            }
+            status.write_text(json.dumps(data))
+            by_repo = wave_status._canonical_issue_numbers_by_repo("29", status)
+        self.assertEqual(by_repo, {"noorinalabs-main": {1114}})
+
+
+class MergedPrsDirectToMain(unittest.TestCase):
+    """merged_prs() for a direct-to-main wave, driven by the canonical scope
+    set rather than base+timestamp alone."""
+
+    def test_base_and_timestamp_alone_would_overcount_but_scope_excludes(self) -> None:
+        """The wave-28 retro false positive, reproduced: a PR in-window on
+        `main` that closes an issue NEVER recorded in the wave's scope
+        (`us#213`-shaped) must be excluded even though base+timestamp alone
+        would have included it."""
+        prs = [
+            {
+                "repo": "noorinalabs-main",
+                "number": 1173,
+                "sha": "sha1173",
+                "mergedAt": "2026-07-30T02:16:40Z",
+                "login": "octocat",
+                "commit_author": "Nino Kavtaradze",
+                "closes": [1172],  # canonical scope row
+            },
+            {
+                "repo": "noorinalabs-main",
+                "number": 9001,
+                "sha": "sha9001",
+                "mergedAt": "2026-07-30T02:20:00Z",  # in-window
+                "login": "octocat",
+                "commit_author": "Someone Else",
+                "closes": [213],  # NOT in scope -- the us#213 false positive
+            },
+        ]
+        fake = _FakeGhDirectToMain(prs)
+        with TemporaryDirectory() as td:
+            status = Path(td) / "cross-repo-status.json"
+            _write_direct_to_main_status(
+                status,
+                wave="29",
+                repos=["noorinalabs-main"],
+                kickoff="2026-07-27T22:56:17Z",
+                tiers={"tier_4_in_wave_findings": [1172]},
+            )
+            with mock.patch.object(wave_status.subprocess, "run", fake):
+                got = wave_status.merged_prs("10", "29", status)
+        self.assertEqual([p["number"] for p in got], [1173])
+
+    def test_issue_number_need_not_equal_pr_number(self) -> None:
+        """main#1172 was delivered by PR #1173 -- a different number. The PR
+        must still be found via its closing-issue reference."""
+        prs = [
+            {
+                "repo": "noorinalabs-main",
+                "number": 1173,
+                "sha": "sha1173",
+                "mergedAt": "2026-07-30T02:16:40Z",
+                "login": "octocat",
+                "commit_author": "Nino Kavtaradze",
+                "closes": [1172],
+            }
+        ]
+        fake = _FakeGhDirectToMain(prs)
+        with TemporaryDirectory() as td:
+            status = Path(td) / "cross-repo-status.json"
+            _write_direct_to_main_status(
+                status,
+                wave="29",
+                repos=["noorinalabs-main"],
+                kickoff="2026-07-27T22:56:17Z",
+                tiers={"tier_4_in_wave_findings": [1172]},
+            )
+            with mock.patch.object(wave_status.subprocess, "run", fake):
+                got = wave_status.merged_prs("10", "29", status)
+        self.assertEqual(len(got), 1)
+        self.assertEqual(got[0]["number"], 1173)
+        self.assertEqual(got[0]["commit_author_name"], "Nino Kavtaradze")
+
+    def test_bundled_pr_counted_once_across_multiple_scope_rows(self) -> None:
+        """#1167/#1168/#1170/#1171 were bundled into ONE PR -- rows != PRs,
+        so the same merged PR must not be double-counted across the four
+        scope rows it satisfies."""
+        prs = [
+            {
+                "repo": "noorinalabs-main",
+                "number": 1174,
+                "sha": "sha1174",
+                "mergedAt": "2026-07-29T12:00:00Z",
+                "login": "octocat",
+                "commit_author": "Weronika Zielinska",
+                "closes": [1167, 1168, 1170, 1171],
+            }
+        ]
+        fake = _FakeGhDirectToMain(prs)
+        with TemporaryDirectory() as td:
+            status = Path(td) / "cross-repo-status.json"
+            _write_direct_to_main_status(
+                status,
+                wave="29",
+                repos=["noorinalabs-main"],
+                kickoff="2026-07-27T22:56:17Z",
+                tiers={"tier_4_in_wave_findings": [1167, 1168, 1170, 1171]},
+            )
+            with mock.patch.object(wave_status.subprocess, "run", fake):
+                got = wave_status.merged_prs("10", "29", status)
+        self.assertEqual(len(got), 1)
+        self.assertEqual(got[0]["number"], 1174)
+
+    def test_real_wave_29_five_pr_set(self) -> None:
+        """Verification fixture pinned to the real wave-29 data in main#1131's
+        acceptance criteria: PRs #1173/#1153/#1154/#1155/#1156, closing
+        canonical issues #1172/#1139/#1134/#1152/#1151 respectively, with an
+        out-of-scope in-window PR (#1178, still OPEN in reality -- modeled
+        here as an unrelated closed number to prove exclusion) filtered out."""
+        real = [
+            (1173, "sha056a", "2026-07-30T02:16:40Z", 1172),
+            (1153, "shab708", "2026-07-30T02:17:04Z", 1139),
+            (1154, "shafbb5", "2026-07-30T02:17:26Z", 1134),
+            (1155, "sha1207", "2026-07-30T02:17:46Z", 1152),
+            (1156, "sha999d", "2026-07-30T02:40:16Z", 1151),
+        ]
+        prs = [
+            {
+                "repo": "noorinalabs-main",
+                "number": number,
+                "sha": sha,
+                "mergedAt": merged_at,
+                "login": "octocat",
+                "commit_author": f"author-{number}",
+                "closes": [closes],
+            }
+            for number, sha, merged_at, closes in real
+        ] + [
+            {
+                "repo": "noorinalabs-main",
+                "number": 9999,
+                "sha": "shaoutofscope",
+                "mergedAt": "2026-07-30T02:41:00Z",
+                "login": "octocat",
+                "commit_author": "Out Of Scope",
+                "closes": [4242],  # not a canonical row anywhere
+            }
+        ]
+        fake = _FakeGhDirectToMain(prs)
+        with TemporaryDirectory() as td:
+            status = Path(td) / "cross-repo-status.json"
+            _write_direct_to_main_status(
+                status,
+                wave="29",
+                repos=["noorinalabs-main"],
+                kickoff="2026-07-27T22:56:17Z",
+                tiers={
+                    "tier_2_process_carry_forward": [1139, 1134, 1152, 1151],
+                    "tier_4_in_wave_findings": [1172],
+                },
+            )
+            with mock.patch.object(wave_status.subprocess, "run", fake):
+                got = wave_status.merged_prs("10", "29", status)
+        self.assertEqual(sorted(p["number"] for p in got), [1153, 1154, 1155, 1156, 1173])
+        self.assertEqual(len(got), 5)
+
+    def test_repo_with_no_canonical_rows_is_skipped(self) -> None:
+        """A repo in `repos_in_scope` with no scope rows at all is skipped
+        entirely -- not queried, not silently zeroed."""
+        fake = _FakeGhDirectToMain([])
+        with TemporaryDirectory() as td:
+            status = Path(td) / "cross-repo-status.json"
+            _write_direct_to_main_status(
+                status,
+                wave="29",
+                repos=["noorinalabs-main", "noorinalabs-isnad-ingest-platform"],
+                kickoff="2026-07-27T22:56:17Z",
+                tiers={"tier_1_track_g": [1114]},
+            )
+            with mock.patch.object(wave_status.subprocess, "run", fake):
+                got = wave_status.merged_prs("10", "29", status)
+        self.assertEqual(got, [])
+        # No "pr list" call was ever made for the scopeless repo.
+        pr_list_repos = {c[c.index("--repo") + 1] for c in fake.calls if c[1:3] == ["pr", "list"]}
+        self.assertNotIn("noorinalabs/noorinalabs-isnad-ingest-platform", pr_list_repos)
+
+    def test_counters_nonzero_and_nonempty_trust_signals_for_direct_to_main(self) -> None:
+        """The whole point of main#1131: compute_counters()/trust_signals must
+        NOT silently return 0/{} for a direct-to-main wave."""
+        prs = [
+            {
+                "repo": "noorinalabs-main",
+                "number": 1173,
+                "sha": "sha1173",
+                "mergedAt": "2026-07-30T02:16:40Z",
+                "login": "octocat",
+                "commit_author": "Nino Kavtaradze",
+                "closes": [1172],
+            }
+        ]
+        fake = _FakeGhDirectToMain(prs)
+        with TemporaryDirectory() as td:
+            status = Path(td) / "cross-repo-status.json"
+            _write_direct_to_main_status(
+                status,
+                wave="29",
+                repos=["noorinalabs-main"],
+                kickoff="2026-07-27T22:56:17Z",
+                tiers={"tier_4_in_wave_findings": [1172]},
+            )
+            with mock.patch.object(wave_status.subprocess, "run", fake):
+                counters = wave_status.compute_counters("10", "29", status)
+        self.assertEqual(counters["final_pr_count"], 1)
+        self.assertNotEqual(
+            counters,
+            {"final_pr_count": 0, "changes_requested_cycles": 0, "top_concentration_pct": 0},
+        )
+
+
+class WaveBranchPathUnchanged(unittest.TestCase):
+    """Regression fixture proving BOTH merge models: an explicit
+    `wave_{M}_merge_model="wave-branch"` record still routes through the
+    pre-existing wave-branch base -- dispatch does not accidentally flip a
+    declared wave-branch wave onto the canonical-scope path."""
+
+    def test_explicit_wave_branch_model_keeps_wave_branch_base(self) -> None:
+        prs = _p5w4_prs()
+        fake = _FakeGh(prs)
+        with TemporaryDirectory() as td:
+            status = Path(td) / "cross-repo-status.json"
+            data = {
+                "wave_4_repos_in_scope": _REPOS,
+                "wave_4_kicked_off_at": "2026-06-15T01:52:55Z",
+                "wave_4_merge_model": "wave-branch",
+            }
+            status.write_text(json.dumps(data))
+            with mock.patch.object(wave_status.subprocess, "run", fake):
+                counters = wave_status.compute_counters("5", "4", status)
+        self.assertEqual(
+            counters,
+            {
+                "final_pr_count": 19,
+                "changes_requested_cycles": 4,
+                "top_concentration_pct": 16,
+            },
+        )
+        # Every "pr list" call based on the wave branch, never "main".
+        pr_list_calls = [c for c in fake.calls if c[1:3] == ["pr", "list"]]
+        self.assertTrue(pr_list_calls)
+        for c in pr_list_calls:
+            self.assertEqual(c[c.index("--base") + 1], "deployments/phase-5/wave-4")
+
+
+class BaseVsHeadDifferential(unittest.TestCase):
+    """Proves the wave-branch path is BYTE-FOR-BYTE unchanged (main#1131):
+    executes the pre-fix `merged_prs` straight out of the base commit's
+    `.claude/lib/wave_status.py` via `git show`, runs it against the same
+    fixture and the same fake gh as HEAD's `_merged_prs_wave_branch`, and
+    diffs the two JSON outputs. Not a want/got table -- an actual base-vs-head
+    runtime comparison of the two implementations."""
+
+    # The commit this fix branch forked from -- main tip immediately
+    # pre-#1131, so `git show <sha>:path` reads the exact pre-fix source.
+    _BASE_SHA = "b290d611e9e6c59db0bf921ef6a9315090dc2eae"
+
+    @classmethod
+    def _load_base_module(cls):
+        import subprocess
+        import types
+
+        repo_root = Path(__file__).resolve().parents[3]
+        src = subprocess.run(
+            ["git", "show", f"{cls._BASE_SHA}:.claude/lib/wave_status.py"],
+            capture_output=True,
+            text=True,
+            check=True,
+            cwd=repo_root,
+        ).stdout
+        mod = types.ModuleType("wave_status_base_pre_1131")
+        mod.__file__ = f"<git show {cls._BASE_SHA}:.claude/lib/wave_status.py>"
+        exec(compile(src, mod.__file__, "exec"), mod.__dict__)  # noqa: S102
+        return mod
+
+    def test_base_and_head_agree_on_wave_branch_output(self) -> None:
+        base_mod = self._load_base_module()
+        prs = _p5w4_prs()
+
+        with TemporaryDirectory() as td:
+            status = Path(td) / "cross-repo-status.json"
+            _write_status(status, repos=_REPOS, wave="4", kickoff="2026-06-15T01:52:55Z")
+
+            with mock.patch.object(base_mod.subprocess, "run", _FakeGh(prs)):
+                base_out = base_mod.merged_prs("5", "4", status)
+            with mock.patch.object(wave_status.subprocess, "run", _FakeGh(prs)):
+                head_out = wave_status._merged_prs_wave_branch("5", "4", status)
+
+        self.assertEqual(base_out, head_out)
+        # Also prove the public dispatcher reaches the identical path when no
+        # merge_model key is recorded (legacy / absent -- the common shape of
+        # every pre-#1131 status file, including the one above).
+        with TemporaryDirectory() as td:
+            status = Path(td) / "cross-repo-status.json"
+            _write_status(status, repos=_REPOS, wave="4", kickoff="2026-06-15T01:52:55Z")
+            with mock.patch.object(wave_status.subprocess, "run", _FakeGh(prs)):
+                dispatch_out = wave_status.merged_prs("5", "4", status)
+        self.assertEqual(base_out, dispatch_out)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.claude/lib/tests/test_wave_status.py
+++ b/.claude/lib/tests/test_wave_status.py
@@ -17,6 +17,7 @@ Verifies:
 from __future__ import annotations
 
 import json
+import re
 import sys
 import unittest
 from pathlib import Path
@@ -414,6 +415,25 @@ class _FakeGhDirectToMain:
             # direct-to-main must query base=main -- never a wave branch.
             self_base = cmd[cmd.index("--base") + 1]
             assert self_base == "main", f"expected --base main, got {self_base!r}"
+
+            # Faithfully model the two real gh behaviors the M2 fix depends on
+            # (main#1131): (1) a `--search merged:>=DATE` qualifier is a
+            # SERVER-SIDE filter applied before any cap, and (2) `--limit`
+            # (default 30 if the flag is absent -- the actual gh default)
+            # truncates whatever remains, newest-mergedAt first (gh's real
+            # default sort). A regression that drops either flag is meant to
+            # be caught by this: dropping `--limit` silently reintroduces the
+            # 30-item gh default; dropping `--search` lets old, irrelevant
+            # history compete for the same 30/1000 slots.
+            candidates = [p for p in self.prs if p["repo"] == repo]
+            if "--search" in cmd:
+                query = cmd[cmd.index("--search") + 1]
+                m = re.match(r"merged:>=(.+)$", query)
+                assert m, f"unrecognised --search query: {query!r}"
+                floor = m.group(1)
+                candidates = [p for p in candidates if p["mergedAt"] >= floor]
+            candidates = sorted(candidates, key=lambda p: p["mergedAt"], reverse=True)
+            limit = int(cmd[cmd.index("--limit") + 1]) if "--limit" in cmd else 30
             listed = [
                 {
                     "number": p["number"],
@@ -421,8 +441,7 @@ class _FakeGhDirectToMain:
                     "mergedAt": p["mergedAt"],
                     "author": {"login": p["login"]},
                 }
-                for p in self.prs
-                if p["repo"] == repo
+                for p in candidates[:limit]
             ]
             return SimpleNamespace(stdout=json.dumps(listed), returncode=0, stderr="")
 
@@ -720,6 +739,100 @@ class MergedPrsDirectToMain(unittest.TestCase):
             counters,
             {"final_pr_count": 0, "changes_requested_cycles": 0, "top_concentration_pct": 0},
         )
+
+
+class PrListPageCap(unittest.TestCase):
+    """`gh pr list` defaults to `--limit 30` (main#1131 M2 -- caught in
+    review). The wave-branch path was structurally immune (`--base
+    <wave-branch>` already bounds the query); `--base main` removes that
+    bound and re-exposes the cap against full repo history. This is
+    mutation-provable: `_FakeGhDirectToMain` truncates to whatever `--limit`
+    (or its absence -> 30) says, newest-``mergedAt`` first, and filters by
+    `--search merged:>=` when present -- exactly mirroring the two real gh
+    behaviors the fix depends on, so regressing either flag away fails
+    these tests for real (not just a fixture too small to trip the cap)."""
+
+    def _prs_exceeding_default_cap(self) -> list[dict]:
+        """35 unrelated, MORE-RECENT filler merges (later waves' traffic to
+        `main` after this wave) crowd the top of the newest-first list, plus
+        the 5 real wave-29 PRs sitting further back (main#1131's acceptance
+        fixture). Without the fix, gh's 30-item default returns only
+        filler -- every real wave PR is silently dropped."""
+        filler = [
+            {
+                "repo": "noorinalabs-main",
+                "number": 2000 + i,
+                "sha": f"shafiller{i:02d}",
+                "mergedAt": f"2026-08-{10 + i:02d}T00:00:00Z",  # after the real PRs
+                "login": "octocat",
+                "commit_author": "Later Wave Author",
+                "closes": [8000 + i],  # never a canonical row
+            }
+            for i in range(35)
+        ]
+        real = [
+            {
+                "repo": "noorinalabs-main",
+                "number": number,
+                "sha": sha,
+                "mergedAt": merged_at,
+                "login": "octocat",
+                "commit_author": f"author-{number}",
+                "closes": [closes],
+            }
+            for number, sha, merged_at, closes in (
+                (1173, "sha056a", "2026-07-30T02:16:40Z", 1172),
+                (1153, "shab708", "2026-07-30T02:17:04Z", 1139),
+                (1154, "shafbb5", "2026-07-30T02:17:26Z", 1134),
+                (1155, "sha1207", "2026-07-30T02:17:46Z", 1152),
+                (1156, "sha999d", "2026-07-30T02:40:16Z", 1151),
+            )
+        ]
+        return filler + real
+
+    def _run(self) -> tuple[list[dict], _FakeGhDirectToMain]:
+        fake = _FakeGhDirectToMain(self._prs_exceeding_default_cap())
+        with TemporaryDirectory() as td:
+            status = Path(td) / "cross-repo-status.json"
+            _write_direct_to_main_status(
+                status,
+                wave="29",
+                repos=["noorinalabs-main"],
+                kickoff="2026-07-27T22:56:17Z",
+                tiers={
+                    "tier_2_process_carry_forward": [1139, 1134, 1152, 1151],
+                    "tier_4_in_wave_findings": [1172],
+                },
+            )
+            with mock.patch.object(wave_status.subprocess, "run", fake):
+                got = wave_status.merged_prs("10", "29", status)
+        return got, fake
+
+    def test_all_five_wave_prs_survive_a_repo_history_of_40(self) -> None:
+        got, _ = self._run()
+        self.assertEqual(sorted(p["number"] for p in got), [1153, 1154, 1155, 1156, 1173])
+
+    def test_pr_list_call_carries_an_explicit_limit_above_the_gh_default(self) -> None:
+        _, fake = self._run()
+        pr_list_calls = [c for c in fake.calls if c[1:3] == ["pr", "list"]]
+        self.assertTrue(pr_list_calls)
+        for c in pr_list_calls:
+            self.assertIn("--limit", c, "no explicit --limit -- gh silently defaults to 30")
+            limit = int(c[c.index("--limit") + 1])
+            self.assertGreater(limit, 30, f"--limit {limit} does not clear gh's own default cap")
+
+    def test_pr_list_call_carries_a_kickoff_search_bound(self) -> None:
+        """Belt-and-suspenders: the server-side bound means the query is
+        never larger than "since this wave started", not "since the repo
+        began" -- the fix does not just raise a number that could someday
+        be exceeded again."""
+        _, fake = self._run()
+        pr_list_calls = [c for c in fake.calls if c[1:3] == ["pr", "list"]]
+        self.assertTrue(pr_list_calls)
+        for c in pr_list_calls:
+            self.assertIn("--search", c)
+            query = c[c.index("--search") + 1]
+            self.assertIn("merged:>=2026-07-27T22:56:17Z", query)
 
 
 class WaveBranchPathUnchanged(unittest.TestCase):

--- a/.claude/lib/wave_status.py
+++ b/.claude/lib/wave_status.py
@@ -120,7 +120,18 @@ def _kickoff_ts(wave: str, status_path: Path) -> str | None:
 
 def _commit_author_name(repo: str, sha: str) -> str:
     """The head commit's author name for *sha* — the identity the
-    top-concentration metric is computed over."""
+    top-concentration metric is computed over.
+
+    *sha* is always a PR's ``headRefOid`` (the PR branch tip, the
+    implementer's own last commit) — deliberately NEVER the merge commit
+    landed on ``main``. That distinction matters here specifically: this
+    org merges with ``--merge`` (never ``--squash``), so a merge commit's
+    author is the orchestrator/CLI identity that ran the merge
+    (``parametrization``) for every PR, which would collapse
+    per-engineer concentration to a single name regardless of who actually
+    authored the work (the #1177 persona-loss failure mode). ``headRefOid``
+    preserves the real implementer identity.
+    """
     return _run_gh(
         [
             "api",
@@ -261,6 +272,21 @@ def _merged_prs_wave_branch(phase: str, wave: str, status_path: Path) -> list[di
     return out
 
 
+# `gh pr list` defaults to `--limit 30` (main#1131 M2). The wave-branch path
+# was structurally immune to this cap -- `--base <wave-branch>` already bounds
+# the query to the wave -- but `--base main` on a direct-to-main wave queries
+# against FULL repo history, which a live check against this repo returned
+# 251 merged-to-main PRs for (`--limit 500`). An unbounded `main` query with
+# the gh default cap silently drops the OLDEST matches once the repo
+# accumulates more than 30 merges-to-main since a wave's kickoff -- exactly
+# the "exits 0, returns a plausible number" failure shape main#1131 exists to
+# kill. 1000 is not a real pagination fix (a wave whose window somehow
+# accrues >1000 merges-to-main would still truncate), but combined with the
+# `--search merged:>=` server-side bound below it comfortably covers any
+# realistic wave, and is cheap insurance regardless.
+_PR_LIST_LIMIT = 1000
+
+
 def _merged_prs_direct_to_main(wave: str, status_path: Path) -> list[dict]:
     """Build the wave's merged-PR set for a ``direct-to-main`` wave (main#1131).
 
@@ -274,6 +300,16 @@ def _merged_prs_direct_to_main(wave: str, status_path: Path) -> list[dict]:
     that repo's canonical scope-issue set (:func:`_canonical_issue_numbers_by_repo`).
     A repo with no canonical scope rows is skipped entirely rather than
     querying every merged PR in that repo.
+
+    The listing itself is bounded two ways (main#1131 M2 — `gh pr list`
+    defaults to `--limit 30`, and `--base main` removes the wave-branch's
+    natural scope, exposing that cap against full repo history): a
+    server-side ``--search merged:>=<kickoff>`` qualifier so the query never
+    reaches further back than the wave itself, and an explicit
+    :data:`_PR_LIST_LIMIT` well above any realistic wave's merge volume. The
+    ``merged_at < kickoff`` filter below is kept as defense-in-depth in case
+    the search qualifier's date granularity and the recorded kickoff instant
+    ever disagree at the second.
     """
     repos = read_repos(wave, status_path)
     kickoff = _kickoff_ts(wave, status_path)
@@ -284,22 +320,23 @@ def _merged_prs_direct_to_main(wave: str, status_path: Path) -> list[dict]:
         canonical_issues = issue_numbers_by_repo.get(repo)
         if not canonical_issues:
             continue
-        listed = json.loads(
-            _run_gh(
-                [
-                    "pr",
-                    "list",
-                    "--repo",
-                    f"noorinalabs/{repo}",
-                    "--state",
-                    "merged",
-                    "--base",
-                    "main",
-                    "--json",
-                    "number,headRefOid,mergedAt,author",
-                ]
-            )
-        )
+        args = [
+            "pr",
+            "list",
+            "--repo",
+            f"noorinalabs/{repo}",
+            "--state",
+            "merged",
+            "--base",
+            "main",
+            "--limit",
+            str(_PR_LIST_LIMIT),
+            "--json",
+            "number,headRefOid,mergedAt,author",
+        ]
+        if kickoff:
+            args += ["--search", f"merged:>={kickoff}"]
+        listed = json.loads(_run_gh(args))
         for pr in listed:
             merged_at = pr.get("mergedAt") or ""
             if kickoff and merged_at < kickoff:

--- a/.claude/lib/wave_status.py
+++ b/.claude/lib/wave_status.py
@@ -45,6 +45,12 @@ import sys
 from collections import Counter
 from pathlib import Path
 
+# wave_merge_model lives alongside this file in .claude/lib/. When this module
+# is run as a script its own directory is on sys.path[0]; the tests add the
+# lib dir explicitly (mirrors the trust_signals.py -> wave_status.py import).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import wave_merge_model  # noqa: E402
+
 # upsert_status_keys.py lives alongside this file in .claude/lib/. When this
 # module is run as a script its own directory is on sys.path[0]; the tests add
 # the lib dir explicitly. Import lazily inside _write_counters so a missing
@@ -112,13 +118,107 @@ def _kickoff_ts(wave: str, status_path: Path) -> str | None:
     return str(val) if val else None
 
 
-def merged_prs(phase: str, wave: str, status_path: Path) -> list[dict]:
+def _commit_author_name(repo: str, sha: str) -> str:
+    """The head commit's author name for *sha* — the identity the
+    top-concentration metric is computed over."""
+    return _run_gh(
+        [
+            "api",
+            f"repos/noorinalabs/{repo}/commits/{sha}",
+            "--jq",
+            ".commit.author.name",
+        ]
+    ).strip()
+
+
+def _canonical_issue_numbers_by_repo(wave: str, status_path: Path) -> dict[str, set[int]]:
+    """Canonical scope-issue numbers per repo, from ``wave_{M}_scope``.
+
+    ``wave_{M}_scope`` (the record ``/wave-scope`` maintains) holds an
+    arbitrary, wave-specific set of ``tier_*`` arrays — tier names are NOT
+    fixed across waves (main#1131: wave-29 introduced ``tier_4_...`` that did
+    not exist in earlier waves), so every key is iterated generically via
+    ``key.startswith("tier_")``, exactly as
+    ``post_wave_kickoff_comment.py:find_assignment_row`` does. Each dict row's
+    ``id`` field is the fully-qualified ``noorinalabs-<repo>#<number>`` shape;
+    rows without a parseable ``id`` (legacy plain-string tier entries) are
+    skipped — they carry no repo/number to key on.
+
+    This is the base+timestamp-is-not-sufficient fix from the wave-28 retro:
+    a merged-to-main PR in the timestamp window is only in scope if it closes
+    an issue that is actually recorded as part of the wave's scope (the
+    wave-28 false positive was ``us#213`` — in-window, but never a scope row).
+    """
+    data = _load_status(status_path)
+    scope = data.get(f"wave_{wave}_scope")
+    if not isinstance(scope, dict):
+        raise KeyError(f"wave_{wave}_scope")
+
+    by_repo: dict[str, set[int]] = {}
+    for key, value in scope.items():
+        if not key.startswith("tier_") or not isinstance(value, list):
+            continue
+        for row in value:
+            if not isinstance(row, dict):
+                continue
+            row_id = row.get("id")
+            if not isinstance(row_id, str) or "#" not in row_id:
+                continue
+            repo, _, number = row_id.rpartition("#")
+            if not repo or not number.isdigit():
+                continue
+            by_repo.setdefault(repo, set()).add(int(number))
+    return by_repo
+
+
+def _pr_closing_issue_numbers(repo: str, number: int) -> set[int]:
+    """Issue numbers GitHub recognises *number* as closing, via GraphQL.
+
+    The REST-backed ``gh pr list --json`` surface (this org pins gh 2.45.0)
+    has no ``closingIssuesReferences`` field, so this goes through
+    ``gh api graphql`` instead. A row-number match is not assumed: main#1172
+    was delivered by PR #1173 (a different number), and #1167/#1168/#1170/
+    #1171 were bundled into a single PR — the closing-reference set is the
+    only reliable link between a scope row and the PR that actually delivered
+    it under a direct-to-main wave.
+    """
+    query = (
+        "query($owner:String!,$name:String!,$number:Int!){"
+        "repository(owner:$owner,name:$name){"
+        "pullRequest(number:$number){"
+        "closingIssuesReferences(first:25){nodes{number}}"
+        "}}}"
+    )
+    raw = _run_gh(
+        [
+            "api",
+            "graphql",
+            "-f",
+            f"query={query}",
+            "-f",
+            "owner=noorinalabs",
+            "-f",
+            f"name={repo}",
+            "-F",
+            f"number={number}",
+            "--jq",
+            "[.data.repository.pullRequest.closingIssuesReferences.nodes[].number]",
+        ]
+    )
+    return {int(n) for n in json.loads(raw or "[]")}
+
+
+def _merged_prs_wave_branch(phase: str, wave: str, status_path: Path) -> list[dict]:
     """Build the wave's merged-PR set across every in-scope repo.
 
     For each repo: list merged PRs based on ``deployments/phase-<P>/wave-<M>``,
     drop any merged before ``wave_{M}_kicked_off_at`` (the #423 cross-window
     filter), and attach the head commit's author name (the identity the
     top-concentration metric is computed over).
+
+    UNCHANGED behavior (main#1131) — this is the pre-existing wave-branch path,
+    only renamed so :func:`merged_prs` can dispatch on the declared merge
+    model; every line of logic below is identical to the pre-#1131 body.
     """
     repos = read_repos(wave, status_path)
     kickoff = _kickoff_ts(wave, status_path)
@@ -147,14 +247,7 @@ def merged_prs(phase: str, wave: str, status_path: Path) -> list[dict]:
             if kickoff and merged_at < kickoff:
                 continue
             sha = pr["headRefOid"]
-            commit_author = _run_gh(
-                [
-                    "api",
-                    f"repos/noorinalabs/{repo}/commits/{sha}",
-                    "--jq",
-                    ".commit.author.name",
-                ]
-            ).strip()
+            commit_author = _commit_author_name(repo, sha)
             out.append(
                 {
                     "repo": repo,
@@ -166,6 +259,82 @@ def merged_prs(phase: str, wave: str, status_path: Path) -> list[dict]:
                 }
             )
     return out
+
+
+def _merged_prs_direct_to_main(wave: str, status_path: Path) -> list[dict]:
+    """Build the wave's merged-PR set for a ``direct-to-main`` wave (main#1131).
+
+    No wave branch exists under this model, so ``--base <wave-branch>``
+    (:func:`_merged_prs_wave_branch`'s filter) silently matches nothing. The
+    fix is NOT simply switching the base to ``main`` — base+timestamp alone
+    over-counts (wave-28 retro: ``us#213`` was in-window but out-of-scope).
+    Instead: list merged-to-main PRs per in-scope repo, apply the existing
+    ``wave_{M}_kicked_off_at`` cross-window filter as a pre-filter, then keep
+    only the PRs whose GitHub-recognised closing-issue references intersect
+    that repo's canonical scope-issue set (:func:`_canonical_issue_numbers_by_repo`).
+    A repo with no canonical scope rows is skipped entirely rather than
+    querying every merged PR in that repo.
+    """
+    repos = read_repos(wave, status_path)
+    kickoff = _kickoff_ts(wave, status_path)
+    issue_numbers_by_repo = _canonical_issue_numbers_by_repo(wave, status_path)
+
+    out: list[dict] = []
+    for repo in repos:
+        canonical_issues = issue_numbers_by_repo.get(repo)
+        if not canonical_issues:
+            continue
+        listed = json.loads(
+            _run_gh(
+                [
+                    "pr",
+                    "list",
+                    "--repo",
+                    f"noorinalabs/{repo}",
+                    "--state",
+                    "merged",
+                    "--base",
+                    "main",
+                    "--json",
+                    "number,headRefOid,mergedAt,author",
+                ]
+            )
+        )
+        for pr in listed:
+            merged_at = pr.get("mergedAt") or ""
+            if kickoff and merged_at < kickoff:
+                continue
+            closes = _pr_closing_issue_numbers(repo, pr["number"])
+            if not closes & canonical_issues:
+                continue
+            sha = pr["headRefOid"]
+            commit_author = _commit_author_name(repo, sha)
+            out.append(
+                {
+                    "repo": repo,
+                    "number": pr["number"],
+                    "mergedAt": merged_at,
+                    "headRefOid": sha,
+                    "author": (pr.get("author") or {}).get("login"),
+                    "commit_author_name": commit_author,
+                }
+            )
+    return out
+
+
+def merged_prs(phase: str, wave: str, status_path: Path) -> list[dict]:
+    """Build the wave's merged-PR set across every in-scope repo.
+
+    Dispatches on the declared ``wave_{M}_merge_model`` (main#1131):
+    ``direct-to-main`` routes through the canonical-scope path
+    (:func:`_merged_prs_direct_to_main`, no wave branch exists to filter on);
+    ``wave-branch`` and an unrecorded/legacy model (``None``) both keep the
+    pre-existing behavior unchanged (:func:`_merged_prs_wave_branch`).
+    """
+    model = wave_merge_model.read_merge_model(wave, status_path)
+    if model == wave_merge_model.DIRECT_TO_MAIN:
+        return _merged_prs_direct_to_main(wave, status_path)
+    return _merged_prs_wave_branch(phase, wave, status_path)
 
 
 def _changes_requested_cycles(prs: list[dict]) -> int:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,16 @@ jobs:
       ENVIRONMENT: test
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history (main#1131): test_wave_status.py's
+          # BaseVsHeadDifferential execs the pre-fix wave_status.py straight
+          # out of a historical commit via `git show <base-sha>:path` to prove
+          # the wave-branch path is byte-for-byte unchanged. The default
+          # shallow checkout (fetch-depth 1) does not have that object, so the
+          # `git show` dies with exit 128 — CI-red even though the test passes
+          # locally against a complete clone. Same reason the doc-freshness
+          # job below already sets this.
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"


### PR DESCRIPTION
## Summary

`.claude/lib/wave_status.py`'s `merged_prs()` hardcoded a
`deployments/phase-{P}/wave-{M}` base. On a `direct-to-main` wave (the
common case since the 2026-06-09 every-wave-merges-to-main directive) no
such branch exists, so the call silently returned an empty set —
`compute_counters()` reported `final_pr_count=0` and
`trust_signals.extract_signals()` returned `{}`. Neither errored. Since
wave-29 is itself declared `direct-to-main`, its own `/wave-wrapup`
depended on this fix.

Base+timestamp alone is **not sufficient** — the wave-28 retro recorded a
concrete false positive (`us#213`, in-window but out-of-scope). The fix
instead derives a **canonical scope-issue set** per repo from
`wave_{M}_scope`'s `tier_*` rows (iterated generically via
`key.startswith("tier_")` — tier names are not fixed across waves; wave-29
introduced `tier_4_in_wave_findings`, absent from earlier waves), lists
merged-to-main PRs per in-scope repo (pre-filtered by
`wave_{M}_kicked_off_at`), and keeps only the PRs whose
GitHub-recognised closing-issue references (`gh api graphql`
`closingIssuesReferences` — not available on this org's pinned gh 2.45.0
REST-backed `--json` surface) intersect that canonical set. Scope rows
are not assumed 1:1 with PRs: `main#1172` was delivered by PR `#1173`
(a different number), and `#1167`/`#1168`/`#1170`/`#1171` bundle into a
single PR.

The pre-existing wave-branch path is renamed to `_merged_prs_wave_branch`
but is otherwise byte-for-byte unchanged; `merged_prs()` now dispatches on
`wave_merge_model.read_merge_model()` — `direct-to-main` routes to the new
canonical-scope path, everything else (`wave-branch`, or an unrecorded
legacy model) keeps the old behavior. `trust_signals.py` needed no changes
— it consumes `wave_status.merged_prs()` and inherits the fix.

## Verification

**Real wave-29 data, before/after:**

| | `final_pr_count` | `changes_requested_cycles` | `top_concentration_pct` | trust signals |
|---|---|---|---|---|
| Before (unfixed, base `b290d61`) | `0` | `0` | `0` | `{}` |
| After (this PR) | `5` | `3` | `20` | 6 engineers, real signals |

`merged-prs` on the fixed code finds exactly `#1173, #1153, #1154,
#1155, #1156` — the five PRs the issue names as ground truth — and
correctly excludes the still-open `#1178`.

**Wave-branch path unchanged:** `BaseVsHeadDifferential` in
`test_wave_status.py` execs the pre-fix `merged_prs` straight out of the
base commit via `git show <sha>:.claude/lib/wave_status.py` and diffs its
JSON output against head's `_merged_prs_wave_branch` (and against the
public `merged_prs()` dispatcher on a status file with no
`merge_model` key) on the same fixture/fake-gh — an actual runtime
comparison, not a want/got table.

**Tests fail against unfixed code:** stashed the source change,
re-ran the new tests — all 9 new direct-to-main / differential tests
failed (the pre-existing `WaveBranchPathUnchanged` test passed
unchanged, as expected); restored the fix and all 27 tests in the file
pass again.

**Regression coverage, both merge models:** `CanonicalIssueNumbers`,
`MergedPrsDirectToMain` (over-count guard / bundled-PR dedup /
issue-number != PR-number / no-canonical-rows skip / real wave-29 5-PR
set), `WaveBranchPathUnchanged` (explicit `wave-branch` model keeps the
old base), `BaseVsHeadDifferential`.

**Full suite:** `.claude/lib/tests` + `.claude/hooks/tests` — 3171
passed, 253 subtests. `ruff format`/`ruff lint` clean. `mypy`: no
issues. Sync-drift gate: OK. Pre-commit and pre-push hook sets both ran
clean, no `--no-verify`.

Closes #1131.

## Test plan
- [x] `ENVIRONMENT=test python3 -m pytest .claude/lib/tests/test_wave_status.py -q` — 27 passed
- [x] `ENVIRONMENT=test python3 -m pytest .claude/lib/tests .claude/hooks/tests -q` — 3171 passed, 253 subtests
- [x] `python3 -m mypy .claude/lib/wave_status.py .claude/lib/tests/test_wave_status.py` — no issues
- [x] `python3 .claude/lib/pre_commit_ci_sync.py .` — OK
- [x] `python3 .claude/lib/wave_status.py counters 10 29 --status cross-repo-status.json` against real data — non-zero, matches ground truth
- [x] Stash-and-rerun: new tests fail against unfixed `wave_status.py`
