### PR TITLE
fix(hook4): derive the branch author from commit identity when the head ref names none

### DIFF
--- a/.claude/hooks/tests/test_validate_pr_review.py
+++ b/.claude/hooks/tests/test_validate_pr_review.py
@@ -4744,12 +4744,61 @@ class StrictlyNonRelaxingTests(_ResolveOverFakeCommentsHarness):
         "Santiago Ferreira",
     )
 
-    def _sets(self, head_ref: str, authors: tuple[str, ...]):
+    # `CASES` above all run against the 4-name `THREAD`, so `before` lands on 3
+    # or 4 distinct reviewers in EVERY one of them — comfortably over the
+    # 2-reviewer bar. That makes them useless to
+    # `test_a_blocked_pr_never_becomes_an_allowed_one`, whose whole subject is
+    # what happens to a PR the gate was BLOCKING: with no blocking start state
+    # in the matrix, its guard body never ran and the test passed under a no-op
+    # (`feedback_fixture_makes_guard_assertion_inert` / #1203, caught in review
+    # of this very PR). These cases start from a thread SHORT of the bar, so
+    # `before` blocks and the guard actually executes.
+    #
+    # Counts below are MEASURED, not reasoned — `before -> after` total_distinct.
+    #
+    # (head_ref, commit authors, verdict thread)
+    BLOCKING_CASES = (
+        # Commit-derived exclusion fires from a blocked state: 1 -> 0.
+        ("feature/hand-made", ("Nino Kavtaradze",), ("Nino Kavtaradze",)),
+        # Nadia's suggested case — the ref names nobody, the author reviews herself. 1 -> 0.
+        ("feature/hand-made", ("Aino Virtanen",), ("Aino Virtanen",)),
+        # A persona ref, blocked by the REF-prefix exclusion alone (Lucas dropped),
+        # with commit authors present in the fixture. 1 -> 1, and that is the point:
+        # `resolve_review_verdicts` passes `()` for commit identities whenever the
+        # ref already names a persona, so the commit arm is silent here BY
+        # CONSTRUCTION. This case pins that the two sources cannot stack into a
+        # double exclusion on the same PR.
+        ("L.Ferreira/1210-x", ("Nino Kavtaradze",), ("Lucas Ferreira", "Nino Kavtaradze")),
+        # Blocked and stays blocked with NO exclusion firing (1 -> 1) — the
+        # other half of the guard's domain.
+        ("dependabot/npm_and_yarn/x-1.2.3", ("dependabot[bot]",), ("Lucas Ferreira",)),
+    )
+
+    def _all_cases(self):
+        """`CASES` (allowed-before) + `BLOCKING_CASES` (blocked-before)."""
+        return [(head_ref, authors, self.THREAD) for head_ref, authors in self.CASES] + list(
+            self.BLOCKING_CASES
+        )
+
+    @staticmethod
+    def _gate_allows(verdicts) -> bool:
+        """`check()`'s OWN allow-condition, transcribed — not a proxy for it.
+
+        Mirrors the `total_distinct == 1 and wave_bootstrap_exception` /
+        `total_distinct < 2` ladder in `check()`. Spelling it out here keeps
+        "allowed" meaning what the gate means by it, so the property below is
+        about the merge decision rather than about a count that resembles one.
+        """
+        return verdicts.total_distinct >= 2 or (
+            verdicts.total_distinct == 1 and verdicts.wave_bootstrap_exception
+        )
+
+    def _sets(self, head_ref: str, authors: tuple[str, ...], thread: tuple[str, ...] | None = None):
         commits = [
             _api_commit(f"c{n}", "2026-07-15T19:13:59Z", author_name=name)
             for n, name in enumerate(authors)
         ]
-        comments = [self._verdict(name) for name in self.THREAD]
+        comments = [self._verdict(name) for name in (self.THREAD if thread is None else thread)]
         after = self._resolve(head_ref, comments, commits=commits)
         # "Before" == the same pipeline with the commit-derived author source
         # switched off, which is exactly the pre-#1210 code path.
@@ -4758,9 +4807,9 @@ class StrictlyNonRelaxingTests(_ResolveOverFakeCommentsHarness):
         return before, after
 
     def test_reviewer_set_never_grows(self):
-        for head_ref, authors in self.CASES:
-            with self.subTest(head_ref=head_ref, authors=authors):
-                before, after = self._sets(head_ref, authors)
+        for head_ref, authors, thread in self._all_cases():
+            with self.subTest(head_ref=head_ref, authors=authors, thread=thread):
+                before, after = self._sets(head_ref, authors, thread=thread)
                 self.assertTrue(
                     after.distinct_reviewers <= before.distinct_reviewers,
                     f"{after.distinct_reviewers} is not a subset of {before.distinct_reviewers}",
@@ -4783,17 +4832,153 @@ class StrictlyNonRelaxingTests(_ResolveOverFakeCommentsHarness):
         self.assertTrue(shrank, "no case exercised the exclusion — the matrix proves nothing")
 
     def test_a_blocked_pr_never_becomes_an_allowed_one(self):
-        """The property expressed as the gate's own verdict, not as a count."""
-        for head_ref, authors in self.CASES:
-            with self.subTest(head_ref=head_ref, authors=authors):
-                before, after = self._sets(head_ref, authors)
-                before_allows = before.total_distinct >= 2
-                after_allows = after.total_distinct >= 2
-                if not before_allows:
-                    self.assertFalse(
-                        after_allows,
-                        "a PR the gate blocked before #1210 must not now pass",
-                    )
+        """The property expressed as the gate's own verdict, not as a count.
+
+        Scope, stated honestly so nobody reads more into a green run than is
+        there: on the CURRENT pipeline no input can actually flip blocked ->
+        allowed, because `after` is a subset of `before` and a blocked `before`
+        is already at most 1. That was measured, not assumed — the fail-open
+        mutant that unifies the two author sources (drop the `() if
+        branch_author_lastname` guard in `resolve_review_verdicts`, then let the
+        commit arm of `is_self_review` supersede the ref arm) is caught by
+        `test_reviewer_set_never_grows`, and this test correctly stays green
+        because the mutant only loses the exclusion, it does not push a blocked
+        PR over the bar. So the sibling subset test is the load-bearing one;
+        this is the TRIPWIRE for a future change that could ADD a reviewer to a
+        blocked PR, and its value depends entirely on the guard body actually
+        executing — which the anti-vacuity assertions at the bottom enforce.
+        """
+        reached = []
+        for head_ref, authors, thread in self._all_cases():
+            with self.subTest(head_ref=head_ref, authors=authors, thread=thread):
+                before, after = self._sets(head_ref, authors, thread=thread)
+                if self._gate_allows(before):
+                    continue
+                reached.append((head_ref, authors, thread))
+                self.assertFalse(
+                    self._gate_allows(after),
+                    "a PR the gate blocked before #1210 must not now pass",
+                )
+        # Anti-vacuity, same discipline as the sibling test above: the guard is
+        # inside an `if`, so a matrix in which nothing is blocked-before makes
+        # the whole test a no-op that still reports green.
+        #
+        # BOTH assertions are load-bearing and the order matters. `assertEqual`
+        # alone is NOT enough: emptying `BLOCKING_CASES` degrades it to
+        # `assertEqual([], [])`, which passes — i.e. deleting the blocking
+        # matrix silently restores the exact #1203 inertness this test was
+        # rewritten to remove. (Measured, not assumed: emptying the tuple with
+        # only the `assertEqual` present left this test green.) `assertTrue`
+        # pins the floor — the guard ran at all — and `assertEqual` then pins
+        # WHICH cases reached it, catching both a blocking case that quietly
+        # stops blocking and a `CASES` entry that starts.
+        self.assertTrue(
+            reached,
+            "no case in the matrix started from a BLOCKED state, so the guard body never "
+            "executed — this test would pass under a no-op implementation (#1203)",
+        )
+        self.assertEqual(
+            reached,
+            list(self.BLOCKING_CASES),
+            "the blocked-before guard did not execute over exactly the blocking matrix — "
+            "the property this test is named for was not actually checked",
+        )
+
+
+class SelfReviewExclusionKeepsTechDebtBlockTests(_ResolveOverFakeCommentsHarness):
+    """M13: the #1210 exclusion must not swallow the missing-TechDebt block.
+
+    In `check_comment_reviews` the self-review exclusion and the TechDebt
+    attestation check are two INDEPENDENT `if is_verdict_comment:` blocks, and
+    the non-relaxing argument for #1210 leans on that independence: the
+    exclusion may only ever remove a name from the reviewer SET, never relieve
+    a verdict of its attestation. Nothing pinned it. Moving the TechDebt block
+    inside the `if not is_self_review(...)` branch left the entire suite green
+    while a BLOCK turned into a PASS — the sole survivor of Nino Kavtaradze's
+    15-mutation run on this PR.
+
+    The transition is real, not theoretical: `check()` reaches the TechDebt
+    gate only AFTER clearing the 2-reviewer gate, so a PR with two clean
+    approvals plus the branch author's own attestation-less verdict is blocked
+    today and merges under the mutant.
+    """
+
+    HEAD_REF = "feature/hand-made"  # names no persona — commits are the ONLY author source
+    AUTHOR = "Aino Virtanen"
+
+    @staticmethod
+    def _verdict_without_tech_debt(requestor: str) -> dict:
+        """A well-formed Approved verdict carrying NO `TechDebt:` line."""
+        return {
+            "body": (
+                f"Requestor: {requestor}\nRequestee: Someone Else\nRequestOrReplied: Approved"
+            ),
+            "created_at": "2026-07-20T00:00:00Z",
+        }
+
+    def _comments(self) -> list[dict]:
+        # Two clean approvals clear the 2-reviewer gate, so the ONLY thing that
+        # can still block is the branch author's missing attestation.
+        return [
+            self._verdict("Lucas Ferreira"),
+            self._verdict("Nino Kavtaradze"),
+            self._verdict_without_tech_debt(self.AUTHOR),
+        ]
+
+    def _commits(self) -> list[dict]:
+        return [_api_commit("c0", "2026-07-15T19:13:59Z", author_name=self.AUTHOR)]
+
+    def test_branch_authors_own_verdict_is_excluded_but_still_owes_tech_debt(self):
+        """The two effects are independent: dropped from the set, still attesting."""
+        verdicts = self._resolve(self.HEAD_REF, self._comments(), commits=self._commits())
+        # Excluded from the reviewer set — the #1210 behaviour, unchanged.
+        self.assertEqual(
+            verdicts.distinct_reviewers,
+            {"lucas ferreira", "nino kavtaradze"},
+            "author not excluded",
+        )
+        self.assertEqual(verdicts.total_distinct, 2)
+        # ...and STILL on the hook for the attestation. This is the assertion
+        # the mutant kills.
+        self.assertEqual(verdicts.reviews_missing_tech_debt, [self.AUTHOR])
+
+    def test_check_still_blocks_the_merge_on_the_authors_missing_attestation(self):
+        """The same property as a merge decision — a BLOCK the mutant turns into a PASS."""
+        input_data = {
+            "tool_name": "Bash",
+            "tool_input": {"command": "gh pr merge 691 --repo noorinalabs/noorinalabs-main"},
+        }
+        comments, commits = self._comments(), self._commits()
+
+        def fake_run(args, capture_output, text, timeout):  # noqa: ARG001
+            result = mock.MagicMock()
+            result.returncode = 0
+            if args[0] == "gh" and args[1:3] == ["repo", "view"]:
+                result.stdout = json.dumps({"owner": {"login": "noorinalabs"}, "name": "r"})
+            else:
+                result.stdout = json.dumps(comments)
+            return result
+
+        with (
+            mock.patch.object(hook.subprocess, "run", side_effect=fake_run),
+            mock.patch.object(hook, "fetch_pr_commits", return_value=commits),
+            mock.patch.object(hook, "_load_roster_names", return_value=set(self.ROSTER)),
+            mock.patch.object(hook, "get_pr_data", return_value=self._pr_data(self.HEAD_REF)),
+            mock.patch.object(hook, "log_pretooluse_block"),
+        ):
+            result = hook.check(input_data)
+
+        assert result is not None, (
+            "check() returned None — the merge was ALLOWED despite the branch author's "
+            "verdict carrying no TechDebt line (the M13 mutant's signature)"
+        )
+        self.assertEqual(result["decision"], "block")
+        reason = str(result["reason"])
+        # Pin the REASON too: blocking for some unrelated cause (a reviewer
+        # shortfall, say) would satisfy a bare `decision == "block"` while the
+        # attestation check was in fact suppressed.
+        self.assertIn("TechDebt: attestation line", reason)
+        self.assertIn(self.AUTHOR, reason)
 
 
 class CommitAuthorBlockDiagnosticTests(_ResolveOverFakeCommentsHarness):

--- a/.claude/hooks/tests/test_validate_pr_review.py
+++ b/.claude/hooks/tests/test_validate_pr_review.py
@@ -123,6 +123,11 @@ class _CheckCommentReviewsHarness(unittest.TestCase):
                 # explicit "no content binding" value these ~30 pre-#950 callers
                 # exercise (every verdict counted unconditionally).
                 content_ts=None,
+                # commit_author_identities is REQUIRED for the same fail-open
+                # reason (#1210); `()` is the explicit "the ref already named the
+                # author, no commit-derived identity applies" value these
+                # pre-#1210 callers exercise.
+                commit_author_identities=(),
             )
 
     @staticmethod
@@ -131,11 +136,15 @@ class _CheckCommentReviewsHarness(unittest.TestCase):
         branch_author: str,
         repo: str | None = None,
         content_ts: "datetime | None" = None,
+        commit_author_identities: tuple = (),
     ):
         """As `_run_with_fake_api`, but binds verdicts to a T_content (#950).
 
         Kept as a separate entry point so the ~30 pre-#950 callers of
         `_run_with_fake_api` keep exercising the unbound path unchanged.
+
+        `commit_author_identities` (#1210) defaults to `()` — the pre-#1210
+        answer — so those callers stay unchanged; the #1210 tests pass it.
         """
         comments_stdout = json.dumps(comments_list)
 
@@ -154,6 +163,7 @@ class _CheckCommentReviewsHarness(unittest.TestCase):
                 branch_author,
                 repo=repo,
                 content_ts=content_ts,
