### PR TITLE
fix(wave-status): repo-qualify closing-issue matching + reconciliation warning

### DIFF
--- a/.claude/lib/tests/test_wave_status.py
+++ b/.claude/lib/tests/test_wave_status.py
@@ -720,9 +720,14 @@ class MergedPrsDirectToMain(unittest.TestCase):
         self.assertEqual(sorted(p["number"] for p in got), [1153, 1154, 1155, 1156, 1173])
         self.assertEqual(len(got), 5)
 
-    def test_repo_with_no_canonical_rows_is_skipped(self) -> None:
-        """A repo in `repos_in_scope` with no scope rows at all is skipped
-        entirely -- not queried, not silently zeroed."""
+    def test_repo_with_no_canonical_rows_of_its_own_is_still_queried(self) -> None:
+        """main#1200 (found independently by Wanjiku Mwangi and Weronika
+        Zielinska in PR #1198 review): a repo in `repos_in_scope` with no
+        scope rows OF ITS OWN must still be queried, because a genuine
+        cross-repo closing reference can only ever be found if that repo's
+        merged PRs are listed at all. This inverts the pre-#1200 contract
+        (`test_repo_with_no_canonical_rows_is_skipped`), which asserted the
+        skip as intended -- that assertion was the bug."""
         fake = _FakeGhDirectToMain([])
         with TemporaryDirectory() as td:
             status = Path(td) / "cross-repo-status.json"
@@ -735,10 +740,73 @@ class MergedPrsDirectToMain(unittest.TestCase):
             )
             with mock.patch.object(wave_status.subprocess, "run", fake):
                 got = wave_status.merged_prs("10", "29", status)
-        self.assertEqual(got, [])
-        # No "pr list" call was ever made for the scopeless repo.
+        self.assertEqual(got, [])  # no PRs in the fixture -- nothing to find
+        # A "pr list" call WAS made for the scopeless repo (main#1200's fix).
         pr_list_repos = {c[c.index("--repo") + 1] for c in fake.calls if c[1:3] == ["pr", "list"]}
-        self.assertNotIn("noorinalabs/noorinalabs-isnad-ingest-platform", pr_list_repos)
+        self.assertIn("noorinalabs/noorinalabs-isnad-ingest-platform", pr_list_repos)
+
+    def test_wave_with_no_canonical_scope_at_all_skips_every_repo(self) -> None:
+        """The ONLY remaining skip condition after main#1200: when the wave's
+        canonical scope is empty across every repo, nothing could ever match,
+        so no repo is queried at all -- not a per-repo decision, a wave-level
+        one."""
+        fake = _FakeGhDirectToMain([])
+        with TemporaryDirectory() as td:
+            status = Path(td) / "cross-repo-status.json"
+            _write_direct_to_main_status(
+                status,
+                wave="29",
+                repos=["noorinalabs-main", "noorinalabs-isnad-ingest-platform"],
+                kickoff="2026-07-27T22:56:17Z",
+                tiers={},  # no canonical scope rows anywhere
+            )
+            with mock.patch.object(wave_status.subprocess, "run", fake):
+                got = wave_status.merged_prs("10", "29", status)
+        self.assertEqual(got, [])
+        self.assertEqual(fake.calls, [])  # no gh call of any kind was made
+
+    def test_cross_repo_reference_from_a_repo_with_zero_own_scope_rows(self) -> None:
+        """main#1200's exact repro: a repo that owns NO canonical scope rows
+        of its own still delivers a genuine cross-repo scope row. Before the
+        fix, `noorinalabs-isnad-graph` here is never queried at all (the
+        pre-#1200 per-repo skip), so PR #77 -- which closes the wave's only
+        canonical row, recorded under `noorinalabs-main` -- is silently
+        dropped: `merged_prs()` returns `[]` instead of `[77]`."""
+        prs = [
+            {
+                "repo": "noorinalabs-isnad-graph",
+                "number": 77,
+                "sha": "sha77",
+                "mergedAt": "2026-07-30T03:00:00Z",
+                "login": "octocat",
+                "commit_author": "Zero Own Rows Author",
+                "closes": [("noorinalabs-main", 1200)],
+            }
+        ]
+        fake = _FakeGhDirectToMain(prs)
+        with TemporaryDirectory() as td:
+            status = Path(td) / "cross-repo-status.json"
+            scope: dict = {"theme": "test fixture", "merge_model": "direct-to-main"}
+            # The wave's ONLY canonical row lives under noorinalabs-main.
+            # noorinalabs-isnad-graph is in repos_in_scope but owns zero rows
+            # of its own -- exactly the shape main#1200 requires.
+            scope["tier_1_main"] = [_scope_row(("noorinalabs-main", 1200))]
+            data = {
+                "current_wave": 29,
+                "wave_29_repos_in_scope": ["noorinalabs-main", "noorinalabs-isnad-graph"],
+                "wave_29_kicked_off_at": "2026-07-27T22:56:17Z",
+                "wave_29_merge_model": "direct-to-main",
+                "wave_29_scope": scope,
+            }
+            status.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+            with mock.patch.object(wave_status.subprocess, "run", fake):
+                got = wave_status.merged_prs("10", "29", status)
+        self.assertEqual([p["number"] for p in got], [77])
+        # Both repos were queried -- isnad-graph despite owning no row of
+        # its own.
+        pr_list_repos = {c[c.index("--repo") + 1] for c in fake.calls if c[1:3] == ["pr", "list"]}
+        self.assertIn("noorinalabs/noorinalabs-isnad-graph", pr_list_repos)
+        self.assertIn("noorinalabs/noorinalabs-main", pr_list_repos)
 
     def test_counters_nonzero_and_nonempty_trust_signals_for_direct_to_main(self) -> None:
         """The whole point of main#1131: compute_counters()/trust_signals must

--- a/.claude/lib/tests/test_wave_status.py
+++ b/.claude/lib/tests/test_wave_status.py
@@ -398,6 +398,14 @@ class _FakeGhDirectToMain:
     commit_author, closes (the issue numbers GitHub records this PR as
     closing — NOT assumed to equal the PR number, mirroring main#1172 being
     delivered by PR #1173).
+
+    ``closes`` entries are repo-qualifiable (main#1189): a bare int (e.g.
+    ``1172``) means "closes that number in this PR's own repo" — the shape
+    every pre-#1189 fixture uses, kept working unchanged. A ``(repo, number)``
+    tuple (e.g. ``("noorinalabs-main", 1172)``) means "closes that number in
+    a DIFFERENT repo" — the cross-repo case the fixture could not previously
+    express at all (a bare-int list has no way to name a repo other than the
+    PR's own), which is exactly the gap main#1189 fixes.
     """
 
     def __init__(self, prs: list[dict]) -> None:
