### PR TITLE
audit(G6): org_repos single source of truth

### DIFF
--- a/.claude/hooks/session_handoff.py
+++ b/.claude/hooks/session_handoff.py
@@ -14,6 +14,7 @@ Exit codes:
 """
 
 import json
+import os
 import re
 import subprocess
 import sys
@@ -21,6 +22,10 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+_LIB_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "lib")
+sys.path.insert(0, os.path.abspath(_LIB_DIR))
+from org_repos import ALL_REPOS  # noqa: E402
 
 # Project memory is version-controlled in-repo (#732 relocation) so it travels
 # with a git pull. The handoff file itself stays gitignored — it's per-session
@@ -64,18 +69,14 @@ def _get_git_state() -> dict:
 
 
 def _get_open_prs() -> list[str]:
-    """Get open PRs across all repos."""
-    repos = [
-        "noorinalabs-main",
-        "noorinalabs-isnad-graph",
-        "noorinalabs-user-service",
-        "noorinalabs-deploy",
-        "noorinalabs-design-system",
-        "noorinalabs-landing-page",
-        "noorinalabs-data-acquisition",
-    ]
+    """Get open PRs across all repos.
+
+    Queries org_repos.ALL_REPOS (main#1118 / audit G6) — the previous hand-copied
+    list here omitted noorinalabs-isnad-ingest-platform (BUG-08), silently
+    querying only 7 of 8 org repos.
+    """
     prs = []
-    for repo in repos:
+    for repo in ALL_REPOS:
         raw = _run(
             f"gh pr list --repo noorinalabs/{repo} --state open --json number,title --limit 5",
             timeout=15,

--- a/.claude/hooks/tests/test_session_handoff.py
+++ b/.claude/hooks/tests/test_session_handoff.py
@@ -109,6 +109,40 @@ class GetWaveStatusTests(unittest.TestCase):
         self.assertEqual(result, "No cross-repo-status.json found")
 
 
+class GetOpenPrsQueriesAllOrgReposTests(unittest.TestCase):
+    """main#1118 / audit G6, BUG-08 regression: `_get_open_prs()` used to iterate
+    a hand-copied 7-repo list that silently omitted
+    noorinalabs-isnad-ingest-platform. It now iterates org_repos.ALL_REPOS, so
+    this asserts all 8 org repos are queried (non-vacuous: fails if the count
+    regresses to 7, or if a caller reintroduces a hand-copied list)."""
+
+    def test_queries_all_eight_repos(self) -> None:
+        from unittest.mock import patch
+
+        queried: list[str] = []
+
+        def _fake_run(cmd: str, cwd: str | None = None, timeout: int = 10) -> str:
+            for repo in hook.ALL_REPOS:
+                if f"noorinalabs/{repo}" in cmd:
+                    queried.append(repo)
+                    break
+            return "[]"
+
+        with patch.object(hook, "_run", side_effect=_fake_run):
+            hook._get_open_prs()
+
+        self.assertEqual(sorted(queried), sorted(hook.ALL_REPOS))
+        self.assertEqual(len(queried), 8)
+        self.assertIn("noorinalabs-isnad-ingest-platform", queried)
+
+    def test_all_repos_is_org_repos_ssot(self) -> None:
+        # session_handoff.ALL_REPOS must BE org_repos.ALL_REPOS (imported, not
+        # re-derived) so the two can never drift apart again.
+        import org_repos
+
+        self.assertIs(hook.ALL_REPOS, org_repos.ALL_REPOS)
+
+
 class HandoffPathLocationTests(unittest.TestCase):
     """#741: the Stop hook must write the handoff into the in-repo,
     version-controlled .claude/memory/ — NOT the user-space auto-memory dir —

--- a/.claude/hooks/tests/test_warn_ghcr_image.py
+++ b/.claude/hooks/tests/test_warn_ghcr_image.py
@@ -144,5 +144,26 @@ class WarningBehaviorTests(unittest.TestCase):
         self.assertIsNone(hook.check(_input(cmd)))
 
 
+class RepoImageMapDriftGuardTests(unittest.TestCase):
+    """main#1118 / audit G6: REPO_IMAGE_MAP is a deliberate GHCR-publishing
+    SUBSET of the org's children, not the full org_repos.CHILD_REPOS list —
+    but every key must still be a real, canonically-spelled child repo name,
+    or a typo/rename would silently drift with nothing to announce it."""
+
+    def test_every_key_is_a_canonical_child_repo(self):
+        sys.path.insert(0, str(_HOOKS_DIR.parent / "lib"))
+        from org_repos import CHILD_REPOS
+
+        self.assertTrue(set(hook.REPO_IMAGE_MAP).issubset(CHILD_REPOS))
+
+    def test_map_is_a_proper_subset_not_the_full_list(self):
+        # Documents the intentional divergence so a future "helpfully" full
+        # sync doesn't silently widen this GHCR-only map to non-publishing repos.
+        sys.path.insert(0, str(_HOOKS_DIR.parent / "lib"))
+        from org_repos import CHILD_REPOS
+
+        self.assertLess(set(hook.REPO_IMAGE_MAP), set(CHILD_REPOS))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.claude/hooks/validate_wave_audit.py
+++ b/.claude/hooks/validate_wave_audit.py
@@ -199,6 +199,10 @@ from pathlib import Path
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from annunaki_log import log_pretooluse_block  # noqa: E402
 
+_LIB_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "lib")
+sys.path.insert(0, os.path.abspath(_LIB_DIR))
+from org_repos import ALL_REPOS  # noqa: E402
+
 # Skills gated by this hook. Exact match against tool_input.skill.
 _GATED_SKILLS = frozenset({"wave-wrapup", "wave-retro", "handoff"})
 
