### PR TITLE
fix(hook4): scan PR comment verdicts for every head ref, and make a skipped scan visible

### DIFF
--- a/.claude/hooks/tests/test_validate_pr_review.py
+++ b/.claude/hooks/tests/test_validate_pr_review.py
@@ -3814,5 +3814,401 @@ class SurnameCollisionSelfReviewTests(unittest.TestCase):
         self.assertEqual(captured.get("branch_author_initial"), "l")
 
 
+class CommentScanScopeTotalityTests(unittest.TestCase):
+    """#1206: `comment_scan_scope` must return a SCANNING mode for every head ref.
+
+    The defect was a dispatch that recognised exactly two head-ref shapes and
+    fell through to no scan at all for everything else — so a `dependabot/**`
+    PR carrying two correctly-formed, roster-valid, non-stale Approved verdicts
+    reported `0/2 required — (none)`, blaming the reviewers for a scan that
+    never ran (noorinalabs-deploy#691).
+
+    Totality is the property that kills the whole defect class rather than the
+    one observed shape: it is not enough to add `dependabot/**` to the list of
+    recognised prefixes, because the next unrecognised shape fails the same way.
+    """
+
+    def test_persona_branch_selects_author_exclusion(self):
+        """Positive control for the discriminator below: the persona shapes must
+        actually resolve to the OTHER mode, or the totality assertions would be
+        satisfied by a function that returned NO_BRANCH_AUTHOR unconditionally.
+        """
+        for ref in (
+            "S.Ferreira/1189-wave-status-scoping",
+            "A.Virtanen/1206-review-scan-nonpersona-headref",
+            "A.Virtanen-0179-branch-regex-fix",  # dash separator, also charter-shaped
+        ):
+            with self.subTest(ref=ref):
+                self.assertEqual(hook.comment_scan_scope(ref), hook.COMMENT_SCAN_AUTHOR_EXCLUDED)
+
+    def test_non_persona_refs_select_the_no_branch_author_scan(self):
+        """THE DEFECT, at the dispatch level. Every one of these returned "no
+        scan" before #1206; each must now name a real scanning mode."""
+        for ref in (
+            "dependabot/docker/integration-tests/fake_oauth/python-d3400aa",
+            "deployments/phase-10/wave-29",
+            "feature/some-hand-made-branch",
+            "nohashinthisref",  # no `/` at all
+            "",  # headRefName absent from the API response
+            "renovate/pytest-8.x",
+            "1206-bare-issue-number-branch",
+        ):
+            with self.subTest(ref=ref):
+                self.assertEqual(hook.comment_scan_scope(ref), hook.COMMENT_SCAN_NO_BRANCH_AUTHOR)
+
+    def test_no_head_ref_shape_ever_yields_not_run(self):
+        """The invariant itself, stated once: NOT_RUN is not a reachable scope.
+
+        Kept separate from the case list above so the property survives someone
+        later adding a third scanning mode — a new mode would keep this green
+        and correctly fail only the specific-mode assertions it changes.
+        """
+        for ref in (
+            "",
+            "/",
+            "a",
+            "A.Virtanen/1206-x",
+            "dependabot/npm_and_yarn/x-1.2.3",
+            "deployments/phase-10/wave-29",
+            "..",
+            "x" * 300,
+        ):
+            with self.subTest(ref=ref):
+                self.assertNotEqual(hook.comment_scan_scope(ref), hook.COMMENT_SCAN_NOT_RUN)
+
+
+class _ResolveOverFakeCommentsHarness(unittest.TestCase):
+    """Drives the REAL `resolve_review_verdicts` over a faked `gh api` boundary.
+
+    Deliberately does NOT mock `check_comment_reviews`: the #1206 defect lived
+    in the resolver's DISPATCH to that function, so a test that stubs the callee
+    still exercises the dispatch, but a test that stubs the dispatch would prove
+    nothing at all.
+    """
+
+    REPO = "noorinalabs/noorinalabs-main"
+    ROSTER = {"lucas ferreira", "nino kavtaradze", "aino virtanen", "santiago ferreira"}
+
+    @staticmethod
+    def _verdict(requestor: str, requestee: str = "Someone Else", direction: str = "Approved"):
+        return {
+            "body": (
+                f"Requestor: {requestor}\nRequestee: {requestee}\n"
+                f"RequestOrReplied: {direction}\nTechDebt: none"
+            ),
+            "created_at": "2026-07-20T00:00:00Z",
+        }
+
+    @staticmethod
+    def _pr_data(head_ref: str, *, author="parametrization", reviews=(), labels=()):
+        return {
+            "author": author,
+            "number": 691,
+            "reviews": list(reviews),
+            "headRefName": head_ref,
+            "labels": list(labels),
+        }
+
+    def _resolve(self, head_ref: str, comments: list[dict], *, roster=None):
+        def fake_run(args, capture_output, text, timeout):  # noqa: ARG001
+            result = mock.MagicMock()
+            result.returncode = 0
+            if args[0] == "gh" and args[1:3] == ["repo", "view"]:
+                result.stdout = json.dumps({"owner": {"login": "noorinalabs"}, "name": "r"})
+            else:
+                result.stdout = json.dumps(comments)
+            return result
+
+        with (
+            mock.patch.object(hook.subprocess, "run", side_effect=fake_run),
+            mock.patch.object(
+                hook,
+                "get_latest_content_commit",
+                # T_content sits BEFORE the fixture comments, so nothing is stale
+                # and a shortfall can only come from the scan, not from staleness.
+                return_value=("837c272a", hook._parse_iso8601("2026-07-15T19:13:59Z")),
+            ),
+            mock.patch.object(
+                hook,
+                "_load_roster_names",
+                return_value=set(self.ROSTER if roster is None else roster),
+            ),
+        ):
+            return hook.resolve_review_verdicts(self._pr_data(head_ref), repo=self.REPO)
+
+
+class NonPersonaHeadRefScanTests(_ResolveOverFakeCommentsHarness):
+    """#1206: the comment verdict scan must run for EVERY head-ref shape.
+
+    Each assertion below is a kill-shot on the pre-fix resolver: it returned
+    `comment_reviewers == set()` and `total_distinct == 0` for all of these
+    inputs, so every `assertEqual(..., 2)` here was `0` before the fix.
+    """
+
+    DEPENDABOT_REF = "dependabot/docker/integration-tests/fake_oauth/python-d3400aa"
+
+    def test_dependabot_head_ref_with_two_approvals_reaches_two_of_two(self):
+        """THE LIVE DEFECT, reproduced offline (noorinalabs-deploy#691)."""
+        verdicts = self._resolve(
+            self.DEPENDABOT_REF,
+            [self._verdict("Lucas Ferreira"), self._verdict("Nino Kavtaradze")],
+        )
+        self.assertEqual(verdicts.distinct_reviewers, {"lucas ferreira", "nino kavtaradze"})
+        self.assertEqual(verdicts.total_distinct, 2)
+        self.assertEqual(verdicts.comment_scan, hook.COMMENT_SCAN_NO_BRANCH_AUTHOR)
+
+    def test_head_ref_with_no_slash_neither_crashes_nor_skips(self):
+        """A ref with no separator at all used to fall through both branches."""
+        verdicts = self._resolve(
+            "nohashinthisref",
+            [self._verdict("Lucas Ferreira"), self._verdict("Nino Kavtaradze")],
+        )
+        self.assertEqual(verdicts.total_distinct, 2)
+        self.assertTrue(verdicts.comment_scan_ran)
+
+    def test_empty_head_ref_still_scans(self):
+        """`get_pr_data` defaults `headRefName` to `""`; that must scan, not skip."""
+        verdicts = self._resolve("", [self._verdict("Aino Virtanen")])
+        self.assertEqual(verdicts.distinct_reviewers, {"aino virtanen"})
+        self.assertTrue(verdicts.comment_scan_ran)
+
+    def test_none_head_ref_does_not_crash(self):
+        """A hand-built `pr_data` carrying `None` must degrade, not raise."""
+        pr_data = self._pr_data("")
+        pr_data["headRefName"] = None
+
+        def fake_run(args, capture_output, text, timeout):  # noqa: ARG001
+            result = mock.MagicMock()
+            result.returncode = 0
+            result.stdout = json.dumps([self._verdict("Aino Virtanen")])
+            return result
+
+        with (
+            mock.patch.object(hook.subprocess, "run", side_effect=fake_run),
+            mock.patch.object(hook, "get_latest_content_commit", return_value=None),
+            mock.patch.object(hook, "_load_roster_names", return_value=set(self.ROSTER)),
+        ):
+            verdicts = hook.resolve_review_verdicts(pr_data, repo=self.REPO)
+
+        self.assertEqual(verdicts.head_ref, "")
+        self.assertEqual(verdicts.distinct_reviewers, {"aino virtanen"})
+
+    def test_non_roster_requestor_on_a_bot_branch_still_does_not_count(self):
+        """The gate is not relaxed: widening the sentinel must not smuggle a
+        non-roster Requestor past the #498 filter. Paired with a roster name in
+        the SAME thread as the positive control — a fix that broke roster
+        filtering outright would satisfy neither half.
+        """
+        verdicts = self._resolve(
+            self.DEPENDABOT_REF,
+            [self._verdict("Lucas Ferreira"), self._verdict("Mallory Impostor")],
+        )
+        self.assertEqual(verdicts.roster_comment_reviewers, {"lucas ferreira"})
+        self.assertEqual(verdicts.non_roster_requestors, {"mallory impostor"})
+        self.assertEqual(verdicts.total_distinct, 1)
+
+    def test_changes_requested_on_a_bot_branch_still_does_not_count(self):
+        """Nor may it admit a non-Approved verdict (#940 stays in force)."""
+        verdicts = self._resolve(
+            self.DEPENDABOT_REF,
+            [
+                self._verdict("Lucas Ferreira"),
+                self._verdict("Nino Kavtaradze", direction="Changes Requested"),
+            ],
+        )
+        self.assertEqual(verdicts.distinct_reviewers, {"lucas ferreira"})
+        self.assertEqual(verdicts.total_distinct, 1)
+
+    def test_stale_verdict_on_a_bot_branch_is_still_excluded(self):
+        """Content binding (#950) must survive the widened dispatch."""
+        stale = self._verdict("Lucas Ferreira")
+        stale["created_at"] = "2026-01-01T00:00:00Z"  # before T_content
+        verdicts = self._resolve(self.DEPENDABOT_REF, [stale, self._verdict("Nino Kavtaradze")])
+        self.assertEqual(verdicts.distinct_reviewers, {"nino kavtaradze"})
+        self.assertEqual(len(verdicts.stale_verdicts_comment), 1)
+        self.assertEqual(verdicts.stale_verdicts_comment[0].reviewer, "Lucas Ferreira")
+
+
+class HeadRefScanRegressionTests(_ResolveOverFakeCommentsHarness):
+    """The two behaviours #1206 must leave EXACTLY as they were."""
+
+    def test_persona_branch_still_excludes_the_pr_author(self):
+        """Self-review exclusion is the reason the head ref is consulted at all.
+
+        Lucas Ferreira's own Approved on `L.Ferreira/…` must stay out, while
+        Aino Virtanen's is admitted — the admitted half is the positive control
+        proving the scan ran, so a regression that skipped the scan entirely
+        would fail this test rather than passing its absence assertion.
+        """
+        verdicts = self._resolve(
+            "L.Ferreira/1206-x",
+            [self._verdict("Lucas Ferreira"), self._verdict("Aino Virtanen")],
+        )
+        self.assertNotIn("lucas ferreira", verdicts.distinct_reviewers)
+        self.assertEqual(verdicts.distinct_reviewers, {"aino virtanen"})
+        self.assertEqual(verdicts.branch_author_lastname, "Ferreira")
+        self.assertEqual(verdicts.comment_scan, hook.COMMENT_SCAN_AUTHOR_EXCLUDED)
+
+    def test_persona_branch_still_admits_the_same_surname_colleague(self):
+        """#1172 must not regress: Santiago is not Lucas."""
+        verdicts = self._resolve(
+            "L.Ferreira/1206-x",
+            [self._verdict("Santiago Ferreira"), self._verdict("Lucas Ferreira")],
+        )
+        self.assertEqual(verdicts.distinct_reviewers, {"santiago ferreira"})
+
+    def test_wave_merge_branch_behaviour_is_unchanged(self):
+        """`deployments/phase-N/wave-M` counted every roster reviewer before the
+        fix (main#294's empty sentinel) and must still do so — same reviewers,
+        same count, and now under the generalised no-branch-author mode."""
+        verdicts = self._resolve(
+            "deployments/phase-10/wave-29",
+            [self._verdict("Lucas Ferreira"), self._verdict("Nino Kavtaradze")],
+        )
+        self.assertEqual(verdicts.distinct_reviewers, {"lucas ferreira", "nino kavtaradze"})
+        self.assertEqual(verdicts.total_distinct, 2)
+        self.assertEqual(verdicts.comment_scan, hook.COMMENT_SCAN_NO_BRANCH_AUTHOR)
+        self.assertIsNone(verdicts.branch_author_lastname)
+
+    def test_two_reviewer_threshold_is_not_relaxed_anywhere(self):
+        """One approval is still one approval, on a bot branch as on any other.
+
+        The whole risk of this change is that "count the verdicts that exist"
+        slides into "need fewer verdicts". Pinned on the exact shape that was
+        broken.
+        """
+        verdicts = self._resolve(
+            NonPersonaHeadRefScanTests.DEPENDABOT_REF, [self._verdict("Lucas Ferreira")]
+        )
+        self.assertEqual(verdicts.total_distinct, 1)
+        self.assertFalse(verdicts.total_distinct >= 2)
+
+
+class CommentScanNotMeasuredTests(_ResolveOverFakeCommentsHarness):
+    """#1206 half two: a non-measurement must never render as a measurement.
+
+    The original defect was invisible for months precisely because the report
+    said `0/2 required — (none)` and `stale verdicts: none` — two sentences
+    that describe findings — when nothing had been looked at. These pin that a
+    skipped scan is now loud at every layer.
+    """
+
+    def test_review_verdicts_defaults_to_not_measured(self):
+        """The DEFAULT must be the honest one. A future field-by-field
+        construction that forgets `comment_scan` has to degrade to "not
+        measured", never to a false claim that the thread was read."""
+        verdicts = hook.ReviewVerdicts(
+            number=1,
+            head_ref="x",
+            labels=[],
+            branch_author_lastname=None,
+            content_sha="",
+            content_ts=None,
+            formal_reviewers=set(),
+            comment_reviewers=set(),
+            non_roster_requestors=set(),
+            roster_comment_reviewers=set(),
+            roster_names=set(),
+            distinct_reviewers=set(),
+            stale_verdicts_comment=[],
+            stale_verdicts_formal=[],
+            reviews_missing_tech_debt=[],
+            tech_debt_issue_numbers=[],
+            tech_debt_unparseable=[],
+            wave_bootstrap_exception=False,
+        )
+        self.assertEqual(verdicts.comment_scan, hook.COMMENT_SCAN_NOT_RUN)
+        self.assertFalse(verdicts.comment_scan_ran)
+
+    def test_a_reintroduced_skip_path_fails_closed_with_a_named_reason(self):
+        """The regression guard, exercised rather than asserted-by-comment.
+
+        Patching `comment_scan_scope` to return NOT_RUN simulates exactly the
+        future edit this guard exists for — a head-ref shape that dispatches to
+        no scan. The resolver must raise rather than return a zero, because a
+        zero from an unscanned thread is the absence of evidence, not evidence
+        of absence (#981's stance, applied one level up).
+        """
+        with mock.patch.object(hook, "comment_scan_scope", return_value=hook.COMMENT_SCAN_NOT_RUN):
+            with self.assertRaises(hook.CommentScanUndeterminedError) as ctx:
+                self._resolve("whatever/ref", [self._verdict("Lucas Ferreira")])
+        self.assertIn("not dispatched", ctx.exception.reason)
+        self.assertIn("whatever/ref", ctx.exception.reason)
+
+    def test_positive_control_same_setup_does_not_raise_unpatched(self):
+        """Proves the experiment above ran: identical inputs WITHOUT the patch
+        must resolve cleanly. Without this, the assertRaises could be passing
+        on some unrelated failure in the harness."""
+        verdicts = self._resolve("whatever/ref", [self._verdict("Lucas Ferreira")])
+        self.assertEqual(verdicts.distinct_reviewers, {"lucas ferreira"})
+        self.assertTrue(verdicts.comment_scan_ran)
+
+    def _block_reason(self, verdicts) -> str:
+        input_data = {
+            "tool_name": "Bash",
+            "tool_input": {"command": "gh pr merge 691 --repo noorinalabs/noorinalabs-main"},
+        }
+        with (
+            mock.patch.object(
+                hook,
+                "get_pr_data",
+                return_value=self._pr_data("dependabot/docker/x-1.2.3"),
+            ),
+            mock.patch.object(hook, "resolve_review_verdicts", return_value=verdicts),
+            mock.patch.object(hook, "log_pretooluse_block"),
+        ):
+            result = hook.check(input_data)
+        # `assert` rather than `assertIsNotNone` so mypy narrows away the
+        # `dict | None` return before the indexing below.
+        assert result is not None, "check() must BLOCK a 0/2 PR, not return None"
+        self.assertEqual(result["decision"], "block")
+        return str(result["reason"])
+
+    @staticmethod
+    def _empty_verdicts(comment_scan: str):
+        return hook.ReviewVerdicts(
+            number=691,
+            head_ref="dependabot/docker/x-1.2.3",
+            labels=[],
+            branch_author_lastname=None,
+            content_sha="837c272a",
+            content_ts=None,
+            formal_reviewers=set(),
+            comment_reviewers=set(),
+            non_roster_requestors=set(),
+            roster_comment_reviewers=set(),
+            roster_names={"lucas ferreira"},
+            distinct_reviewers=set(),
+            stale_verdicts_comment=[],
+            stale_verdicts_formal=[],
+            reviews_missing_tech_debt=[],
+            tech_debt_issue_numbers=[],
+            tech_debt_unparseable=[],
+            wave_bootstrap_exception=False,
+            comment_scan=comment_scan,
+        )
+
+    def test_block_message_distinguishes_not_measured_from_measured_empty(self):
+        """Same 0/2 count, two different causes, two different messages.
+
+        Both branches are asserted in BOTH directions — the not-measured
+        message must say so and the measured one must NOT — so a change that
+        emitted the alarming wording unconditionally fails just as loudly as
+        one that emitted it never.
+        """
+        not_measured = self._block_reason(self._empty_verdicts(hook.COMMENT_SCAN_NOT_RUN))
+        measured = self._block_reason(self._empty_verdicts(hook.COMMENT_SCAN_NO_BRANCH_AUTHOR))
+
+        self.assertNotEqual(not_measured, measured)
+        self.assertIn("DID NOT RUN", not_measured)
+        self.assertIn("NOT a measurement", not_measured)
+        self.assertNotIn("DID NOT RUN", measured)
+        self.assertIn("The scan DID run", measured)
+        # Both still block on the same threshold — the wording differs, the
+        # gate does not.
+        self.assertIn("0/2 required peer reviews", not_measured)
+        self.assertIn("0/2 required peer reviews", measured)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.claude/hooks/validate_pr_review.py
+++ b/.claude/hooks/validate_pr_review.py
@@ -748,6 +748,65 @@ def extract_branch_author_lastname(head_ref: str) -> str | None:
     return None
 
 