@@ -452,7 +460,17 @@ class _FakeGhDirectToMain:
             closes = next(
                 p["closes"] for p in self.prs if p["repo"] == repo and p["number"] == number
             )
-            return SimpleNamespace(stdout=json.dumps(closes), returncode=0, stderr="")
+            # Mirrors the real `--jq` filter's output shape (main#1189):
+            # `[{number, repo: .repository.name}]`. A bare int closes-entry
+            # defaults to the PR's own repo; a `(repo, number)` tuple names a
+            # different repo explicitly.
+            nodes = [
+                {"number": c[1], "repo": c[0]}
+                if isinstance(c, tuple)
+                else {"number": c, "repo": repo}
+                for c in closes
+            ]
+            return SimpleNamespace(stdout=json.dumps(nodes), returncode=0, stderr="")
 
         if cmd[1] == "api":
             path = cmd[2]
@@ -469,8 +487,22 @@ class _FakeGhDirectToMain:
         raise AssertionError(f"unexpected gh call: {cmd!r}")
 
 
-def _scope_row(issue_number: int) -> dict:
-    return {"id": f"noorinalabs-main#{issue_number}", "ref": f"main#{issue_number}"}
+def _scope_row(entry: int | tuple[str, int]) -> dict:
+    """A ``wave_{M}_scope`` tier row, shaped like the real record.
+
+    A bare int defaults to ``noorinalabs-main`` (every pre-#1189 call site's
+    assumption, kept working unchanged). A ``(repo, issue_number)`` tuple
+    names a different repo explicitly -- the shape needed to express a
+    multi-repo canonical scope for the main#1189 cross-repo regression test.
+    """
+    if isinstance(entry, tuple):
+        repo, issue_number = entry
+    else:
+        repo, issue_number = "noorinalabs-main", entry
+    return {
+        "id": f"{repo}#{issue_number}",
+        "ref": f"{repo.removeprefix('noorinalabs-')}#{issue_number}",
+    }
 
 
 def _write_direct_to_main_status(
@@ -739,6 +771,188 @@ class MergedPrsDirectToMain(unittest.TestCase):
             counters,
             {"final_pr_count": 0, "changes_requested_cycles": 0, "top_concentration_pct": 0},
         )
