### PR TITLE
fix(commit-identity): route interpreter option runs through the shared grammar (#1149)

### DIFF
--- a/.claude/hooks/_shell_parse.py
+++ b/.claude/hooks/_shell_parse.py
@@ -1178,12 +1178,26 @@ class InterpreterInvocation(NamedTuple):
     shell-accurate answer and is what a consumer that must resolve a real path
     (the script-invocation check) should use.
 
-    `words` is every non-flag token in the invocation, including words consumed
-    as option VALUES. It is a deliberate superset of `operands` for consumers
-    that are gates: a cluster mixing a value-letter with `c` can shift the
-    payload index by one in ways that differ between shells, and a gate that
-    guesses wrong fails OPEN. Option values are short words like `pipefail`, so
-    scanning them too costs nothing and removes the whole class of index error.
+    `words` is every token of the invocation except the `--` sentinel — the set
+    the command string is guaranteed to be a member of. It is deliberately a
+    SUPERSET of `operands`, and consumers that are gates must use it, because
+    `operands` alone fails OPEN in two measured ways:
+
+      - a cluster mixing a value-letter with `c` shifts the payload index, and
+        differently per shell: `zsh -cO '<cmd>'` runs `<cmd>`, but the shared
+        grammar pairs the clustered `-O` with it as a VALUE, so `operands` is
+        empty;
+      - `end` is only a LOWER bound on where the option run stops.
+        `_consume_wrapper_options` treats every dash-leading token as an option,
+        so a command string that itself starts with `-` is swallowed into the
+        run. Both `bash -c -- '-x; git commit …'` and `zsh -abc '-x; git
+        commit …'` really execute, and both left `operands` empty.
+
+    Rather than re-derive the exact boundary — reintroducing precisely the
+    per-shell option knowledge this module exists to avoid — `words` keeps
+    everything. The extra tokens are option spellings (`-l`, `--login`,
+    `pipefail`); none can carry a `git … commit` bridge, and the cost was priced
+    at zero verdict changes over 7.6k real recorded commands.
     """
 
     name: str
@@ -1258,7 +1272,7 @@ def parse_interpreter_invocation(segment: list[str]) -> InterpreterInvocation | 
     end = _consume_wrapper_options(rest, SHELL_VALUE_OPTIONS, 0)
     has_command_string = _COMMAND_STRING_FLAG in rest[:end]
     operands = tuple(rest[end:])
-    words = tuple(t for t in rest if t != "--" and not _looks_like_flag(t))
+    words = tuple(t for t in rest if t != "--")
     return InterpreterInvocation(name, has_command_string, operands, words)
 
 

--- a/.claude/hooks/_shell_parse.py
+++ b/.claude/hooks/_shell_parse.py
@@ -1126,6 +1126,196 @@ def strip_command_prefixes(segment: list[str], *, compound_leaders: bool = True)
     return tokens
 
 
+# ---------------------------------------------------------------------------
+# Shell-interpreter invocations (main#1149)
+# ---------------------------------------------------------------------------
+#
+# `validate_commit_identity` matched `<shell> -c <payload>` with a regex that
+# required `-c` to be a BARE token immediately after the interpreter. Real
+# shells accept the command-string flag combined into a short-flag cluster and
+# after an arbitrary option run, so 8 of 9 ordinary spellings walked straight
+# past the gate and committed with whatever ambient identity git resolved.
+#
+# The grammar below is deliberately NOT a second regex. It normalizes the
+# interpreter's own option tokens into the shape `_consume_wrapper_options`
+# already understands and then defers to it, so there is exactly one option-run
+# implementation in this module (main#1150's invariant).
+#
+# Every rule here was measured against bash / sh / zsh / dash with an execution
+# oracle (does the candidate payload actually run?), not reasoned from man
+# pages. The three findings that a from-first-principles fix would have missed:
+#
+#   `bash -cl CMD`  runs CMD — the command-string letter does NOT have to be
+#                   last in the cluster, so a `-[a-z]*c$` regex is still wrong.
+#   `bash +x -c CMD` runs CMD — `+`-form options are options, but
+#                   `_looks_like_flag` only recognises a leading `-`.
+#   `bash -oc pipefail CMD` runs CMD — a value-taking letter INSIDE a cluster
+#                   still eats the next word, shifting the payload by one.
+#   `bash -- -c CMD` does NOT run CMD — `--` ends the option run, which
+#                   `_consume_wrapper_options` already models correctly.
+
+# Interpreter options that consume a following word as their value. `-o`/`-O`
+# name a `set`/`shopt` option; bash's two startup-file options take a path.
+SHELL_VALUE_OPTIONS = frozenset({"-o", "-O", "--rcfile", "--init-file"})
+
+# Cluster letters that consume a following word (the short forms of the above).
+_SHELL_VALUE_LETTERS = frozenset("oO")
+
+# The letter that introduces a command string: `sh -c '<cmd>'`.
+_COMMAND_STRING_FLAG = "-c"
+
+
+class InterpreterInvocation(NamedTuple):
+    """A decoded `<shell> [options] [operands ...]` command.
+
+    `name` is the interpreter basename (`/usr/bin/bash` -> `bash`).
+
+    `has_command_string` is True when the option run carries `-c` in any
+    spelling — bare, clustered (`-lc`, `-cl`, `-cabm`), or after other options.
+
+    `operands` are the tokens after the option run, i.e. what the shell itself
+    treats as `<command-string> [$0 $1 ...]` or `<script> [args]`. This is the
+    shell-accurate answer and is what a consumer that must resolve a real path
+    (the script-invocation check) should use.
+
+    `words` is every non-flag token in the invocation, including words consumed
+    as option VALUES. It is a deliberate superset of `operands` for consumers
+    that are gates: a cluster mixing a value-letter with `c` can shift the
+    payload index by one in ways that differ between shells, and a gate that
+    guesses wrong fails OPEN. Option values are short words like `pipefail`, so
+    scanning them too costs nothing and removes the whole class of index error.
+    """
+
+    name: str
+    has_command_string: bool
+    operands: tuple[str, ...]
+    words: tuple[str, ...]
+
+
+def _expand_shell_option_token(tok: str) -> list[str]:
+    """Rewrite one interpreter option token into `_consume_wrapper_options` form.
+
+    Two normalizations, each closing a measured bypass:
+
+      `+x` -> `-x`, `+o` -> `-o`
+          `set`-style options may be turned off with a leading `+`, and
+          `bash +x -c '<cmd>'` really does run `<cmd>`. `_looks_like_flag` keys
+          on a leading `-` only, so without this the `+x` reads as the wrapped
+          command and the option run ends before `-c` is ever seen.
+
+      `-lc` -> `-l -c`
+          De-clustering makes the command-string flag a plain token-equality
+          test instead of a second regex over cluster spellings, and it lets
+          the shared grammar pair a clustered value-letter with its value.
+
+    Value-taking letters are emitted LAST within an expanded cluster. Within one
+    cluster the letters' order does not change WHICH following words are
+    consumed as values — only the order they are consumed in — so moving them to
+    the end is semantics-preserving for our purpose, and it puts each value flag
+    immediately before the word it consumes, which is the only arrangement
+    `_consume_wrapper_options` can pair up (it refuses to let a value flag eat a
+    flag-shaped token). Without the reorder, `bash -oc pipefail 'git commit …'`
+    resolves the payload to `pipefail` and the gate fails open.
+
+    Long options, `--`, `=`-forms and anything non-alphabetic are returned
+    unchanged: only a `[-+][A-Za-z]{2,}` run is a short-flag cluster.
+    """
+    if len(tok) < 2 or tok[0] not in "-+":
+        return [tok]
+    body = tok[1:]
+    if body.startswith("-") or not body.isalpha():
+        # `--login`, `--rcfile=F`, `--`, `-2`, `-o=x` — not a short cluster.
+        return ["-" + body] if tok[0] == "+" else [tok]
+    if len(body) == 1:
+        return ["-" + body]
+    plain = ["-" + ch for ch in body if ch not in _SHELL_VALUE_LETTERS]
+    valued = ["-" + ch for ch in body if ch in _SHELL_VALUE_LETTERS]
+    return plain + valued
+
+
+def parse_interpreter_invocation(segment: list[str]) -> InterpreterInvocation | None:
+    """Decode `segment` as a shell-interpreter invocation, or return None.
+
+    Transparent command-prefix wrappers are stripped first, so
+    `timeout 30 env FOO=1 bash -lc '<cmd>'` decodes the same as `bash -lc
+    '<cmd>'`. A leading path is reduced to its basename (`/bin/sh` -> `sh`).
+
+    Returns None when the segment is empty or its head is not one of
+    `SHELL_INTERPRETERS` — callers must treat None as "not an interpreter
+    invocation", never as "safe".
+    """
+    tokens = strip_command_prefixes(segment)
+    if not tokens:
+        return None
+    name = tokens[0].rsplit("/", 1)[-1]
+    if name not in SHELL_INTERPRETERS:
+        return None
+
+    rest: list[str] = []
+    for tok in tokens[1:]:
+        rest.extend(_expand_shell_option_token(tok))
+
+    end = _consume_wrapper_options(rest, SHELL_VALUE_OPTIONS, 0)
+    has_command_string = _COMMAND_STRING_FLAG in rest[:end]
+    operands = tuple(rest[end:])
+    words = tuple(t for t in rest if t != "--" and not _looks_like_flag(t))
+    return InterpreterInvocation(name, has_command_string, operands, words)
+
+
+def iter_interpreter_invocations(command: str) -> list[InterpreterInvocation]:
+    """Decode every shell-interpreter invocation in a compound command.
+
+    Heredoc bodies are removed before tokenizing: a body is not part of the
+    invocation's own argument list, and leaving it in would let its words be
+    read as segments. Callers that care about heredoc BODIES (they are executed
+    when the heredoc is fed to a shell) must handle them separately —
+    `classify_heredocs` is the primitive for that.
+
+    Unbalanced-quote repair. A command that shlex cannot tokenize would
+    otherwise yield nothing, and for a fail-closed gate that is a bypass an
+    evader reaches by typing one extra quote character:
+
+        bash -lc "git commit -m x" && echo "unclosed
+
+    The invocation itself is well-formed; only the tail is broken. So on a parse
+    failure we retry once per quote character with that character appended.
+    Repairing the QUOTING (rather than splitting the text on separators, the
+    other obvious recovery) is what keeps this safe: quoted prose stays a single
+    token, so a malformed `gh issue comment --body '…bash -lc "git commit"…'`
+    still resolves to a segment headed by `gh` and matches nothing. The
+    head-anchored `parse_interpreter_invocation` does the rest — a repaired
+    parse can only ever add segments, never move an interpreter into command
+    position that was not already there.
+
+    Returns an empty list when even the repaired text cannot be tokenized. A
+    security gate must therefore still keep a text-level fallback rather than
+    reading an empty list as "nothing here".
+
+    Perf prefilter (#1113 discipline): an interpreter invocation cannot exist
+    unless the interpreter's name appears literally somewhere in the command, so
+    a substring test skips the tokenize for the overwhelming majority of Bash
+    calls. The helpers below are individually memoized, so a command that does
+    reach them is parsed once per process regardless of how many hooks ask.
+    """
+    if not any(name in command for name in SHELL_INTERPRETERS):
+        return []
+    text = strip_heredocs(command)
+    tokens = tokenize(normalize_command_separators(text))
+    if tokens is None:
+        for repair in ("'", '"'):
+            tokens = tokenize(normalize_command_separators(text + repair))
+            if tokens is not None:
+                break
+    if tokens is None:
+        return []
+    found: list[InterpreterInvocation] = []
+    for segment in iter_command_segments(tokens):
+        invocation = parse_interpreter_invocation(segment)
+        if invocation is not None:
+            found.append(invocation)
+    return found
+
+
 def find_git_subcommand(segment: list[str]) -> tuple[list[str], list[str]] | None:
     """If `segment` is a `git ...` invocation, return (global_opts, [subcmd, ...]).
 

--- a/.claude/hooks/tests/test_interpreter_option_grammar.py
+++ b/.claude/hooks/tests/test_interpreter_option_grammar.py
@@ -1,0 +1,506 @@
+#!/usr/bin/env python3
+"""Regression tests for main#1149 — interpreter option grammar in the commit-identity gate.
+
+`validate_commit_identity` decided "is this `<shell> -c '<payload>'`?" with a
+regex that required `-c` to be a BARE token immediately after the interpreter,
+and "is this `<shell> <script>`?" with a regex that required the path to sit in
+the same position. Real shells accept an arbitrary option run first, and accept
+the command-string flag combined into a short-flag cluster. Eight of the nine
+ordinary spellings in the issue therefore let an identity-less commit through,
+and the whole `<shell> -x <script>` family did too.
+
+The fix routes both shapes through `_shell_parse.parse_interpreter_invocation`,
+which normalizes the interpreter's option tokens and then defers to the SHARED
+`_consume_wrapper_options` primitive — one option-run implementation in the
+module instead of two divergent regexes (main#1150's invariant).
+
+What these tests pin, and why in this shape
+===========================================
+
+* `ShellTruthTests` is the load-bearing one. It runs a REAL shell and asks
+  whether the payload actually executed, then requires the hook to block every
+  form that did. The marker is assembled from random bytes at run time and the
+  verdict is "did this file appear on disk", so a payload that is merely
+  DISPLAYED (echoed, error-quoted) can never be scored as executed. Both #1151
+  families survived the old suite precisely because the tests encoded the
+  implementation instead of the shell.
+* The remaining classes vary ONE dimension each — cluster spelling, option
+  position, interpreter identity, payload quoting, segment role — because three
+  consecutive review rounds on main#1155 each found a defect sitting in whatever
+  the previous corpus had held constant.
+* `MustStayAllowedTests` and `PreviouslyBlockedStillBlockTests` are the two
+  no-regression directions. Widening a gate is only correct if nothing that
+  blocked before now passes AND ordinary work is still allowed.
+
+Run: python3 -m pytest .claude/hooks/tests/test_interpreter_option_grammar.py -v
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_HOOKS_DIR = _HERE.parent
+sys.path.insert(0, str(_HOOKS_DIR))
+
+import validate_commit_identity as hook  # noqa: E402
+from _shell_parse import (  # noqa: E402
+    SHELL_INTERPRETERS,
+    _expand_shell_option_token,
+    iter_interpreter_invocations,
+    parse_interpreter_invocation,
+)
+
+# An identity-less commit: no `-c user.name=` / `-c user.email=` anywhere. Every
+# shape below is a charter violation the gate exists to stop.
+NAKED_COMMIT = "git commit -m x"
+
+
+def verdict(command: str, *, cwd: str | None = None) -> str:
+    """Run the hook over `command` and return "BLOCK" or "allow"."""
+    payload: dict = {"tool_name": "Bash", "tool_input": {"command": command}}
+    if cwd is not None:
+        payload["cwd"] = cwd
+    return "BLOCK" if hook.check(payload) else "allow"
+
+
+class NineFormsFromTheIssueTests(unittest.TestCase):
+    """The exact nine-row table from main#1149. Eight of these used to pass."""
+
+    FORMS = [
+        ("interpreter + bare -c", f"bash -c '{NAKED_COMMIT}'"),
+        ("combined -lc", f"bash -lc '{NAKED_COMMIT}'"),
+        ("combined -ic", f"bash -ic '{NAKED_COMMIT}'"),
+        ("combined -xc", f"bash -xc '{NAKED_COMMIT}'"),
+        ("combined -ec", f"bash -ec '{NAKED_COMMIT}'"),
+        ("-l then separate -c", f"bash -l -c '{NAKED_COMMIT}'"),
+        ("--login then separate -c", f"bash --login -c '{NAKED_COMMIT}'"),
+        ("-o pipefail then separate -c", f"bash -o pipefail -c '{NAKED_COMMIT}'"),
+        ("zsh with combined -lc", f"zsh -lc '{NAKED_COMMIT}'"),
+    ]
+
+    def test_all_nine_forms_block(self):
+        for label, command in self.FORMS:
+            with self.subTest(form=label):
+                self.assertEqual(verdict(command), "BLOCK", command)
+
+    def test_block_reason_names_the_shell_c_shape(self):
+        result = hook.check(
+            {"tool_name": "Bash", "tool_input": {"command": f"bash -lc '{NAKED_COMMIT}'"}}
+        )
+        assert result is not None
+        self.assertIn("indirect-exec wrapper detected", result["reason"])
+        self.assertIn("shell -c", result["reason"])
+
+
+class ClusterSpellingTests(unittest.TestCase):
+    """Vary the short-flag CLUSTER; hold interpreter and payload constant.
+
+    `-cl` is the row that kills the "widen the regex to `-[a-z]*c`" shortcut the
+    issue offered as a minimum-viable fix: the command-string letter does not
+    have to be last in the cluster, and every shell measured runs the payload
+    anyway.
+    """
+
+    CLUSTERS = ["-lc", "-cl", "-cx", "-ce", "-vc", "-uc", "-fc", "-lxc", "-abc", "-cabm"]
+
+    def test_every_cluster_containing_c_blocks(self):
+        for cluster in self.CLUSTERS:
+            with self.subTest(cluster=cluster):
+                self.assertEqual(verdict(f"bash {cluster} '{NAKED_COMMIT}'"), "BLOCK")
+
+    def test_cluster_without_c_is_not_a_command_string(self):
+        invocation = parse_interpreter_invocation(["bash", "-lx", NAKED_COMMIT])
+        assert invocation is not None
+        self.assertFalse(invocation.has_command_string)
+
+
+class PrecedingOptionTests(unittest.TestCase):
+    """Vary the option run BEFORE `-c`; hold cluster shape and payload constant."""
+
+    OPTION_RUNS = [
+        "-l",
+        "-x",
+        "-e",
+        "-p",
+        "-s",
+        "+x",
+        "--login",
+        "--noprofile --norc",
+        "-o pipefail",
+        "+o histexpand",
+        "-O extglob",
+        "--rcfile /dev/null",
+        "--init-file /dev/null",
+        "-lo pipefail",
+        "-l -x -o pipefail +o histexpand",
+    ]
+
+    def test_option_run_before_c_still_blocks(self):
+        for run in self.OPTION_RUNS:
+            with self.subTest(options=run):
+                self.assertEqual(verdict(f"bash {run} -c '{NAKED_COMMIT}'"), "BLOCK")
+
+    def test_value_letter_inside_cluster_does_not_shift_the_payload_away(self):
+        """`bash -oc pipefail '<commit>'` — the clustered `o` eats `pipefail`.
+
+        Measured under bash: the payload is the word AFTER the option value, so
+        a walker that pairs the cluster naively resolves the payload to
+        `pipefail`, finds no commit shape, and fails open.
+        """
+        self.assertEqual(verdict(f"bash -oc pipefail '{NAKED_COMMIT}'"), "BLOCK")
+
+    def test_payload_consumed_as_an_option_value_is_still_scanned(self):
+        """`zsh -cO '<commit>'` runs the payload, but the shared grammar pairs
+        the clustered `-O` with it as a VALUE, leaving `operands` empty.
+
+        Measured: `-cO`, `-Oc` and `-cOl` all execute under zsh (bash/sh/dash
+        reject them). This is the shape that makes the gate scan
+        `InterpreterInvocation.words` — the superset including option values —
+        rather than `operands`. Scanning `operands` alone fails OPEN here.
+        """
+        for cluster in ("-cO", "-Oc", "-cOl"):
+            with self.subTest(cluster=cluster):
+                inv = parse_interpreter_invocation(["zsh", cluster, NAKED_COMMIT])
+                assert inv is not None
+                self.assertEqual(inv.operands, (), "precondition: operands must be empty")
+                self.assertEqual(inv.words, (NAKED_COMMIT,))
+                self.assertEqual(verdict(f"zsh {cluster} '{NAKED_COMMIT}'"), "BLOCK")
+
+    def test_double_dash_ends_the_option_run(self):
+        """`bash -- -c '<commit>'` does NOT execute the payload under any shell.
+
+        Pinned as an ALLOW so a future widening cannot quietly turn the option
+        grammar into "does the text contain -c somewhere".
+        """
+        self.assertEqual(verdict(f"bash -- -c '{NAKED_COMMIT}'"), "allow")
+
+
+class InterpreterIdentityTests(unittest.TestCase):
+    """Vary the interpreter; hold flag shape and payload constant."""
+
+    def test_every_recognised_interpreter_blocks(self):
+        for name in sorted(SHELL_INTERPRETERS):
+            with self.subTest(interpreter=name):
+                self.assertEqual(verdict(f"{name} -lc '{NAKED_COMMIT}'"), "BLOCK")
+
+    def test_absolute_path_interpreter_blocks(self):
+        for path in ("/bin/bash", "/usr/bin/zsh", "/bin/sh", "/usr/local/bin/dash"):
+            with self.subTest(path=path):
+                self.assertEqual(verdict(f"{path} -lc '{NAKED_COMMIT}'"), "BLOCK")
+
+    def test_non_interpreter_head_is_not_an_invocation(self):
+        """`echo bash -lc '<commit>'` prints; it does not execute."""
+        self.assertIsNone(parse_interpreter_invocation(["echo", "bash", "-lc", NAKED_COMMIT]))
+
+
+class PayloadQuotingTests(unittest.TestCase):
+    """Vary the payload QUOTING; hold interpreter and flag shape constant."""
+
+    def test_quoting_variants_block(self):
+        cases = {
+            "single": f"bash -lc '{NAKED_COMMIT}'",
+            "double": f'bash -lc "{NAKED_COMMIT}"',
+            "backslash-escaped word": "bash -lc git\\ commit",
+            "nested quotes": "bash -lc 'git commit -m \"a b\"'",
+            "inner single in double": "bash -lc \"git commit -m 'a b'\"",
+        }
+        for label, command in cases.items():
+            with self.subTest(quoting=label):
+                self.assertEqual(verdict(command), "BLOCK", command)
+
+    def test_unbalanced_quote_tail_does_not_restore_the_bypass(self):
+        """One stray quote used to defeat the tokenizer and re-open every form.
+
+        The invocation is well-formed; only the tail is broken. Quote repair in
+        `iter_interpreter_invocations` recovers it.
+        """
+        cases = [
+            f'bash -lc "{NAKED_COMMIT}" && echo "unclosed',
+            f'bash -c "{NAKED_COMMIT}" && echo "unclosed',
+            f"bash -lc '{NAKED_COMMIT}",
+            f"bash -o pipefail -c '{NAKED_COMMIT}' ; echo 'unclosed",
+        ]
+        for command in cases:
+            with self.subTest(command=command):
+                self.assertEqual(verdict(command), "BLOCK", command)
+
+
+class SegmentRoleTests(unittest.TestCase):
+    """Vary the STRUCTURAL ROLE of the invocation; hold the invocation constant."""
+
+    def test_invocation_in_any_segment_position_blocks(self):
+        inner = f"bash -lc '{NAKED_COMMIT}'"
+        cases = {
+            "leading": inner,
+            "after &&": f"cd /tmp && {inner}",
+            "after ||": f"false || {inner}",
+            "after ;": f"echo hi; {inner}",
+            "after unspaced ;": f"echo hi;{inner}",
+            "after newline": f"echo hi\n{inner}",
+            "downstream of a pipe": f"echo hi | {inner}",
+            "line continuation": "bash \\\n  -lc '%s'" % NAKED_COMMIT,
+        }
+        for label, command in cases.items():
+            with self.subTest(position=label):
+                self.assertEqual(verdict(command), "BLOCK", command)
+
+    def test_transparent_wrappers_do_not_hide_the_invocation(self):
+        inner = f"bash -lc '{NAKED_COMMIT}'"
+        for wrapper in ("timeout 30", "env FOO=1", "nohup", "nice -n 5", "command", "sudo"):
+            with self.subTest(wrapper=wrapper):
+                self.assertEqual(verdict(f"{wrapper} {inner}"), "BLOCK")
+
+
+class ScriptInvocationOptionTests(unittest.TestCase):
+    """`<shell> [options] <script>` — the same too-narrow grammar, one matcher over.
+
+    `_SCRIPT_INVOKE_RE` required the path to be the token immediately after the
+    interpreter, so every option before it hid the script. All four forms below
+    execute the script under bash / sh / zsh / dash.
+    """
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp(prefix="t1149-script-")
+        self.addCleanup(shutil.rmtree, self.tmp, True)
+        self.naked = os.path.join(self.tmp, "naked_script")
+        Path(self.naked).write_text(NAKED_COMMIT + "\n", encoding="utf-8")
+        self.innocent = os.path.join(self.tmp, "innocent_script")
+        Path(self.innocent).write_text("echo hello\n", encoding="utf-8")
+
+    def test_options_before_the_script_path_still_block(self):
+        for pre in ("", "-x", "-l", "+x", "--", "-o pipefail", "-lx"):
+            with self.subTest(options=pre or "(none)"):
+                command = f"bash {pre} {self.naked}".replace("  ", " ")
+                self.assertEqual(verdict(command), "BLOCK", command)
+
+    def test_wrapped_script_invocation_blocks(self):
+        self.assertEqual(verdict(f"timeout 9 bash -x {self.naked}"), "BLOCK")
+
+    def test_innocent_script_is_still_allowed(self):
+        for pre in ("", "-x", "-l"):
+            with self.subTest(options=pre or "(none)"):
+                self.assertEqual(verdict(f"bash {pre} {self.innocent}".replace("  ", " ")), "allow")
+
+
+class MustStayAllowedTests(unittest.TestCase):
+    """Ordinary work must not become collateral. Widening a gate has two failure
+    directions and this is the one a bypass-only corpus never asks about."""
+
+    ALLOWED = {
+        "plain ls": "ls -la",
+        "innocent -lc": "bash -lc 'echo hello'",
+        "git status via -lc": "bash -lc 'git status'",
+        "npm through a shell": "bash -lc 'npm run build'",
+        "docker exec": "docker exec x sh -lc 'ls /'",
+        "interpreter with no arguments": "bash -l",
+        "prose in a gh body": 'gh issue comment 5 --body "never run bash -lc to commit"',
+        "ripgrep for the phrase": "rg -n 'bash -lc' .claude/hooks",
+        "commit-shaped path": "git log --oneline -- src/commit/mod.rs",
+        "unrelated -c flag": "npm run build -- -c prod",
+        "data heredoc naming the shape": (
+            "cat > /tmp/notes.md <<'EOF'\nbash -lc 'git commit -m x' is forbidden\nEOF"
+        ),
+    }
+
+    def test_ordinary_commands_are_untouched(self):
+        for label, command in self.ALLOWED.items():
+            with self.subTest(case=label):
+                self.assertEqual(verdict(command), "allow", command)
+
+
+class PreviouslyBlockedStillBlockTests(unittest.TestCase):
+    """Every shape the gate caught before #1149 must still be caught.
+
+    The only way to "fix" a fail-open wrongly is to stop blocking something real
+    while widening something else.
+    """
+
+    BLOCKED = {
+        "bare -c": f"bash -c '{NAKED_COMMIT}'",
+        "printf piped to a shell": f"printf '{NAKED_COMMIT}' | bash",
+        "echo piped to a shell": f"echo '{NAKED_COMMIT}' | sh",
+        "process substitution": f"bash <(echo '{NAKED_COMMIT}')",
+        "heredoc fed to a shell": f"bash <<'EOF'\n{NAKED_COMMIT}\nEOF",
+        "here-string": f"bash <<<'{NAKED_COMMIT}'",
+        "eval": f"eval '{NAKED_COMMIT}'",
+        "cat heredoc piped to a shell": f"cat <<'EOF' | bash\n{NAKED_COMMIT}\nEOF",
+        "tee process substitution": f"tee >(bash) <<'EOF'\n{NAKED_COMMIT}\nEOF",
+        "direct commit, no identity": NAKED_COMMIT,
+        "direct commit, unknown name": (
+            'git -c user.name="Nobody Here" -c user.email="x@y.z" commit -m x'
+        ),
+    }
+
+    def test_prior_shapes_still_block(self):
+        for label, command in self.BLOCKED.items():
+            with self.subTest(case=label):
+                self.assertEqual(verdict(command), "BLOCK", command)
+
+
+class OptionTokenExpansionTests(unittest.TestCase):
+    """Unit-level pins on the normalization that feeds the shared grammar."""
+
+    def test_clusters_split_with_value_letters_last(self):
+        self.assertEqual(_expand_shell_option_token("-lc"), ["-l", "-c"])
+        self.assertEqual(_expand_shell_option_token("-cl"), ["-c", "-l"])
+        self.assertEqual(_expand_shell_option_token("-abc"), ["-a", "-b", "-c"])
+        # `o` is value-taking, so it must land adjacent to the word it consumes.
+        self.assertEqual(_expand_shell_option_token("-oc"), ["-c", "-o"])
+        self.assertEqual(_expand_shell_option_token("-lo"), ["-l", "-o"])
+
+    def test_plus_form_options_normalize_to_minus(self):
+        self.assertEqual(_expand_shell_option_token("+x"), ["-x"])
+        self.assertEqual(_expand_shell_option_token("+o"), ["-o"])
+
+    def test_non_clusters_pass_through(self):
+        for tok in ("--login", "--rcfile=F", "--", "-c", "-2", "-o=x", "script.sh"):
+            with self.subTest(token=tok):
+                self.assertEqual(_expand_shell_option_token(tok), [tok])
+
+
+class InvocationParsingTests(unittest.TestCase):
+    """Unit-level pins on `parse_interpreter_invocation` / the iterator."""
+
+    def test_operands_and_words_for_a_clustered_value_option(self):
+        inv = parse_interpreter_invocation(["bash", "-oc", "pipefail", NAKED_COMMIT])
+        assert inv is not None
+        self.assertEqual(inv.name, "bash")
+        self.assertTrue(inv.has_command_string)
+        self.assertEqual(inv.operands, (NAKED_COMMIT,))
+        # `words` is the superset that makes the gate immune to index error.
+        self.assertEqual(inv.words, ("pipefail", NAKED_COMMIT))
+
+    def test_double_dash_moves_c_out_of_the_option_run(self):
+        inv = parse_interpreter_invocation(["bash", "--", "-c", NAKED_COMMIT])
+        assert inv is not None
+        self.assertFalse(inv.has_command_string)
+        self.assertEqual(inv.operands, ("-c", NAKED_COMMIT))
+
+    def test_wrapper_is_stripped_and_path_reduced_to_basename(self):
+        inv = parse_interpreter_invocation(["timeout", "30", "/bin/zsh", "-cl", NAKED_COMMIT])
+        assert inv is not None
+        self.assertEqual(inv.name, "zsh")
+        self.assertTrue(inv.has_command_string)
+
+    def test_iterator_finds_one_invocation_per_segment(self):
+        found = iter_interpreter_invocations("echo hi | bash -lc 'true' && sh -c 'false'")
+        self.assertEqual([i.name for i in found], ["bash", "sh"])
+
+    def test_iterator_skips_commands_with_no_interpreter(self):
+        self.assertEqual(iter_interpreter_invocations("git status --porcelain"), [])
+
+    def test_iterator_recovers_from_an_unbalanced_quote(self):
+        found = iter_interpreter_invocations('bash -lc "true" && echo "unclosed')
+        self.assertEqual([i.name for i in found], ["bash"])
+
+
+def _which(name: str) -> str | None:
+    return shutil.which(name)
+
+
+class ShellTruthTests(unittest.TestCase):
+    """Cross-check the gate against what a REAL shell does.
+
+    For each form we hand a live shell a payload that writes a marker file whose
+    name is generated at run time, then ask the filesystem whether it ran. The
+    contract asserted is the security-relevant direction:
+
+        the shell EXECUTED the payload  =>  the hook MUST block
+
+    The converse is deliberately not asserted. Blocking a form the shell would
+    not have run (`bash -n -c …` parses without executing) is the conservative
+    error and this gate is allowed to make it.
+    """
+
+    shells: list[tuple[str, str]] = []
+    work: str = ""
+
+    FORMS = [
+        ["-c"],
+        ["-lc"],
+        ["-cl"],
+        ["-xc"],
+        ["-ec"],
+        ["-vc"],
+        ["-abc"],
+        ["-cabm"],
+        ["-l", "-c"],
+        ["-x", "-c"],
+        ["+x", "-c"],
+        ["--login", "-c"],
+        ["-o", "pipefail", "-c"],
+        ["-oc", "pipefail"],
+        # zsh-only: the payload lands in an option-value slot, not an operand.
+        ["-cO"],
+        ["-Oc"],
+        ["-cOl"],
+        ["--"],
+        ["--", "-c"],
+        ["-l"],
+    ]
+
+    @classmethod
+    def setUpClass(cls):
+        found = [(n, _which(n)) for n in ("bash", "sh", "zsh", "dash")]
+        cls.shells = [(n, p) for n, p in found if p is not None]
+        if not cls.shells:
+            raise unittest.SkipTest("no POSIX shell available to establish shell truth")
+        cls.work = tempfile.mkdtemp(prefix="t1149-truth-")
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls.work:
+            shutil.rmtree(cls.work, ignore_errors=True)
+
+    def _executes(self, shell_path: str, pre: list[str]) -> bool:
+        """True iff the shell actually ran the payload as a command string."""
+        marker = os.path.join(self.work, "m_" + secrets.token_hex(8))
+        payload = "printf %s x > " + marker
+        try:
+            subprocess.run(
+                [shell_path, *pre, payload],
+                stdin=subprocess.DEVNULL,
+                capture_output=True,
+                timeout=15,
+                cwd=self.work,
+                env={"PATH": os.environ.get("PATH", ""), "HOME": self.work},
+            )
+        except (subprocess.TimeoutExpired, OSError):
+            return False
+        return os.path.exists(marker)
+
+    def test_hook_blocks_every_form_a_real_shell_executes(self):
+        checked = 0
+        for name, path in self.shells:
+            for pre in self.FORMS:
+                if not self._executes(path, pre):
+                    continue
+                checked += 1
+                command = "{} {} '{}'".format(name, " ".join(pre), NAKED_COMMIT)
+                with self.subTest(shell=name, form=" ".join(pre)):
+                    self.assertEqual(
+                        verdict(command),
+                        "BLOCK",
+                        f"{name} really executes this form but the gate allowed it: {command}",
+                    )
+        # Guard against the oracle silently degrading to "nothing executes",
+        # which would make every assertion above vacuous.
+        self.assertGreater(checked, 10, "shell-truth oracle found almost nothing executable")
+
+    def test_oracle_distinguishes_executed_from_not_executed(self):
+        """The oracle must be able to answer NO, or it proves nothing."""
+        _name, path = self.shells[0]
+        self.assertFalse(self._executes(path, ["--"]), "`--` must not run the payload")
+        self.assertTrue(self._executes(path, ["-c"]), "bare `-c` must run the payload")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/hooks/tests/test_interpreter_option_grammar.py
+++ b/.claude/hooks/tests/test_interpreter_option_grammar.py
@@ -453,6 +453,24 @@ class InvocationParsingTests(unittest.TestCase):
         self.assertEqual(inv.words, ("-c", "-o", "pipefail", NAKED_COMMIT))
 
     def test_words_drops_only_the_double_dash_sentinel(self):
+        """Pins a DESIGN DECISION, not a correctness result — read before editing.
+
+        A bounded alternative (scan only the window between `-c` and the end of
+        the option run) is equally correct on true positives: both score zero
+        holes against the shell-truth oracle, and both produce byte-identical
+        block sets over ~75k real recorded commands. The superset was chosen on
+        DURABILITY, not on detection power (main#1193 merge-gate review):
+
+          - the bounded window needs `rest.index("-c")`, which is only correct
+            while cluster expansion is right for every shell — re-importing the
+            per-shell option knowledge this module exists to delete;
+          - its failure mode is a silent index error, i.e. fail-OPEN. The
+            superset's failure mode is an over-block, which is noisy.
+
+        So a future reader who finds `words` "too broad" is looking at a
+        deliberate trade, not an oversight. Narrowing it to non-flag tokens is
+        not a style change — it re-opens `zsh -abc '-x; git commit …'`.
+        """
         inv = parse_interpreter_invocation(["bash", "-c", "--", "-x; " + NAKED_COMMIT])
         assert inv is not None
         self.assertNotIn("--", inv.words)

--- a/.claude/hooks/tests/test_interpreter_option_grammar.py
+++ b/.claude/hooks/tests/test_interpreter_option_grammar.py
@@ -171,8 +171,25 @@ class PrecedingOptionTests(unittest.TestCase):
                 inv = parse_interpreter_invocation(["zsh", cluster, NAKED_COMMIT])
                 assert inv is not None
                 self.assertEqual(inv.operands, (), "precondition: operands must be empty")
-                self.assertEqual(inv.words, (NAKED_COMMIT,))
+                self.assertIn(NAKED_COMMIT, inv.words)
                 self.assertEqual(verdict(f"zsh {cluster} '{NAKED_COMMIT}'"), "BLOCK")
+
+    def test_plus_form_option_with_a_non_alpha_body(self):
+        """`zsh +2 -c '<commit>'` executes; bash/sh/dash reject `+2` outright.
+
+        This is the shape that justifies the `+`-with-non-alpha-body arm of
+        `_expand_shell_option_token`. Without the `+` -> `-` rewrite, `+2` is
+        not flag-shaped, the option run ends before `-c` is reached, and the
+        gate fails open. `-2` (already flag-shaped) reaches the same place
+        through the general path, so it does NOT cover the `+` arm.
+        """
+        self.assertEqual(_expand_shell_option_token("+2"), ["-2"])
+        for pre in ("+2", "+1", "+0"):
+            with self.subTest(option=pre):
+                inv = parse_interpreter_invocation(["zsh", pre, "-c", NAKED_COMMIT])
+                assert inv is not None
+                self.assertTrue(inv.has_command_string)
+                self.assertEqual(verdict(f"zsh {pre} -c '{NAKED_COMMIT}'"), "BLOCK")
 
     def test_double_dash_ends_the_option_run(self):
         """`bash -- -c '<commit>'` does NOT execute the payload under any shell.
@@ -199,6 +216,62 @@ class InterpreterIdentityTests(unittest.TestCase):
     def test_non_interpreter_head_is_not_an_invocation(self):
         """`echo bash -lc '<commit>'` prints; it does not execute."""
         self.assertIsNone(parse_interpreter_invocation(["echo", "bash", "-lc", NAKED_COMMIT]))
+
+
+class DashLeadingPayloadTests(unittest.TestCase):
+    """Vary the payload's SURFACE SHAPE; hold interpreter and flag form constant.
+
+    This dimension was missing from the first head of #1193 and it hid a live
+    fail-open. Every other class here varies the *invocation*; none of them
+    varied what the command string itself looks like, and the option-run walker
+    is exactly the component whose answer depends on that.
+
+    Two independent mechanisms swallow a `-`-leading command string:
+
+      `bash -c -- '-x; <commit>'`  — `--` puts the payload in `operands`, but a
+          whole-list flag filter dropped it again. `_DASH_C_RE` misses too: it
+          captures the `--` itself as its payload group.
+      `zsh -abc '-x; <commit>'`    — no `--` at all. `_consume_wrapper_options`
+          treats every dash-leading token as an option, so the payload is
+          swallowed INTO the option run and `operands` comes back empty.
+
+    Both really execute (bash/sh/zsh/dash for the first, zsh for the second).
+    """
+
+    # The command string's leading characters, before the commit text.
+    PREFIXES = ["-x; ", "--foo; ", "-", "--", "-x && ", "+x; ", "---; ", "-- "]
+
+    def test_dash_leading_payload_after_double_dash_blocks(self):
+        for prefix in self.PREFIXES:
+            for interp in ("bash", "sh", "zsh", "dash"):
+                with self.subTest(prefix=prefix, interpreter=interp):
+                    command = f"{interp} -c -- '{prefix}{NAKED_COMMIT}'"
+                    self.assertEqual(verdict(command), "BLOCK", command)
+
+    def test_dash_leading_payload_swallowed_by_the_option_run_blocks(self):
+        """No `--`: the payload is inside the option run, not in `operands`."""
+        for cluster in ("-abc", "-cabm", "-lc", "-cl"):
+            with self.subTest(cluster=cluster):
+                inv = parse_interpreter_invocation(["zsh", cluster, "-x; " + NAKED_COMMIT])
+                assert inv is not None
+                self.assertEqual(inv.operands, (), "precondition: operands must be empty")
+                self.assertIn("-x; " + NAKED_COMMIT, inv.words)
+                self.assertEqual(verdict(f"zsh {cluster} '-x; {NAKED_COMMIT}'"), "BLOCK")
+
+    def test_words_is_a_superset_of_operands(self):
+        """The invariant that makes the gate immune to payload-index error."""
+        cases = [
+            ["bash", "-c", NAKED_COMMIT],
+            ["bash", "-c", "--", "-x; " + NAKED_COMMIT],
+            ["bash", "-oc", "pipefail", NAKED_COMMIT],
+            ["zsh", "-cO", NAKED_COMMIT],
+            ["zsh", "-abc", "-x; " + NAKED_COMMIT],
+        ]
+        for segment in cases:
+            with self.subTest(segment=" ".join(segment)):
+                inv = parse_interpreter_invocation(segment)
+                assert inv is not None
+                self.assertTrue(set(inv.operands).issubset(set(inv.words)))
 
 
 class PayloadQuotingTests(unittest.TestCase):
@@ -375,8 +448,15 @@ class InvocationParsingTests(unittest.TestCase):
         self.assertEqual(inv.name, "bash")
         self.assertTrue(inv.has_command_string)
         self.assertEqual(inv.operands, (NAKED_COMMIT,))
-        # `words` is the superset that makes the gate immune to index error.
-        self.assertEqual(inv.words, ("pipefail", NAKED_COMMIT))
+        # `words` keeps every token but `--`, so the command string is in it no
+        # matter how the cluster shifted the payload index.
+        self.assertEqual(inv.words, ("-c", "-o", "pipefail", NAKED_COMMIT))
+
+    def test_words_drops_only_the_double_dash_sentinel(self):
+        inv = parse_interpreter_invocation(["bash", "-c", "--", "-x; " + NAKED_COMMIT])
+        assert inv is not None
+        self.assertNotIn("--", inv.words)
+        self.assertEqual(inv.words, ("-c", "-x; " + NAKED_COMMIT))
 
     def test_double_dash_moves_c_out_of_the_option_run(self):
         inv = parse_interpreter_invocation(["bash", "--", "-c", NAKED_COMMIT])
@@ -445,7 +525,23 @@ class ShellTruthTests(unittest.TestCase):
         ["--"],
         ["--", "-c"],
         ["-l"],
+        # `--` in the OPTION run (not before it) — puts the command string in
+        # the operand region, where a `-`-leading payload used to be dropped.
+        ["-c", "--"],
+        ["-lc", "--"],
+        ["-cl", "--"],
+        ["-abc", "--"],
+        ["-o", "pipefail", "-c", "--"],
+        ["+2", "-c"],
     ]
+
+    # PAYLOAD SHAPE is a first-class dimension, not a constant. Every other
+    # class in this file varies the invocation and holds the command string's
+    # surface fixed — which is exactly how the `-`-leading payload fail-open
+    # survived the first head of #1193. The option-run walker's answer depends
+    # on what the payload LOOKS like, so that has to be varied against the same
+    # shell-truth contract as everything else.
+    PAYLOAD_PREFIXES = ["", "-x; ", "--foo; ", "-", "--", "-x && ", "+x; ", "-- "]
 
     @classmethod
     def setUpClass(cls):
@@ -460,10 +556,10 @@ class ShellTruthTests(unittest.TestCase):
         if cls.work:
             shutil.rmtree(cls.work, ignore_errors=True)
 
-    def _executes(self, shell_path: str, pre: list[str]) -> bool:
+    def _executes(self, shell_path: str, pre: list[str], prefix: str = "") -> bool:
         """True iff the shell actually ran the payload as a command string."""
         marker = os.path.join(self.work, "m_" + secrets.token_hex(8))
-        payload = "printf %s x > " + marker
+        payload = prefix + "printf %s x > " + marker
         try:
             subprocess.run(
                 [shell_path, *pre, payload],
@@ -481,25 +577,37 @@ class ShellTruthTests(unittest.TestCase):
         checked = 0
         for name, path in self.shells:
             for pre in self.FORMS:
-                if not self._executes(path, pre):
-                    continue
-                checked += 1
-                command = "{} {} '{}'".format(name, " ".join(pre), NAKED_COMMIT)
-                with self.subTest(shell=name, form=" ".join(pre)):
-                    self.assertEqual(
-                        verdict(command),
-                        "BLOCK",
-                        f"{name} really executes this form but the gate allowed it: {command}",
-                    )
+                for prefix in self.PAYLOAD_PREFIXES:
+                    if not self._executes(path, pre, prefix):
+                        continue
+                    checked += 1
+                    body = prefix + NAKED_COMMIT
+                    command = "{} {} '{}'".format(name, " ".join(pre), body)
+                    with self.subTest(shell=name, form=" ".join(pre), payload=prefix + "..."):
+                        self.assertEqual(
+                            verdict(command),
+                            "BLOCK",
+                            f"{name} really executes this form but the gate allowed it: {command}",
+                        )
         # Guard against the oracle silently degrading to "nothing executes",
         # which would make every assertion above vacuous.
-        self.assertGreater(checked, 10, "shell-truth oracle found almost nothing executable")
+        self.assertGreater(checked, 40, "shell-truth oracle found almost nothing executable")
 
     def test_oracle_distinguishes_executed_from_not_executed(self):
         """The oracle must be able to answer NO, or it proves nothing."""
         _name, path = self.shells[0]
         self.assertFalse(self._executes(path, ["--"]), "`--` must not run the payload")
         self.assertTrue(self._executes(path, ["-c"]), "bare `-c` must run the payload")
+
+    def test_oracle_is_sensitive_to_the_payload_dimension(self):
+        """A dash-leading payload must change at least one form's answer.
+
+        If it never did, adding `PAYLOAD_PREFIXES` would be decoration rather
+        than a dimension, and the class would be claiming coverage it lacks.
+        """
+        _name, path = self.shells[0]
+        self.assertTrue(self._executes(path, ["-c", "--"], "-x; "))
+        self.assertFalse(self._executes(path, ["-c"], "-x; "))
 
 
 if __name__ == "__main__":

--- a/.claude/hooks/validate_commit_identity.py
+++ b/.claude/hooks/validate_commit_identity.py
@@ -38,6 +38,17 @@ Indirect-exec bypass detection (#475 fix 2, extended in #482):
       dash|ksh -c '...'                  (extended _INTERPRETERS alternation)
       bash <script.bash>                 (extension-agnostic; *.sh restriction removed)
 
+  #1149 widens the option grammar of the two interpreter-argument shapes
+  (`-c '<payload>'` and `<script>`) from "the flag/path must be the bare token
+  immediately after the interpreter" to the real shell grammar, walked through
+  the shared `_shell_parse` option primitive:
+      bash -lc '...'  /  bash -cl '...'  /  bash -l -c '...'
+      bash --login -c '...'  /  bash -o pipefail -c '...'  /  bash +x -c '...'
+      bash -x <script>  /  bash -- <script>
+  Eight of nine ordinary `-c` spellings previously allowed an identity-less
+  commit; `bash -- -c '...'` correctly still does not match, because `--` ends
+  the option run in the shared grammar exactly as it does in a real shell.
+
   The extension-agnostic script read is the highest-severity #482 change:
   the prior `.sh` restriction was trivially circumvented by renaming the
   bypass script. Now any token after `bash|sh|zsh|dash|ksh` that points to
@@ -106,6 +117,7 @@ from _shell_parse import (  # noqa: E402
     find_git_subcommand,
     iter_command_segments,
     iter_command_segments_ast,
+    iter_interpreter_invocations,
     resolve_tool_cwd,
     strip_data_heredocs,
     strip_heredocs,
@@ -276,6 +288,21 @@ _PIPE_TO_SHELL_RE = re.compile(
 # <interpreter> -c '<payload>' or "<payload>" — captures the -c argument
 # verbatim, including its surrounding quotes (we strip them before
 # scanning).
+#
+# DEMOTED TO A PARSE-FAILURE FALLBACK (main#1149). This regex is not the option
+# grammar any more — `_shell_parse.parse_interpreter_invocation` is, and it
+# reuses `_consume_wrapper_options` so there is one implementation instead of
+# two. The regex only ever saw a BARE `-c` immediately after the interpreter, so
+# `bash -lc`, `bash -l -c`, `bash --login -c`, `bash -o pipefail -c` and every
+# other ordinary spelling walked past the gate.
+#
+# It is KEPT, not deleted, because the tokenized walker needs shlex to succeed
+# and this gate is fail-closed by design: on a command with unbalanced quotes
+# `iter_interpreter_invocations` returns [], and `_COMMIT_FALLBACK_RE` does not
+# fire on a `git commit` buried inside a `-c` string (no start-of-line or shell
+# operator precedes it). Dropping the regex would therefore open a bypass for
+# exactly the malformed input the rest of this hook fails closed on. Everything
+# it matched before still blocks; the walker is purely additive.
 _DASH_C_RE = re.compile(
     r"\b" + _INTERPRETERS + r"\s+-c\s+(?P<payload>(?P<q>['\"]).*?(?P=q)|\S+)",
     re.DOTALL,
@@ -305,6 +332,14 @@ _PROCESS_SUB_RE = re.compile(
 # rejects `bash -c '…'` because the first token char is `-`. The `bash`
 # bare-interactive form (no following token) has no match because the
 # `\s+(?P<path>…)` requires at least one whitespace + path char.
+#
+# ALSO DEMOTED TO A PARSE-FAILURE FALLBACK (main#1149). Requiring the path to
+# sit immediately after the interpreter is the same too-narrow option grammar as
+# `_DASH_C_RE`, one matcher over: `bash -x script.sh`, `bash -l script.sh`,
+# `bash +x script.sh` and `bash -- script.sh` all execute the script under
+# bash/sh/zsh/dash and none of them matched here. The tokenized walker resolves
+# the script path from `InterpreterInvocation.operands`, which is the shell's
+# own answer; this regex stays for the unparseable-input case only.
 _SCRIPT_INVOKE_RE = re.compile(
     r"\b" + _INTERPRETERS + r"\s+(?P<path>[^\s\-<>|;&(][^\s|;&<>]*)",
 )
@@ -413,18 +448,24 @@ def _detect_indirect_commit(command: str, *, cwd: str | None = None) -> str | No
     caller's block message) when the inner payload looks like a git
     commit, or None when no wrapper-with-commit shape is matched.
 
-    Shapes checked, in order:
+    Shapes checked:
       1. printf/echo … | bash|sh|zsh|dash|ksh
-      2. bash|sh|zsh|dash|ksh -c '<payload>'
+      2. bash|sh|zsh|dash|ksh [options] -c '<payload>'  (any -c spelling, #1149)
       3. bash|sh|zsh|dash|ksh <(…)  (process substitution)
       4. bash|sh|zsh|dash|ksh <<DELIM ... DELIM  (heredoc body, #482)
       5. bash|sh|zsh|dash|ksh <<<'<payload>'  (here-string, #482)
       6. eval '<payload>'  (shell builtin, #482)
-      7. bash|sh|zsh|dash|ksh <scriptpath>  (extension-agnostic, #482)
+      7. bash|sh|zsh|dash|ksh [options] <scriptpath>  (#482, options #1149)
 
-    The script-path check is LAST because it requires disk I/O — all
-    pattern-only checks run first to short-circuit common cases without
-    hitting the filesystem.
+    Shapes 2 and 7 are resolved together by one tokenized pass, because they are
+    the same question — what does this interpreter's option run end at? — and
+    splitting them into two regexes is what let both be too narrow (#1149).
+    That pass runs FIRST: it is the accurate one, and the regex sweeps below it
+    exist only for input it cannot tokenize.
+
+    Among the regex fallbacks the script-path check is LAST because it requires
+    disk I/O — all pattern-only checks run first to short-circuit common cases
+    without hitting the filesystem.
 
     Perf prefilter (#1113): shapes 1-6 carry their payload INLINE in
     `command`, so `_payload_looks_like_commit` (which requires `\bcommit\b`
@@ -455,8 +496,32 @@ def _detect_indirect_commit(command: str, *, cwd: str | None = None) -> str | No
     shape was measurably ALLOWED before this change. The classifier already
     computes "is this body fed to an interpreter?" including through a pipe, so
     the check is added here rather than left as a known hole.
+
+    Option grammar (main#1149). Shapes 2 and 7 are decided by
+    `_shell_parse.iter_interpreter_invocations`, which tokenizes the command and
+    walks each interpreter's option run through the SHARED
+    `_consume_wrapper_options` primitive. The two regexes they used to rely on
+    each hard-coded a narrower grammar than any real shell's — `-c` had to be a
+    bare token immediately after the interpreter, and a script path likewise —
+    so `bash -lc '<commit>'` and `bash -x <script>` were both allowed. Both
+    regexes are retained BELOW the walker as fail-closed fallbacks for input
+    shlex cannot tokenize; the walker only ever adds detections, so no command
+    that blocked before this change is allowed after it.
     """
     scanned = strip_data_heredocs(command)
+
+    for invocation in iter_interpreter_invocations(command):
+        if invocation.has_command_string:
+            # `words`, not `operands`: a cluster that mixes a value-taking
+            # letter with `c` can shift the payload index, and differently
+            # between shells. Guessing that index wrong fails OPEN, so the gate
+            # scans every non-flag word of the invocation.
+            if any(_payload_looks_like_commit(word) for word in invocation.words):
+                return "shell -c"
+        elif invocation.operands:
+            content = _read_script_if_safe(invocation.operands[0], cwd)
+            if content and _payload_looks_like_commit(content):
+                return f"shell script ({invocation.operands[0]})"
 
     if "commit" in scanned:
         for m in _PIPE_TO_SHELL_RE.finditer(scanned):

--- a/.claude/hooks/validate_commit_identity.py
+++ b/.claude/hooks/validate_commit_identity.py
@@ -512,10 +512,14 @@ def _detect_indirect_commit(command: str, *, cwd: str | None = None) -> str | No
 
     for invocation in iter_interpreter_invocations(command):
         if invocation.has_command_string:
-            # `words`, not `operands`: a cluster that mixes a value-taking
-            # letter with `c` can shift the payload index, and differently
-            # between shells. Guessing that index wrong fails OPEN, so the gate
-            # scans every non-flag word of the invocation.
+            # `words`, not `operands`: `words` is every token of the invocation
+            # except the `--` sentinel — deliberately a SUPERSET of `operands`,
+            # because `end` is only a lower bound on where the option run stops
+            # and a cluster mixing a value-letter with `c` shifts the payload
+            # index differently per shell. Guessing that index wrong fails OPEN.
+            # Narrowing this back to non-flag tokens re-opens
+            # `zsh -abc '-x; git commit …'`; see `_shell_parse.
+            # InterpreterInvocation` for the full contract and the measurements.
             if any(_payload_looks_like_commit(word) for word in invocation.words):
                 return "shell -c"
         elif invocation.operands:


### PR DESCRIPTION
Closes #1149. Closes #1196. Under umbrella #1150.

## The defect

`_DASH_C_RE` required the command-string flag to be a **bare** `-c` immediately after the interpreter. `_SCRIPT_INVOKE_RE` had the identical defect one matcher over — it required the script path in that same position. Both are the #1150 shape: a hook re-implementing command parsing in a grammar narrower than the real command's, failing **open**.

This gate is what stands between an agent and an unvalidated commit, and an identity-less commit that slips it gets mechanically re-attributed later (the #1134/#1161 failure). Pre-existing on `main`; not caused by #1143.

## The fix

Both shapes now resolve through one tokenized pass: `_shell_parse.parse_interpreter_invocation` normalizes the interpreter's own option tokens and then defers to the **shared** `_consume_wrapper_options`. One option-run implementation in the module instead of two divergent regexes.

The two regexes are **retained but demoted** to fail-closed fallbacks for input shlex cannot tokenize, and labelled as such in the source. That is deliberate: `_COMMIT_FALLBACK_RE` does not fire on a `git commit` buried inside a `-c` string, so deleting them would have opened a bypass on exactly the malformed input the rest of the hook fails closed on. The walker is purely additive, which is what makes the differential below clean by construction as well as by measurement.

## Grammar measured, not assumed

Every rule came from an execution oracle against bash / sh / zsh / dash — run the form, ask the filesystem whether a runtime-generated marker appeared. Four results a from-first-principles fix would have got wrong:

| measured | consequence |
|---|---|
| `bash -cl CMD` **runs** CMD | `c` need not be last in the cluster — the `-[a-z]*c$` regex widening the issue offered as "minimum viable" is still wrong |
| `bash +x -c CMD` **runs** CMD | `+`-form options are options; `_looks_like_flag` only sees a leading `-` |
| `bash -oc pipefail CMD` **runs** CMD | a value letter *inside* a cluster still eats the next word, shifting the payload by one |
| `bash -- -c CMD` does **not** run CMD | `--` ends the option run — the shared primitive already models this correctly, and it is pinned as an ALLOW |

`zsh -cO` / `-Oc` / `-cOl` also execute, and there the payload lands in an option-**value** slot. That is why the gate scans `InterpreterInvocation.words` (the superset including option values) rather than `operands` — scanning `operands` alone fails open on those three, which mutation M6 demonstrates.

## The nine forms from the issue

| form | base | head |
|---|---|---|
| interpreter + bare `-c` | BLOCK | BLOCK |
| combined `-lc` | allow | **BLOCK** |
| combined `-ic` | allow | **BLOCK** |
| combined `-xc` | allow | **BLOCK** |
| combined `-ec` | allow | **BLOCK** |
| `-l` then separate `-c` | allow | **BLOCK** |
| `--login` then separate `-c` | allow | **BLOCK** |
| `-o pipefail` then separate `-c` | allow | **BLOCK** |
| `zsh` with combined `-lc` | allow | **BLOCK** |

## Base-vs-head differential

Not a want/got table: the same corpus was run against `git show origin/main:` copies of the hook in a separate temp tree and against this branch, in isolated subprocesses so the two module versions cannot share import state.

85 shapes across 9 families, each varying **one** dimension independently — interpreter identity, cluster spelling, option position, payload quoting, segment role, script-file options — plus a must-stay-allowed family and a previously-blocked family.

```
WEAKENED (block -> allow):        0
newly blocked (allow -> block):  59
must-stay-allowed preserved:  13/13
```

## False-positive cost

Widening a gate has two failure directions, and a bypass-only corpus never asks about the second. Base vs head over **7,616 real recorded Bash commands** (the repo's own `real_comment_invocations.jsonl` fixture, every Bash invocation in this machine's transcripts, and 42 hand-built ordinary shapes):

```
base BLOCK count: 6      head BLOCK count: 6
allow -> BLOCK:   0      BLOCK -> allow:   0
```

Zero verdict changes on real traffic, in either direction.

## Tests are not inert

`.claude/hooks/tests/test_interpreter_option_grammar.py` — 31 tests, 160 subtests. `ShellTruthTests` is the load-bearing class: it runs a **real shell**, decides "executed" by whether a runtime-assembled marker file appeared (so a payload that is merely *displayed* can never score as executed), and requires the hook to block every form the shell actually ran. It also asserts the oracle can answer NO, so the class cannot degrade into vacuity.

Proven against mutants — 11 mutations, **11 killed, 0 survivors**:

| | mutation | result |
|---|---|---|
| M0 | both sources reverted to `origin/main` | killed (cannot even import) |
| M0b | same revert, behavioural classes only | killed — **126 failures** |
| M1 | de-clustering disabled | killed |
| M2 | value-letters not reordered | killed |
| M3 | `+x`/`+o` normalization removed | killed |
| M4 | quote repair removed | killed |
| M5 | `--` no longer ends the option run | killed |
| M6 | scan `operands` instead of `words` | killed |
| M7 | walker removed (regexes only) | killed |
| M8 | script shape stops reading operands | killed |
| M9 | interpreter basename not resolved | killed |

M6 initially **survived** and that is worth recording: the conservative `words` scan had no behavioural test, and killing it required going back to the shell oracle to find `zsh -cO`, the shape that actually justifies it. A defensive branch nobody can write a failing test for is a branch nobody has justified.

## Extra fix, declared not silent

The `<shell> [options] <script>` family is repaired in the same pass, because it is the same defect in the adjacent matcher and the walker yields it for free. `bash -x <script>`, `bash -l <script>`, `bash +x <script>`, `bash -- <script>` all execute under all four shells and none of them matched `_SCRIPT_INVOKE_RE`. Six rows of the differential's `newly blocked` column.

Also closed: appending **one unmatched quote** defeated shlex and restored every form (`bash -lc "git commit -m x" && echo "unclosed`). `iter_interpreter_invocations` retries once per quote character. Repairing the *quoting* rather than splitting the text on separators is what keeps that safe — quoted prose stays a single token, so a malformed `gh issue comment --body '…bash -lc "git commit"…'` still resolves to a `gh`-headed segment and matches nothing. The FP sweep above is the evidence.

## Gates

`ruff-format`, `ruff-lint`, `mypy`, `pytest` (3192 passed), `pytest-skills`, `checksums-ascii`, `memory-budget`, `headcount-budget`, `doc-freshness`, `office-drift`, `mermaid-render` — all green at pre-push. `pre_commit_ci_sync.py` clean.

## Known bound

An interpreter held in a variable, reached via an alias, or invoked through a non-wrapper relay (`xargs bash -c`, #1168) is still out of reach — unchanged by this PR and consistent with #1150's recorded out-of-scope list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