+# How the PR-comment verdict scan was dispatched for a given PR (#1206).
+#
+# These exist because an empty `comment_reviewers` set cannot say WHY it is
+# empty, and the two reasons are not remotely equivalent: "the thread was read
+# and nobody has approved" is a measurement, "the thread was never read" is the
+# absence of one. Before #1206 the resolver silently produced the second and
+# every surface rendered it as the first — the `feedback_silent_zero_is_not_a_
+# measurement` shape, and the sibling of the `CommentReviewResult.undetermined`
+# field that exists for the same reason one level down.
+#
+# NOT_RUN is deliberately the DEFAULT on both `ReviewVerdicts` and
+# `pr_review_state.ReviewState`: a construction that forgets to set the scope
+# must degrade to the honest "not measured" rendering, never to a false claim
+# that the scan ran. `comment_scan_scope` below never returns it, and
+# `resolve_review_verdicts` hard-blocks if it ever sees it — so in production it
+# marks a regression, not a state.
+COMMENT_SCAN_NOT_RUN = "not-run"
+COMMENT_SCAN_AUTHOR_EXCLUDED = "author-excluded"
+COMMENT_SCAN_NO_BRANCH_AUTHOR = "no-branch-author"
+
+
+def comment_scan_scope(head_ref: str) -> str:
+    """Return which self-review-exclusion mode the comment verdict scan runs in.
+
+    The head ref's ONLY role in the comment scan is naming the branch author for
+    the self-review exclusion, so there are exactly two modes and **no third
+    "don't scan" mode**:
+
+      - `COMMENT_SCAN_AUTHOR_EXCLUDED` — the ref carries the charter
+        `{Initial}.{Lastname}[-/]…` prefix, so the branch author is identifiable
+        and is excluded from the reviewer set.
+      - `COMMENT_SCAN_NO_BRANCH_AUTHOR` — the ref names no persona (a
+        `deployments/phase-N/wave-M` wave-merge branch, a `dependabot/**` bot
+        branch, a hand-made `feature/x`, or an empty `headRefName`). The scan
+        still runs, under the `""` sentinel the wave-merge path has used since
+        main#294, which `charter_trailer.is_branch_author` reads as "nobody is
+        the branch author".
+
+    This function is TOTAL: it returns a scanning mode for every possible head
+    ref, including `""`. That totality IS the #1206 fix — the pre-fix resolver
+    branched on the ref shape and fell through to no scan at all for anything
+    that was neither a persona branch nor `deployments/**`, which made a
+    `dependabot/**` PR carrying two valid Approveds report `0/2 — (none)`
+    (noorinalabs-deploy#691). `.claude/hooks/tests/test_validate_pr_review.py::
+    CommentScanScopeTotalityTests` pins the totality directly.
+
+    Widening the sentinel does NOT relax the gate: the threshold is still two
+    distinct roster-valid current Approveds and roster filtering is untouched.
+    Losing author-exclusion on a bot branch is the correct outcome — a bot is
+    never a roster persona, so it could never have been in the reviewer set. On
+    a ref that DOES name a persona, exclusion is unchanged.
+    """
+    return (
+        COMMENT_SCAN_AUTHOR_EXCLUDED
+        if extract_branch_author_lastname(head_ref)
+        else COMMENT_SCAN_NO_BRANCH_AUTHOR
+    )
+
+
 PROJECT_NUMBER = 2
 ORG = "noorinalabs"
 