+
+    def test_cross_repo_closing_reference_no_undercount_or_misattribution(self) -> None:
+        """main#1189: a closing reference is not necessarily in the closing
+        PR's own repo -- child-repo PRs routinely close a parent meta-issue
+        recorded under a different repo. Two failure modes proven together:
+
+        PR #77 (repo noorinalabs-isnad-graph) closes noorinalabs-main#1200 --
+        a genuine CROSS-REPO scope row, not one of isnad-graph's own rows.
+        Bare-number matching against only isnad-graph's own canonical set
+        ({50, 500}) would never see 1200 there and DROP a real match
+        (under-count).
+
+        PR #80 (also repo noorinalabs-isnad-graph) closes
+        noorinalabs-main#500 -- an issue that only numerically COLLIDES with
+        isnad-graph's own scope row #500 (a different, unrelated issue).
+        Bare-number matching against isnad-graph's own canonical set would
+        find 500 there and wrongly count PR #80 as closing isnad-graph#500
+        (mis-attribution).
+
+        Repo-qualified matching against the FULL (repo, number) canonical set
+        gets both right: PR #77 counted, PR #80 excluded.
+        """
+        prs = [
+            {
+                "repo": "noorinalabs-isnad-graph",
+                "number": 77,
+                "sha": "sha77",
+                "mergedAt": "2026-07-30T03:00:00Z",
+                "login": "octocat",
+                "commit_author": "Cross Repo Author",
+                "closes": [("noorinalabs-main", 1200)],
+            },
+            {
+                "repo": "noorinalabs-isnad-graph",
+                "number": 80,
+                "sha": "sha80",
+                "mergedAt": "2026-07-30T03:05:00Z",
+                "login": "octocat",
+                "commit_author": "Collision Author",
+                "closes": [("noorinalabs-main", 500)],  # NOT isnad-graph's own #500
+            },
+        ]
+        fake = _FakeGhDirectToMain(prs)
+        with TemporaryDirectory() as td:
+            status = Path(td) / "cross-repo-status.json"
+            scope: dict = {"theme": "test fixture", "merge_model": "direct-to-main"}
+            scope["tier_1_main"] = [_scope_row(("noorinalabs-main", 1200))]
+            scope["tier_2_isnad_graph"] = [
+                _scope_row(("noorinalabs-isnad-graph", 50)),
+                _scope_row(("noorinalabs-isnad-graph", 500)),
+            ]
+            data = {
+                "current_wave": 29,
+                "wave_29_repos_in_scope": ["noorinalabs-main", "noorinalabs-isnad-graph"],
+                "wave_29_kicked_off_at": "2026-07-27T22:56:17Z",
+                "wave_29_merge_model": "direct-to-main",
+                "wave_29_scope": scope,
+            }
+            status.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+            with mock.patch.object(wave_status.subprocess, "run", fake):
+                got = wave_status.merged_prs("10", "29", status)
+        self.assertEqual([p["number"] for p in got], [77])
+
+
+class ReconciliationWarning(unittest.TestCase):
+    """main#1190: canonical scope rows no merged PR's closing references
+    claimed are surfaced as a WARNING (never an error, never silently
+    dropped)."""
+
+    def test_warns_on_unclaimed_canonical_scope_rows(self) -> None:
+        prs = [
+            {
+                "repo": "noorinalabs-main",
+                "number": 1173,
+                "sha": "sha1173",
+                "mergedAt": "2026-07-30T02:16:40Z",
+                "login": "octocat",
+                "commit_author": "Nino Kavtaradze",
+                "closes": [1172],
+            }
+        ]
+        fake = _FakeGhDirectToMain(prs)
+        with TemporaryDirectory() as td:
+            status = Path(td) / "cross-repo-status.json"
+            _write_direct_to_main_status(
+                status,
+                wave="29",
+                repos=["noorinalabs-main"],
+                kickoff="2026-07-27T22:56:17Z",
+                tiers={"tier_4_in_wave_findings": [1172, 1160, 1162]},
+            )
+            with mock.patch.object(wave_status.subprocess, "run", fake):
+                warning = wave_status.reconciliation_warning("10", "29", status)
+        self.assertIsNotNone(warning)
+        assert warning is not None  # narrows the type for the checks below
+        self.assertIn("scope rows with no matching merged PR", warning)
+        self.assertIn("main#1160", warning)
+        self.assertIn("main#1162", warning)
+        self.assertNotIn("main#1172", warning)  # claimed by PR #1173 -- must not appear
+        self.assertIn("2 of 3", warning)
+
+    def test_no_warning_when_every_scope_row_is_claimed(self) -> None:
+        prs = [
+            {
+                "repo": "noorinalabs-main",
+                "number": 1173,
+                "sha": "sha1173",
+                "mergedAt": "2026-07-30T02:16:40Z",
+                "login": "octocat",
+                "commit_author": "Nino Kavtaradze",
+                "closes": [1172],
+            }
+        ]
+        fake = _FakeGhDirectToMain(prs)
+        with TemporaryDirectory() as td:
+            status = Path(td) / "cross-repo-status.json"
+            _write_direct_to_main_status(
+                status,
+                wave="29",
+                repos=["noorinalabs-main"],
+                kickoff="2026-07-27T22:56:17Z",
+                tiers={"tier_4_in_wave_findings": [1172]},
+            )
+            with mock.patch.object(wave_status.subprocess, "run", fake):
+                warning = wave_status.reconciliation_warning("10", "29", status)
+        self.assertIsNone(warning)
+
+    def test_no_warning_under_wave_branch_model(self) -> None:
+        """The wave-branch path's base+timestamp counting has no
+        closing-reference dependency -- reconciliation is a
+        direct-to-main-only concept."""
+        prs = _p5w4_prs()
+        fake = _FakeGh(prs)
+        with TemporaryDirectory() as td:
+            status = Path(td) / "cross-repo-status.json"
+            data = {
+                "wave_4_repos_in_scope": _REPOS,
+                "wave_4_kicked_off_at": "2026-06-15T01:52:55Z",
+                "wave_4_merge_model": "wave-branch",
+            }
+            status.write_text(json.dumps(data))
+            with mock.patch.object(wave_status.subprocess, "run", fake):
+                warning = wave_status.reconciliation_warning("5", "4", status)
+        self.assertIsNone(warning)
+
+    def test_cmd_counters_emits_warning_to_stderr_not_stdout(self) -> None:
+        """The warning must not corrupt the counters JSON on stdout (a
+        `--write` caller pipes stdout) -- it goes to stderr, same channel as
+        the existing ERROR lines."""
+        import io
+        from contextlib import redirect_stderr, redirect_stdout
+
+        prs = [
+            {
+                "repo": "noorinalabs-main",
+                "number": 1173,
+                "sha": "sha1173",
+                "mergedAt": "2026-07-30T02:16:40Z",
+                "login": "octocat",
+                "commit_author": "Nino Kavtaradze",
+                "closes": [1172],
+            }
+        ]
+        fake = _FakeGhDirectToMain(prs)
+        with TemporaryDirectory() as td:
+            status = Path(td) / "cross-repo-status.json"
+            _write_direct_to_main_status(
+                status,
+                wave="29",
+                repos=["noorinalabs-main"],
+                kickoff="2026-07-27T22:56:17Z",
+                tiers={"tier_4_in_wave_findings": [1172, 1160]},
+            )
+            out, err = io.StringIO(), io.StringIO()
+            with mock.patch.object(wave_status.subprocess, "run", fake):
+                with redirect_stdout(out), redirect_stderr(err):
+                    rc = wave_status.main(["counters", "10", "29", "--status", str(status)])
+        self.assertEqual(rc, 0)
+        stdout_val = out.getvalue()
+        stderr_val = err.getvalue()
+        json.loads(stdout_val)  # stdout is pure valid JSON -- no warning text mixed in
+        self.assertIn("main#1160", stderr_val)
 
 
 class PrListPageCap(unittest.TestCase):