@@ -222,18 +226,11 @@ _GATED_SKILLS = frozenset({"wave-wrapup", "wave-retro", "handoff"})
 # green, but not a dead end either.
 _COVERAGE_BLOCKING_SKILLS = frozenset({"wave-wrapup", "wave-retro"})
 
-# Org-known repos for cross-repo audit. Sourced from charter skills.md
-# § Audit command. This list MUST stay in sync with that charter section.
-_ORG_REPOS = (
-    "noorinalabs-main",
-    "noorinalabs-isnad-graph",
-    "noorinalabs-user-service",
-    "noorinalabs-deploy",
-    "noorinalabs-design-system",
-    "noorinalabs-landing-page",
-    "noorinalabs-data-acquisition",
-    "noorinalabs-isnad-ingest-platform",
-)
+# Org-known repos for cross-repo audit. Sourced from org_repos.py (main#1118
+# / audit G6) — the single source of truth for the org repo list; the charter
+# skills.md § Audit command example command should stay in sync with it too,
+# but this constant itself no longer hand-copies the list.
+_ORG_REPOS = ALL_REPOS
 
 # Carry-forward detection patterns (case-insensitive). Any one suffices.
 # Anchored loosely — looking for explicit author intent, not accidental phrasing.

--- a/.claude/hooks/warn_ghcr_image.py
+++ b/.claude/hooks/warn_ghcr_image.py
@@ -45,7 +45,13 @@ from _shell_parse import (  # noqa: E402
 # Deploy-related workflow names/files
 DEPLOY_PATTERNS = re.compile(r"deploy|release|cd[.-]|deliver", re.IGNORECASE)
 
-# Map of repo short names to GHCR image paths
+# Map of repo short names to GHCR image paths. Deliberately NOT the full
+# org_repos.CHILD_REPOS membership (main#1118 / audit G6) — this is the
+# GHCR-image-publishing subset of children, a different axis (build/publish
+# topology) than "which repos exist in the org". test_warn_ghcr_image.py
+# asserts every key here is a real child repo name (org_repos.CHILD_REPOS) —
+# catches a typo/rename drifting silently — without forcing full membership
+# or importing org_repos into this advisory hook's runtime path.
 REPO_IMAGE_MAP = {
     "noorinalabs-isnad-graph": "ghcr.io/noorinalabs/noorinalabs-isnad-graph",
     "noorinalabs-landing-page": "ghcr.io/noorinalabs/noorinalabs-landing-page",

--- a/.claude/lib/apply_implementor_labels.py
+++ b/.claude/lib/apply_implementor_labels.py
@@ -43,16 +43,11 @@ from collections import Counter, defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any
 
-ALL_REPOS = [
-    "noorinalabs-main",
-    "noorinalabs-isnad-graph",
-    "noorinalabs-user-service",
-    "noorinalabs-deploy",
-    "noorinalabs-design-system",
-    "noorinalabs-data-acquisition",
-    "noorinalabs-isnad-ingest-platform",
-    "noorinalabs-landing-page",
-]
+from org_repos import ALL_REPOS as _ALL_REPOS_TUPLE
+
+# main#1118 / audit G6: sourced from org_repos.py, the org repo-list SSOT.
+# Kept as a list (not the imported tuple) since callers mutate/slice it.
+ALL_REPOS = list(_ALL_REPOS_TUPLE)
 PERSONA_RE = re.compile(r"^[A-Z][A-Z.-]*_[A-Z][A-Z.-]*$")
 PERSONA_SPACE_RE = re.compile(r"^[A-Z][a-z][A-Za-z'’-]* [A-Z][A-Za-z'’-]+$")
 BRANCH_RE = re.compile(r"^([A-Za-z])\.([A-Za-z][A-Za-z'-]*)/0*([0-9]+)-")

--- a/.claude/lib/check_child_checkouts.py
+++ b/.claude/lib/check_child_checkouts.py
@@ -43,6 +43,11 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 
+# The 7 canonical child repos (CLAUDE.md Repository Map), sourced from
+# org_repos.py (main#1118 / audit G6) — the org repo-list SSOT. Kept in sync
+# with the session-start Step 0 worktree iteration list.
+from org_repos import CHILD_REPOS
+
 # Reuse the deterministic git primitives + safe fast-forward from sync_main so
 # the two guards share one implementation of "what is dirty" / "how to ff".
 from sync_main import (
@@ -54,18 +59,6 @@ from sync_main import (
 )
 from sync_main import (
     sync_main as _sync_branch,
-)
-
-# The 7 canonical child repos (CLAUDE.md Repository Map). Kept in sync with the
-# session-start Step 0 worktree iteration list.
-CHILD_REPOS: tuple[str, ...] = (
-    "noorinalabs-isnad-graph",
-    "noorinalabs-user-service",
-    "noorinalabs-deploy",
-    "noorinalabs-design-system",
-    "noorinalabs-data-acquisition",
-    "noorinalabs-isnad-ingest-platform",
-    "noorinalabs-landing-page",
 )
 
 # Statuses that need a human call (the FLAGGED block). Everything else

--- a/.claude/lib/ontology_gen/aggregate.py
+++ b/.claude/lib/ontology_gen/aggregate.py
@@ -36,22 +36,19 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+from org_repos import CHILD_REPOS
+
 from .generate import generate
 from .model import CodeGraph, Edge, GraphDict, Node, serialize_graph
 
 # Short namespace -> repo directory relative to the noorinalabs-main root. The short
 # names match the overlay's repo vocabulary (domain.yaml ``repos: [isnad-graph, ...]``).
-# Child repos are cloned beneath the parent root (CLAUDE.md § Repository Map); "main" is
-# the parent itself (".") so its own index is rolled in alongside the children.
+# Child repos are cloned beneath the parent root, sourced from org_repos.CHILD_REPOS
+# (main#1118 / audit G6, the org repo-list SSOT); "main" is the parent itself (".")
+# so its own index is rolled in alongside the children.
 DEFAULT_REPOS: dict[str, str] = {
     "main": ".",
-    "isnad-graph": "noorinalabs-isnad-graph",
-    "user-service": "noorinalabs-user-service",
-    "deploy": "noorinalabs-deploy",
-    "design-system": "noorinalabs-design-system",
-    "data-acquisition": "noorinalabs-data-acquisition",
-    "isnad-ingest-platform": "noorinalabs-isnad-ingest-platform",
-    "landing-page": "noorinalabs-landing-page",
+    **{r.removeprefix("noorinalabs-"): r for r in CHILD_REPOS},
 }
 
 # Where each repo's generated per-repo index lives (relative to that repo's root).

--- a/.claude/lib/org_repos.py
+++ b/.claude/lib/org_repos.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Single source of truth for the org repo list (main#1118, audit item G6).
+
+Before this module, the canonical repo set was retyped as a literal list in
+~9 places across `.claude/lib` and `.claude/hooks` (plus assorted single-repo
+mentions), each hand-copied from CLAUDE.md's `## Repository Map` table with
+no shared source. One of those copies drifted — `.claude/hooks/
+session_handoff.py`'s `_get_open_prs()` list omitted
+`noorinalabs-isnad-ingest-platform` after the repo was added to CLAUDE.md,
+so `/handoff` silently queried only 7 of 8 repos with nothing announcing the
+gap (BUG-08). This module is the one place the canonical membership and
+canonical order live; every other module imports from here instead of
+retyping the list.
+
+Canonical order matches CLAUDE.md's `## Repository Map` table exactly (main
+first, then children in table row order), so a drift check against that
+table is a pure sequence comparison — see
+`.claude/lib/tests/test_org_repos.py`, which parses the table and asserts
+`CHILD_REPOS` matches it row-for-row (the issue's explicit "prose→code test"
+ask).
+
+Not every consumer wants the full membership — importing this module does
+NOT mean "use `ALL_REPOS`/`CHILD_REPOS` verbatim everywhere":
+
+  * `roster_union_sync.py` deliberately EXCLUDES `noorinalabs-deploy` (it
+    keeps no aggregated `roster.json`, so there is nothing to cross-check) —
+    filter `CHILD_REPOS`, don't hand-list a replacement.
+  * `warn_ghcr_image.py` deliberately covers ONLY the GHCR-image-publishing
+    subset of children — a different axis (build/publish topology) than
+    "which repos exist in the org" — so it keeps its own explicit dict
+    rather than importing a list from here.
+
+Import convention: this module has no dependencies and lives flat in
+`.claude/lib/`, so `import org_repos` resolves for any caller that already
+has `.claude/lib` on `sys.path` (either via `PYTHONPATH=.claude/lib`, or via
+the `sys.path.insert(0, str(Path(__file__).resolve().parent.parent))`
+pattern every `.claude/lib/tests/test_*.py` module uses, or via the
+`.claude/hooks/*.py` two-insert pattern — own dir, then `../lib` — e.g.
+`gh_quota_gate.py`).
+"""
+
+from __future__ import annotations
+
+# GitHub org/owner every repo below lives under.
+ORG = "noorinalabs"
+
+# The parent repo this file lives in. `.gitignore`s the children below and
+# clones them as independent git repos beneath it (CLAUDE.md § Architecture).
+MAIN_REPO = "noorinalabs-main"
+
+# The 7 child repos, in CLAUDE.md's `## Repository Map` table order.
+CHILD_REPOS: tuple[str, ...] = (
+    "noorinalabs-isnad-graph",
+    "noorinalabs-user-service",
+    "noorinalabs-deploy",
+    "noorinalabs-design-system",
+    "noorinalabs-data-acquisition",
+    "noorinalabs-isnad-ingest-platform",
+    "noorinalabs-landing-page",
+)
+
+# main + all 7 children: main first, then CHILD_REPOS in table order.
+ALL_REPOS: tuple[str, ...] = (MAIN_REPO, *CHILD_REPOS)

--- a/.claude/lib/premise_check.py
+++ b/.claude/lib/premise_check.py
@@ -76,6 +76,8 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from org_repos import ALL_REPOS
+
 # Repo root = two parents above .claude/lib/ (lib -> .claude -> root). Resolved
 # from this file so the default repos-root is correct from any cwd or worktree.
 _REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -149,8 +151,10 @@ _BACKTICK_RE = re.compile(r"`([^`\n]+)`")
 # is a real repo path even without a recognized extension (main#1047: a slash
 # alone is NOT evidence — "A/B", "recall/precision", "origin/main", "986/650"
 # all contain "/" and are not paths). Covers this org's top-level source roots
-# plus every child repo name (a cross-repo mention like
-# `noorinalabs-deploy/terraform/...` is a real path even mid-prose).
+# plus every repo name (a cross-repo mention like
+# `noorinalabs-deploy/terraform/...` is a real path even mid-prose). The repo
+# names come from org_repos.ALL_REPOS (main#1118 / audit G6, the org repo-list
+# SSOT) rather than being hand-copied here.
 _KNOWN_ROOT_COMPONENTS = frozenset(
     {
         "src",
@@ -167,16 +171,8 @@ _KNOWN_ROOT_COMPONENTS = frozenset(
         "alembic",
         "docker",
         "integration-tests",
-        "noorinalabs-main",
-        "noorinalabs-isnad-graph",
-        "noorinalabs-user-service",
-        "noorinalabs-deploy",
-        "noorinalabs-design-system",
-        "noorinalabs-data-acquisition",
-        "noorinalabs-isnad-ingest-platform",
-        "noorinalabs-landing-page",
     }
-)
+) | frozenset(ALL_REPOS)
 
 # Known git refs / ref prefixes: `origin/main`, `refs/heads/x`, `HEAD` are
 # never file paths even though `origin/main` contains a slash (main#1047).

--- a/.claude/lib/red_sweep.py
+++ b/.claude/lib/red_sweep.py
@@ -46,20 +46,12 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
-_ORG = "noorinalabs"
-_MAIN_REPO = "noorinalabs-main"
+from org_repos import ALL_REPOS as CANONICAL_REPOS
+from org_repos import MAIN_REPO as _MAIN_REPO
+from org_repos import ORG as _ORG
 
-#: All canonical org repos (CLAUDE.md Repository Map) — the cron sweeps every one.
-CANONICAL_REPOS: tuple[str, ...] = (
-    "noorinalabs-main",
-    "noorinalabs-isnad-graph",
-    "noorinalabs-user-service",
-    "noorinalabs-deploy",
-    "noorinalabs-design-system",
-    "noorinalabs-data-acquisition",
-    "noorinalabs-isnad-ingest-platform",
-    "noorinalabs-landing-page",
-)
+#: All canonical org repos (CLAUDE.md Repository Map) — the cron sweeps every
+#: one. Sourced from org_repos.py (main#1118 / audit G6), the org repo-list SSOT.
 
 #: Publish/deploy/release-class workflow names (same pattern the skill used).
 _WORKFLOW_CLASS_RE = re.compile(r"publish|deploy|release|promote|ghcr|image", re.IGNORECASE)

--- a/.claude/lib/roster_union_sync.py
+++ b/.claude/lib/roster_union_sync.py
@@ -62,19 +62,17 @@ import subprocess
 import sys
 from pathlib import Path
 
+from org_repos import CHILD_REPOS as _ALL_CHILD_REPOS
+
 # The org's child repos that publish an aggregated `.claude/team/roster.json`.
-# Mirrors the repo map in CLAUDE.md. `noorinalabs-deploy` is intentionally
-# absent: it keeps only a per-member `roster/` directory (no aggregated
-# roster.json), so there is nothing to fetch — its personas are folded into the
-# parent roster directly. A child not listed here is simply not cross-checked;
-# add it when it grows an aggregated roster.json.
-DEFAULT_CHILD_REPOS: tuple[str, ...] = (
-    "noorinalabs-isnad-graph",
-    "noorinalabs-user-service",
-    "noorinalabs-design-system",
-    "noorinalabs-data-acquisition",
-    "noorinalabs-isnad-ingest-platform",
-    "noorinalabs-landing-page",
+# Filtered from org_repos.CHILD_REPOS (main#1118 / audit G6, the org repo-list
+# SSOT) — `noorinalabs-deploy` is intentionally EXCLUDED: it keeps only a
+# per-member `roster/` directory (no aggregated roster.json), so there is
+# nothing to fetch — its personas are folded into the parent roster directly.
+# A child not listed here is simply not cross-checked; add it back when it
+# grows an aggregated roster.json.
+DEFAULT_CHILD_REPOS: tuple[str, ...] = tuple(
+    r for r in _ALL_CHILD_REPOS if r != "noorinalabs-deploy"
 )
 
 ROSTER_PATH_IN_REPO = ".claude/team/roster.json"

--- a/.claude/lib/tests/test_org_repos.py
+++ b/.claude/lib/tests/test_org_repos.py
@@ -1,0 +1,105 @@
+"""Tests for org_repos — the org repo-list SSOT (main#1118, audit item G6).
+
+Covers the constant shapes (membership, no duplicates, main+children
+composition) and the drift gate the issue explicitly asked for: a
+prose→code test asserting `CHILD_REPOS` matches CLAUDE.md's
+`## Repository Map` table, row for row.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import unittest
+from pathlib import Path
+
+# Package lives at .claude/lib/org_repos.py; this test is at .claude/lib/tests/.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from org_repos import ALL_REPOS, CHILD_REPOS, MAIN_REPO, ORG  # noqa: E402
+
+# .claude/lib/tests/test_org_repos.py -> repo root is 3 parents up.
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+CLAUDE_MD = REPO_ROOT / "CLAUDE.md"
+
+_TABLE_ROW_RE = re.compile(r"^\|\s*`(noorinalabs-[a-z-]+)`\s*\|", re.MULTILINE)
+
+
+def _table_repos_from_claude_md(text: str) -> list[str]:
+    """Backtick-quoted repo names from CLAUDE.md's Repository Map table, in row order.
+
+    Isolates the section between the ``## Repository Map`` heading and the next
+    ``## `` heading, then pulls the first (Repository) column of every data row.
+    """
+    match = re.search(r"## Repository Map\n(.*?)\n## ", text, re.S)
+    if not match:
+        return []
+    return _TABLE_ROW_RE.findall(match.group(1))
+
+
+class TestOrgReposConstants(unittest.TestCase):
+    def test_main_repo(self) -> None:
+        self.assertEqual(MAIN_REPO, "noorinalabs-main")
+
+    def test_org(self) -> None:
+        self.assertEqual(ORG, "noorinalabs")
+
+    def test_child_repos_count(self) -> None:
+        # main + 7 children per CLAUDE.md § Repository Map.
+        self.assertEqual(len(CHILD_REPOS), 7)
+
+    def test_all_repos_is_main_plus_children(self) -> None:
+        self.assertEqual(ALL_REPOS, (MAIN_REPO, *CHILD_REPOS))
+        self.assertEqual(len(ALL_REPOS), 8)
+
+    def test_no_duplicates(self) -> None:
+        self.assertEqual(len(set(ALL_REPOS)), len(ALL_REPOS))
+
+    def test_all_names_prefixed(self) -> None:
+        for repo in ALL_REPOS:
+            self.assertTrue(repo.startswith("noorinalabs-"), repo)
+
+    def test_main_not_in_child_repos(self) -> None:
+        self.assertNotIn(MAIN_REPO, CHILD_REPOS)
+
+
+class TestProseParserSelfTest(unittest.TestCase):
+    """The parser helper must actually parse — not silently return [] on any
+    input, which would make TestProseCodeParity below vacuously pass."""
+
+    def test_parses_a_minimal_synthetic_table(self) -> None:
+        synthetic = (
+            "# Doc\n\n## Repository Map\n\n"
+            "| Repository | Description | Path |\n"
+            "|---|---|---|\n"
+            "| `noorinalabs-foo` | Foo | `noorinalabs-foo/` |\n"
+            "| `noorinalabs-bar` | Bar | `noorinalabs-bar/` |\n\n"
+            "## Next Section\n\nmore text `noorinalabs-not-in-table` here\n"
+        )
+        self.assertEqual(
+            _table_repos_from_claude_md(synthetic),
+            ["noorinalabs-foo", "noorinalabs-bar"],
+        )
+
+    def test_missing_heading_returns_empty(self) -> None:
+        self.assertEqual(_table_repos_from_claude_md("# Doc\n\nno such section\n"), [])
+
+
+class TestProseCodeParity(unittest.TestCase):
+    """G6's explicit ask: CHILD_REPOS must match CLAUDE.md's Repository Map."""
+
+    def test_claude_md_repository_map_matches_child_repos(self) -> None:
+        self.assertTrue(CLAUDE_MD.is_file(), f"CLAUDE.md not found at {CLAUDE_MD}")
+        table_repos = _table_repos_from_claude_md(CLAUDE_MD.read_text(encoding="utf-8"))
+        # Non-vacuous: a parse that silently found zero rows must fail loudly
+        # rather than let the tuple-equality below pass on two empty sequences.
+        self.assertTrue(
+            table_repos,
+            "parsed zero repos from CLAUDE.md's Repository Map table — "
+            "has the heading or table shape moved?",
+        )
+        self.assertEqual(tuple(table_repos), CHILD_REPOS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/lib/tests/test_pre_commit_ci_sync.py
+++ b/.claude/lib/tests/test_pre_commit_ci_sync.py
@@ -19,6 +19,7 @@ from pathlib import Path
 # .claude/lib/tests/test_*.py. parent.parent reaches the lib root.
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
+from org_repos import CHILD_REPOS  # noqa: E402
 from pre_commit_ci_sync import (  # noqa: E402
     check_repo,
     compute_drift,
@@ -981,17 +982,10 @@ _EXPECTED_KINDS = {
 # checkout-independent OLD==NEW parity scan — never to assert a hardcoded kind
 # snapshot (see the _EXPECTED_KINDS note above). A child is scanned when its
 # checkout is present beside the parent and skipped when absent, so this can
-# never false-fail in the parent-less CI checkout. Keep in step with the
-# Repository Map in the org CLAUDE.md.
-_CHILD_REPO_DIRS = (
-    "noorinalabs-isnad-graph",
-    "noorinalabs-user-service",
-    "noorinalabs-deploy",
-    "noorinalabs-design-system",
-    "noorinalabs-data-acquisition",
-    "noorinalabs-isnad-ingest-platform",
-    "noorinalabs-landing-page",
-)
+# never false-fail in the parent-less CI checkout. Sourced from org_repos.py
+# (main#1118 / audit G6) — the org repo-list SSOT — instead of hand-copying
+# the Repository Map from the org CLAUDE.md.
+_CHILD_REPO_DIRS = CHILD_REPOS
 
 
 class ParityAcrossRealConfigs(unittest.TestCase):


### PR DESCRIPTION
## Summary

Adds `.claude/lib/org_repos.py` as the single source of truth for the org repo list (`ORG`, `MAIN_REPO`, `CHILD_REPOS`, `ALL_REPOS`) and switches every hand-copied "list of org repos" consumer in `.claude/lib` and `.claude/hooks` to import from it, per CODE_AUDIT.md item G6 (fixes BUG-08's drift class).

## How every consumer was enumerated

1. `rg -l --no-ignore "noorinalabs-isnad-graph" . -g '!*.git*'` at repo root — every file mentioning the isnad-graph repo name anywhere (33+ hits across prose docs, ontology yaml, and code).
2. Narrowed to `.claude/lib` and `.claude/hooks` (`rg -l --no-ignore "noorinalabs-isnad-graph" .claude/lib .claude/hooks`) and read every literal `noorinalabs-` occurrence in each hit (`rg -n "noorinalabs-" --no-ignore <file>...`) to distinguish an actual **enumerated list** (the DRY-violation pattern G6 targets) from a single-repo mention (a path example, an error message, a docstring reference) — the latter is not in scope.
3. Cross-checked the orchestrator-supplied consumer list from the ontology-librarian brief against my own enumeration — found it consistent but not exhaustive; my own sweep additionally caught `.claude/lib/ontology_gen/aggregate.py`'s `DEFAULT_REPOS` dict (short-name → path mapping, same underlying duplication in a different shape) and `.claude/lib/tests/test_pre_commit_ci_sync.py`'s `_CHILD_REPO_DIRS`.
4. Searched separately for `w4-kickoff.py` / `w4-project-add.py` (named in the issue) and `board_add_audit_issues.sh` (found via the repo-name grep) — all three are **frozen historical scripts** recording specific numbered GH operations at a point in time (their own docstrings say so), not general repo-enumeration utilities; consolidating them would corrupt the audit trail they exist to preserve, per their own "frozen historical script" comments. Left untouched — flagging here rather than silently dropping them from scope.
5. Confirmed via `rg -n "REPOS|ALL_REPOS|CHILD_REPOS|repo_list|REPO_LIST"` that no other flat module holds a duplicate list under a different constant name.

## Consumers switched to `org_repos`

| File | Constant | Notes |
|---|---|---|
| `.claude/hooks/session_handoff.py` | `_get_open_prs()`'s repo list | **The BUG-08 drift site** — the old 7-item list omitted `noorinalabs-isnad-ingest-platform`, so `/handoff` silently queried 7 of 8 repos. Now `ALL_REPOS` (8). |
| `.claude/hooks/validate_wave_audit.py` | `_ORG_REPOS` | Was already correct (8), now sourced from the SSOT instead of hand-copied. |
| `.claude/lib/apply_implementor_labels.py` | `ALL_REPOS` | List (not tuple) preserved for existing mutate/slice call sites. |
| `.claude/lib/check_child_checkouts.py` | `CHILD_REPOS` | Direct re-export. |
| `.claude/lib/red_sweep.py` | `CANONICAL_REPOS`, `_MAIN_REPO`, `_ORG` | Direct import/alias. |
| `.claude/lib/roster_union_sync.py` | `DEFAULT_CHILD_REPOS` | Filters `CHILD_REPOS` to exclude `noorinalabs-deploy` — preserved as a **deliberate** exclusion (no aggregated `roster.json` there), not silently widened. |
| `.claude/lib/premise_check.py` | `_KNOWN_ROOT_COMPONENTS` | Repo-name subset of the frozenset now unioned in from `ALL_REPOS` instead of hand-copied. |
| `.claude/lib/ontology_gen/aggregate.py` | `DEFAULT_REPOS` | Rebuilt from `CHILD_REPOS` (short-name-stripped) + the `"main": "."` special case. |
| `.claude/lib/tests/test_pre_commit_ci_sync.py` | `_CHILD_REPO_DIRS` | Direct re-export. |

**Deliberately left as its own subset (not unified):** `.claude/hooks/warn_ghcr_image.py`'s `REPO_IMAGE_MAP` covers only the GHCR-image-publishing children — a different axis (build/publish topology) than "which repos exist in the org." Forcing it onto `CHILD_REPOS` would incorrectly widen it to non-publishing repos. Instead, `test_warn_ghcr_image.py` gained a drift guard asserting its keys stay a subset of `org_repos.CHILD_REPOS` (catches a typo/rename) and a test documenting the subset is proper (not silently widened to the full list).

## Tests

- New `.claude/lib/tests/test_org_repos.py` — constant shape (membership, no dupes, `ALL_REPOS = (MAIN_REPO, *CHILD_REPOS)`), plus the issue's explicit ask: a **prose→code test** that parses CLAUDE.md's `## Repository Map` table and asserts `CHILD_REPOS` matches it row-for-row (non-vacuous — a synthetic-table self-test guards against the parser silently matching zero rows).
- New `GetOpenPrsQueriesAllOrgReposTests` in `test_session_handoff.py` — mocks `_run` and asserts `_get_open_prs()` queries all 8 repos including `noorinalabs-isnad-ingest-platform` (regression coverage for BUG-08), plus an identity check that `hook.ALL_REPOS is org_repos.ALL_REPOS`.
- New `RepoImageMapDriftGuardTests` in `test_warn_ghcr_image.py` (see above).

## Verified

- `PYTHONDONTWRITEBYTECODE=1 ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/ .claude/lib/tests/ -q` — 3448 passed, 647 subtests passed.
- `python3 -m ruff format --check .claude/lib .claude/hooks` / `python3 -m ruff check .claude/lib .claude/hooks` — clean.
- `python3 -m mypy .claude/hooks/ .claude/lib/ --ignore-missing-imports --no-error-summary` — no errors.
- `python3 .claude/lib/pre_commit_ci_sync.py .` — `OK: pre-commit config mirrors all CI-enforced checks.`
- `pre-commit run --all-files` and `pre-commit run --all-files --hook-stage pre-push` — both fully green (ruff-format, ruff-lint, actionlint, cspell, fixture-realism, skill-graphql-pagination, checksums-ascii, mypy, pytest, pytest-skills, memory-budget, headcount-budget, doc-freshness (advisory), office-drift, mermaid-render).
- `git push` triggered the same pre-push suite again (identical hooks config) — green, and the branch pushed cleanly.

Not yet verified: live CI on the PR itself (will check `gh pr view --json statusCheckRollup` once it reports).

Closes #1118