@@ -1490,6 +1549,18 @@ class ReviewVerdicts:
     # a merge decision, only surfaced.
     tech_debt_unparseable: list[tuple[str, str]]
     wave_bootstrap_exception: bool
+    # WHICH comment-scan mode produced `comment_reviewers` (#1206) — see the
+    # COMMENT_SCAN_* constants. Carried on the shared pipeline output so BOTH
+    # callers can distinguish "scanned, nobody approved" from "never scanned",
+    # which an empty `comment_reviewers` alone cannot express. Defaulted to
+    # NOT_RUN so a construction that omits it renders as not-measured rather
+    # than falsely claiming a measurement.
+    comment_scan: str = COMMENT_SCAN_NOT_RUN
+
+    @property
+    def comment_scan_ran(self) -> bool:
+        """True iff the PR-comment verdict scan actually read the thread."""
+        return self.comment_scan != COMMENT_SCAN_NOT_RUN
 
     @property
     def stale_verdicts(self) -> list[StaleVerdict]:
@@ -1509,7 +1580,9 @@ def resolve_review_verdicts(pr_data: dict, repo: str | None = None) -> ReviewVer
 
       1. `get_latest_content_commit` → T_content (`content_ts`/`content_sha`, #950).
       2. `partition_formal_reviewers` + `check_comment_reviews`, both bound to
-         T_content, on the feature-branch or wave-merge head-ref path.
+         T_content. The comment scan runs for EVERY head ref (#1206); the ref
+         selects only which self-review exclusion applies (`comment_scan_scope`),
+         and the chosen mode is reported on `ReviewVerdicts.comment_scan`.
       3. `_load_roster_names` and non-roster Requestor filtering (#498).
       4. Union formal + roster-filtered comment reviewers into the distinct
          reviewer set, plus the wave-bootstrap single-reviewer exception (#228).
@@ -1523,7 +1596,8 @@ def resolve_review_verdicts(pr_data: dict, repo: str | None = None) -> ReviewVer
         CommitFetchError: T_content could not be established (#950) —
             propagated verbatim from `get_latest_content_commit`.
         CommentScanUndeterminedError: the comment thread could not be
-            completely scanned (#981) — carries `.reason`.
+            completely scanned (#981), or the scan was never dispatched at all
+            (#1206 defense-in-depth) — carries `.reason`.
         RosterResolutionError: a named child repo's roster could not be
             resolved (#552) — propagated verbatim from `_load_roster_names`.
 
@@ -1532,7 +1606,11 @@ def resolve_review_verdicts(pr_data: dict, repo: str | None = None) -> ReviewVer
     """
     author = pr_data["author"]
     reviews = pr_data["reviews"]
-    head_ref = pr_data["headRefName"]
+    # `or ""` because a missing/None `headRefName` must degrade to "no
+    # identifiable branch author" (a scannable state), never to a skipped scan
+    # or a `re.match(None)` crash (#1206). `get_pr_data` already defaults it to
+    # `""`; this covers hand-built `pr_data` from other callers and tests.
+    head_ref = pr_data["headRefName"] or ""
     number = pr_data["number"]
     labels = pr_data["labels"]
 
@@ -1542,23 +1620,53 @@ def resolve_review_verdicts(pr_data: dict, repo: str | None = None) -> ReviewVer
 
     formal_reviewers, stale_formal = partition_formal_reviewers(reviews, author, content_ts)
 
-    comment_result = CommentReviewResult()
-    branch_author_lastname = None
-    if head_ref:
-        branch_author_lastname = extract_branch_author_lastname(head_ref)
-        if branch_author_lastname:
-            comment_result = check_comment_reviews(
-                number,
-                branch_author_lastname,
-                repo=repo,
-                content_ts=content_ts,
-                branch_author_initial=branch_author_first_initial(head_ref),
-            )
-        elif head_ref.startswith("deployments/") and "/wave-" in head_ref:
-            # Wave-merge PR (head = deployments/phase-{N}/wave-{M}); no
-            # implementer-branch author. Empty sentinel admits any non-empty
-            # reviewer. See main#294.
-            comment_result = check_comment_reviews(number, "", repo=repo, content_ts=content_ts)
+    # The comment verdict scan runs UNCONDITIONALLY (#1206). It used to be
+    # dispatched only for two head-ref shapes — a `{Initial}.{Lastname}[-/]…`
+    # persona branch, or a `deployments/**` wave-merge branch. EVERY other shape
+    # (`dependabot/**`, any hand-made branch off the charter naming convention,
+    # an empty `headRefName`) fell through with the empty `CommentReviewResult()`
+    # default and returned zero comment reviewers with no error and no
+    # diagnostic — indistinguishable from "scanned the thread and nobody
+    # approved". On noorinalabs-deploy#691 that reported two correctly-formed,
+    # roster-valid, non-stale Approved verdicts as `0/2 required — (none)`, and
+    # blamed the reviewers for it.
+    #
+    # `comment_scan_scope` is total over head refs, so there is no longer a
+    # shape that skips the scan; the ref only selects WHICH self-review
+    # exclusion applies. This does not relax the gate — the threshold is
+    # unchanged and roster filtering below is untouched; it only makes the
+    # verdicts that already exist countable.
+    #
+    # `branch_author_first_initial` returns `""` on exactly the refs
+    # `extract_branch_author_lastname` returns None for (the two regexes have
+    # the same shape), so the two halves of the branch author's identity cannot
+    # disagree about whether an author was found.
+    scan_scope = comment_scan_scope(head_ref)
+    if scan_scope == COMMENT_SCAN_NOT_RUN:
+        # Defense in depth (#1206): unreachable today, because
+        # `comment_scan_scope` is total. Reaching it means a future edit
+        # reintroduced a head-ref shape that skips the scan — and an unscanned
+        # thread is NOT a zero-approval thread. Fail CLOSED with a named reason
+        # (the #981 stance) rather than returning the silent zero this issue
+        # exists to kill.
+        raise CommentScanUndeterminedError(
+            f"the PR-comment verdict scan was not dispatched for head ref {head_ref!r}. "
+            "An unscanned comment thread is not evidence of zero approvals, so this is a "
+            "determinate failure rather than a 0-reviewer result (#1206)."
+        )
+
+    branch_author_lastname = extract_branch_author_lastname(head_ref)
+    comment_result = check_comment_reviews(
+        number,
+        # The `""` sentinel means "no identifiable branch author, so no reviewer
+        # is the author" (`charter_trailer.is_branch_author`, main#294). Losing
+        # author-exclusion on a bot branch is correct: a bot is never a roster
+        # persona, so it could never have been in the reviewer set anyway.
+        branch_author_lastname or "",
+        repo=repo,
+        content_ts=content_ts,
+        branch_author_initial=branch_author_first_initial(head_ref),
+    )
 
     if comment_result.undetermined:
         raise CommentScanUndeterminedError(comment_result.undetermined)
@@ -1591,6 +1699,7 @@ def resolve_review_verdicts(pr_data: dict, repo: str | None = None) -> ReviewVer
         tech_debt_issue_numbers=list(comment_result.tech_debt_issue_numbers),
         tech_debt_unparseable=list(comment_result.tech_debt_unparseable),
         wave_bootstrap_exception=wave_bootstrap_exception,
+        comment_scan=scan_scope,
     )
 
 
@@ -1897,10 +2006,36 @@ def check(input_data: dict) -> dict | None:
                 "NOT count toward the 2-reviewer threshold. Re-post the verdict under a "
                 "roster persona, or amend the roster if this is a new member.\n\n"
             )
+        # State the comment scan's OWN status alongside the count (#1206). A
+        # shortfall reported without it is ambiguous between "the thread was
+        # read and the approvals are not there" and "the thread was never
+        # read" — and for every non-persona head ref the answer used to be the
+        # second one, silently. Naming the mode makes the count self-describing
+        # on the surface an operator actually sees at merge time.
+        scan_diagnostic = ""
+        if not verdicts.comment_scan_ran:
+            scan_diagnostic = (
+                f"BLOCKED: PR {pr_display} — the PR-comment verdict scan DID NOT RUN, so the "
+                f"{total_distinct}/2 count below is NOT a measurement of this PR's approvals.\n"
+                "Any comment-based Approved verdicts on this PR were never read (#1206). This "
+                "is a hook defect, not a review shortfall — report it rather than asking "
+                "reviewers to re-approve.\n\n"
+            )
+        elif verdicts.comment_scan == COMMENT_SCAN_NO_BRANCH_AUTHOR:
+            scan_diagnostic = (
+                f"NOTE: head ref `{verdicts.head_ref or '(unknown)'}` carries no "
+                "`{Initial}.{Lastname}` branch-author prefix (a bot branch, a wave-merge "
+                "branch, or a branch off the charter naming convention), so the comment "
+                "verdict scan ran WITHOUT self-review exclusion — every roster-valid "
+                "Approved Requestor counts. The scan DID run; the count below is a real "
+                "measurement (#1206).\n\n"
+            )
+
         result = {
             "decision": "block",
             "reason": (
-                stale_diagnostic
+                scan_diagnostic
+                + stale_diagnostic
                 + roster_diagnostic
                 + f"BLOCKED: PR {pr_display} has {total_distinct}/2 required peer reviews. "
                 "At least TWO Approved reviews from distinct non-authors are required before "

--- a/.claude/lib/pr_review_state.py
+++ b/.claude/lib/pr_review_state.py
@@ -19,9 +19,18 @@ charter-comment parsing, nor re-assemble that pipeline with its own argument
 list: a fork would silently drift from the gate, and that drift is the exact
 failure #707 exists to prevent. The PASS/FAIL verdict computed here mirrors
 `validate_pr_review.check()` step for step (T_content verdict staleness,
-formal + roster-filtered comment reviewers, the wave-merge head-ref sentinel,
-the single-reviewer exception, and the missing-TechDebt block) because both
-now compute it via the same `resolve_review_verdicts` call.
+formal + roster-filtered comment reviewers, the no-branch-author head-ref
+sentinel, the single-reviewer exception, and the missing-TechDebt block)
+because both now compute it via the same `resolve_review_verdicts` call.
+
+#1206 adds the `comment_scan` field to that shared output and renders it here.
+Reusing the gate's pipeline made this tool AGREE with the gate, but both agreed
+on a non-answer: for any head ref that was neither a persona branch nor
+`deployments/**` the comment scan was never dispatched, and this report printed
+`0/2 required — (none)` plus `stale verdicts: none` for a dependabot PR carrying
+two valid Approveds (noorinalabs-deploy#691). Parity with the gate is not the
+same as measuring anything, so the report now states whether the scan RAN before
+it states what the scan found.
 
 Reusing the gate's functions is necessary but NOT sufficient for parity — the
 ARGUMENTS matter as much as the callee. #1046: this driver called
@@ -116,6 +125,20 @@ class ReviewState:
     # carried so the report can NAME them. A stale verdict that is silently
     # subtracted reads to an operator as a broken tool (#950 diagnostic lesson).
     stale_verdicts: list[dict] = dataclasses.field(default_factory=list)
+    # Which comment-scan mode produced `comment_reviewers` (#1206) — one of the
+    # gate's COMMENT_SCAN_* values. Carried so the report can distinguish "the
+    # thread was read and nobody approved" from "the thread was never read",
+    # which the reviewer counts alone cannot express: pre-#1206 this tool
+    # printed `0/2 required — (none)` AND `stale verdicts: none` for a
+    # dependabot PR carrying two valid Approveds, and both lines read as
+    # findings when neither was one. Defaults to NOT_RUN so an omission renders
+    # as not-measured rather than as a false measurement.
+    comment_scan: str = gate.COMMENT_SCAN_NOT_RUN
+
+    @property
+    def comment_scan_ran(self) -> bool:
+        """True iff the PR-comment verdict scan actually read the thread."""
+        return self.comment_scan != gate.COMMENT_SCAN_NOT_RUN
 
     def passes(self) -> bool:
         """True iff `validate_pr_review` would ALLOW the merge.
@@ -250,6 +273,34 @@ def compute_review_state(pr_number: str, repo: str | None = None) -> ReviewState
         content_sha=verdicts.content_sha,
         content_ts=verdicts.content_ts.isoformat() if verdicts.content_ts else None,
         stale_verdicts=stale_verdicts,
+        comment_scan=verdicts.comment_scan,
+    )
+
+
+def _describe_comment_scan(state: ReviewState) -> str:
+    """One line saying whether the comment verdict scan RAN, and in which mode.
+
+    The report's reviewer counts describe a measurement; this line describes
+    whether a measurement happened at all. Without it, `0/2 required — (none)`
+    is ambiguous between "nobody approved" and "nobody looked" — and for every
+    non-persona head ref the answer was the second one, silently, until #1206.
+    """
+    if not state.comment_scan_ran:
+        return (
+            "NOT RUN — the PR comment thread was never read, so the reviewer count "
+            "above is NOT a measurement of this PR's approvals (#1206). Treat it as "
+            "unknown, not as zero."
+        )
+    if state.comment_scan == gate.COMMENT_SCAN_AUTHOR_EXCLUDED:
+        author = state.branch_author_lastname or "?"
+        return (
+            f"RAN — head ref names branch author {author!r}, whose own verdicts are "
+            "excluded from the reviewer set (self-review exclusion active)."
+        )
+    return (
+        "RAN — head ref names no branch author (bot / wave-merge / non-charter branch), "
+        "so no self-review exclusion was applied. Roster filtering and the 2-reviewer "
+        "threshold are unchanged."
     )
 
 
@@ -262,6 +313,10 @@ def _render_text(state: ReviewState) -> str:
     lines.append(f"  head ref: {state.head_ref or '(unknown)'}")
     lastname = state.branch_author_lastname or "(none — wave-merge / unmatched)"
     lines.append(f"  branch-author lastname: {lastname}")
+
+    # Printed BEFORE the counts, on purpose: it tells the reader whether the
+    # numbers that follow are a measurement at all (#1206).
+    lines.append(f"  comment verdict scan: {_describe_comment_scan(state)}")
 
     approved = state.comment_reviewers + state.formal_reviewers
     lines.append(
@@ -303,8 +358,20 @@ def _render_text(state: ReviewState) -> str:
             "`main` (merge commits) do NOT invalidate a verdict; only new authored "
             "commits do. Fix: ask the reviewer to re-review at the current head."
         )
-    else:
+    elif state.comment_scan_ran:
         lines.append("  stale verdicts: none")
+    else:
+        # `stale verdicts: none` would be TRUE here and still misleading: it
+        # reads as "the thread was scanned and nothing was stale" when the
+        # thread was never scanned. Both halves of the #1206 report were wrong
+        # in exactly this way on noorinalabs-deploy#691 — the count and this
+        # line — so the not-measured case gets its own wording rather than
+        # borrowing the measured-and-empty one.
+        lines.append(
+            "  stale verdicts: NOT MEASURED for comment verdicts — the comment scan did "
+            "not run (see above); only formal GitHub reviews were examined, and none of "
+            "those were stale."
+        )
 
     lines.append(
         "  wave-bootstrap single-reviewer exception: "

--- a/.claude/lib/tests/test_pr_review_state.py
+++ b/.claude/lib/tests/test_pr_review_state.py
@@ -439,13 +439,23 @@ class ContentStalenessTests(unittest.TestCase):
             "compute_review_state must forward T_content to check_comment_reviews (#1046)",
         )
 
-    def test_content_ts_forwarded_on_wave_merge_call_site(self):
-        """The `:137` wave-merge call site is a SECOND omission surface (#1046)."""
+    def test_content_ts_forwarded_on_the_no_branch_author_path(self):
+        """A head ref naming NO branch author is a second omission surface (#1046).
+
+        Since #1206 this is no longer a separate `deployments/**` call site —
+        the resolver has ONE `check_comment_reviews` call for every head-ref
+        shape — but the wave-merge ref is still the shape that must arrive with
+        the `""` author sentinel, so the assertion is kept and pointed at the
+        unified call site. `branch_author_initial` must be `""` here too: a
+        non-empty initial would mean the resolver had invented an author for a
+        branch that names none.
+        """
         captured = {}
 
-        def fake_check(number, lastname, repo=None, content_ts=None):
+        def fake_check(number, lastname, repo=None, content_ts=None, branch_author_initial=""):
             captured["content_ts"] = content_ts
             captured["lastname"] = lastname
+            captured["initial"] = branch_author_initial
             return _comment_result(reviewers=())
 
         with (
@@ -462,6 +472,7 @@ class ContentStalenessTests(unittest.TestCase):
             prs.compute_review_state("1040", repo=self.REPO)
 
         self.assertEqual(captured["lastname"], "")
+        self.assertEqual(captured["initial"], "")
         self.assertEqual(captured["content_ts"], _NOW)
 
     def test_stale_formal_review_is_excluded_and_recorded(self):
@@ -655,6 +666,160 @@ class UndeterminableRepoAndScanTests(unittest.TestCase):
             with self.assertRaises(prs.ReviewStateError) as ctx:
                 prs.compute_review_state("451", repo="noorinalabs/noorinalabs-main")
         self.assertIn("HTTP 403", str(ctx.exception))
+
+
+class CommentScanReportedInTheReportTests(unittest.TestCase):
+    """#1206 half two: the report must distinguish NOT-MEASURED from MEASURED-EMPTY.
+
+    On noorinalabs-deploy#691 this tool printed, for a PR carrying two valid
+    Approveds:
+
+        distinct Approved reviewers: 0/2 required — (none)
+        stale verdicts: none
+
+    Every word of that is a claim about what a scan found. No scan had run. The
+    count was recoverable by fixing the dispatch; the misleading REPORT is a
+    separate defect, because it is what made the first one survive — a
+    non-measurement that renders as a measurement cannot be noticed.
+
+    Both directions are asserted throughout: the not-measured report must carry
+    the warning AND the measured one must not. An implementation that printed
+    the alarming wording unconditionally would fail here just as loudly as one
+    that never printed it.
+    """
+
+    @staticmethod
+    def _state(comment_scan, **overrides):
+        kwargs = dict(
+            pr_number="691",
+            repo="noorinalabs/noorinalabs-deploy",
+            head_ref="dependabot/docker/integration-tests/fake_oauth/python-d3400aa",
+            branch_author_lastname=None,
+            formal_reviewers=[],
+            comment_reviewers=[],
+            non_roster_requestors=[],
+            distinct_reviewer_count=0,
+            wave_bootstrap_exception=False,
+            reviews_missing_tech_debt=[],
+            tech_debt_issue_numbers=[],
+            content_sha="837c272a",
+            comment_scan=comment_scan,
+        )
+        kwargs.update(overrides)
+        return prs.ReviewState(**kwargs)
+
+    def test_default_is_not_measured(self):
+        """A ReviewState built without the field must claim nothing."""
+        state = prs.ReviewState(
+            pr_number="1",
+            repo=None,
+            head_ref="x",
+            branch_author_lastname=None,
+            formal_reviewers=[],
+            comment_reviewers=[],
+            non_roster_requestors=[],
+            distinct_reviewer_count=0,
+            wave_bootstrap_exception=False,
+            reviews_missing_tech_debt=[],
+            tech_debt_issue_numbers=[],
+        )
+        self.assertEqual(state.comment_scan, prs.gate.COMMENT_SCAN_NOT_RUN)
+        self.assertFalse(state.comment_scan_ran)
+
+    def test_not_measured_and_measured_empty_render_differently(self):
+        """The core distinction, on IDENTICAL reviewer data (0 reviewers, no
+        stale verdicts). If the two texts were equal, the report would still be
+        unable to tell an operator which situation they are in."""
+        not_measured = prs._render_text(self._state(prs.gate.COMMENT_SCAN_NOT_RUN))
+        measured = prs._render_text(self._state(prs.gate.COMMENT_SCAN_NO_BRANCH_AUTHOR))
+        self.assertNotEqual(not_measured, measured)
+
+    def test_not_measured_report_warns_and_measured_one_does_not(self):
+        not_measured = prs._render_text(self._state(prs.gate.COMMENT_SCAN_NOT_RUN))
+        measured = prs._render_text(self._state(prs.gate.COMMENT_SCAN_NO_BRANCH_AUTHOR))
+
+        self.assertIn("NOT RUN", not_measured)
+        self.assertIn("NOT a measurement", not_measured)
+        self.assertNotIn("NOT RUN", measured)
+        self.assertIn("comment verdict scan: RAN", measured)
+
+    def test_stale_verdicts_none_is_only_claimed_when_the_scan_ran(self):
+        """`stale verdicts: none` is TRUE in both cases and honest in only one.
+
+        The measured assertion is the positive control: it proves the exact
+        string is reachable, so the not-measured assertion is testing the
+        conditional rather than a string that never appears at all.
+        """
+        not_measured = prs._render_text(self._state(prs.gate.COMMENT_SCAN_NOT_RUN))
+        measured = prs._render_text(self._state(prs.gate.COMMENT_SCAN_NO_BRANCH_AUTHOR))
+
+        self.assertIn("  stale verdicts: none\n", measured + "\n")
+        self.assertNotIn("  stale verdicts: none\n", not_measured + "\n")
+        self.assertIn("NOT MEASURED", not_measured)
+
+    def test_author_excluded_mode_names_the_excluded_author(self):
+        """The third mode must be distinguishable too — a report that collapsed
+        both scanning modes into one line would hide whether self-review
+        exclusion was in force on this PR."""
+        text = prs._render_text(
+            self._state(
+                prs.gate.COMMENT_SCAN_AUTHOR_EXCLUDED,
+                head_ref="L.Ferreira/1206-x",
+                branch_author_lastname="Ferreira",
+            )
+        )
+        self.assertIn("comment verdict scan: RAN", text)
+        self.assertIn("Ferreira", text)
+        self.assertIn("self-review exclusion active", text)
+
+    def test_json_output_carries_the_scan_mode(self):
+        """A machine consumer must see it too, not just the human report."""
+        payload = json.loads(prs._render_json(self._state(prs.gate.COMMENT_SCAN_NOT_RUN)))
+        self.assertEqual(payload["comment_scan"], prs.gate.COMMENT_SCAN_NOT_RUN)
+
+    def test_compute_review_state_propagates_the_gate_scan_mode(self):
+        """Wiring: without this the field would be correct in the dataclass and
+        permanently NOT_RUN in production, so every real report would carry the
+        alarming warning and the distinction would be worthless.
+
+        Driven through the REAL `resolve_review_verdicts` over a faked comment
+        API, on the exact head-ref shape #1206 is about.
+        """
+        approved = {
+            "body": (
+                "Requestor: Lucas Ferreira\nRequestee: Dependabot\n"
+                "RequestOrReplied: Approved\nTechDebt: none"
+            ),
+            "created_at": "2026-07-20T00:00:00Z",
+        }
+        pr_data = {
+            "author": "app/dependabot",
+            "number": 691,
+            "reviews": [],
+            "headRefName": "dependabot/docker/integration-tests/fake_oauth/python-d3400aa",
+            "labels": [],
+        }
+
+        def fake_run(args, capture_output, text, timeout):  # noqa: ARG001
+            result = mock.MagicMock()
+            result.returncode = 0
+            result.stdout = json.dumps([approved])
+            return result
+
+        with (
+            mock.patch.object(prs.gate, "get_pr_data", return_value=pr_data),
+            mock.patch.object(prs.gate.subprocess, "run", side_effect=fake_run),
+            mock.patch.object(prs.gate, "get_latest_content_commit", return_value=None),
+            mock.patch.object(prs.gate, "_load_roster_names", return_value={"lucas ferreira"}),
+        ):
+            state = prs.compute_review_state("691", repo="noorinalabs/noorinalabs-deploy")
+
+        self.assertEqual(state.comment_scan, prs.gate.COMMENT_SCAN_NO_BRANCH_AUTHOR)
+        self.assertTrue(state.comment_scan_ran)
+        # And the verdict itself is now counted — the driver-level form of the
+        # #1206 defect (this was `[]` / 0 before the fix).
+        self.assertEqual(state.comment_reviewers, ["lucas ferreira"])
+        self.assertEqual(state.distinct_reviewer_count, 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #1206

## The defect, confirmed

Every claim in #1206 reproduces exactly. Measured before the change, live:

```
$ python3 .claude/lib/pr_review_state.py 691 --repo noorinalabs/noorinalabs-deploy
PR #691 (noorinalabs/noorinalabs-deploy) — merge gate would BLOCK
  head ref: dependabot/docker/integration-tests/fake_oauth/python-d3400aa
  distinct Approved reviewers: 0/2 required — (none)
  stale verdicts: none
```

while the counting primitive, same PR, same `T_content`, called with the sentinel
the wave-merge path already uses, returns `['lucas ferreira', 'nino kavtaradze']`
— both roster-valid, neither stale, both carrying `TechDebt`. `resolve_review_verdicts`
dispatched the comment scan for exactly two head-ref shapes and left
`comment_result` at its empty default for everything else, so the PR reported a
silent zero and blamed the reviewers for it.

## What changed

**1 — the skip.** `comment_scan_scope(head_ref)` is **total**: it returns a scanning
*mode* for every possible head ref and never "do not scan". The head ref's only role
in the comment scan is naming the branch author for the self-review exclusion, and
`check_comment_reviews` already has an honest value for "no identifiable author" — the
`""` sentinel `charter_trailer.is_branch_author` reads as "nobody is the author"
(main#294). Totality is deliberately the design point rather than adding `dependabot/**`
to a prefix list: the defect is the fall-through, and a longer list of recognised
prefixes fails the same way on the next unrecognised shape.

**This does not relax the gate.** Still 2 distinct roster-valid *current* Approveds.
Roster filtering (#498), content-staleness binding (#950), the latest-verdict rule
(#940) and the TechDebt attestation are all untouched, and each is pinned by a test on
the bot-branch path specifically. Author-exclusion is unchanged wherever the ref names a
persona; losing it on a bot branch is correct — a bot is never a roster persona, so it
could never have been in the reviewer set.

**2 — the misleading report.** This half matters as much, because it is *why* the first
defect survived: `0/2 required — (none)` and `stale verdicts: none` are both sentences
about what a scan found, and neither was. `ReviewVerdicts.comment_scan` /
`ReviewState.comment_scan` now record which mode ran. Both **default to `not-run`**, so a
construction that forgets the field degrades to the honest "not measured" rather than to a
false claim of measurement. `pr_review_state` prints the scan's status *before* the counts
and refuses to print a bare `stale verdicts: none` when nothing was scanned; `check()`'s
block message distinguishes the two causes of the same shortfall. As defence in depth the
resolver raises `CommentScanUndeterminedError` — the #981 stance, applied one level up —
rather than returning a zero, if a future edit ever reintroduces a skip path.

## After

```
PR #691 (noorinalabs/noorinalabs-deploy) — merge gate would PASS
  comment verdict scan: RAN — head ref names no branch author (bot / wave-merge /
    non-charter branch), so no self-review exclusion was applied. Roster filtering
    and the 2-reviewer threshold are unchanged.
  distinct Approved reviewers: 2/2 required — lucas ferreira, nino kavtaradze
```

Live regression control on a persona branch (main#1199) is unchanged: author exclusion
active, `Kavtaradze` named, and its two stale `ChangesRequested` verdicts still excluded.

## Tests — mutation-verified, not merely green

Restoring the pre-fix dispatch turns **21 assertions red**; collapsing the report's
not-measured branch turns 1 red; dropping the scan-mode propagation turns 1 red. Where a
test asserts an absence it is paired with a positive control proving the experiment ran
(cf. #1203, where five assertions matched unconditional boilerplate and passed at a real
0/2).

| Test | What it catches |
|---|---|
| `CommentScanScopeTotalityTests` (3, subtested over 17 refs) | Any head-ref shape that dispatches to no scan — the defect class, not the instance. `dependabot/**`, `renovate/**`, `feature/x`, no-slash, `""`, `/`, `..` |
| `…::test_persona_branch_selects_author_exclusion` | Positive control: a function returning `no-branch-author` unconditionally would satisfy totality but fails here |
| `NonPersonaHeadRefScanTests::test_dependabot_head_ref_with_two_approvals_reaches_two_of_two` | The live defect, offline: 2/2 on a `dependabot/**` ref |
| `…::test_head_ref_with_no_slash_neither_crashes_nor_skips` | A ref with no separator falling through both old branches |
| `…::test_empty_head_ref_still_scans` / `…::test_none_head_ref_does_not_crash` | Missing `headRefName` skipping, or crashing `re.match` |
| `…::test_non_roster_requestor_on_a_bot_branch_still_does_not_count` | Widened sentinel smuggling a non-roster Requestor past #498 |
| `…::test_changes_requested_on_a_bot_branch_still_does_not_count` | #940 latest-verdict rule bypassed on the new path |
| `…::test_stale_verdict_on_a_bot_branch_is_still_excluded` | #950 content binding bypassed on the new path |
| `HeadRefScanRegressionTests::test_persona_branch_still_excludes_the_pr_author` | Self-review exclusion lost — the one real relaxation risk. Admitted reviewer is the positive control |
| `…::test_persona_branch_still_admits_the_same_surname_colleague` | #1172 regression (Santiago vs Lucas Ferreira) |
| `…::test_wave_merge_branch_behaviour_is_unchanged` | `deployments/phase-N/wave-M` behaviour drift |
| `…::test_two_reviewer_threshold_is_not_relaxed_anywhere` | "count what exists" sliding into "need fewer" |
| `CommentScanNotMeasuredTests::test_review_verdicts_defaults_to_not_measured` | A default that falsely claims the scan ran |
| `…::test_a_reintroduced_skip_path_fails_closed_with_a_named_reason` | A future skip path returning a silent zero (exercised by patching the scope fn, not asserted by comment) |
| `…::test_positive_control_same_setup_does_not_raise_unpatched` | Proves the `assertRaises` above isn't passing on harness breakage |
| `…::test_block_message_distinguishes_not_measured_from_measured_empty` | Hook-surface wording asserted in BOTH directions |
| `CommentScanReportedInTheReportTests` (7) | Report-surface distinction: differing renders on identical reviewer data, `stale verdicts: none` claimed only when scanned (with the reachability positive control), the third mode named, `--json` carrying the field, and `compute_review_state` actually propagating it (without which the field is inert in production) |

`test_content_ts_forwarded_on_wave_merge_call_site` was renamed and its stub widened —
there is no longer a separate wave-merge call site, only one. Its assertions are kept and
strengthened (`branch_author_initial` must be `""` there).

## CI

All local gates green, full parity: `ruff-format`, `ruff-lint`, `mypy`, `pytest`
(3270 passed / 607 subtests), `pytest-skills`, `cspell`, `actionlint`, `checksums-ascii`,
`fixture-realism`, `memory-budget`, `headcount-budget`, `office-drift`, `mermaid-render`,
and `pre_commit_ci_sync.py` (`OK: pre-commit config mirrors all CI-enforced checks`).

## Two findings filed separately, out of scope here

1. **Sibling-hook divergence** — `validate_pr_review.extract_branch_author_lastname`
   accepts `[-/]`; `validate_review_comment_format`'s copy accepts `/` only. On a
   dash-form branch the gate identifies the author and the format hook does not. Same
   family as #1175 / #932. Not fixed here as a drive-by.
2. **Ontology overlay inaccuracy** — `ontology/conventions.md:240` describes this hook as
   "Enforce charter review comment format"; it is the 2-reviewer merge gate (that
   description belongs to the sibling hook). `ontology/**` is out of scope for this PR.