--- a/.claude/lib/wave_status.py
+++ b/.claude/lib/wave_status.py
@@ -182,8 +182,19 @@ def _canonical_issue_numbers_by_repo(wave: str, status_path: Path) -> dict[str, 
     return by_repo
 
 
-def _pr_closing_issue_numbers(repo: str, number: int) -> set[int]:
-    """Issue numbers GitHub recognises *number* as closing, via GraphQL.
+def _pr_closing_issue_numbers(repo: str, number: int) -> set[tuple[str, int]]:
+    """Repo-qualified issue numbers GitHub recognises *number* as closing.
+
+    Returns ``{(repo_name, issue_number), ...}`` — deliberately NOT bare
+    issue numbers (main#1189). A closing reference is not necessarily in
+    *repo*: child-repo PRs routinely close a parent meta-issue recorded
+    under a different repo (e.g. ``noorinalabs-main``), and two repos can
+    independently have an issue #N. Comparing bare numbers against a single
+    repo's canonical scope set either silently drops the cross-repo case
+    (under-count) or, on a same-number collision across repos, matches the
+    wrong issue (mis-attribution) — confirmed live via `gh api graphql`
+    against PR #1173. ``repository{name}`` is available on the same GraphQL
+    node at no extra cost.
 
     The REST-backed ``gh pr list --json`` surface (this org pins gh 2.45.0)
     has no ``closingIssuesReferences`` field, so this goes through
@@ -192,12 +203,21 @@ def _pr_closing_issue_numbers(repo: str, number: int) -> set[int]:
     #1171 were bundled into a single PR — the closing-reference set is the
     only reliable link between a scope row and the PR that actually delivered
     it under a direct-to-main wave.
+
+    ``first:100`` (raised from the pre-#1189 ``first:25``) — the same
+    silent-truncation family as :data:`_PR_LIST_LIMIT` below: a PR closing
+    more issues than the page size would otherwise drop the excess with no
+    signal. 100 is GitHub's GraphQL connection page-size ceiling for this
+    field, so it is the maximum obtainable in a single page; a PR closing
+    over 100 issues would need real pagination (``endCursor``/``hasNextPage``)
+    — no real wave has approached that, so it is flagged here rather than
+    silently left uncapped or unremarked.
     """
     query = (
         "query($owner:String!,$name:String!,$number:Int!){"
         "repository(owner:$owner,name:$name){"
         "pullRequest(number:$number){"
-        "closingIssuesReferences(first:25){nodes{number}}"
+        "closingIssuesReferences(first:100){nodes{number repository{name}}}"
         "}}}"
     )
     raw = _run_gh(
@@ -213,10 +233,12 @@ def _pr_closing_issue_numbers(repo: str, number: int) -> set[int]:
             "-F",
             f"number={number}",
             "--jq",
-            "[.data.repository.pullRequest.closingIssuesReferences.nodes[].number]",
+            "[.data.repository.pullRequest.closingIssuesReferences.nodes[]"
+            " | {number, repo: .repository.name}]",
         ]
     )
-    return {int(n) for n in json.loads(raw or "[]")}
+    nodes = json.loads(raw or "[]")
+    return {(str(n["repo"]), int(n["number"])) for n in nodes}
 
 
 def _merged_prs_wave_branch(phase: str, wave: str, status_path: Path) -> list[dict]:
@@ -287,7 +309,9 @@ def _merged_prs_wave_branch(phase: str, wave: str, status_path: Path) -> list[di
 _PR_LIST_LIMIT = 1000
 
 
-def _merged_prs_direct_to_main(wave: str, status_path: Path) -> list[dict]:
+def _merged_prs_direct_to_main(
+    wave: str, status_path: Path
+) -> tuple[list[dict], set[tuple[str, int]]]:
     """Build the wave's merged-PR set for a ``direct-to-main`` wave (main#1131).
 
     No wave branch exists under this model, so ``--base <wave-branch>``
@@ -297,9 +321,14 @@ def _merged_prs_direct_to_main(wave: str, status_path: Path) -> list[dict]:
     Instead: list merged-to-main PRs per in-scope repo, apply the existing
     ``wave_{M}_kicked_off_at`` cross-window filter as a pre-filter, then keep
     only the PRs whose GitHub-recognised closing-issue references intersect
-    that repo's canonical scope-issue set (:func:`_canonical_issue_numbers_by_repo`).
-    A repo with no canonical scope rows is skipped entirely rather than
-    querying every merged PR in that repo.
+    the wave's FULL canonical scope-issue set, across every repo
+    (:func:`_canonical_issue_numbers_by_repo`) — not just the queried repo's
+    own scope rows (main#1189: a closing reference is not necessarily in the
+    same repo as the PR, e.g. a child-repo PR closing a parent meta-issue, and
+    matching against only the queried repo's own numbers either drops that
+    case or, on a same-number collision across repos, attributes it to the
+    wrong issue). A repo with no canonical scope rows of its own is skipped
+    entirely rather than querying every merged PR in that repo.
 
     The listing itself is bounded two ways (main#1131 M2 — `gh pr list`
     defaults to `--limit 30`, and `--base main` removes the wave-branch's
@@ -310,12 +339,22 @@ def _merged_prs_direct_to_main(wave: str, status_path: Path) -> list[dict]:
     ``merged_at < kickoff`` filter below is kept as defense-in-depth in case
     the search qualifier's date granularity and the recorded kickoff instant
     ever disagree at the second.
+
+    Returns ``(merged_prs, claimed_pairs)`` — alongside the PR list, the set
+    of canonical ``(repo, issue_number)`` scope pairs actually claimed by some
+    merged PR's closing references. :func:`reconciliation_warning` (main#1190)
+    needs this to report scope rows no merged PR claims, without re-running
+    every ``gh api graphql`` closing-reference call a second time.
     """
     repos = read_repos(wave, status_path)
     kickoff = _kickoff_ts(wave, status_path)
     issue_numbers_by_repo = _canonical_issue_numbers_by_repo(wave, status_path)
+    canonical_pairs: set[tuple[str, int]] = {
+        (repo_name, n) for repo_name, nums in issue_numbers_by_repo.items() for n in nums
+    }
 
     out: list[dict] = []
+    claimed: set[tuple[str, int]] = set()
     for repo in repos:
         canonical_issues = issue_numbers_by_repo.get(repo)
         if not canonical_issues:
@@ -342,8 +381,10 @@ def _merged_prs_direct_to_main(wave: str, status_path: Path) -> list[dict]:
             if kickoff and merged_at < kickoff:
                 continue
             closes = _pr_closing_issue_numbers(repo, pr["number"])
-            if not closes & canonical_issues:
+            hit = closes & canonical_pairs
+            if not hit:
                 continue
+            claimed |= hit
             sha = pr["headRefOid"]
             commit_author = _commit_author_name(repo, sha)
             out.append(
@@ -356,7 +397,23 @@ def _merged_prs_direct_to_main(wave: str, status_path: Path) -> list[dict]:
                     "commit_author_name": commit_author,
                 }
             )
-    return out
+    return out, claimed
+
+
+def _merged_prs_with_claims(
+    phase: str, wave: str, status_path: Path
+) -> tuple[list[dict], set[tuple[str, int]] | None]:
+    """Dispatch on merge model, same as :func:`merged_prs`, but also surface
+    the claimed-canonical-pairs side channel :func:`_merged_prs_direct_to_main`
+    returns (``None`` under the wave-branch model, which has no
+    closing-issue-reference dependency to reconcile against). Single source
+    for both :func:`compute_counters` and the reconciliation warning so a CLI
+    invocation does not re-run every ``gh`` call a second time.
+    """
+    model = wave_merge_model.read_merge_model(wave, status_path)
+    if model == wave_merge_model.DIRECT_TO_MAIN:
+        return _merged_prs_direct_to_main(wave, status_path)
+    return _merged_prs_wave_branch(phase, wave, status_path), None
 
 
 def merged_prs(phase: str, wave: str, status_path: Path) -> list[dict]:
@@ -368,10 +425,55 @@ def merged_prs(phase: str, wave: str, status_path: Path) -> list[dict]:
     ``wave-branch`` and an unrecorded/legacy model (``None``) both keep the
     pre-existing behavior unchanged (:func:`_merged_prs_wave_branch`).
     """
-    model = wave_merge_model.read_merge_model(wave, status_path)
-    if model == wave_merge_model.DIRECT_TO_MAIN:
-        return _merged_prs_direct_to_main(wave, status_path)
-    return _merged_prs_wave_branch(phase, wave, status_path)
+    prs, _claimed = _merged_prs_with_claims(phase, wave, status_path)
+    return prs
+
+
+def _canonical_pairs(wave: str, status_path: Path) -> set[tuple[str, int]]:
+    """Flatten :func:`_canonical_issue_numbers_by_repo` into ``(repo, number)``
+    pairs across every repo — the same shape :func:`_merged_prs_direct_to_main`
+    matches closing references against."""
+    issue_numbers_by_repo = _canonical_issue_numbers_by_repo(wave, status_path)
+    return {(repo_name, n) for repo_name, nums in issue_numbers_by_repo.items() for n in nums}
+
+
+def _reconciliation_warning_from_claims(
+    wave: str, status_path: Path, claimed: set[tuple[str, int]] | None
+) -> str | None:
+    """Format the main#1190 reconciliation line from an already-computed
+    ``claimed`` set (see :func:`_merged_prs_with_claims`) — a pure function of
+    (canonical scope, claimed pairs), so it costs no extra ``gh`` calls beyond
+    whatever already produced ``claimed``.
+
+    Deliberately a WARNING, never an error: an open scope row is normal
+    mid-wave. Returns ``None`` for a wave-branch wave (``claimed is None`` —
+    that path's base+timestamp counting has no closing-reference dependency
+    to reconcile against) or when every canonical row is claimed.
+    """
+    if claimed is None:
+        return None
+    canonical = _canonical_pairs(wave, status_path)
+    if not canonical:
+        return None
+    unclaimed = sorted(canonical - claimed)
+    if not unclaimed:
+        return None
+    rows = ", ".join(f"{repo_name.removeprefix('noorinalabs-')}#{n}" for repo_name, n in unclaimed)
+    return f"scope rows with no matching merged PR: {rows} ({len(unclaimed)} of {len(canonical)})"
+
+
+def reconciliation_warning(phase: str, wave: str, status_path: Path) -> str | None:
+    """Public entry point for main#1190 — canonical scope rows no merged PR's
+    closing references claimed, under the direct-to-main path.
+
+    Runs its own single pass via :func:`_merged_prs_with_claims` (for callers,
+    e.g. tests, that want the warning in isolation); ``_cmd_counters`` and
+    ``_cmd_merged_prs`` instead reuse the pass they already ran, via
+    :func:`_reconciliation_warning_from_claims`, so a CLI invocation never
+    pays for the closing-reference lookups twice.
+    """
+    _prs, claimed = _merged_prs_with_claims(phase, wave, status_path)
+    return _reconciliation_warning_from_claims(wave, status_path, claimed)
 
 
 def _changes_requested_cycles(prs: list[dict]) -> int:
@@ -406,14 +508,18 @@ def _top_concentration_pct(prs: list[dict]) -> int:
     return math.floor(top * 100 / total + 0.5)
 
 
-def compute_counters(phase: str, wave: str, status_path: Path) -> dict[str, int]:
-    """Compute the three canonical wave counters from the merged-PR set."""
-    prs = merged_prs(phase, wave, status_path)
+def _compute_counters_from_prs(prs: list[dict]) -> dict[str, int]:
     return {
         "final_pr_count": len(prs),
         "changes_requested_cycles": _changes_requested_cycles(prs),
         "top_concentration_pct": _top_concentration_pct(prs),
     }
+
+
+def compute_counters(phase: str, wave: str, status_path: Path) -> dict[str, int]:
+    """Compute the three canonical wave counters from the merged-PR set."""
+    prs = merged_prs(phase, wave, status_path)
+    return _compute_counters_from_prs(prs)
 
 
 def _write_counters(wave: str, counters: dict[str, int], status_path: Path) -> int:
@@ -539,13 +645,26 @@ def _cmd_repos(args: argparse.Namespace) -> int:
 
 
 def _cmd_merged_prs(args: argparse.Namespace) -> int:
-    print(json.dumps(merged_prs(args.phase, args.wave, args.status), indent=2))
+    prs, claimed = _merged_prs_with_claims(args.phase, args.wave, args.status)
+    print(json.dumps(prs, indent=2))
+
+    warning = _reconciliation_warning_from_claims(args.wave, args.status, claimed)
+    if warning:
+        print(f"WARNING: {warning}", file=sys.stderr)
     return 0
 
 
 def _cmd_counters(args: argparse.Namespace) -> int:
-    counters = compute_counters(args.phase, args.wave, args.status)
+    prs, claimed = _merged_prs_with_claims(args.phase, args.wave, args.status)
+    counters = _compute_counters_from_prs(prs)
     print(json.dumps(counters, indent=2))
+
+    # main#1190: a reconciliation WARNING (never an error -- an open scope
+    # row is normal mid-wave), computed from the same pass above so this
+    # never re-runs the closing-reference `gh` calls.
+    warning = _reconciliation_warning_from_claims(args.wave, args.status, claimed)
+    if warning:
+        print(f"WARNING: {warning}", file=sys.stderr)
 
     if args.expect is not None and counters["final_pr_count"] != args.expect:
         print(

--- a/.claude/lib/wave_status.py
+++ b/.claude/lib/wave_status.py
@@ -318,17 +318,29 @@ def _merged_prs_direct_to_main(
     (:func:`_merged_prs_wave_branch`'s filter) silently matches nothing. The
     fix is NOT simply switching the base to ``main`` — base+timestamp alone
     over-counts (wave-28 retro: ``us#213`` was in-window but out-of-scope).
-    Instead: list merged-to-main PRs per in-scope repo, apply the existing
-    ``wave_{M}_kicked_off_at`` cross-window filter as a pre-filter, then keep
-    only the PRs whose GitHub-recognised closing-issue references intersect
-    the wave's FULL canonical scope-issue set, across every repo
-    (:func:`_canonical_issue_numbers_by_repo`) — not just the queried repo's
-    own scope rows (main#1189: a closing reference is not necessarily in the
-    same repo as the PR, e.g. a child-repo PR closing a parent meta-issue, and
-    matching against only the queried repo's own numbers either drops that
-    case or, on a same-number collision across repos, attributes it to the
-    wrong issue). A repo with no canonical scope rows of its own is skipped
-    entirely rather than querying every merged PR in that repo.
+    Instead: list merged-to-main PRs for EVERY repo in ``repos_in_scope``,
+    apply the existing ``wave_{M}_kicked_off_at`` cross-window filter as a
+    pre-filter, then keep only the PRs whose GitHub-recognised closing-issue
+    references intersect the wave's FULL canonical scope-issue set, across
+    every repo (:func:`_canonical_issue_numbers_by_repo`) — not just the
+    queried repo's own scope rows (main#1189: a closing reference is not
+    necessarily in the same repo as the PR, e.g. a child-repo PR closing a
+    parent meta-issue, and matching against only the queried repo's own
+    numbers either drops that case or, on a same-number collision across
+    repos, attributes it to the wrong issue).
+
+    A repo is skipped ONLY when the wave has no canonical scope at all
+    (``canonical_pairs`` empty) — never on whether that individual repo owns
+    scope rows of its own (main#1200, found independently by Wanjiku Mwangi
+    and Weronika Zielinska in PR #1198 review: gating the skip on the
+    per-repo set relocated #1189's exact under-count from the matching step
+    to the listing step — a repo with no scope rows of its own, e.g. one
+    tracked entirely via a meta-issue filed under a different repo, never had
+    its merged PRs listed at all, so a genuine cross-repo closing reference
+    from that repo could never be found regardless of how correct the
+    intersection below is). Querying a repo that turns out to own no
+    canonical rows just means every PR found there fails the intersection
+    below — no different in cost or outcome from any other non-matching PR.
 
     The listing itself is bounded two ways (main#1131 M2 — `gh pr list`
     defaults to `--limit 30`, and `--base main` removes the wave-branch's
@@ -355,10 +367,12 @@ def _merged_prs_direct_to_main(
 
     out: list[dict] = []
     claimed: set[tuple[str, int]] = set()
+    if not canonical_pairs:
+        # Nothing anywhere in the wave's scope could ever match -- skip
+        # listing entirely rather than pay for `gh pr list` calls whose
+        # result is guaranteed to intersect empty (main#1200).
+        return out, claimed
     for repo in repos:
-        canonical_issues = issue_numbers_by_repo.get(repo)
-        if not canonical_issues:
-            continue
         args = [
             "pr",
             "list",


### PR DESCRIPTION
## Summary

Two defects in `.claude/lib/wave_status.py` (authored via #1185, merged this session), fixed together in one PR because they live in the same function and a two-PR split would conflict.

### Defect 1 — #1189: closing-issue numbers are not repo-qualified

`_pr_closing_issue_numbers` returned bare `set[int]` from the `closingIssuesReferences` GraphQL selection (`nodes{number}}`, no `repository`). `_merged_prs_direct_to_main` then intersected those bare ints against the *queried repo's own* canonical scope set. A closing reference is not necessarily in the closing PR's own repo (child-repo PRs routinely close a parent meta-issue recorded under a different repo, e.g. `noorinalabs-main`), and two repos can independently have an issue with the same number — so the old comparison either silently **dropped** a genuine cross-repo match (under-count) or, on a same-number collision, **credited the wrong issue** (mis-attribution).

**Fix:** `closingIssuesReferences` now also selects `repository{name}` (confirmed live via `gh api graphql` against PR #1173/#1178 — no extra query cost); `_pr_closing_issue_numbers` returns `set[tuple[str, int]]`; `_merged_prs_direct_to_main` matches a PR's closing references against the wave's **full** canonical `(repo, number)` pair set across every repo, not just the queried repo's own rows.

Also raised the unguarded `closingIssuesReferences(first:25)` page cap to `first:100` — GitHub's GraphQL connection page-size ceiling for this field, and the exact number `.claude/lib/lint_skill_graphql_pagination.py`'s `skill-graphql-pagination` pre-commit hook treats as the org-wide cap (confirmed by inspecting that hook while implementing this fix). Same silent-truncation family as the existing `_PR_LIST_LIMIT` guard on `gh pr list`; a PR closing >100 issues would still need real cursor pagination, which no real wave has approached.

### Defect 2 — #1190: silent drop when a `Closes` reference is missing

Under direct-to-main, a merged PR only counts if GitHub recognises one of its closing references as a canonical scope row — so `final_pr_count` silently depended on PR-description hygiene: a wave PR omitting `Closes #N`, or a scope row closed by hand, produced no signal.

**Fix:** a reconciliation **warning** (never an error — an open scope row is normal mid-wave) reporting canonical scope rows no merged PR's closing references claimed, e.g.:

```
WARNING: scope rows with no matching merged PR: main#1114, main#1116, ... (24 of 36)
```

Wired into the `counters` and `merged-prs` CLI subcommands via a single shared merged-PR pass (`_merged_prs_with_claims`) so the closing-reference `gh api graphql` calls never run twice per invocation — the warning reuses the same claimed-pairs side-channel `_merged_prs_direct_to_main` already computes, rather than re-querying gh.

## Mutation testing (original commit)

- **Mutation A** (Defect 1): reverted the intersection in `_merged_prs_direct_to_main` from the full canonical-pairs set back to the pre-fix per-repo-only set (`closes & {(repo, n) for n in canonical_issues}`). Result: **1 failure, 34 pass** — `MergedPrsDirectToMain::test_cross_repo_closing_reference_no_undercount_or_misattribution` goes red; every other test stays green.
- **Mutation B** (Defect 2): made `_reconciliation_warning_from_claims` unconditionally `return None`. Result: **2 failures, 33 pass** — `ReconciliationWarning::test_warns_on_unclaimed_canonical_scope_rows` and `ReconciliationWarning::test_cmd_counters_emits_warning_to_stderr_not_stdout` go red; `test_no_warning_when_every_scope_row_is_claimed` and `test_no_warning_under_wave_branch_model` correctly stay green.
- Both mutations reverted; original commit's suite green (35/35 in `test_wave_status.py`, 956/956 across `.claude/lib/tests/`).

## Update — #1200 fixup (additive commit, head now `9df3efc`)

**Both reviewers converged on the same must-fix finding, independently, from different fixtures:**
- Wanjiku Mwangi: https://github.com/noorinalabs/noorinalabs-main/pull/1198#issuecomment-5137132165
- Weronika Zielinska: https://github.com/noorinalabs/noorinalabs-main/pull/1198#issuecomment-5137150657 (amended from an initial `Approved`+tech-debt disposition to `ChangesRequested` after independently converging with Wanjiku's finding)

`_merged_prs_direct_to_main`'s per-repo skip guard (`if not issue_numbers_by_repo.get(repo): continue`) was untouched by the original #1189 fix. The repo-qualified intersection against `canonical_pairs` was correct, but the loop never reached it for a repo with zero canonical scope rows *of its own* — `gh pr list` was never even called for that repo, so a genuine cross-repo closing reference from it (a child-repo PR closing a parent meta-issue — #1189's own "normal in this org" scenario) was silently dropped. The exact under-count #1189 fixed at the matching step, relocated one step earlier to the listing step.

**Fix:** the skip now gates on `canonical_pairs` (does the *wave* have any canonical scope at all) instead of `issue_numbers_by_repo.get(repo)` (does *this repo* own rows). Every repo in `repos_in_scope` is queried unless the wave's canonical scope is empty everywhere — bounded the same way as before (`--search merged:>=<kickoff>` + `_PR_LIST_LIMIT`). The docstring sentence that documented the old skip as intentional is rewritten.

**Test changes:** `test_repo_with_no_canonical_rows_is_skipped` asserted the old skip as contract; inverted to `test_repo_with_no_canonical_rows_of_its_own_is_still_queried` in the same commit. Added `test_cross_repo_reference_from_a_repo_with_zero_own_scope_rows` (a repo with zero own canonical rows delivering a PR that closes a genuine cross-repo row — Wanjiku's own repro shape) and `test_wave_with_no_canonical_scope_at_all_skips_every_repo` (the one remaining, now wave-level, skip condition).

**Mutation testing (fixup commit):**
- **Mutation C**: reverted the guard back to the pre-#1200 per-repo gate. Result: **2 failures, 35 pass** — `test_repo_with_no_canonical_rows_of_its_own_is_still_queried` and `test_cross_repo_reference_from_a_repo_with_zero_own_scope_rows` go red.
- Re-verified **Mutation A** is still non-equivalent against the new guard: reverting the intersection now fails *both* the original and the new zero-own-rows cross-repo test (2 failures, 35 pass) — the two fixes compose rather than mask each other.
- All mutations reverted; full suite green: **37/37 in `test_wave_status.py`, 958/958 across `.claude/lib/tests/`**.

**Live re-verification against wave-29's real 36-row scope:** identical output to before this fixup (both in-scope repos already own ≥1 canonical row this wave, so the guard was not live-reachable either way — confirmed unchanged):

```
$ PYTHONPATH=.claude/lib python3 .claude/lib/wave_status.py counters 10 29 --status cross-repo-status.json
WARNING: scope rows with no matching merged PR: main#1114, main#1116, main#1117, main#1118, main#1119, main#1120, main#1121, main#1122, main#1123, main#1137, main#1141, main#1142, main#1167, main#1168, main#1170, main#1171, main#1175, main#1179, main#1180, main#1181, main#1182, main#1189, main#1190, main#1195 (24 of 36)
{
  "final_pr_count": 11,
  "changes_requested_cycles": 9,
  "top_concentration_pct": 18
}
```

## Out of scope, filed as follow-ups (explicitly not part of this PR)

- **#1201** — reconciliation-warning blind edges (unparseable scope rows shrinking the denominator; a full 100-node `closingIssuesReferences` page truncating with no signal). Filed by Weronika; ruled genuine tech-debt, not held against this PR.
- `first:100` — Weronika ruled this discharged: verified live that `first:101` returns `EXCESSIVE_PAGINATION` and `gh` exits 1, so 100 is GitHub's hard per-page ceiling and no further change is needed here.

## Acceptance checklist

- [x] Cross-repo closing reference no longer under-counts or mis-attributes; regression test proves it
- [x] Fixture model (`_FakeGhDirectToMain`, `_scope_row`) can express a repo-qualified closing reference
- [x] Reconciliation warning lists unclaimed canonical scope rows; warning, not error
- [x] Existing `.claude/lib/tests/test_wave_status.py` suite stays green (37/37 after the fixup)
- [x] Mutation-tested — all mutations and outcomes documented above (A, B, C, plus A re-verified post-fixup)
- [x] Sanity-checked against live wave-29 (36 scope rows, direct-to-main), output pasted above (re-run after fixup, unchanged)
- [x] #1200 (repo-listing skip gated on wave scope, not per-repo scope) — fixed in the additive commit above

Closes #1189
Closes #1190
Closes #1200