+                commit_author_identities=commit_author_identities,
             )
 
 
@@ -581,7 +591,12 @@ class ContentTsRequiredTests(unittest.TestCase):
 
     def test_check_comment_reviews_without_content_ts_raises_type_error(self):
         with self.assertRaises(TypeError):
-            hook.check_comment_reviews(451, "pham", repo="noorinalabs/x")  # missing content_ts
+            hook.check_comment_reviews(
+                451,
+                "pham",
+                repo="noorinalabs/x",
+                commit_author_identities=(),
+            )  # missing content_ts
 
     def test_partition_formal_reviewers_without_content_ts_raises_type_error(self):
         with self.assertRaises(TypeError):
@@ -596,7 +611,13 @@ class ContentTsRequiredTests(unittest.TestCase):
                 returncode=0, stdout="[]"
             ),
         ):
-            result = hook.check_comment_reviews(451, "pham", repo="noorinalabs/x", content_ts=None)
+            result = hook.check_comment_reviews(
+                451,
+                "pham",
+                repo="noorinalabs/x",
+                content_ts=None,
+                commit_author_identities=(),
+            )
         self.assertEqual(result.undetermined, "")
 
     def test_partition_formal_reviewers_still_accepts_explicit_none(self):
@@ -613,7 +634,13 @@ class ContentTsRequiredTests(unittest.TestCase):
         positional third argument must now raise TypeError rather than
         silently binding to `repo`."""
         with self.assertRaises(TypeError):
-            hook.check_comment_reviews(451, "pham", "noorinalabs/x")  # repo positional
+            hook.check_comment_reviews(
+                451,
+                "pham",
+                "noorinalabs/x",  # repo positional
+                content_ts=None,
+                commit_author_identities=(),
+            )
 
 
 class ExtractBranchAuthorLastnameTests(unittest.TestCase):
@@ -868,12 +895,18 @@ class _NoContentBindingHarness(unittest.TestCase):
 
     Staleness itself is covered by `StaleVerdictBindingTests`,
     `BranchUpdateRegressionTests`, and `CommitFetchFailClosedTests`, which patch
-    `get_latest_content_commit` with real values instead.
+    `fetch_pr_commits` with real commit data instead.
+
+    Patching the FETCH rather than the analysis (#1210) means the real
+    `latest_content_commit` and `commit_author_identities` still run over the
+    stub: an empty commit list yields no content binding AND no commit-derived
+    branch author, which is exactly the pre-#950/pre-#1210 behaviour these
+    tests intend.
     """
 
     def setUp(self) -> None:
         super().setUp()
-        patcher = mock.patch.object(hook, "get_latest_content_commit", return_value=None)
+        patcher = mock.patch.object(hook, "fetch_pr_commits", return_value=[])
         patcher.start()
         self.addCleanup(patcher.stop)
 
@@ -1144,7 +1177,11 @@ class CommentPaginationTests(_CheckCommentReviewsHarness):
 
         with mock.patch.object(hook.subprocess, "run", side_effect=fake_run):
             hook.check_comment_reviews(
-                self.PR_NUMBER, self.BRANCH_AUTHOR, repo=self.REPO, content_ts=None
+                self.PR_NUMBER,
+                self.BRANCH_AUTHOR,
+                repo=self.REPO,
+                content_ts=None,
+                commit_author_identities=(),
             )
 
         gh_api_calls = [a for a in captured_args if a[0] == "gh" and a[1] == "api"]
@@ -2563,6 +2600,32 @@ def _ts(value: str) -> datetime:
     return datetime.fromisoformat(value.replace("Z", "+00:00"))
 
 
+def _api_commit(
+    sha: str,
+    date: str,
+    parents: int = 1,
+    author_name: str = "",
+    author_email: str = "",
+) -> dict:
+    """Build a `pulls/{n}/commits` payload entry.
+
+    Shaped like the real API response — `parents` list, `commit.committer.date`,
+    `commit.author.{name,email}` — so a fixture cannot pass by omitting the very
+    field the code under test reads (`feedback_fixture_makes_guard_assertion_
+    inert`). `author_name`/`author_email` default to empty, which is the honest
+    "this fixture says nothing about who authored it" and yields no #1210
+    identity.
+    """
+    return {
+        "sha": sha,
+        "parents": [{"sha": f"p{i}"} for i in range(parents)],
+        "commit": {
+            "committer": {"date": date},
+            "author": {"date": date, "name": author_name, "email": author_email},
+        },
+    }
+
+
 def _verdict_comment(requestor: str, ror: str, created_at: str, tech_debt: str = "none") -> dict:
     """Build an issues-API comment payload carrying a charter verdict trailer.
 
@@ -2667,8 +2730,8 @@ class ResolveReviewVerdictsSharedBoundaryTests(unittest.TestCase):
             mock.patch.object(hook.subprocess, "run", side_effect=fake_run),
             mock.patch.object(
                 hook,
-                "get_latest_content_commit",
-                return_value=("ac8bcfa", hook._parse_iso8601("2026-01-02T00:00:00Z")),
+                "fetch_pr_commits",
+                return_value=[_api_commit("ac8bcfa", "2026-01-02T00:00:00Z")],
             ),
             mock.patch.object(hook, "_load_roster_names", return_value={"lucas ferreira"}),
         ):
@@ -2931,13 +2994,7 @@ class BranchUpdateRegressionTests(unittest.TestCase):
     range that does not exclude merge commits is corrupted by routine mechanics.
     """
 
-    @staticmethod
-    def _commit(sha: str, date: str, parents: int = 1) -> dict:
-        return {
-            "sha": sha,
-            "parents": [{"sha": f"p{i}"} for i in range(parents)],
-            "commit": {"committer": {"date": date}, "author": {"date": date}},
-        }
+    _commit = staticmethod(_api_commit)
 
     @staticmethod
     def _fake_commit_api(commits: list[dict]):
@@ -2950,8 +3007,14 @@ class BranchUpdateRegressionTests(unittest.TestCase):
         return fake_run
 
     def _latest(self, commits: list[dict]):
-        with mock.patch.object(hook.subprocess, "run", side_effect=self._fake_commit_api(commits)):
-            return hook.get_latest_content_commit(423, repo="noorinalabs/x")
+        """T_content over a commit list — the pure analysis, no fetch (#1210).
+
+        `latest_content_commit` is now a pure function, so these assertions no
+        longer need a subprocess mock at all. `test_commit_fetch_is_paginated`
+        below still drives the real `fetch_pr_commits`, so the pagination
+        guarantee stays pinned against the code that actually shells out.
+        """
+        return hook.latest_content_commit(commits)
 
     def test_merge_commit_from_main_does_not_advance_t_content(self):
         """The load-bearing assertion: a `main` merge lands AFTER the approval and
@@ -3064,7 +3127,7 @@ class BranchUpdateRegressionTests(unittest.TestCase):
             return result
 
         with mock.patch.object(hook.subprocess, "run", side_effect=fake_run):
-            hook.get_latest_content_commit(423, repo="noorinalabs/x")
+            hook.fetch_pr_commits(423, repo="noorinalabs/x")
         self.assertIn("--paginate", captured[0])
         self.assertTrue(any("pulls/423/commits" in a for a in captured[0]))
 
@@ -3093,28 +3156,20 @@ class CommitFetchFailClosedTests(unittest.TestCase):
     def test_nonzero_gh_api_raises_commit_fetch_error(self):
         with mock.patch.object(hook.subprocess, "run", side_effect=self._failing_api()):
             with self.assertRaises(hook.CommitFetchError):
-                hook.get_latest_content_commit(423, repo="noorinalabs/x")
+                hook.fetch_pr_commits(423, repo="noorinalabs/x")
 
     def test_unparseable_json_raises_commit_fetch_error(self):
         with mock.patch.object(
             hook.subprocess, "run", side_effect=self._failing_api(returncode=0, stdout="<html>")
         ):
             with self.assertRaises(hook.CommitFetchError):
-                hook.get_latest_content_commit(423, repo="noorinalabs/x")
+                hook.fetch_pr_commits(423, repo="noorinalabs/x")
 
     def test_non_merge_commit_without_timestamp_raises(self):
         """Silently skipping it would UNDERSTATE T_content and wave stale verdicts through."""
         commits = [{"sha": "aaaaaaaa", "parents": [{"sha": "p"}], "commit": {"committer": {}}}]
-
-        def fake_run(args, capture_output, text, timeout):
-            result = mock.MagicMock()
-            result.returncode = 0
-            result.stdout = json.dumps(commits)
-            return result
-
-        with mock.patch.object(hook.subprocess, "run", side_effect=fake_run):
-            with self.assertRaises(hook.CommitFetchError):
-                hook.get_latest_content_commit(423, repo="noorinalabs/x")
+        with self.assertRaises(hook.CommitFetchError):
+            hook.latest_content_commit(commits)
 
     def test_check_blocks_on_commit_fetch_error_with_two_valid_approvals(self):
         """THE fail-open test: a PR that WOULD merge (2 approvals) must BLOCK when
@@ -3134,7 +3189,7 @@ class CommitFetchFailClosedTests(unittest.TestCase):
             mock.patch.object(hook, "check_comment_reviews", return_value=review_result),
             mock.patch.object(
                 hook,
-                "get_latest_content_commit",
+                "fetch_pr_commits",
                 side_effect=hook.CommitFetchError("HTTP 502"),
             ),
         ):
@@ -3181,8 +3236,8 @@ class StaleVerdictDiagnosticTests(unittest.TestCase):
             mock.patch.object(hook, "check_comment_reviews", return_value=review_result),
             mock.patch.object(
                 hook,
-                "get_latest_content_commit",
-                return_value=(DA423_C3_SHA, _ts(DA423_C3_AT)),
+                "fetch_pr_commits",
+                return_value=[_api_commit(DA423_C3_SHA, DA423_C3_AT)],
             ),
         ):
             result = hook.check(
@@ -3242,8 +3297,8 @@ class FormalReviewStalenessTests(unittest.TestCase):
             mock.patch.object(hook, "check_comment_reviews", return_value=review_result),
             mock.patch.object(
                 hook,
-                "get_latest_content_commit",
-                return_value=(DA423_C3_SHA, _ts(DA423_C3_AT)),
+                "fetch_pr_commits",
+                return_value=[_api_commit(DA423_C3_SHA, DA423_C3_AT)],
             ),
         ):
             return hook.check(
@@ -3567,7 +3622,9 @@ class IncompleteCommentScanFailsClosedTests(_NoContentBindingHarness):
     def test_clean_scan_leaves_undetermined_empty(self):
         """The negative match — a successful empty scan must NOT be flagged."""
         with mock.patch.object(hook.subprocess, "run", side_effect=self._fake_run()):
-            result = hook.check_comment_reviews(451, "pham", repo="noorinalabs/x", content_ts=None)
+            result = hook.check_comment_reviews(
+                451, "pham", repo="noorinalabs/x", content_ts=None, commit_author_identities=()
+            )
         self.assertEqual(result.undetermined, "")
         self.assertEqual(result.reviewers, set())
 
@@ -3577,7 +3634,9 @@ class IncompleteCommentScanFailsClosedTests(_NoContentBindingHarness):
             "run",
             side_effect=self._fake_run(returncode=1, stdout="", stderr="HTTP 403: Forbidden"),
         ):
-            result = hook.check_comment_reviews(451, "pham", repo="noorinalabs/x", content_ts=None)
+            result = hook.check_comment_reviews(
+                451, "pham", repo="noorinalabs/x", content_ts=None, commit_author_identities=()
+            )
         self.assertTrue(result.undetermined)
         self.assertIn("403", result.undetermined)
 
@@ -3585,19 +3644,25 @@ class IncompleteCommentScanFailsClosedTests(_NoContentBindingHarness):
         with mock.patch.object(
             hook.subprocess, "run", side_effect=hook.subprocess.TimeoutExpired("gh", 30)
         ):
-            result = hook.check_comment_reviews(451, "pham", repo="noorinalabs/x", content_ts=None)
+            result = hook.check_comment_reviews(
+                451, "pham", repo="noorinalabs/x", content_ts=None, commit_author_identities=()
+            )
         self.assertIn("TimeoutExpired", result.undetermined)
 
     def test_unparseable_json_sets_undetermined(self):
         with mock.patch.object(
             hook.subprocess, "run", side_effect=self._fake_run(stdout="not json")
         ):
-            result = hook.check_comment_reviews(451, "pham", repo="noorinalabs/x", content_ts=None)
+            result = hook.check_comment_reviews(
+                451, "pham", repo="noorinalabs/x", content_ts=None, commit_author_identities=()
+            )
         self.assertIn("JSONDecodeError", result.undetermined)
 
     def test_unresolvable_owner_repo_sets_undetermined(self):
         with mock.patch.object(hook, "_resolve_owner_repo", return_value=None):
-            result = hook.check_comment_reviews(451, "pham", repo=None, content_ts=None)
+            result = hook.check_comment_reviews(
+                451, "pham", repo=None, content_ts=None, commit_author_identities=()
+            )
         self.assertIn("could not resolve the target repository", result.undetermined)
 
     def test_check_hard_blocks_on_an_incomplete_scan(self):
@@ -3703,6 +3768,7 @@ class SurnameCollisionSelfReviewTests(unittest.TestCase):
                     self.BRANCH_LASTNAME,
                     repo=self.REPO,
                     content_ts=None,
+                    commit_author_identities=(),
                     branch_author_initial=initial,
                 ).reviewers
             )
@@ -3806,7 +3872,7 @@ class SurnameCollisionSelfReviewTests(unittest.TestCase):
             mock.patch.object(
                 hook, "check_comment_reviews", side_effect=fake_check_comment_reviews
             ),
-            mock.patch.object(hook, "get_latest_content_commit", return_value=None),
+            mock.patch.object(hook, "fetch_pr_commits", return_value=[]),
             mock.patch.object(hook, "_load_roster_names", return_value=set()),
         ):
             hook.resolve_review_verdicts(pr_data, repo=self.REPO)
@@ -3909,7 +3975,13 @@ class _ResolveOverFakeCommentsHarness(unittest.TestCase):
             "labels": list(labels),
         }
 
