### PR TITLE
fix(hooks): union the org manifest into Hook 4's review-class roster set (#1179)

### DIFF
--- a/.claude/hooks/tests/test_validate_pr_review.py
+++ b/.claude/hooks/tests/test_validate_pr_review.py
@@ -1971,7 +1971,17 @@ class OrgManifestReviewerUnionTests(_NoContentBindingHarness):
         self.assertNotIn("steven french", hook._load_roster_names(repo=self.CHILD_REPO))
 
     def test_tool_identity_cannot_supply_an_approval(self):
-        """End-to-end: `Annunaki` + one real reviewer is 1/2, not 2/2."""
+        """End-to-end: `Annunaki` + one real reviewer is 1/2, not 2/2.
+
+        The ratio assertion MUST stay anchored to the computed sentence. Hook 4's
+        peer-review BLOCK help text embeds the literal `1/2 false-block` three
+        times unconditionally (the P3W11 batch-11 instance list, source lines
+        1955/1957/1959), so a bare `assertIn("1/2", reason)` matches boilerplate
+        rather than the count. Measured on this fixture: the real ratio is 1/2
+        with 4 occurrences of `1/2` at head and 0/2 with 3 occurrences once the
+        manifest union is reverted — and the bare form passes in BOTH. Only the
+        anchored sentence discriminates. Do not "simplify" this back.
+        """
         review_result = hook.CommentReviewResult()
         review_result.reviewers = {"annunaki", "nikolaos papadopoulos"}
         with (
@@ -1982,7 +1992,7 @@ class OrgManifestReviewerUnionTests(_NoContentBindingHarness):
         self.assertIsNotNone(result, "a tool identity must not supply an approval")
         assert result is not None
         self.assertEqual(result["decision"], "block")
-        self.assertIn("1/2", result["reason"])
+        self.assertIn("BLOCKED: PR #42 has 1/2 required peer reviews", result["reason"])
 
     def test_persona_filter_shape(self):
         """Direct coverage of the identity-shape rule, independent of the tree."""

--- a/.claude/hooks/tests/test_validate_pr_review.py
+++ b/.claude/hooks/tests/test_validate_pr_review.py
@@ -1250,9 +1250,23 @@ class RosterValidationGateTests(_NoContentBindingHarness):
     repo's `_load_roster_names()` (via `_iter_roster_entries`).
 
     Repro target: PR #487 verdict comments posted under "Camila Restrepo" and
-    "Imelda Santos" — neither in `.claude/team/roster/`. Pre-fix Hook 4
-    counted both and merged. Post-fix both are filtered out.
+    "Imelda Santos" — at the time in no roster anywhere. Pre-fix Hook 4 counted
+    both and merged. Post-fix both are filtered out.
+
+    Those two original strings are NO LONGER usable as the fixture (#1179). The
+    org has since onboarded real personas by exactly those names —
+    `noorinalabs-isnad-ingest-platform/.claude/team/roster/data_lead_camila.md`
+    and `data_engineer_imelda.md`, both carried in `.claude/team/roster.json`.
+    Once #1179 unions the org manifest into `_load_roster_names`, they resolve,
+    and asserting otherwise would assert that two genuine org personas cannot
+    review — the #1179 bug in miniature. The SUBJECT of these tests is the
+    non-roster filter, not those particular strings, so the fixture moves to
+    strings that are definitionally not personas and the history stays here.
     """
+
+    # Deliberately un-personable: no `+First.Last` identity can ever be minted
+    # for these, so they cannot silently become real the way #487's names did.
+    FABRICATED = ("phantom persona", "fabricated reviewer")
 
     @staticmethod
     def _input(command: str) -> dict:
@@ -1273,7 +1287,7 @@ class RosterValidationGateTests(_NoContentBindingHarness):
     def test_two_non_roster_requestors_blocked(self):
         """Regression: 2 non-roster Requestors must BLOCK (P3W11 #487 repro)."""
         review_result = hook.CommentReviewResult()
-        review_result.reviewers = {"camila restrepo", "imelda santos"}
+        review_result.reviewers = set(self.FABRICATED)
         with (
             mock.patch.object(hook, "get_pr_data", return_value=self._pr_data()),
             mock.patch.object(hook, "check_comment_reviews", return_value=review_result),
@@ -1283,15 +1297,15 @@ class RosterValidationGateTests(_NoContentBindingHarness):
         assert result is not None
         self.assertEqual(result["decision"], "block")
         reason = result["reason"]
-        self.assertIn("camila restrepo", reason.lower())
-        self.assertIn("imelda santos", reason.lower())
+        for fabricated in self.FABRICATED:
+            self.assertIn(fabricated, reason.lower())
         self.assertIn("Non-roster:", reason)
         self.assertIn("roster", reason.lower())
 
     def test_mixed_roster_and_non_roster_blocked(self):
         """1 roster + 1 non-roster → 1/2 (only the roster member counts)."""
         review_result = hook.CommentReviewResult()
-        review_result.reviewers = {"aino virtanen", "imelda santos"}
+        review_result.reviewers = {"aino virtanen", self.FABRICATED[1]}
         with (
             mock.patch.object(hook, "get_pr_data", return_value=self._pr_data()),
             mock.patch.object(hook, "check_comment_reviews", return_value=review_result),
@@ -1301,7 +1315,7 @@ class RosterValidationGateTests(_NoContentBindingHarness):
         assert result is not None
         self.assertEqual(result["decision"], "block")
         reason = result["reason"]
-        self.assertIn("imelda santos", reason.lower())
+        self.assertIn(self.FABRICATED[1], reason.lower())
         self.assertNotIn("aino virtanen", reason.lower().split("non-roster:")[1].split("\n")[0])
         # Final count should reflect the filtered roster-only set.
         self.assertIn("1/2", reason)
@@ -1801,6 +1815,254 @@ class ChildRosterResolutionTests(_NoContentBindingHarness):
             result,
             "child-repo enforcer should satisfy the single-reviewer exception on a child PR",
         )
+
+
+class OrgManifestReviewerUnionTests(_NoContentBindingHarness):
+    """Issue #1179: the merge-time reviewer set unions the org-union manifest.
+
+    #1162/#1178 made `/wave-scope` § 12.5 and `/wave-kickoff` § 0b resolve
+    REVIEW-class slots against `.claude/team/roster.json` (78 names), so a
+    reviewer drawn from a THIRD child repo — charter-permitted by
+    `charter/agents/spawn-discipline.md` § Child-Repo Implementer Rule step 5 —
+    passes scope. Hook 4 did not: `_load_roster_names` unioned exactly
+    parent-cards ∪ target-child-cards (#552), so that reviewer's `Approved` was
+    filtered as non-roster (#498), the gate counted zero, and the only exit was
+    `--admin` — a moderate feedback event per `charter/pull-requests.md`
+    § Single-Reviewer Exception.
+
+    Hermetic on-disk tree: a parent repo with two card personas, a target child
+    repo with one, and a manifest carrying those plus a third-child persona, a
+    tool identity (`Annunaki`) and a bare-principal identity (`Steven French`).
+    """
+
+    PARENT_PERSONAS = {
+        "standards_lead_aino": "Aino Virtanen",
+        "program_director_nadia": "Nadia Khoury",
+    }
+    # Charter-enforcer prefix (`manager_*`) so the enforcer path is exercised too.
+    CHILD_PERSONAS = {"manager_bereket": "Bereket Tadesse"}
+    CHILD_REPO_NAME = "noorinalabs-isnad-ingest-platform"
+    CHILD_REPO = f"noorinalabs/{CHILD_REPO_NAME}"
+
+    # Third-child personas: cards live in `noorinalabs-data-acquisition`, which is
+    # neither the parent nor the merge target — so from this gate's point of view
+    # they exist ONLY in the manifest. This is the live W28 assignment.
+    THIRD_CHILD = {
+        "Nikolaos Papadopoulos": "parametrization+Nikolaos.Papadopoulos@gmail.com",
+        "Oyunbileg Batbayar": "parametrization+Oyunbileg.Batbayar@gmail.com",
+    }
+    # Non-persona manifest entries (#1181). `Annunaki` is the error monitor — it
+    # posts real comments on real PRs, so it is the concrete risk of widening.
+    NON_PERSONA = {
+        "Annunaki": "parametrization+Annunaki@gmail.com",
+        "Steven French": "parametrization@gmail.com",
+    }
+
+    @staticmethod
+    def _input(command: str) -> dict:
+        return {"tool_name": "Bash", "tool_input": {"command": command}}
+
+    @staticmethod
+    def _pr_data(**overrides) -> dict:
+        base = {
+            "author": "parametrization",
+            "number": 42,
+            "reviews": [],
+            "headRefName": "N.Kavtaradze/1179-hook4-manifest-union",
+            "labels": [],
+        }
+        base.update(overrides)
+        return base
+
+    def _write_roster(self, roster_dir: Path, personas: dict[str, str]) -> None:
+        roster_dir.mkdir(parents=True, exist_ok=True)
+        for slug, name in personas.items():
+            (roster_dir / f"{slug}.md").write_text(
+                f"# Roster Card\n\n## Identity\n- **Name:** {name}\n", encoding="utf-8"
+            )
+
+    def _write_manifest(self, payload: object) -> None:
+        text = payload if isinstance(payload, str) else json.dumps(payload)
+        self._manifest_path.write_text(text, encoding="utf-8")
+
+    def setUp(self) -> None:
+        import tempfile
+
+        super().setUp()
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        parent_repo = Path(self._tmp.name) / "noorinalabs-main"
+        self._parent_roster = parent_repo / ".claude" / "team" / "roster"
+        self._write_roster(self._parent_roster, self.PARENT_PERSONAS)
+        self._write_roster(
+            parent_repo / self.CHILD_REPO_NAME / ".claude" / "team" / "roster",
+            self.CHILD_PERSONAS,
+        )
+
+        # `_load_org_manifest_names` derives the manifest path from `_ROSTER_DIR`
+        # at CALL time, so patching `_ROSTER_DIR` keeps this hermetic — the live
+        # 78-name manifest never leaks into these assertions.
+        self._manifest_path = self._parent_roster.parent / "roster.json"
+        self._write_manifest(
+            {
+                "Aino Virtanen": "parametrization+Aino.Virtanen@gmail.com",
+                "Nadia Khoury": "parametrization+Nadia.Khoury@gmail.com",
+                "Bereket Tadesse": "parametrization+Bereket.Tadesse@gmail.com",
+                **self.THIRD_CHILD,
+                **self.NON_PERSONA,
+            }
+        )
+
+        for attr, value in (
+            ("_ROSTER_DIR", self._parent_roster),
+            ("_PARENT_REPO_ROOT", parent_repo),
+        ):
+            patcher = mock.patch.object(hook, attr, value)
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
+    # --- acceptance 1: a third-child reviewer counts ----------------------
+
+    def test_third_child_reviewer_resolves_via_manifest(self):
+        names = hook._load_roster_names(repo=self.CHILD_REPO)
+        self.assertIn("nikolaos papadopoulos", names)
+        self.assertIn("oyunbileg batbayar", names)
+        # Card-derived names are still there — the manifest widens, not replaces.
+        self.assertIn("aino virtanen", names)
+        self.assertIn("bereket tadesse", names)
+
+    def test_third_child_reviewers_reach_the_two_reviewer_threshold(self):
+        """MUTATION TARGET (#1179 acceptance 4).
+
+        Both reviewers are manifest-only from this PR's point of view. Drop the
+        `| _load_org_manifest_names()` union in `_load_roster_names` and this
+        goes red: 0/2 approvals, BLOCK, `--admin` as the only exit.
+        """
+        review_result = hook.CommentReviewResult()
+        review_result.reviewers = {"nikolaos papadopoulos", "oyunbileg batbayar"}
+        with (
+            mock.patch.object(hook, "get_pr_data", return_value=self._pr_data()),
+            mock.patch.object(hook, "check_comment_reviews", return_value=review_result),
+        ):
+            result = hook.check(self._input(f"gh pr merge 42 --repo {self.CHILD_REPO} --squash"))
+        self.assertIsNone(
+            result,
+            "two charter-permitted third-child reviewers must reach the 2-reviewer "
+            "threshold at merge time, not just at scope time (#1179)",
+        )
+
+    def test_manifest_widens_parent_repo_prs_too(self):
+        """The union is repo-agnostic, matching the scope-time twin.
+
+        `validate_matrix_names.validate` computes `review_combined` for EVERY
+        repo including the parent, and the charter permits a cross-team reviewer
+        on any PR. Scoping the union to child PRs would leave the identical
+        false block reachable on a parent-repo PR.
+        """
+        self.assertIn("nikolaos papadopoulos", hook._load_roster_names(repo=None))
+
+    # --- acceptance 3: non-personas must not slip through -----------------
+
+    def test_tool_identity_does_not_count_as_a_reviewer(self):
+        self.assertNotIn("annunaki", hook._load_roster_names(repo=self.CHILD_REPO))
+
+    def test_bare_principal_identity_does_not_count_as_a_reviewer(self):
+        """`Steven French` → `parametrization@gmail.com`, no `+First.Last` tag."""
+        self.assertNotIn("steven french", hook._load_roster_names(repo=self.CHILD_REPO))
+
+    def test_tool_identity_cannot_supply_an_approval(self):
+        """End-to-end: `Annunaki` + one real reviewer is 1/2, not 2/2."""
+        review_result = hook.CommentReviewResult()
+        review_result.reviewers = {"annunaki", "nikolaos papadopoulos"}
+        with (
+            mock.patch.object(hook, "get_pr_data", return_value=self._pr_data()),
+            mock.patch.object(hook, "check_comment_reviews", return_value=review_result),
+        ):
+            result = hook.check(self._input(f"gh pr merge 42 --repo {self.CHILD_REPO} --squash"))
+        self.assertIsNotNone(result, "a tool identity must not supply an approval")
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+        self.assertIn("1/2", result["reason"])
+
+    def test_persona_filter_shape(self):
+        """Direct coverage of the identity-shape rule, independent of the tree."""
+        self.assertEqual(
+            hook._load_org_manifest_names(self._manifest_path),
+            {
+                "aino virtanen",
+                "nadia khoury",
+                "bereket tadesse",
+                "nikolaos papadopoulos",
+                "oyunbileg batbayar",
+            },
+        )
+
+    # --- acceptance 2: the enforcer boundary does not move ----------------
+
+    def test_manifest_does_not_widen_charter_enforcer_names(self):
+        """`load_charter_enforcer_names` stays card-only and role-filtered.
+
+        It gates the Single-Reviewer Exception and filters on card FILENAME
+        prefixes the flat manifest cannot supply, so a manifest hit must never
+        qualify a sole reviewer for the exception.
+        """
+        enforcers = hook.load_charter_enforcer_names(repo=self.CHILD_REPO)
+        self.assertIn("bereket tadesse", enforcers)  # child `manager_*` card
+        self.assertNotIn("nikolaos papadopoulos", enforcers)
+        self.assertNotIn("annunaki", enforcers)
+        self.assertNotIn("steven french", enforcers)
+
+    def test_manifest_persona_cannot_claim_the_single_reviewer_exception(self):
+        """A manifest-only sole reviewer on a `wave-bootstrap` PR is still 1/2."""
+        self.assertFalse(
+            hook.is_single_reviewer_exception(
+                ["wave-bootstrap"], {"nikolaos papadopoulos"}, repo=self.CHILD_REPO
+            )
+        )
+
+    # --- degraded-mode invariants -----------------------------------------
+
+    def test_manifest_never_substitutes_for_an_unreadable_card_tree(self):
+        """Empty card set ⇒ empty result, so the caller still fails closed.
+
+        `_load_roster_names`' documented contract is "empty ⇒ roster unreadable".
+        A readable manifest beside an unreadable card tree must not quietly
+        re-enable the gate. (`_ROSTER_DIR` moves; the manifest beside it stays.)
+        """
+        with mock.patch.object(hook, "_ROSTER_DIR", self._parent_roster.parent / "gone"):
+            self.assertEqual(hook._load_roster_names(repo=None), set())
+
+    def test_missing_child_roster_still_hard_blocks_with_a_manifest_present(self):
+        """#552's safe direction survives: `_resolve_roster_dirs` raises first."""
+        with self.assertRaises(hook.RosterResolutionError):
+            hook._load_roster_names(repo="noorinalabs/noorinalabs-does-not-exist")
+
+    def test_absent_manifest_fails_open_to_pre_1179_behaviour(self):
+        self._manifest_path.unlink()
+        self.assertEqual(
+            hook._load_roster_names(repo=self.CHILD_REPO),
+            {"aino virtanen", "nadia khoury", "bereket tadesse"},
+        )
+
+    def test_malformed_manifest_fails_open_to_pre_1179_behaviour(self):
+        self._write_manifest("{not json")
+        self.assertEqual(hook._load_org_manifest_names(self._manifest_path), set())
+
+    def test_non_object_manifest_fails_open(self):
+        self._write_manifest(["Nikolaos Papadopoulos"])
+        self.assertEqual(hook._load_org_manifest_names(self._manifest_path), set())
+
+    def test_non_string_entry_value_narrows_rather_than_guessing(self):
+        """A future richer per-entry schema (#1181) re-blocks; it never admits."""
+        self._write_manifest(
+            {
+                "Nikolaos Papadopoulos": {
+                    "email": "parametrization+Nikolaos.Papadopoulos@gmail.com",
+                    "persona": True,
+                }
+            }
+        )
+        self.assertEqual(hook._load_org_manifest_names(self._manifest_path), set())
 
 
 class ResolveRosterDirsTests(unittest.TestCase):

--- a/.claude/hooks/validate_pr_review.py
+++ b/.claude/hooks/validate_pr_review.py
@@ -1248,6 +1248,78 @@ def load_charter_enforcer_names(repo: str | None = None) -> set[str]:
     return names
 
 
+# A manifest entry is a PERSONA only if its address is a charter-conformant
+# per-persona commit identity: `<principal>+<First>.<Last>@<domain>` (CLAUDE.md
+# § Key Rules / charter `pull-requests.md` § Commit Identity). The `+`-tag with
+# an internal `.` separator is what makes an entry spawnable and commit-capable,
+# so it is the org's own definition of "a person" — not a hand-maintained
+# blocklist that a new tool entry would silently slip past.
+#
+# Measured against `.claude/team/roster.json` (78 entries, 2026-07-30) this
+# excludes exactly the two entries #1181 identifies as non-persona:
+#   - `Annunaki` → `parametrization+Annunaki@gmail.com` (tool identity; no
+#     `First.Last` tag) — the error monitor, which posts real comments on real
+#     PRs, so admitting it as a Requestor is the live risk, not a hypothetical.
+#   - `Steven French` → `parametrization@gmail.com` (bare principal, no `+`tag).
+_PERSONA_ALIAS_RE = re.compile(r"^[^\s@+]+\+[^\s@+]+\.[^\s@+]+@[^\s@]+\.[^\s@]+$")
+
+
+def _load_org_manifest_names(manifest_path: Path | None = None) -> set[str]:
+    """Parse PERSONA names from the org-union manifest `.claude/team/roster.json`.
+
+    Mirrors `.claude/skills/wave-scope/validate_matrix_names._load_org_manifest_names`
+    (#1162) so scope-time and merge-time resolve the same review-class authority.
+    That module's docstring already argues WHY the manifest is acceptable for a
+    review-class set and must not widen a commit-capable one; this is the
+    merge-time half of the same decision (#1179) and inherits that reasoning
+    verbatim rather than re-deriving it.
+
+    The manifest is a flat `{"<name>": "<email>"}` object covering every persona
+    across the org — a strict superset of the parent's own card directory, and
+    the only place a persona whose card lives in a repo that is NOT the target
+    repo can be recognised without cloning that repo. That is exactly the
+    charter-permitted "third-child reviewer" (`charter/agents/spawn-discipline.md`
+    § Child-Repo Implementer Rule step 5) whose `Approved` Hook 4 counted as zero
+    before #1179.
+
+    **Persona filter (#1179 acceptance 3).** Only entries whose address matches
+    `_PERSONA_ALIAS_RE` are returned. The manifest is the LOOSER authority — it
+    can carry an entry that corresponds to no spawnable person, and #1181 shows
+    18 such manifest-only names of which `Annunaki` is definitionally not a
+    reviewer. Filtering on identity SHAPE keeps this gate correct today without
+    waiting on #1181's classification work, and stays correct if #1181 adds more
+    tool entries. #1181 may narrow the set further (manifest-orphan reconciliation);
+    it will not need to widen it.
+
+    Fails OPEN (empty set) when the file is missing or malformed — same posture
+    as the scope-time twin, and safe here for the same reason: the manifest only
+    ever WIDENS a review-class set, so an unreadable manifest degrades to exactly
+    the pre-#1179 behaviour (a loud BLOCK) rather than admitting anyone.
+
+    A non-string value is treated as non-persona. If `roster.json` ever grows a
+    richer per-entry schema (one of #1181's options), this parser narrows rather
+    than guessing — narrowing re-blocks, which is the recoverable direction.
+
+    Names are returned in lowercase to match `CommentReviewResult.reviewers`'
+    dedup key, as `_iter_roster_entries` does.
+    """
+    path = manifest_path if manifest_path is not None else _ROSTER_DIR.parent / "roster.json"
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return set()
+    if not isinstance(data, dict):
+        return set()
+    return {
+        name.strip().lower()
+        for name, address in data.items()
+        if isinstance(name, str)
+        and name.strip()
+        and isinstance(address, str)
+        and _PERSONA_ALIAS_RE.match(address.strip())
+    }
+
+
 def _load_roster_names(repo: str | None = None) -> set[str]:
     """Read the relevant roster dirs and return ALL canonical persona names.
 
@@ -1261,6 +1333,27 @@ def _load_roster_names(repo: str | None = None) -> set[str]:
     legitimate child-repo reviewers were filtered as non-roster and child PRs
     could not reach the real 2-reviewer threshold — forcing `--admin`.
 
+    The org-union manifest is unioned on top (#1179). Cards alone cover only
+    parent ∪ target-child, so a reviewer drawn from a THIRD child repo — which
+    `/wave-scope` § 12.5 and `/wave-kickoff` § 0b have accepted since #1162 —
+    was still filtered as non-roster here, counted zero, and left `--admin` as
+    the only exit (a moderate feedback event). This is review-class ONLY:
+    `load_charter_enforcer_names` stays card-only and fail-closed, because it is
+    role-filtered on card FILENAME prefixes the flat manifest cannot supply and
+    it gates the Single-Reviewer Exception. Do not union the manifest there.
+
+    Two invariants the ordering below preserves deliberately:
+
+    1. **The manifest WIDENS a card set; it never SUBSTITUTES for one.** It is
+       unioned only when the card dirs yielded at least one name, so the
+       documented "empty set ⇒ roster unreadable ⇒ caller fails closed" contract
+       still holds. A readable manifest beside an unreadable card tree must not
+       quietly re-enable the gate.
+    2. **`RosterResolutionError` still hard-blocks.** `_resolve_roster_dirs`
+       raises BEFORE the manifest is consulted, so a `--repo`-named child whose
+       roster dir is missing keeps failing closed (#552) instead of being papered
+       over by a manifest hit.
+
     Names are returned in lowercase. Empty set indicates the roster could not
     be read (missing dir or I/O failure); the caller is responsible for
     failing closed. Propagates `RosterResolutionError` when a named child
@@ -1269,7 +1362,9 @@ def _load_roster_names(repo: str | None = None) -> set[str]:
     names: set[str] = set()
     for roster_dir in _resolve_roster_dirs(repo):
         names |= _iter_roster_entries(role_prefix_filter=None, roster_dir=roster_dir)
-    return names
+    if not names:
+        return names
+    return names | _load_org_manifest_names()
 
 
 def is_single_reviewer_exception(


### PR DESCRIPTION
Closes #1179

## The defect (re-verified on merged main `b4922c5`, not paraphrased)

```
python3 -c "import sys; sys.path.insert(0,'.claude/hooks'); import validate_pr_review as v; \
  n=v._load_roster_names('noorinalabs/noorinalabs-isnad-ingest-platform'); \
  print(len(n)); print({w: w in n for w in ['nikolaos papadopoulos','oyunbileg batbayar','weronika zielinska']})"
```

| | count | nikolaos | oyunbileg | weronika |
|---|---|---|---|---|
| main `b4922c5` | 20 | `False` | `False` | `True` |
| this branch | 76 | `True` | `True` | `True` |

`_load_roster_names` unioned exactly parent-cards ∪ target-child-cards (#552) and never the 78-name org manifest. A reviewer drawn from a THIRD child repo — charter-permitted by `spawn-discipline.md` § Child-Repo Implementer Rule step 5, and accepted at **scope** time since #1162/#1178 — was filtered as non-roster (#498), counted **zero**, and left `--admin` as the only exit (a moderate feedback event per `charter/pull-requests.md` § Single-Reviewer Exception). #1178's skill doc now tells operators, at `wave-scope/SKILL.md:548`, *not* to "fix" such an assignment by reassigning it — so the documented-correct action lands on a gate that rejects it.

## What changed

`_load_org_manifest_names()` in `.claude/hooks/validate_pr_review.py`, mirroring `.claude/skills/wave-scope/validate_matrix_names._load_org_manifest_names` so scope time and merge time trust the same review-class authority. It inherits that module's rationale (§ *Why the manifest is acceptable HERE* — consequence asymmetry: a review slot never commits and fails loudly) rather than re-deriving it. `_load_roster_names` unions it; nothing else moves.

## Security boundaries — held deliberately

**`load_charter_enforcer_names` is untouched.** Confirmed: it does not appear in the diff. It stays card-only, role-filtered on card *filename* prefixes the flat manifest cannot supply, and fail-closed. Widening it would loosen the Single-Reviewer Exception. `test_manifest_does_not_widen_charter_enforcer_names` and `test_manifest_persona_cannot_claim_the_single_reviewer_exception` pin this. **I did not move this boundary and am not proposing to.**

**Non-personas are excluded by identity SHAPE, not a name blocklist.** An entry counts only if its address is a charter-conformant per-persona commit identity, `<principal>+<First>.<Last>@<domain>` (`_PERSONA_ALIAS_RE`). That is the org's own definition of a spawnable, commit-capable person, so a *future* tool entry is excluded automatically — a hardcoded `{"Annunaki"}` would not be. Measured against the live 78-entry `roster.json`, it excludes exactly the two entries #1181 identifies as non-persona and nothing else:

- `Annunaki` → `parametrization+Annunaki@gmail.com` — no `First.Last` tag. This is the live risk, not a hypothetical: the error monitor posts real comments on real PRs, so admitting it as a `Requestor` is a real path to a manufactured approval.
- `Steven French` → `parametrization@gmail.com` — bare principal, no `+`-tag.

The other 16 manifest-only names from #1181 are charter-conformant identities and do resolve — that is the point of the change. #1181 may narrow the set further (manifest-orphan reconciliation); it will not need to widen it, and this filter composes with whatever classification it lands.

**The manifest widens a card set; it never substitutes for one.** It is unioned only when the card dirs yielded at least one name, so `_load_roster_names`' documented contract — "empty ⇒ roster unreadable ⇒ caller fails closed" — still holds exactly. A readable manifest beside an unreadable card tree must not quietly re-enable the gate.

**#552's hard block survives.** `_resolve_roster_dirs` raises `RosterResolutionError` *before* the manifest is consulted, so a `--repo`-named child with a missing roster dir still fails closed instead of being papered over by a manifest hit.

**Degraded modes fail toward BLOCK.** Missing, malformed, non-object, or non-string-valued manifest → empty set → pre-#1179 behaviour (a loud, recoverable BLOCK). If `roster.json` ever grows a richer per-entry schema (one of #1181's options), this parser narrows rather than guessing.

## Mutation test (acceptance 4)

**Mutation:** in `_load_roster_names`, revert the union —

```python
    if not names:
        return names
    return names | _load_org_manifest_names()   # ← replaced with:  return names
```

**Result at `f05eab87`: RED — 4 failed, 11 passed.** (At `b8bf343f` it was 3 failed / 12 passed; the fourth kill is the review fix below.)

```
FAILED OrgManifestReviewerUnionTests::test_third_child_reviewers_reach_the_two_reviewer_threshold
FAILED OrgManifestReviewerUnionTests::test_third_child_reviewer_resolves_via_manifest
FAILED OrgManifestReviewerUnionTests::test_manifest_widens_parent_repo_prs_too
FAILED OrgManifestReviewerUnionTests::test_tool_identity_cannot_supply_an_approval   # added at f05eab87
```

The end-to-end one reproduces the exact production block text:

```
BLOCKED: PR #42 has 2 distinct Requestor string(s) on Approved verdicts but only 0 are recognized roster members.
Non-roster: nikolaos papadopoulos, oyunbileg batbayar
```

The **11 that stay green under the mutation are the point of the other half of the suite** — the non-persona, enforcer-boundary and degraded-mode tests must hold in *both* worlds, so a green there is evidence they are pinning the boundary rather than the union. Restored and re-verified green (3238 passed).

> **Correction (`f05eab87`).** The original version of this section claimed that argument for **12** tests. It was wrong for one of them. `test_tool_identity_cannot_supply_an_approval` asserted a bare `assertIn("1/2", ...)`, and Hook 4's BLOCK help text embeds the literal `1/2 false-block` three times unconditionally — so that test stayed green under the mutation because it could not observe the ratio at all, not because it was pinning a boundary. Both reviewers caught it independently. It is now anchored to the computed sentence and kills the mutant, which is why the count moved from 3/12 to 4/11. The inaccurate claim is corrected here rather than quietly deleted, because it was offered as evidence.

## Judgment call for the reviewer — the union is repo-agnostic

I applied the manifest union to parent-repo PRs as well as child-repo PRs, where the issue's acceptance criterion only names child-repo PRs.

Rationale: `validate_matrix_names.validate` computes `review_combined` for **every** repo including the parent, and the charter permits a cross-team reviewer on any PR. Restricting the union to child PRs would leave the identical false block reachable on a parent-repo PR, and the conditional's only justification would be "the issue said child".

The honest cost: `ChildRosterResolutionTests::test_child_reviewer_does_not_count_on_parent_pr` asserts a "no leak" property that now holds against the **card** set only, not against the live manifest. That test still passes (its tree is hermetic and has no `roster.json`), and `test_manifest_widens_parent_repo_prs_too` documents the new intended behaviour explicitly rather than leaving it implicit. If you want the union scoped to child PRs, say so and I will add it as an additive commit — I would rather you make that call than have me quietly widen it.

## Out-of-scope finding, surfaced not silently fixed

**The #487 regression fixture had gone stale, and my change is what revealed it.** `RosterValidationGateTests` used "Camila Restrepo" and "Imelda Santos" as fabricated non-roster Requestors — the P3W11 PR #487 repro. Both are now **real personas**: `noorinalabs-isnad-ingest-platform/.claude/team/roster/data_lead_camila.md` and `data_engineer_imelda.md`, both carried in `.claude/team/roster.json`. Once the manifest is unioned they resolve, and the two tests went red.

I retargeted the fixture rather than leaving a red gate, because a red gate is a stop and the alternative was to assert that two genuine org personas cannot review — the #1179 bug in miniature. The subject of those tests is the non-roster **filter**, not those particular strings, so the strings moved to ones that are definitionally un-personable (`phantom persona`, `fabricated reviewer` — no `+First.Last` identity can ever be minted for them, so they cannot silently become real the way #487's names did) and the full history stays in the class docstring.

Worth naming as a class, though: **a regression fixture that depends on a name NOT existing decays silently as the org onboards people.** That is a general pattern in this suite, not a one-off. I have not filed it as an issue because it is a single observed instance and I would rather Aino decide whether it is a real class or a coincidence — flag it and I will file.

## Sequencing

Lands before #1123 (decompose `validate_pr_review.check`, same file, also mine). Diff kept deliberately tight — no opportunistic restructuring; #1123 rebases onto this.

## Verification

- `ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/ .claude/lib/tests/ -q` → **3238 passed, 589 subtests passed**
- `pre-commit run --hook-stage pre-push --all-files` → all green (ruff-format, ruff-lint, actionlint, cspell, mypy, pytest, pytest-skills, memory-budget, headcount-budget, doc-freshness, office-drift, mermaid-render, fixture-realism, skill-graphql-pagination, checksums-ascii)
- `python3 .claude/lib/pre_commit_ci_sync.py .` → `OK: pre-commit config mirrors all CI-enforced checks.`

Reviewer: Aino Virtanen. Merge-gate reviewer: Weronika Zielinska. I am not merging this.