-    def _resolve(self, head_ref: str, comments: list[dict], *, roster=None):
+    # Default commit fixture: one non-merge commit whose author fields are
+    # EMPTY, so it yields no #1210 identity. That keeps every pre-#1210 test in
+    # this harness exercising the "ref is the only author source" path; a test
+    # that wants commit-derived identity passes `commits=` explicitly.
+    DEFAULT_COMMITS = [_api_commit("837c272a", "2026-07-15T19:13:59Z")]
+
+    def _resolve(self, head_ref: str, comments: list[dict], *, roster=None, commits=None):
         def fake_run(args, capture_output, text, timeout):  # noqa: ARG001
             result = mock.MagicMock()
             result.returncode = 0
@@ -3923,10 +3995,10 @@ class _ResolveOverFakeCommentsHarness(unittest.TestCase):
             mock.patch.object(hook.subprocess, "run", side_effect=fake_run),
             mock.patch.object(
                 hook,
-                "get_latest_content_commit",
+                "fetch_pr_commits",
                 # T_content sits BEFORE the fixture comments, so nothing is stale
                 # and a shortfall can only come from the scan, not from staleness.
-                return_value=("837c272a", hook._parse_iso8601("2026-07-15T19:13:59Z")),
+                return_value=self.DEFAULT_COMMITS if commits is None else commits,
             ),
             mock.patch.object(
                 hook,
@@ -3985,7 +4057,7 @@ class NonPersonaHeadRefScanTests(_ResolveOverFakeCommentsHarness):
 
         with (
             mock.patch.object(hook.subprocess, "run", side_effect=fake_run),
-            mock.patch.object(hook, "get_latest_content_commit", return_value=None),
+            mock.patch.object(hook, "fetch_pr_commits", return_value=[]),
             mock.patch.object(hook, "_load_roster_names", return_value=set(self.ROSTER)),
         ):
             verdicts = hook.resolve_review_verdicts(pr_data, repo=self.REPO)
@@ -4208,6 +4280,599 @@ class CommentScanNotMeasuredTests(_ResolveOverFakeCommentsHarness):
         # gate does not.
         self.assertIn("0/2 required peer reviews", not_measured)
         self.assertIn("0/2 required peer reviews", measured)
+
+
+class PersonaAliasFromEmailTests(unittest.TestCase):
+    """#1210: which commit-author ADDRESSES name a persona, and which do not.
+
+    This is where the squash hazard (#1177) is decided, so the negative cases
+    matter more than the positive one.
+    """
+
+    def test_persona_alias_resolves(self):
+        self.assertEqual(
+            hook.persona_alias_from_email("parametrization+Aino.Virtanen@gmail.com"),
+            "Aino.Virtanen",
+        )
+
+    def test_bare_principal_resolves_to_nothing(self):
+        """THE #1177 decision, stated as a test.
+
+        A squash re-authors a persona's commit to the bare principal, so this
+        address is evidence that identity was DESTROYED. Mapping it to a name
+        would make the gate exclude a persona who may have had nothing to do
+        with the branch.
+        """
+        self.assertEqual(hook.persona_alias_from_email("parametrization@gmail.com"), "")
+
+    def test_roster_json_maps_the_bare_principal_and_this_function_refuses_to(self):
+        """The trap is REAL and this function deliberately walks past it.
+
+        `.claude/team/roster.json` genuinely maps `parametrization@gmail.com` to
+        a persona name. Anyone "improving" this function by consulting that map
+        would ship the silent-wrong-persona bug — so the map's existence is
+        asserted here, next to the refusal, rather than left as a comment.
+        """
+        roster_path = Path(__file__).resolve().parents[2] / "team" / "roster.json"
+        roster = json.loads(roster_path.read_text(encoding="utf-8"))
+        bare_mapped = [
+            name for name, email in roster.items() if email == "parametrization@gmail.com"
+        ]
+        self.assertTrue(
+            bare_mapped,
+            "fixture premise gone: roster.json no longer maps the bare principal, so this "
+            "test no longer proves the refusal is meaningful — re-check the #1177 reasoning",
+        )
+        self.assertEqual(hook.persona_alias_from_email("parametrization@gmail.com"), "")
+
+    def test_github_noreply_login_is_not_a_persona(self):
+        """`12345+octocat@…` has a `+` but the part after it is a login.
+
+        This is what keeps a GitHub-UI or bot commit from inventing an author,
+        without a bot-name blocklist that could be incomplete.
+        """
+        for email in (
+            "49699333+dependabot[bot]@users.noreply.github.com",
+            "1234567+octocat@users.noreply.github.com",
+            "noreply@github.com",
+        ):
+            with self.subTest(email=email):
+                self.assertEqual(hook.persona_alias_from_email(email), "")
+
+    def test_hyphenated_and_compound_roster_names_resolve(self):
+        """Real roster aliases, not idealised ones."""
+        for alias in ("Jun-Seo.Park", "Marisol.Vega-Cruz", "Nadia.Boukhari"):
+            with self.subTest(alias=alias):
+                self.assertEqual(
+                    hook.persona_alias_from_email(f"parametrization+{alias}@gmail.com"), alias
+                )
+
+    def test_malformed_input_yields_empty(self):
+        for value in ("", "not-an-email", "parametrization+@gmail.com", "+Aino@gmail.com"):
+            with self.subTest(value=value):
+                self.assertEqual(hook.persona_alias_from_email(value), "")
+
+
+class CommitAuthorIdentityDerivationTests(unittest.TestCase):
+    """#1210: deriving the branch author from the PR's commits."""
+
+    @staticmethod
+    def _names(identities) -> set[tuple[str, str]]:
+        """The comparison KEY of each derived identity — `(lastname, initial)`.
+
+        Asserted on the key rather than on the display string so a test cannot
+        pass because two different people happened to render the same way.
+        """
+        return {(i.lastname.lower(), i.initial) for i in identities}
+
+    def test_author_name_yields_lastname_and_initial(self):
+        identities = hook.commit_author_identities(
+            [_api_commit("a1", "2026-07-20T00:00:00Z", author_name="Aino Virtanen")]
+        )
+        self.assertEqual(self._names(identities), {("virtanen", "a")})
+
+    def test_merge_commit_authors_are_not_branch_authors(self):
+        """Running `gh pr merge` into a wave branch does not make you its author.
+
+        Excluding merge authors would false-block the wave merges the release
+        coordinator is required to review — the `feedback_commit_author_gate_
+        exclude_merges` lesson, applied to the identity half.
+        """
+        identities = hook.commit_author_identities(
+            [
+                _api_commit("m1", "2026-07-20T00:00:00Z", parents=2, author_name="Nadia Khoury"),
+                _api_commit("c1", "2026-07-20T01:00:00Z", author_name="Aino Virtanen"),
+            ]
+        )
+        self.assertEqual(self._names(identities), {("virtanen", "a")})
+
+    def test_every_non_merge_author_is_returned_not_just_the_latest(self):
+        """A branch handed between two personas has TWO authors.
+
+        Taking only the latest content commit's author would leave the earlier
+        one free to self-approve.
+        """
+        identities = hook.commit_author_identities(
+            [
+                _api_commit("c1", "2026-07-20T00:00:00Z", author_name="Lucas Ferreira"),
+                _api_commit("c2", "2026-07-20T01:00:00Z", author_name="Aino Virtanen"),
+            ]
+        )
+        self.assertEqual(self._names(identities), {("ferreira", "l"), ("virtanen", "a")})
+
+    def test_name_and_matching_alias_dedupe_to_one_person(self):
+        identities = hook.commit_author_identities(
+            [
+                _api_commit(
+                    "c1",
+                    "2026-07-20T00:00:00Z",
+                    author_name="Aino Virtanen",
+                    author_email="parametrization+Aino.Virtanen@gmail.com",
+                )
+            ]
+        )
+        self.assertEqual(len(identities), 1)
+        self.assertEqual(self._names(identities), {("virtanen", "a")})
+
+    def test_email_alias_recovers_the_person_when_the_name_is_a_handle(self):
+        """The union's reason to exist: the two sources disagree exactly when
+        one of them is not a name."""
+        identities = hook.commit_author_identities(
+            [
+                _api_commit(
+                    "c1",
+                    "2026-07-20T00:00:00Z",
+                    author_name="octocat",
+                    author_email="parametrization+Aino.Virtanen@gmail.com",
+                )
+            ]
+        )
+        self.assertIn(("virtanen", "a"), self._names(identities))
+
+    def test_bare_principal_email_contributes_nothing(self):
+        """Only the NAME survives a squash-flattened address — never the address."""
+        identities = hook.commit_author_identities(
+            [
+                _api_commit(
+                    "c1",
+                    "2026-07-20T00:00:00Z",
+                    author_name="",
+                    author_email="parametrization@gmail.com",
+                )
+            ]
+        )
+        self.assertEqual(identities, ())
+
+    def test_empty_author_fields_yield_no_identity(self):
+        self.assertEqual(
+            hook.commit_author_identities([_api_commit("c1", "2026-07-20T00:00:00Z")]), ()
+        )
+        self.assertEqual(hook.commit_author_identities([]), ())
+
+    def test_bot_commit_matches_no_roster_persona(self):
+        """Bots stay neutral BY CONSTRUCTION, not by a blocklist.
+
+        Asserted at the level that matters — no roster name is treated as a
+        self-review — rather than by asserting the derivation returned nothing,
+        which would pass for a bot name the derivation happened to mangle.
+        """
+        identities = hook.commit_author_identities(
+            [
+                _api_commit(
+                    "c1",
+                    "2026-07-20T00:00:00Z",
+                    author_name="dependabot[bot]",
+                    author_email="49699333+dependabot[bot]@users.noreply.github.com",
+                )
+            ]
+        )
+        for persona in ("Lucas Ferreira", "Nino Kavtaradze", "Aino Virtanen", "Steven French"):
+            with self.subTest(persona=persona):
+                self.assertFalse(hook.is_self_review(persona, "", "", identities))
+
+
+class IsSelfReviewTests(unittest.TestCase):
+    """#1210 reuses the ONE person-comparison (#1172), on both author sources."""
+
+    LUCAS = hook.CommitAuthorIdentity(lastname="Ferreira", initial="l", display="Lucas Ferreira")
+
+    def test_commit_author_is_a_self_review(self):
+        self.assertTrue(hook.is_self_review("Lucas Ferreira", "", "", (self.LUCAS,)))
+
+    def test_same_surname_colleague_is_not_the_commit_author(self):
+        """The Ferreira/Ferreira collision, on the NEW path.
+
+        A hand-rolled surname comparison here would re-create main#1172 in the
+        commit-identity source while `charter_trailer` stayed correct.
+        """
+        self.assertFalse(hook.is_self_review("Santiago Ferreira", "", "", (self.LUCAS,)))
+
+    def test_ref_prefix_arm_is_unchanged(self):
+        self.assertTrue(hook.is_self_review("Lucas Ferreira", "Ferreira", "l", ()))
+        self.assertFalse(hook.is_self_review("Santiago Ferreira", "Ferreira", "l", ()))
+
+    def test_no_author_from_either_source_excludes_nobody(self):
+        self.assertFalse(hook.is_self_review("Lucas Ferreira", "", "", ()))
+
+
+class RefineCommentScanScopeTests(unittest.TestCase):
+    """#1210: the ONE allowed scope transition, and the three forbidden ones."""
+
+    IDENT = (hook.CommitAuthorIdentity(lastname="Virtanen", initial="a", display="Aino Virtanen"),)
+
+    def test_no_branch_author_upgrades_when_commits_named_someone(self):
+        self.assertEqual(
+            hook.refine_comment_scan_scope(hook.COMMENT_SCAN_NO_BRANCH_AUTHOR, self.IDENT),
+            hook.COMMENT_SCAN_COMMIT_AUTHOR_EXCLUDED,
+        )
+
+    def test_no_branch_author_stays_when_commits_named_nobody(self):
+        self.assertEqual(
+            hook.refine_comment_scan_scope(hook.COMMENT_SCAN_NO_BRANCH_AUTHOR, ()),
+            hook.COMMENT_SCAN_NO_BRANCH_AUTHOR,
+        )
+
+    def test_ref_derived_author_is_never_downgraded(self):
+        self.assertEqual(
+            hook.refine_comment_scan_scope(hook.COMMENT_SCAN_AUTHOR_EXCLUDED, self.IDENT),
+            hook.COMMENT_SCAN_AUTHOR_EXCLUDED,
+        )
+
+    def test_not_run_is_never_upgraded(self):
+        """A scan that did not happen cannot acquire a mode.
+
+        Laundering NOT_RUN into a real mode here would defeat the #1206
+        defense-in-depth hard-block one layer up.
+        """
+        self.assertEqual(
+            hook.refine_comment_scan_scope(hook.COMMENT_SCAN_NOT_RUN, self.IDENT),
+            hook.COMMENT_SCAN_NOT_RUN,
+        )
+
+
+class CommitIdentitySelfReviewExclusionTests(_ResolveOverFakeCommentsHarness):
+    """#1210 end-to-end: the residual #1207 disclosed, closed.
+
+    THE case, from the issue's own table — a human persona on a NON-CHARTER
+    branch posts their own `Approved` plus one genuine reviewer approves:
+
+        pre-#1207   0/2 blocked (wrongly — the genuine reviewer was uncounted)
+        post-#1207  2/2 PASSES  (wrongly — the self-review was counted)
+        correct     1/2 blocked
+    """
+
+    NON_CHARTER_REF = "feature/some-hand-made-branch"
+    WAVE_REF = "deployments/phase-10/wave-29"
+    DEPENDABOT_REF = "dependabot/docker/integration-tests/fake_oauth/python-d3400aa"
+
+    @staticmethod
+    def _authored_by(*names: str) -> list[dict]:
+        return [
+            _api_commit(
+                f"c{n}",
+                "2026-07-15T19:13:59Z",
+                author_name=name,
+                author_email=f"parametrization+{name.replace(' ', '.')}@gmail.com",
+            )
+            for n, name in enumerate(names)
+        ]
+
+    def test_self_approval_on_a_non_charter_ref_no_longer_reaches_two_of_two(self):
+        """THE #1210 kill-shot. RED before the fix: `total_distinct == 2`."""
+        verdicts = self._resolve(
+            self.NON_CHARTER_REF,
+            [self._verdict("Nino Kavtaradze"), self._verdict("Aino Virtanen")],
+            commits=self._authored_by("Nino Kavtaradze"),
+        )
+        self.assertEqual(verdicts.distinct_reviewers, {"aino virtanen"})
+        self.assertEqual(verdicts.total_distinct, 1)
+        self.assertEqual(verdicts.comment_scan, hook.COMMENT_SCAN_COMMIT_AUTHOR_EXCLUDED)
+
+    def test_positive_control_two_genuine_reviewers_still_reach_two_of_two(self):
+        """Anti-vacuity (`feedback_fixture_makes_guard_assertion_inert`).
+
+        Identical shape, except the branch author is NOT one of the reviewers.
+        Without this, the assertion above would be satisfied by a change that
+        simply stopped counting comment verdicts on non-charter refs — which
+        would re-break #1206.
+        """
+        verdicts = self._resolve(
+            self.NON_CHARTER_REF,
+            [self._verdict("Nino Kavtaradze"), self._verdict("Aino Virtanen")],
+            commits=self._authored_by("Lucas Ferreira"),
+        )
+        self.assertEqual(verdicts.distinct_reviewers, {"nino kavtaradze", "aino virtanen"})
+        self.assertEqual(verdicts.total_distinct, 2)
+
+    def test_wave_merge_branch_now_excludes_its_author_too(self):
+        """The PRE-EXISTING main#294 hole, closed by the same derivation.
+
+        `deployments/**` has carried this since main#294; #1210 closes it, not
+        just the increment #1207 added.
+        """
+        verdicts = self._resolve(
+            self.WAVE_REF,
+            [self._verdict("Nadia Khoury"), self._verdict("Aino Virtanen")],
+            roster=self.ROSTER | {"nadia khoury"},
+            commits=self._authored_by("Nadia Khoury"),
+        )
+        self.assertEqual(verdicts.distinct_reviewers, {"aino virtanen"})
+        self.assertEqual(verdicts.total_distinct, 1)
+
+    def test_both_authors_of_a_handed_over_branch_are_excluded(self):
+        verdicts = self._resolve(
+            self.NON_CHARTER_REF,
+            [
+                self._verdict("Nino Kavtaradze"),
+                self._verdict("Lucas Ferreira"),
+                self._verdict("Aino Virtanen"),
+            ],
+            commits=self._authored_by("Nino Kavtaradze", "Lucas Ferreira"),
+        )
+        self.assertEqual(verdicts.distinct_reviewers, {"aino virtanen"})
+
+    def test_same_surname_colleague_still_counts_on_a_commit_derived_author(self):
+        """#1172 must hold on the new source too: Santiago is not Lucas."""
+        verdicts = self._resolve(
+            self.NON_CHARTER_REF,
+            [self._verdict("Santiago Ferreira"), self._verdict("Aino Virtanen")],
+            commits=self._authored_by("Lucas Ferreira"),
+        )
+        self.assertEqual(verdicts.distinct_reviewers, {"santiago ferreira", "aino virtanen"})
+
+    def test_bot_branch_with_two_roster_approvals_still_passes(self):
+        """deploy#691 must stay fixed, and no human author may be fabricated.
+
+        A bot commit is NOT special-cased: `dependabot[bot]` is carried as a
+        derived identity like any other author string. It is neutral because it
+        matches no roster persona, which is the property that actually matters —
+        both approvals still count. The bot's ADDRESS contributes nothing
+        (#1181's matcher), so nothing invents a person from it.
+        """
+        verdicts = self._resolve(
+            self.DEPENDABOT_REF,
+            [self._verdict("Lucas Ferreira"), self._verdict("Nino Kavtaradze")],
+            commits=[
+                _api_commit(
+                    "c0",
+                    "2026-07-15T19:13:59Z",
+                    author_name="dependabot[bot]",
+                    author_email="49699333+dependabot[bot]@users.noreply.github.com",
+                )
+            ],
+        )
+        self.assertEqual(verdicts.distinct_reviewers, {"lucas ferreira", "nino kavtaradze"})
+        self.assertEqual(verdicts.total_distinct, 2)
+        # Exactly ONE identity, from the NAME — the address named nobody, so no
+        # human persona was fabricated for a bot PR.
+        self.assertEqual(
+            [i.display for i in verdicts.commit_author_identities], ["dependabot[bot]"]
+        )
+
+    def test_squash_flattened_identity_excludes_nobody(self):
+        """The bare principal must not resolve to the persona roster.json maps it to.
+
+        A commit whose name is gone and whose address is the bare principal
+        (#1177) yields no identity, so `Steven French` — the name that address
+        maps to — is NOT excluded and still counts as a reviewer.
+        """
+        verdicts = self._resolve(
+            self.NON_CHARTER_REF,
+            [self._verdict("Steven French"), self._verdict("Aino Virtanen")],
+            roster=self.ROSTER | {"steven french"},
+            commits=[
+                _api_commit(
+                    "c0",
+                    "2026-07-15T19:13:59Z",
+                    author_name="",
+                    author_email="parametrization@gmail.com",
+                )
+            ],
+        )
+        self.assertEqual(verdicts.distinct_reviewers, {"steven french", "aino virtanen"})
+        self.assertEqual(verdicts.comment_scan, hook.COMMENT_SCAN_NO_BRANCH_AUTHOR)
+
+    def test_persona_ref_does_not_consult_commit_identity(self):
+        """Scope guard: 86.7% of the org's PRs must be byte-for-byte unchanged.
+
+        On `L.Ferreira/…` the ref is authoritative. Nino authored the commits
+        here and his Approved must STILL count — if commit identity leaked onto
+        the persona path, anyone who pushed a fixup to someone else's branch
+        would lose their review.
+        """
+        verdicts = self._resolve(
+            "L.Ferreira/1210-x",
+            [self._verdict("Nino Kavtaradze"), self._verdict("Aino Virtanen")],
+            commits=self._authored_by("Nino Kavtaradze"),
+        )
+        self.assertEqual(verdicts.distinct_reviewers, {"nino kavtaradze", "aino virtanen"})
+        self.assertEqual(verdicts.comment_scan, hook.COMMENT_SCAN_AUTHOR_EXCLUDED)
+        self.assertEqual(verdicts.commit_author_identities, ())
+
+    def test_merge_only_branch_derives_no_author(self):
+        """No authored commits ⇒ no identity ⇒ the pre-#1210 state, unchanged."""
+        verdicts = self._resolve(
+            self.WAVE_REF,
+            [self._verdict("Lucas Ferreira"), self._verdict("Nino Kavtaradze")],
+            commits=[
+                _api_commit("m0", "2026-07-15T19:13:59Z", parents=2, author_name="Lucas Ferreira")
+            ],
+        )
+        self.assertEqual(verdicts.total_distinct, 2)
+        self.assertEqual(verdicts.comment_scan, hook.COMMENT_SCAN_NO_BRANCH_AUTHOR)
+
+    def test_commit_fetch_failure_still_hard_blocks_on_a_non_charter_ref(self):
+        """Degradation: no commit data ⇒ no branch author ⇒ STOP, never proceed."""
+        with (
+            mock.patch.object(
+                hook, "fetch_pr_commits", side_effect=hook.CommitFetchError("HTTP 502")
+            ),
+            mock.patch.object(hook, "_load_roster_names", return_value=set(self.ROSTER)),
+        ):
+            with self.assertRaises(hook.CommitFetchError):
+                hook.resolve_review_verdicts(self._pr_data(self.NON_CHARTER_REF), repo=self.REPO)
+
+
+class StrictlyNonRelaxingTests(_ResolveOverFakeCommentsHarness):
+    """The BAR for #1210: no input may make the gate pass what it blocked.
+
+    The property is checked directly rather than argued: for a matrix of
+    (head ref x commit authors x verdict thread), the post-fix reviewer set must
+    be a SUBSET of the pre-fix one (pre-fix == the same resolve with no
+    commit-derived identity). A subset can only lower `total_distinct`, and
+    `check()` allows only on `>= 2` or on `== 1 with the wave-bootstrap
+    exception` — neither of which a shrinking set can newly satisfy from a
+    blocking state.
+    """
+
+    CASES = (
+        ("feature/hand-made", ("Nino Kavtaradze",)),
+        ("feature/hand-made", ("Lucas Ferreira", "Nino Kavtaradze")),
+        ("feature/hand-made", ("Weronika Zielinska",)),
+        ("deployments/phase-10/wave-29", ("Nino Kavtaradze",)),
+        ("dependabot/npm_and_yarn/x-1.2.3", ("dependabot[bot]",)),
+        ("", ("Aino Virtanen",)),
+        ("nohashinthisref", ("Santiago Ferreira",)),
+        ("L.Ferreira/1210-x", ("Nino Kavtaradze",)),
+        ("L.Ferreira/1210-x", ("Lucas Ferreira",)),
+    )
+
+    THREAD = (
+        "Lucas Ferreira",
+        "Nino Kavtaradze",
+        "Aino Virtanen",
+        "Santiago Ferreira",
+    )
+
+    def _sets(self, head_ref: str, authors: tuple[str, ...]):
+        commits = [
+            _api_commit(f"c{n}", "2026-07-15T19:13:59Z", author_name=name)
+            for n, name in enumerate(authors)
+        ]
+        comments = [self._verdict(name) for name in self.THREAD]
+        after = self._resolve(head_ref, comments, commits=commits)
+        # "Before" == the same pipeline with the commit-derived author source
+        # switched off, which is exactly the pre-#1210 code path.
+        with mock.patch.object(hook, "commit_author_identities", return_value=()):
+            before = self._resolve(head_ref, comments, commits=commits)
+        return before, after
+
+    def test_reviewer_set_never_grows(self):
+        for head_ref, authors in self.CASES:
+            with self.subTest(head_ref=head_ref, authors=authors):
+                before, after = self._sets(head_ref, authors)
+                self.assertTrue(
+                    after.distinct_reviewers <= before.distinct_reviewers,
+                    f"{after.distinct_reviewers} is not a subset of {before.distinct_reviewers}",
+                )
+                self.assertLessEqual(after.total_distinct, before.total_distinct)
+
+    def test_fixture_is_not_vacuous_at_least_one_case_actually_shrinks(self):
+        """Guards the subset property against passing because nothing changed.
+
+        A no-op implementation satisfies `after <= before` for every case. At
+        least one case must strictly shrink, or the class above certifies
+        nothing (`feedback_fixture_makes_guard_assertion_inert`).
+        """
+        shrank = [
+            (head_ref, authors)
+            for head_ref, authors in self.CASES
+            if self._sets(head_ref, authors)[1].distinct_reviewers
+            < self._sets(head_ref, authors)[0].distinct_reviewers
+        ]
+        self.assertTrue(shrank, "no case exercised the exclusion — the matrix proves nothing")
+
+    def test_a_blocked_pr_never_becomes_an_allowed_one(self):
+        """The property expressed as the gate's own verdict, not as a count."""
+        for head_ref, authors in self.CASES:
+            with self.subTest(head_ref=head_ref, authors=authors):
+                before, after = self._sets(head_ref, authors)
+                before_allows = before.total_distinct >= 2
+                after_allows = after.total_distinct >= 2
+                if not before_allows:
+                    self.assertFalse(
+                        after_allows,
+                        "a PR the gate blocked before #1210 must not now pass",
+                    )
+
+
+class CommitAuthorBlockDiagnosticTests(_ResolveOverFakeCommentsHarness):
+    """A subtraction the operator cannot see is a tool that looks broken (#950)."""
+
+    def _block_reason(self, verdicts) -> str:
+        input_data = {
+            "tool_name": "Bash",
+            "tool_input": {"command": "gh pr merge 691 --repo noorinalabs/noorinalabs-main"},
+        }
+        with (
+            mock.patch.object(hook, "get_pr_data", return_value=self._pr_data("feature/x")),
+            mock.patch.object(hook, "resolve_review_verdicts", return_value=verdicts),
+            mock.patch.object(hook, "log_pretooluse_block"),
+        ):
+            result = hook.check(input_data)
+        assert result is not None, "check() must BLOCK a 1/2 PR, not return None"
+        self.assertEqual(result["decision"], "block")
+        return str(result["reason"])
+
+    @staticmethod
+    def _verdicts(comment_scan: str, identities=()):
+        return hook.ReviewVerdicts(
+            number=691,
+            head_ref="feature/x",
+            labels=[],
+            branch_author_lastname=None,
+            content_sha="837c272a",
+            content_ts=None,
+            formal_reviewers=set(),
+            comment_reviewers={"aino virtanen"},
+            non_roster_requestors=set(),
+            roster_comment_reviewers={"aino virtanen"},
+            roster_names={"aino virtanen"},
+            distinct_reviewers={"aino virtanen"},
+            stale_verdicts_comment=[],
+            stale_verdicts_formal=[],
+            reviews_missing_tech_debt=[],
+            tech_debt_issue_numbers=[],
+            tech_debt_unparseable=[],
+            wave_bootstrap_exception=False,
+            comment_scan=comment_scan,
+            commit_author_identities=identities,
+        )
+
+    def test_block_message_names_the_commit_derived_author(self):
+        reason = self._block_reason(
+            self._verdicts(
+                hook.COMMENT_SCAN_COMMIT_AUTHOR_EXCLUDED,
+                (
+                    hook.CommitAuthorIdentity(
+                        lastname="Kavtaradze", initial="n", display="Nino Kavtaradze"
+                    ),
+                ),
+            )
+        )
+        self.assertIn("COMMIT IDENTITY", reason)
+        self.assertIn("Nino Kavtaradze", reason)
+        self.assertIn("1/2 required peer reviews", reason)
+
+    def test_the_two_no_author_modes_read_differently(self):
+        """Exclusion-applied and exclusion-unavailable must not share wording —
+        they are opposite facts about whether the count can be trusted."""
+        excluded = self._block_reason(
+            self._verdicts(
+                hook.COMMENT_SCAN_COMMIT_AUTHOR_EXCLUDED,
+                (
+                    hook.CommitAuthorIdentity(
+                        lastname="Khoury", initial="n", display="Nadia Khoury"
+                    ),
+                ),
+            )
+        )
+        unavailable = self._block_reason(self._verdicts(hook.COMMENT_SCAN_NO_BRANCH_AUTHOR))
+        self.assertNotEqual(excluded, unavailable)
+        self.assertIn("COMMIT IDENTITY", excluded)
+        self.assertNotIn("COMMIT IDENTITY", unavailable)
+        self.assertIn("WITHOUT self-review exclusion", unavailable)
+        self.assertNotIn("WITHOUT self-review exclusion", excluded)
 
 
 if __name__ == "__main__":

--- a/.claude/hooks/validate_pr_review.py
+++ b/.claude/hooks/validate_pr_review.py
@@ -148,6 +148,46 @@ Reviewer dedup key:
   whom cannot land in one hook and not the other. A true self-review still
   excludes: the author's own initial and surname both match their branch.
 
+Branch author from COMMIT IDENTITY (#1210):
+  All of the above presumes the head ref NAMES the branch author. On a ref
+  without the `{Initial}.{Lastname}` prefix it does not, and the exclusion had
+  no subject: `is_branch_author` returned False for everyone and the author's
+  own `Approved` comment entered the reviewer set. A human self-approving on a
+  non-charter branch plus one genuine reviewer reached 2/2 where 1/2 is correct.
+  That hole is old — `deployments/**` wave-merge branches have carried it since
+  main#294 — and #1207 widened the population of refs it applies to (measured:
+  568/655 PRs persona-prefixed and unaffected, 79 `deployments/**` pre-existing,
+  4 dependabot, 4 newly exposed).
+
+  Every persona commits with `-c user.name="{First} {Last}"` (CLAUDE.md §
+  Commit Identity), so the commits carry the answer the ref does not.
+  `commit_author_identities` derives it off the commit list ALREADY fetched for
+  T_content — no extra API round-trip — and `is_self_review` applies it through
+  the same `charter_trailer.is_branch_author` comparison as the ref prefix.
+
+  Degradation, all in the same direction (`feedback_safety_direction_over_ux_
+  friction`) — none of these can make the gate pass what it blocked before,
+  because the exclusion only ever REMOVES reviewers:
+    - commit list unfetchable  → `CommitFetchError`, HARD BLOCK (unchanged #950)
+    - bot author               → `dependabot[bot]` matches no roster persona,
+                                 so it excludes NOBODY and the counted set is
+                                 the pre-existing one; bots stay neutral by
+                                 construction, not by a blocklist. Their
+                                 ADDRESS yields no identity at all (#1181's
+                                 matcher), and no human author is fabricated
+    - bare `parametrization@`  → the address contributes NOTHING. A squash
+                                 re-authors to the bare principal (#1177), so
+                                 that address is evidence identity was
+                                 destroyed, not evidence of who wrote the code;
+                                 `roster.json` does map it to a name and this
+                                 hook deliberately does not follow that map
+    - merge-only branch        → no authored commits, no identity, unchanged
+    - ambiguous / wrong match  → OVER-excludes, dropping a reviewer and
+                                 blocking; the block message names every derived
+                                 identity so the mistake is visible, not silent
+  Scope: consulted ONLY where the ref names nobody. Where the ref names a
+  persona the behaviour is byte-for-byte unchanged.
+
 Single-Reviewer Exception (resolves #228):
   When the PR is labeled `wave-bootstrap` AND there is exactly ONE distinct
   reviewer who is a charter-enforcer role in the local roster, the hook
@@ -189,6 +229,7 @@ from charter_trailer import (
     branch_author_first_initial,
     extract_charter_field,
     is_branch_author,
+    name_first_initial,
     name_lastname,
     strip_code_regions,
     trailer_block_substring,
@@ -634,32 +675,27 @@ def describe_repo_defect(repo: str | None, defect: str) -> str:
     )
 
 
-def get_latest_content_commit(
+def fetch_pr_commits(
     pr_number: str | int,
     repo: str | None = None,
-) -> tuple[str, datetime] | None:
-    """Return `(short_sha, committed_at)` of the PR's latest NON-MERGE commit (#950).
+) -> list[dict]:
+    """Fetch the PR's commit list ONCE, for every consumer that needs it.
 
-    This is `T_content` — the moment the newest AUTHORED content arrived on the
-    branch, and the line a verdict must sit at or after to count.
-
-    Merge commits are excluded by parent count (a merge has >= 2 parents; a
-    normal commit has 1 and a root commit has 0, so `< 2` is the non-merge test).
-    Excluding them is what lets an approval SURVIVE a routine branch update from
-    `main` — that merge commit moves the head without changing what the reviewer
-    read. Including them would invalidate every approval in the org at the moment
-    of merge (see `feedback_commit_author_gate_exclude_merges`).
-
-    The COMMITTER date is used, not the author date: a rebase or amend preserves
-    the original author date while rewriting the commit object, so only the
-    committer date tracks when the content actually landed on the branch.
+    Two independent facts are read off this ONE response — `T_content` (#950,
+    `latest_content_commit`) and the branch author's identity (#1210,
+    `commit_author_identities`). They were separate concerns fetched by one call
+    even before #1210: `get_latest_content_commit` already pulled the full
+    commit objects and discarded `commit.author`. Splitting the FETCH from the
+    two ANALYSES keeps that single round-trip while letting each analysis be
+    unit-tested as a pure function over a commit list, with no subprocess mock.
 
     `--paginate` is mandatory: without it a PR with >100 commits silently
-    truncates and T_content is computed from a stale prefix (the same trap #303
-    fixed for the comment fetch).
+    truncates, T_content is computed from a stale prefix, and — post-#1210 — a
+    commit author past the 100th is invisible to the self-review exclusion (the
+    same trap #303 fixed for the comment fetch).
 
-    Returns None when the PR has NO non-merge commits — a degenerate branch that
-    contributes no authored content, so nothing can be stale against it.
+    Non-dict entries are dropped here rather than in each analysis, so both
+    consumers see the same validated shape.
 
     Raises:
         CommitFetchError: the commit list could not be fetched or parsed. There
@@ -708,11 +744,47 @@ def get_latest_content_commit(
             f"{type(commits).__name__}, expected a list"
         )
 
+    return [c for c in commits if isinstance(c, dict)]
+
+
+def _is_merge_commit(commit: dict) -> bool:
+    """True for a merge commit — >= 2 parents.
+
+    A normal commit has 1 parent and a root commit has 0, so `< 2` is the
+    non-merge test. ONE definition, shared by `latest_content_commit` and
+    `commit_author_identities`, because the two must agree on what "authored
+    content" means: a merge commit moves the head without changing content, and
+    the person who ran the merge is not thereby an author of it.
+    """
+    return len(commit.get("parents") or []) >= 2
+
+
+def latest_content_commit(commits: list[dict]) -> tuple[str, datetime] | None:
+    """Return `(short_sha, committed_at)` of the latest NON-MERGE commit (#950).
+
+    This is `T_content` — the moment the newest AUTHORED content arrived on the
+    branch, and the line a verdict must sit at or after to count.
+
+    Merge commits are excluded (`_is_merge_commit`). Excluding them is what lets
+    an approval SURVIVE a routine branch update from `main` — that merge commit
+    moves the head without changing what the reviewer read. Including them would
+    invalidate every approval in the org at the moment of merge (see
+    `feedback_commit_author_gate_exclude_merges`).
+
+    The COMMITTER date is used, not the author date: a rebase or amend preserves
+    the original author date while rewriting the commit object, so only the
+    committer date tracks when the content actually landed on the branch.
+
+    Returns None when there are NO non-merge commits — a degenerate branch that
+    contributes no authored content, so nothing can be stale against it.
+
+    Raises:
+        CommitFetchError: a non-merge commit carries no parseable committer
+            date, so T_content cannot be established.
+    """
     latest: tuple[str, datetime] | None = None
     for commit in commits:
-        if not isinstance(commit, dict):
-            continue
-        if len(commit.get("parents") or []) >= 2:
+        if _is_merge_commit(commit):
             continue  # merge commit — moves the head without changing content
         committed_at = _parse_iso8601(
             (commit.get("commit", {}).get("committer", {}) or {}).get("date")
@@ -730,6 +802,186 @@ def get_latest_content_commit(
             latest = (str(commit.get("sha", "?"))[:8], committed_at)
 
     return latest
+
+
+@dataclasses.dataclass(frozen=True)
+class CommitAuthorIdentity:
+    """A PERSON derived from a PR commit's author fields (#1210).
+
+    Carries the same two-part discriminator the charter branch prefix carries —
+    `lastname` + lowercased first `initial` — so it can be handed straight to
+    `charter_trailer.is_branch_author`, the ONE person-comparison in the org
+    (#1172). It deliberately does NOT carry an email or a roster row: a raw
+    display string plus the pair is everything the comparison needs, and adding
+    a roster lookup here would invite the address→persona mapping that
+    `persona_alias_from_email` exists to refuse.
+
+    `display` is the RAW source string, kept only so the block diagnostic can
+    name who was excluded and an operator can see whether the derivation picked
+    the right person. `initial` is `""` when none is derivable (a single-token
+    author name), which `is_branch_author` reads as "unknown" and falls back to
+    lastname-only — the OVER-excluding, fail-closed direction.
+    """
+
+    lastname: str
+    initial: str
+    display: str
+
+
+def persona_alias_from_email(email: str) -> str:
+    """Return the `First.Last` persona alias in a commit author address, or `""`.
+
+    Every persona commits as `parametrization+{First}.{Last}@gmail.com`
+    (CLAUDE.md § Commit Identity) — the personas are `+alias`es of ONE Gmail
+    principal — so the alias names the person deterministically.
+
+    Reuses `_PERSONA_ALIAS_RE`, the SAME matcher the #1181 roster-manifest
+    persona filter uses (defined below, alongside the reasoning that chose it),
+    rather than a second address regex. A duplicated matcher that drifts from
+    its twin is the defect class `repo_argument_defect` cites and #1046 was:
+    one matcher, reused. It also means this function inherits an already-argued
+    decision instead of re-deriving one — #1181 excludes exactly the two
+    non-persona entries in `roster.json`, and both exclusions are load-bearing
+    here for the same reasons.
+
+    THE BARE PRINCIPAL RESOLVES TO NOTHING, ON PURPOSE. An address with no
+    `+alias` (`parametrization@gmail.com`) returns `""` and contributes no
+    identity. This is the #1177 hazard: a squash re-authors a persona's commit
+    to the bare principal, so the bare address is evidence that identity was
+    DESTROYED, not evidence about who wrote the code. `.claude/team/roster.json`
+    does map `parametrization@gmail.com` to a name (`Steven French`) — following
+    that map here is precisely how the gate would silently exclude the wrong
+    persona from a squashed branch, so this function does not consult it. #1181
+    reached the same verdict on the same address for the same reason.
+
+    The `First.Last` shape requirement also rejects GitHub's
+    `12345+octocat@users.noreply.github.com` (the `+` part is a login, not a
+    persona) and every bot address, which is what keeps bot ADDRESSES from
+    inventing an author — by construction, not by a bot blocklist that a new
+    tool entry could slip past.
+
+    Returns the alias VERBATIM (`Aino.Virtanen`) — `charter_trailer._name_tokens`
+    splits on `.` as well as whitespace, so the dotted form is already a
+    two-token person name to every downstream comparison.
+    """
+    address = email.strip()
+    if not _PERSONA_ALIAS_RE.match(address):
+        return ""
+    local, _, _domain = address.partition("@")
+    _base, _, alias = local.partition("+")
+    return alias
+
+
+def _identity_from_name(raw: str) -> CommitAuthorIdentity | None:
+    """Build a `CommitAuthorIdentity` from a person-name string, or None.
+
+    Name parsing is `charter_trailer`'s (`name_lastname` / `name_first_initial`)
+    — the same parser the trailer fields go through — so a commit author and a
+    `Requestor:` value can never be split into tokens two different ways.
+
+    Returns None when no lastname is derivable (empty / whitespace-only), which
+    keeps a junk author out of the exclusion set rather than adding an entry
+    that `is_branch_author` would treat as the never-matching `""` sentinel.
+    """
+    lastname = name_lastname(raw)
+    if not lastname:
+        return None
+    return CommitAuthorIdentity(
+        lastname=lastname,
+        initial=name_first_initial(raw),
+        display=raw.strip(),
+    )
+
+
+def commit_author_identities(commits: list[dict]) -> tuple[CommitAuthorIdentity, ...]:
+    """Derive the branch's author identities from its commits (#1210).
+
+    WHY THIS EXISTS. `extract_branch_author_lastname` can only name the branch
+    author on a ref carrying the charter `{Initial}.{Lastname}` prefix. On every
+    other ref — `deployments/**` wave-merge branches (since main#294), and after
+    #1207 any hand-made branch — the gate had NO branch author, so
+    `is_branch_author` returned False for everyone and the author's OWN
+    `Approved` comment entered the reviewer set. A human self-approving on a
+    non-charter branch plus one genuine reviewer reached 2/2 where 1/2 is
+    correct. The commit objects carry the answer the ref does not: every persona
+    commits with `-c user.name="{First} {Last}"`.
+
+    TWO SOURCES PER COMMIT, UNIONED: `commit.author.name` (what `-c user.name`
+    writes) and the `+alias` in `commit.author.email` (`persona_alias_from_email`
+    — `""` for the bare principal and for every bot address). Unioning them can
+    only ADD exclusions, never remove one, so it moves strictly in the
+    fail-closed direction; it is worth doing because the two disagree exactly
+    when one of them is a handle rather than a name.
+
+    The AUTHOR is read, not the committer: `-c` sets both, but a rebase or an
+    amend by a third party rewrites the committer while the author is who wrote
+    the content. Reading the committer too would exclude whoever last rewrote
+    the branch — over-exclusion, so safe, but it would drop a genuine reviewer
+    who did nothing but run `update-branch`.
+
+    MERGE COMMITS ARE SKIPPED, matching `latest_content_commit`. Running
+    `gh pr merge` into a wave branch does not make the release coordinator an
+    author of that branch's content, and excluding them there would false-block
+    the wave merges they are required to review. The cost is stated in the
+    module docstring: a branch composed ENTIRELY of merge commits yields no
+    identity, and self-review exclusion stays unavailable on it — the
+    pre-existing state, not a regression.
+
+    ALL non-merge commit authors are returned, not just the latest content
+    commit's. A branch handed between two personas has two authors, and both
+    must be excluded; taking only the latest would let the earlier one
+    self-approve. Over-exclusion is the safe direction here, matching the
+    `branch_author_initial` reasoning in `check_comment_reviews`'s docstring.
+
+    NO ROSTER FILTER, deliberately. A derived identity that matches no persona
+    (a bot, `GitHub`, a stranger) simply matches no `Requestor` either, so it is
+    inert — and roster-filtering here would be a second place for the roster to
+    be wrong. Bots stay neutral because nothing named `dependabot[bot]` can
+    equal a roster name, not because they are special-cased.
+
+    Deduplicated on `(lastname, initial)` — the comparison key — with the first
+    display form seen kept for the diagnostic. Order is stable (first
+    appearance) so the block message is deterministic.
+    """
+    identities: dict[tuple[str, str], CommitAuthorIdentity] = {}
+    for commit in commits:
+        if _is_merge_commit(commit):
+            continue
+        author = (commit.get("commit", {}) or {}).get("author", {}) or {}
+        raw_name = str(author.get("name") or "")
+        raw_alias = persona_alias_from_email(str(author.get("email") or ""))
+        for raw in (raw_name, raw_alias):
+            identity = _identity_from_name(raw)
+            if identity is None:
+                continue
+            identities.setdefault((identity.lastname.lower(), identity.initial), identity)
+    return tuple(identities.values())
+
+
+def is_self_review(
+    requestor: str,
+    branch_author_lastname: str,
+    branch_author_initial: str,
+    commit_authors: tuple[CommitAuthorIdentity, ...],
+) -> bool:
+    """True when `requestor` is an author of this branch, by ref OR by commit.
+
+    ONE predicate, so the two ways of naming a branch author cannot disagree.
+    Both arms delegate to `charter_trailer.is_branch_author` — the single
+    person-comparison the org has (#1172, the Ferreira/Ferreira collision).
+    There is deliberately no surname comparison written here; adding one would
+    re-create exactly the defect that helper exists to prevent.
+
+    The ref arm is checked first and is unchanged: on a `{Initial}.{Lastname}`
+    branch the prefix is the author the human declared, and `commit_authors` is
+    empty there by construction (see `resolve_review_verdicts`).
+    """
+    if is_branch_author(requestor, branch_author_lastname, branch_author_initial):
+        return True
+    return any(
+        is_branch_author(requestor, identity.lastname, identity.initial)
+        for identity in commit_authors
+    )
 
 
 def extract_branch_author_lastname(head_ref: str) -> str | None:
@@ -767,14 +1019,21 @@ def extract_branch_author_lastname(head_ref: str) -> str | None:
 COMMENT_SCAN_NOT_RUN = "not-run"
 COMMENT_SCAN_AUTHOR_EXCLUDED = "author-excluded"
 COMMENT_SCAN_NO_BRANCH_AUTHOR = "no-branch-author"
+# The ref named no persona but the PR's COMMITS did (#1210) — self-review
+# exclusion IS active, keyed on commit identity rather than on the ref prefix.
+# A distinct value from AUTHOR_EXCLUDED because the two are derived from
+# different evidence and an operator reading a block message needs to know
+# which: the ref prefix is a human declaration, the commit author is a
+# measurement, and only the latter can be defeated by a squash (#1177).
+COMMENT_SCAN_COMMIT_AUTHOR_EXCLUDED = "commit-author-excluded"
 
 
 def comment_scan_scope(head_ref: str) -> str:
-    """Return which self-review-exclusion mode the comment verdict scan runs in.
+    """Return which self-review-exclusion mode the HEAD REF alone selects.
 
     The head ref's ONLY role in the comment scan is naming the branch author for
-    the self-review exclusion, so there are exactly two modes and **no third
-    "don't scan" mode**:
+    the self-review exclusion, so there are exactly two ref-derived modes and
+    **no third "don't scan" mode**:
 
       - `COMMENT_SCAN_AUTHOR_EXCLUDED` — the ref carries the charter
         `{Initial}.{Lastname}[-/]…` prefix, so the branch author is identifiable
@@ -785,6 +1044,11 @@ def comment_scan_scope(head_ref: str) -> str:
         still runs, under the `""` sentinel the wave-merge path has used since
         main#294, which `charter_trailer.is_branch_author` reads as "nobody is
         the branch author".
+
+    This function stays a pure function OF THE REF. `refine_comment_scan_scope`
+    applies the second, commit-derived discriminator (#1210) on top of its
+    answer — keeping them separate is what lets the ref classification remain
+    total and testable without any commit data.
 
     This function is TOTAL: it returns a scanning mode for every possible head
     ref, including `""`. That totality IS the #1206 fix — the pre-fix resolver
@@ -805,6 +1069,34 @@ def comment_scan_scope(head_ref: str) -> str:
         if extract_branch_author_lastname(head_ref)
         else COMMENT_SCAN_NO_BRANCH_AUTHOR
     )
+
+
+def refine_comment_scan_scope(
+    ref_scope: str,
+    commit_authors: tuple[CommitAuthorIdentity, ...],
+) -> str:
+    """Upgrade a ref-derived scan scope with what the PR's COMMITS said (#1210).
+
+    Exactly ONE transition: `NO_BRANCH_AUTHOR` → `COMMIT_AUTHOR_EXCLUDED`, and
+    only when at least one identity was derived. Everything else is returned
+    untouched, which is the whole safety argument for this function:
+
+      - `AUTHOR_EXCLUDED` is never downgraded — a ref that names a persona keeps
+        its exclusion no matter what the commits say.
+      - `NOT_RUN` is never upgraded — a scan that did not happen cannot acquire
+        a mode. `resolve_review_verdicts` hard-blocks on it upstream, and
+        silently relabelling it here would launder that block into a result.
+      - `NO_BRANCH_AUTHOR` with no derived identity stays as it was, so the
+        honest "exclusion was not available" reporting survives for genuine bot
+        branches and for commit data that named nobody.
+
+    The mode is a REPORT, not a decision: the exclusion itself is applied by
+    `is_self_review` from the same `commit_authors` tuple. They cannot drift
+    because both read that one value.
+    """
+    if ref_scope == COMMENT_SCAN_NO_BRANCH_AUTHOR and commit_authors:
+        return COMMENT_SCAN_COMMIT_AUTHOR_EXCLUDED
+    return ref_scope
 
 
 PROJECT_NUMBER = 2
@@ -968,6 +1260,7 @@ def check_comment_reviews(
     *,
     repo: str | None = None,
     content_ts: datetime | None,
+    commit_author_identities: tuple[CommitAuthorIdentity, ...],
     branch_author_initial: str = "",
 ) -> CommentReviewResult:
     """Check PR comments for charter-format review comments from different authors.
@@ -1007,6 +1300,22 @@ def check_comment_reviews(
     (a same-surname colleague is mistaken for the author, the reviewer count
     drops, the merge blocks). That is the fail-CLOSED direction, so unlike the
     `content_ts` case below an omission cannot silently admit a merge.
+
+    `commit_author_identities` (#1210) is the branch author derived from the
+    PR's COMMITS — the second half of the self-review exclusion, and the only
+    half available on a ref that carries no `{Initial}.{Lastname}` prefix. Any
+    Requestor matching one of them is the branch author and is excluded, exactly
+    as a ref-prefix match is (`is_self_review`).
+
+    It is a REQUIRED keyword-only argument for the same reason `content_ts` is
+    (#1050), and the reason is the FAIL DIRECTION, not taste: omitting it drops
+    exclusions, which ADDS reviewers and moves the gate toward passing — the
+    silent fail-open shape of #1046. `()` remains a legitimate VALUE meaning "no
+    commit-derived author" (a bot branch, a merge-only branch, unusable commit
+    data), and it is what `resolve_review_verdicts` passes on every ref that
+    already names a persona. Contrast `branch_author_initial` below, which keeps
+    a default precisely because omitting THAT one over-excludes and therefore
+    fails closed.
 
     `content_ts` is a REQUIRED keyword-only argument (#1050) — it must be
     passed explicitly on every call, though `None` remains a legitimate
@@ -1107,7 +1416,20 @@ def check_comment_reviews(
                 # first-initial + lastname — the full discriminator the branch
                 # prefix carries — and still excludes a real self-review, whose
                 # initial and surname both match.
-                if not is_branch_author(requestor, branch_author_lastname, branch_author_initial):
+                #
+                # #1210: the branch author is asked for from BOTH the ref prefix
+                # and the PR's commit authors, because on a ref without the
+                # prefix the first source is silent and the author's own verdict
+                # used to walk straight into `latest_verdict`. This is the ONLY
+                # place the exclusion is applied, and it can only ever REMOVE a
+                # reviewer — so no input to it can make the gate pass something
+                # it blocked before.
+                if not is_self_review(
+                    requestor,
+                    branch_author_lastname,
+                    branch_author_initial,
+                    commit_author_identities,
+                ):
                     latest_verdict[requestor.lower()] = ror_value
 
             # TechDebt attestation is required on every verdict
@@ -1320,6 +1642,11 @@ def load_charter_enforcer_names(repo: str | None = None) -> set[str]:
 #     `First.Last` tag) — the error monitor, which posts real comments on real
 #     PRs, so admitting it as a Requestor is the live risk, not a hypothetical.
 #   - `Steven French` → `parametrization@gmail.com` (bare principal, no `+`tag).
+#
+# ALSO used by `persona_alias_from_email` (#1210) to decide which COMMIT author
+# address names a persona. Both call sites need the identical answer on the
+# identical addresses — notably the bare principal, which #1177 makes a squash
+# produce — so they share this one matcher rather than each carrying a regex.
 _PERSONA_ALIAS_RE = re.compile(r"^[^\s@+]+\+[^\s@+]+\.[^\s@+]+@[^\s@]+\.[^\s@]+$")
 
 
@@ -1556,6 +1883,14 @@ class ReviewVerdicts:
     # NOT_RUN so a construction that omits it renders as not-measured rather
     # than falsely claiming a measurement.
     comment_scan: str = COMMENT_SCAN_NOT_RUN
+    # The branch author(s) derived from the PR's COMMITS (#1210), or `()` when
+    # the ref already named a persona / nothing was derivable. Carried on the
+    # shared pipeline output so BOTH callers can NAME who the self-review
+    # exclusion was keyed on — a reviewer whose verdict vanished because the
+    # gate decided they authored the branch must be able to see that decision,
+    # or the #950 "operator concludes the hook is broken" failure repeats with a
+    # new cause. Defaulted so every existing construction keeps working.
+    commit_author_identities: tuple[CommitAuthorIdentity, ...] = ()
 
     @property
     def comment_scan_ran(self) -> bool:
@@ -1578,11 +1913,14 @@ def resolve_review_verdicts(pr_data: dict, repo: str | None = None) -> ReviewVer
     previously re-assembled independently by `check()` and
     `pr_review_state.compute_review_state`:
 
-      1. `get_latest_content_commit` → T_content (`content_ts`/`content_sha`, #950).
+      1. `fetch_pr_commits` ONCE, then `latest_content_commit` → T_content
+         (`content_ts`/`content_sha`, #950) and `commit_author_identities` →
+         the commit-derived branch author (#1210), off that same response.
       2. `partition_formal_reviewers` + `check_comment_reviews`, both bound to
          T_content. The comment scan runs for EVERY head ref (#1206); the ref
-         selects only which self-review exclusion applies (`comment_scan_scope`),
-         and the chosen mode is reported on `ReviewVerdicts.comment_scan`.
+         and the commit authors select only which self-review exclusion applies
+         (`comment_scan_scope` + `refine_comment_scan_scope`), and the chosen
+         mode is reported on `ReviewVerdicts.comment_scan`.
       3. `_load_roster_names` and non-roster Requestor filtering (#498).
       4. Union formal + roster-filtered comment reviewers into the distinct
          reviewer set, plus the wave-bootstrap single-reviewer exception (#228).
@@ -1593,8 +1931,12 @@ def resolve_review_verdicts(pr_data: dict, repo: str | None = None) -> ReviewVer
     before doing anything else.
 
     Raises:
-        CommitFetchError: T_content could not be established (#950) —
-            propagated verbatim from `get_latest_content_commit`.
+        CommitFetchError: the commit list could not be fetched, or T_content
+            could not be established from it (#950) — propagated verbatim from
+            `fetch_pr_commits` / `latest_content_commit`. Note this is also the
+            degradation path for #1210: no commit data means no commit-derived
+            branch author, and the gate BLOCKS rather than proceeding without
+            the discriminator.
         CommentScanUndeterminedError: the comment thread could not be
             completely scanned (#981), or the scan was never dispatched at all
             (#1206 defense-in-depth) — carries `.reason`.
@@ -1614,7 +1956,13 @@ def resolve_review_verdicts(pr_data: dict, repo: str | None = None) -> ReviewVer
     number = pr_data["number"]
     labels = pr_data["labels"]
 
-    latest_content = get_latest_content_commit(number, repo=repo)
+    # ONE commit fetch, TWO readings of it (#1210): T_content for the staleness
+    # binding, and the branch author's identity for the self-review exclusion.
+    # A commit-fetch failure raises `CommitFetchError` here and hard-blocks —
+    # which is also the answer to "what if commit identity is unavailable?": the
+    # gate never proceeds with an unknown branch author, it stops.
+    commits = fetch_pr_commits(number, repo=repo)
+    latest_content = latest_content_commit(commits)
     content_ts = latest_content[1] if latest_content else None
     content_sha = latest_content[0] if latest_content else ""
 
@@ -1656,15 +2004,35 @@ def resolve_review_verdicts(pr_data: dict, repo: str | None = None) -> ReviewVer
         )
 
     branch_author_lastname = extract_branch_author_lastname(head_ref)
+
+    # Commit-derived authors are consulted ONLY where the ref is silent (#1210).
+    #
+    # Scope, and why it is this narrow. On a `{Initial}.{Lastname}` ref the
+    # prefix is the author the human DECLARED, exclusion already works, and
+    # 86.7% of the org's PRs (568/655 measured across 7 repos) take that path —
+    # so adding a second exclusion source there would change the majority path
+    # to fix nothing, while newly discarding the verdict of anyone who happened
+    # to push a fixup commit to someone else's branch. Where the ref names
+    # nobody, `commit_author_identities` is the ONLY discriminator available and
+    # `()` was the standing answer: for `deployments/**` since main#294, and for
+    # every other non-charter ref since #1207 widened the sentinel.
+    commit_authors: tuple[CommitAuthorIdentity, ...] = (
+        () if branch_author_lastname else commit_author_identities(commits)
+    )
+    scan_scope = refine_comment_scan_scope(scan_scope, commit_authors)
+
     comment_result = check_comment_reviews(
         number,
-        # The `""` sentinel means "no identifiable branch author, so no reviewer
-        # is the author" (`charter_trailer.is_branch_author`, main#294). Losing
-        # author-exclusion on a bot branch is correct: a bot is never a roster
-        # persona, so it could never have been in the reviewer set anyway.
+        # The `""` sentinel means "no identifiable branch author from the REF"
+        # (`charter_trailer.is_branch_author`, main#294). It no longer means no
+        # exclusion at all: `commit_author_identities` carries whatever the
+        # commits said. Where BOTH are empty the pre-#1210 behaviour stands —
+        # correctly for a bot branch, since a bot is never a roster persona and
+        # could not have been in the reviewer set anyway.
         branch_author_lastname or "",
         repo=repo,
         content_ts=content_ts,
+        commit_author_identities=commit_authors,
         branch_author_initial=branch_author_first_initial(head_ref),
     )
 
@@ -1700,6 +2068,7 @@ def resolve_review_verdicts(pr_data: dict, repo: str | None = None) -> ReviewVer
         tech_debt_unparseable=list(comment_result.tech_debt_unparseable),
         wave_bootstrap_exception=wave_bootstrap_exception,
         comment_scan=scan_scope,
+        commit_author_identities=commit_authors,
     )
 
 
@@ -2021,14 +2390,31 @@ def check(input_data: dict) -> dict | None:
                 "is a hook defect, not a review shortfall — report it rather than asking "
                 "reviewers to re-approve.\n\n"
             )
+        elif verdicts.comment_scan == COMMENT_SCAN_COMMIT_AUTHOR_EXCLUDED:
+            # Name the derived authors. A reviewer whose verdict was dropped
+            # because the gate concluded they wrote the branch must be able to
+            # SEE that conclusion and check it — an unexplained subtraction is
+            # the #950 "operator concludes the hook is broken" failure with a
+            # new cause.
+            derived = ", ".join(i.display for i in verdicts.commit_author_identities) or "(none)"
+            scan_diagnostic = (
+                f"NOTE: head ref `{verdicts.head_ref or '(unknown)'}` carries no "
+                "`{Initial}.{Lastname}` branch-author prefix, so the branch author was "
+                f"derived from COMMIT IDENTITY instead: {derived}. Verdicts from those "
+                "personas were excluded as self-reviews; every other roster-valid Approved "
+                "Requestor counts. The scan DID run; the count below is a real measurement "
+                "(#1210).\n\n"
+            )
         elif verdicts.comment_scan == COMMENT_SCAN_NO_BRANCH_AUTHOR:
             scan_diagnostic = (
                 f"NOTE: head ref `{verdicts.head_ref or '(unknown)'}` carries no "
                 "`{Initial}.{Lastname}` branch-author prefix (a bot branch, a wave-merge "
-                "branch, or a branch off the charter naming convention), so the comment "
-                "verdict scan ran WITHOUT self-review exclusion — every roster-valid "
-                "Approved Requestor counts. The scan DID run; the count below is a real "
-                "measurement (#1206).\n\n"
+                "branch, or a branch off the charter naming convention), AND the PR's "
+                "commits named no persona either (a bot author, a merge-only branch, or a "
+                "squashed commit re-authored to the bare principal — #1177/#1210), so the "
+                "comment verdict scan ran WITHOUT self-review exclusion — every "
+                "roster-valid Approved Requestor counts. The scan DID run; the count below "
+                "is a real measurement (#1206).\n\n"
             )
 
         result = {

--- a/.claude/lib/pr_review_state.py
+++ b/.claude/lib/pr_review_state.py
@@ -134,6 +134,13 @@ class ReviewState:
     # findings when neither was one. Defaults to NOT_RUN so an omission renders
     # as not-measured rather than as a false measurement.
     comment_scan: str = gate.COMMENT_SCAN_NOT_RUN
+    # Branch author(s) derived from the PR's COMMITS (#1210) — display strings
+    # only, so `dataclasses.asdict` keeps the payload JSON-serializable. Empty
+    # whenever the head ref already named a persona (the derivation is not run
+    # there) or nothing was derivable. Reported because a reviewer whose verdict
+    # was subtracted as a self-review has to be able to see WHO the gate thought
+    # they were.
+    commit_authors: list[str] = dataclasses.field(default_factory=list)
 
     @property
     def comment_scan_ran(self) -> bool:
@@ -274,6 +281,7 @@ def compute_review_state(pr_number: str, repo: str | None = None) -> ReviewState
         content_ts=verdicts.content_ts.isoformat() if verdicts.content_ts else None,
         stale_verdicts=stale_verdicts,
         comment_scan=verdicts.comment_scan,
+        commit_authors=[identity.display for identity in verdicts.commit_author_identities],
     )
 
 
@@ -297,10 +305,21 @@ def _describe_comment_scan(state: ReviewState) -> str:
             f"RAN — head ref names branch author {author!r}, whose own verdicts are "
             "excluded from the reviewer set (self-review exclusion active)."
         )
+    if state.comment_scan == gate.COMMENT_SCAN_COMMIT_AUTHOR_EXCLUDED:
+        # Name the derived identities: this mode SUBTRACTS verdicts on evidence
+        # the head ref does not show, so a report that only said "exclusion
+        # active" would leave an operator unable to check the subtraction.
+        derived = ", ".join(state.commit_authors) or "(none)"
+        return (
+            "RAN — head ref names no branch author, so the branch author was derived "
+            f"from COMMIT IDENTITY: {derived}. Their own verdicts are excluded from the "
+            "reviewer set (self-review exclusion active, #1210)."
+        )
     return (
-        "RAN — head ref names no branch author (bot / wave-merge / non-charter branch), "
-        "so no self-review exclusion was applied. Roster filtering and the 2-reviewer "
-        "threshold are unchanged."
+        "RAN — head ref names no branch author (bot / wave-merge / non-charter branch) "
+        "and the PR's commits named no persona either (bot author, merge-only branch, or "
+        "a squash-flattened identity — #1177/#1210), so no self-review exclusion was "
+        "applied. Roster filtering and the 2-reviewer threshold are unchanged."
     )
 
 

--- a/.claude/lib/tests/test_pr_review_state.py
+++ b/.claude/lib/tests/test_pr_review_state.py
@@ -39,7 +39,29 @@ import pr_review_state as prs  # noqa: E402
 _NOW = datetime(2026, 7, 20, 12, 0, 0, tzinfo=timezone.utc)
 _BEFORE = _NOW - timedelta(hours=6)
 _AFTER = _NOW + timedelta(hours=1)
-_CONTENT_COMMIT = ("ac8bcfa", _NOW)
+
+
+def _api_commit(
+    sha: str, when: datetime, parents: int = 1, name: str = "", email: str = ""
+) -> dict:
+    """Build a `pulls/{n}/commits` payload entry (#1210).
+
+    The driver's fixtures now stub the FETCH (`fetch_pr_commits`) rather than
+    the analysis, so the real `latest_content_commit` and
+    `commit_author_identities` run over this — which is what keeps these tests
+    binding to the gate's actual behaviour instead of to a stubbed answer.
+    """
+    return {
+        "sha": sha,
+        "parents": [{"sha": f"p{i}"} for i in range(parents)],
+        "commit": {
+            "committer": {"date": when.isoformat().replace("+00:00", "Z")},
+            "author": {"name": name, "email": email},
+        },
+    }
+
+
+_CONTENT_COMMITS = [_api_commit("ac8bcfa", _NOW)]
 
 
 def _comment_result(
@@ -89,11 +111,15 @@ class ComputeReviewStateTests(unittest.TestCase):
         comment_result,
         roster_names,
         single_reviewer_exception=False,
-        latest_content=_CONTENT_COMMIT,
+        commits=None,
     ) -> prs.ReviewState:
         with (
             mock.patch.object(prs.gate, "get_pr_data", return_value=pr_data),
-            mock.patch.object(prs.gate, "get_latest_content_commit", return_value=latest_content),
+            mock.patch.object(
+                prs.gate,
+                "fetch_pr_commits",
+                return_value=_CONTENT_COMMITS if commits is None else commits,
+            ),
             mock.patch.object(prs.gate, "check_comment_reviews", return_value=comment_result),
             mock.patch.object(prs.gate, "_load_roster_names", return_value=roster_names),
             mock.patch.object(
@@ -198,7 +224,14 @@ class ComputeReviewStateTests(unittest.TestCase):
         """
         captured = {}
 
-        def fake_check(number, lastname, repo=None, content_ts=None, branch_author_initial=""):
+        def fake_check(
+            number,
+            lastname,
+            repo=None,
+            content_ts=None,
+            commit_author_identities=(),
+            branch_author_initial="",
+        ):
             captured["number"] = number
             captured["lastname"] = lastname
             captured["initial"] = branch_author_initial
@@ -210,7 +243,7 @@ class ComputeReviewStateTests(unittest.TestCase):
                 "get_pr_data",
                 return_value=_pr_data(head_ref="S.Ferreira/0707-pr-review-state"),
             ),
-            mock.patch.object(prs.gate, "get_latest_content_commit", return_value=_CONTENT_COMMIT),
+            mock.patch.object(prs.gate, "fetch_pr_commits", return_value=_CONTENT_COMMITS),
             mock.patch.object(prs.gate, "check_comment_reviews", side_effect=fake_check),
             mock.patch.object(prs.gate, "_load_roster_names", return_value=set()),
             mock.patch.object(prs.gate, "is_single_reviewer_exception", return_value=False),
@@ -331,7 +364,7 @@ def _charter_comment(requestor: str, verdict: str, created_at: datetime) -> dict
 class ContentStalenessTests(unittest.TestCase):
     REPO = "noorinalabs/noorinalabs-main"
 
-    def _compute_with_real_comment_check(self, comments, *, roster, latest_content, reviews=()):
+    def _compute_with_real_comment_check(self, comments, *, roster, commits, reviews=()):
         """Drive compute_review_state through the REAL check_comment_reviews.
 
         Only the network boundary (`gh api`) is faked, so `content_ts` actually
@@ -353,7 +386,7 @@ class ContentStalenessTests(unittest.TestCase):
                 # reason (caught by the anti-vacuity guard while writing these).
                 return_value=_pr_data(head_ref="W.Mwangi/1040-example", reviews=reviews),
             ),
-            mock.patch.object(prs.gate, "get_latest_content_commit", return_value=latest_content),
+            mock.patch.object(prs.gate, "fetch_pr_commits", return_value=commits),
             mock.patch.object(prs.gate.subprocess, "run", side_effect=fake_run),
             mock.patch.object(prs.gate, "_load_roster_names", return_value=roster),
             mock.patch.object(prs.gate, "is_single_reviewer_exception", return_value=False),
@@ -373,7 +406,7 @@ class ContentStalenessTests(unittest.TestCase):
                 _charter_comment("Nino Kavtaradze", "Approved", _AFTER),
             ],
             roster={"lucas ferreira", "nino kavtaradze"},
-            latest_content=_CONTENT_COMMIT,
+            commits=_CONTENT_COMMITS,
         )
         self.assertEqual(state.distinct_reviewer_count, 2)
         self.assertEqual(state.stale_verdicts, [])
@@ -390,7 +423,7 @@ class ContentStalenessTests(unittest.TestCase):
                 _charter_comment("Nino Kavtaradze", "Approved", _BEFORE),
             ],
             roster={"lucas ferreira", "nino kavtaradze"},
-            latest_content=_CONTENT_COMMIT,
+            commits=_CONTENT_COMMITS,
         )
         self.assertEqual(state.distinct_reviewer_count, 0)
         self.assertEqual(state.comment_reviewers, [])
@@ -407,7 +440,7 @@ class ContentStalenessTests(unittest.TestCase):
                 _charter_comment("Nino Kavtaradze", "Approved", _AFTER),
             ],
             roster={"lucas ferreira", "nino kavtaradze"},
-            latest_content=_CONTENT_COMMIT,
+            commits=_CONTENT_COMMITS,
         )
         self.assertEqual(state.comment_reviewers, ["nino kavtaradze"])
         self.assertEqual(state.distinct_reviewer_count, 1)
@@ -418,7 +451,14 @@ class ContentStalenessTests(unittest.TestCase):
         """Direct kill-shot for the #1046 mutation on the `:135` call site."""
         captured = {}
 
-        def fake_check(number, lastname, repo=None, content_ts=None, branch_author_initial=""):
+        def fake_check(
+            number,
+            lastname,
+            repo=None,
+            content_ts=None,
+            commit_author_identities=(),
+            branch_author_initial="",
+        ):
             captured["content_ts"] = content_ts
             return _comment_result(reviewers=())
 
@@ -426,7 +466,7 @@ class ContentStalenessTests(unittest.TestCase):
             mock.patch.object(
                 prs.gate, "get_pr_data", return_value=_pr_data(head_ref="L.Ferreira/1040-x")
             ),
-            mock.patch.object(prs.gate, "get_latest_content_commit", return_value=_CONTENT_COMMIT),
+            mock.patch.object(prs.gate, "fetch_pr_commits", return_value=_CONTENT_COMMITS),
             mock.patch.object(prs.gate, "check_comment_reviews", side_effect=fake_check),
             mock.patch.object(prs.gate, "_load_roster_names", return_value=set()),
             mock.patch.object(prs.gate, "is_single_reviewer_exception", return_value=False),
@@ -452,7 +492,14 @@ class ContentStalenessTests(unittest.TestCase):
         """
         captured = {}
 
-        def fake_check(number, lastname, repo=None, content_ts=None, branch_author_initial=""):
+        def fake_check(
+            number,
+            lastname,
+            repo=None,
+            content_ts=None,
+            commit_author_identities=(),
+            branch_author_initial="",
+        ):
             captured["content_ts"] = content_ts
             captured["lastname"] = lastname
             captured["initial"] = branch_author_initial
@@ -464,7 +511,7 @@ class ContentStalenessTests(unittest.TestCase):
                 "get_pr_data",
                 return_value=_pr_data(head_ref="deployments/phase-9/wave-26"),
             ),
-            mock.patch.object(prs.gate, "get_latest_content_commit", return_value=_CONTENT_COMMIT),
+            mock.patch.object(prs.gate, "fetch_pr_commits", return_value=_CONTENT_COMMITS),
             mock.patch.object(prs.gate, "check_comment_reviews", side_effect=fake_check),
             mock.patch.object(prs.gate, "_load_roster_names", return_value=set()),
             mock.patch.object(prs.gate, "is_single_reviewer_exception", return_value=False),
@@ -484,7 +531,7 @@ class ContentStalenessTests(unittest.TestCase):
         state = self._compute_with_real_comment_check(
             [],
             roster=set(),
-            latest_content=_CONTENT_COMMIT,
+            commits=_CONTENT_COMMITS,
             reviews=[
                 {
                     "author": {"login": "stale-reviewer"},
@@ -506,14 +553,14 @@ class ContentStalenessTests(unittest.TestCase):
         self.assertFalse(state.passes())
 
     def test_no_non_merge_commits_means_nothing_is_stale(self):
-        """`get_latest_content_commit` returning None = no content binding."""
+        """An empty commit list = no non-merge commits = no content binding."""
         state = self._compute_with_real_comment_check(
             [
                 _charter_comment("Lucas Ferreira", "Approved", _BEFORE),
                 _charter_comment("Nino Kavtaradze", "Approved", _BEFORE),
             ],
             roster={"lucas ferreira", "nino kavtaradze"},
-            latest_content=None,
+            commits=[],
         )
         self.assertEqual(state.distinct_reviewer_count, 2)
         self.assertEqual(state.stale_verdicts, [])
@@ -537,7 +584,7 @@ class ContentStalenessTests(unittest.TestCase):
             mock.patch.object(prs.gate, "get_pr_data", return_value=_pr_data()),
             mock.patch.object(
                 prs.gate,
-                "get_latest_content_commit",
+                "fetch_pr_commits",
                 side_effect=prs.gate.CommitFetchError("boom"),
             ),
             mock.patch.object(prs.gate, "check_comment_reviews", return_value=_comment_result()),
@@ -556,7 +603,7 @@ class ContentStalenessTests(unittest.TestCase):
         state = self._compute_with_real_comment_check(
             [_charter_comment("Lucas Ferreira", "Approved", _BEFORE)],
             roster={"lucas ferreira"},
-            latest_content=_CONTENT_COMMIT,
+            commits=_CONTENT_COMMITS,
         )
 
         text = prs._render_text(state)
@@ -659,7 +706,7 @@ class UndeterminableRepoAndScanTests(unittest.TestCase):
         }
         with (
             mock.patch.object(prs.gate, "get_pr_data", return_value=pr_data),
-            mock.patch.object(prs.gate, "get_latest_content_commit", return_value=None),
+            mock.patch.object(prs.gate, "fetch_pr_commits", return_value=[]),
             mock.patch.object(prs.gate, "check_comment_reviews", return_value=undetermined),
             mock.patch.object(prs.gate, "_load_roster_names", return_value={"aino virtanen"}),
         ):
@@ -809,7 +856,7 @@ class CommentScanReportedInTheReportTests(unittest.TestCase):
         with (
             mock.patch.object(prs.gate, "get_pr_data", return_value=pr_data),
             mock.patch.object(prs.gate.subprocess, "run", side_effect=fake_run),
-            mock.patch.object(prs.gate, "get_latest_content_commit", return_value=None),
+            mock.patch.object(prs.gate, "fetch_pr_commits", return_value=[]),
             mock.patch.object(prs.gate, "_load_roster_names", return_value={"lucas ferreira"}),
         ):
             state = prs.compute_review_state("691", repo="noorinalabs/noorinalabs-deploy")
@@ -820,6 +867,115 @@ class CommentScanReportedInTheReportTests(unittest.TestCase):
         # #1206 defect (this was `[]` / 0 before the fix).
         self.assertEqual(state.comment_reviewers, ["lucas ferreira"])
         self.assertEqual(state.distinct_reviewer_count, 1)
+
+
+class CommitAuthorScanModeReportTests(unittest.TestCase):
+    """#1210 at the report layer: which author source the exclusion used.
+
+    The driver replays the gate, so if it could not render the new mode an
+    operator running `pr_review_state` ahead of a merge would see a reviewer
+    count they could not reconcile with the comment thread.
+    """
+
+    @staticmethod
+    def _state(comment_scan, **overrides):
+        kwargs = dict(
+            pr_number="1210",
+            repo="noorinalabs/noorinalabs-main",
+            head_ref="feature/hand-made",
+            branch_author_lastname=None,
+            formal_reviewers=[],
+            comment_reviewers=["aino virtanen"],
+            non_roster_requestors=[],
+            distinct_reviewer_count=1,
+            wave_bootstrap_exception=False,
+            reviews_missing_tech_debt=[],
+            tech_debt_issue_numbers=[],
+            content_sha="837c272a",
+            comment_scan=comment_scan,
+        )
+        kwargs.update(overrides)
+        return prs.ReviewState(**kwargs)
+
+    def test_commit_author_mode_names_the_derived_author(self):
+        text = prs._render_text(
+            self._state(
+                prs.gate.COMMENT_SCAN_COMMIT_AUTHOR_EXCLUDED,
+                commit_authors=["Nino Kavtaradze"],
+            )
+        )
+        self.assertIn("COMMIT IDENTITY", text)
+        self.assertIn("Nino Kavtaradze", text)
+        self.assertIn("self-review exclusion active", text)
+
+    def test_the_two_no_ref_author_modes_read_differently(self):
+        """Exclusion-applied vs exclusion-unavailable are opposite facts about
+        whether the count below them can be trusted."""
+        applied = prs._render_text(
+            self._state(
+                prs.gate.COMMENT_SCAN_COMMIT_AUTHOR_EXCLUDED,
+                commit_authors=["Nino Kavtaradze"],
+            )
+        )
+        unavailable = prs._render_text(self._state(prs.gate.COMMENT_SCAN_NO_BRANCH_AUTHOR))
+        self.assertNotEqual(applied, unavailable)
+        self.assertIn("COMMIT IDENTITY", applied)
+        self.assertNotIn("COMMIT IDENTITY", unavailable)
+        self.assertIn("no self-review exclusion was applied", unavailable)
+        self.assertNotIn("no self-review exclusion was applied", applied)
+
+    def test_json_carries_the_derived_authors(self):
+        payload = json.loads(
+            prs._render_json(
+                self._state(
+                    prs.gate.COMMENT_SCAN_COMMIT_AUTHOR_EXCLUDED,
+                    commit_authors=["Nino Kavtaradze"],
+                )
+            )
+        )
+        self.assertEqual(payload["comment_scan"], prs.gate.COMMENT_SCAN_COMMIT_AUTHOR_EXCLUDED)
+        self.assertEqual(payload["commit_authors"], ["Nino Kavtaradze"])
+
+    def test_compute_review_state_propagates_the_commit_derived_author(self):
+        """Wiring: the field must be populated in production, not just settable.
+
+        Driven through the REAL `resolve_review_verdicts`, on a non-charter ref
+        whose commits name the very persona who posted one of the verdicts —
+        the #1210 case. The self-approval must be subtracted AND named.
+        """
+        pr_data = _pr_data(head_ref="feature/hand-made")
+        comments = [
+            _charter_comment("Nino Kavtaradze", "Approved", _AFTER),
+            _charter_comment("Lucas Ferreira", "Approved", _AFTER),
+        ]
+
+        def fake_run(args, capture_output, text, timeout):  # noqa: ARG001
+            result = mock.MagicMock()
+            result.returncode = 0
+            result.stdout = json.dumps(comments)
+            return result
+
+        with (
+            mock.patch.object(prs.gate, "get_pr_data", return_value=pr_data),
+            mock.patch.object(prs.gate.subprocess, "run", side_effect=fake_run),
+            mock.patch.object(
+                prs.gate,
+                "fetch_pr_commits",
+                return_value=[_api_commit("c0", _NOW, name="Nino Kavtaradze")],
+            ),
+            mock.patch.object(
+                prs.gate,
+                "_load_roster_names",
+                return_value={"lucas ferreira", "nino kavtaradze"},
+            ),
+        ):
+            state = prs.compute_review_state("1210", repo="noorinalabs/noorinalabs-main")
+
+        self.assertEqual(state.comment_scan, prs.gate.COMMENT_SCAN_COMMIT_AUTHOR_EXCLUDED)
+        self.assertEqual(state.commit_authors, ["Nino Kavtaradze"])
+        self.assertEqual(state.comment_reviewers, ["lucas ferreira"])
+        self.assertEqual(state.distinct_reviewer_count, 1)
+        self.assertFalse(state.passes())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #1210.

## The hole

Self-review exclusion only ever had a **subject** on a `{Initial}.{Lastname}` head ref. On every other ref `is_branch_author` returned `False` for everyone, and the branch author's own `Approved` comment walked into the reviewer set:

| | pre-#1207 | post-#1207 | correct |
|---|---|---|---|
| Human persona, non-charter branch, self-approves + one genuine reviewer | 0/2 blocked (wrongly — the genuine reviewer was uncounted too) | **2/2 PASSES** | 1/2 blocked |

`deployments/**` has carried the identical hole since main#294. Measured exposure (655 PRs, 7 repos): 568 persona-prefixed (86.7%, unaffected), 79 `deployments/**` (pre-existing), 4 dependabot, 4 newly exposed.

## How the author is derived

Every persona commits with `-c user.name="{First} {Last}"`, so the commits carry what the ref does not.

- **`fetch_pr_commits`** does the ONE round-trip. `latest_content_commit` (T_content, #950) and `commit_author_identities` (#1210) are now **pure analyses** over its result. This replaces `get_latest_content_commit`, which already fetched the full commit objects and discarded `commit.author` — no new API call.
- Per non-merge commit, two sources are **unioned**: `commit.author.name`, and the `+alias` in `commit.author.email` via `persona_alias_from_email`. A union can only add exclusions, so it moves strictly toward blocking.
- **`is_self_review`** is the one predicate; both author sources go through `charter_trailer.is_branch_author` (#1172). No new surname comparison exists in the diff.
- **Scope: only where the ref names nobody.** On a persona ref the prefix is the author the human declared and behaviour is byte-for-byte unchanged — otherwise anyone who pushed a fixup to someone else's branch would newly lose their review, on the 86.7% path, to fix nothing.

## Degradation — every case toward blocking

| case | behaviour |
|---|---|
| commit list unfetchable | `CommitFetchError` → **hard block** (unchanged #950). No commit data ⇒ no author ⇒ stop. |
| bare `parametrization@gmail.com` | contributes **nothing**. A squash re-authors to the bare principal (#1177), so that address is evidence identity was *destroyed*. `roster.json` maps it to `Steven French`; this deliberately does **not** follow that map — #1181 reached the same verdict on the same address, and this reuses **#1181's own `_PERSONA_ALIAS_RE`** rather than adding a second regex. |
| bot | `dependabot[bot]` matches no roster persona ⇒ excludes nobody, both approvals still count (deploy#691 stays fixed). Its **address** yields no identity at all, so no human author is fabricated. Neutral by construction, not by a blocklist. |
| merge-only branch | no authored commits ⇒ no identity ⇒ pre-existing state, no regression. |
| wrong / ambiguous match | **over**-excludes and blocks, and the block message names every derived identity — visible, not silent. |

Merge-commit authors are skipped, matching `latest_content_commit`: running `gh pr merge` into a wave branch does not make the release coordinator its author, and excluding them would false-block the wave merges they must review.

## Strictly non-relaxing

The derivation feeds **only** the exclusion, and the exclusion can only *remove* reviewers. `total_distinct` can therefore only fall. `check()` allows on `>= 2`, or on `== 1` with the wave-bootstrap exception — from a blocking state (`0`, or `1` without the exception) a shrinking set reaches neither.

`StrictlyNonRelaxingTests` checks this as a property, not as an argument: over a 9-case matrix of (head ref x commit authors), the post-fix reviewer set must be a **subset** of the same resolve with the derivation switched off, plus a non-vacuity case requiring at least one matrix entry to strictly shrink.

## Mutation results

| mutation | tests that went RED |
|---|---|
| revert the derivation (`commit_authors = ()`) | 6 |
| hand-rolled surname comparison instead of `is_branch_author` | 2 |
| follow `roster.json`'s bare-principal map | 4 |
| include merge-commit authors | 2 |
| apply the derivation on persona refs too | 1 |
| `refine_comment_scan_scope` relabels unconditionally | 2 |

## Gates

`pre-commit run --all-files` clean; push stage (mypy 183 files, both pytest suites, skills, budgets, drift) clean; `pre_commit_ci_sync.py .` — `OK: pre-commit config mirrors all CI-enforced checks`. **3311 passed, 639 subtests.**

## Residuals, deliberate

1. **Persona refs are not cross-checked against commit identity.** A `A.Virtanen/…` branch whose commits are authored by someone else still excludes only Aino. Fixing it changes the majority path and trades a real false-block risk for a hole that requires both a mislabelled branch *and* a self-approval. Out of #1210's scope; flag if wanted as a follow-on.
2. **`ontology/conventions.md:240`** still mislabels this hook — that is **#1209**, not touched here.
3. **`ontology/checksums.json`** not marked dirty (the tracker resolves `$CLAUDE_PROJECT_DIR` to the main checkout, not this worktree). #1207 — same four files — did the same; `/ontology-rebuild` reconciles out of band.
4. **Shape change for #1211:** bot/wave refs whose commits carry any author string now report `commit-author-excluded` rather than `no-branch-author`, so #1211's allow-path advisory will fire on a narrower set. Its residual value is unchanged but its trigger population is smaller.

---
Requestor: Aino Virtanen
Requestee: Nino Kavtaradze, Nadia Khoury
RequestOrReplied: Request
TechDebt: none
