### PR TITLE
fix(#1181): manifest-only names no longer resolve as review-class reviewers

### DIFF
--- a/.claude/lib/roster_union_sync.py
+++ b/.claude/lib/roster_union_sync.py
@@ -195,13 +195,16 @@ def parent_roster_names(repo_root: Path) -> set[str]:
 def local_card_names(repo_root: Path) -> set[str]:
     """Parse member names from the LOCAL repo's own `.claude/team/roster/*.md` cards.
 
-    Local-only by design (#1181): this script runs in CI with just the
-    `noorinalabs-main` checkout, so a child repo's card directory is never on
-    disk here — there is no card-fetch equivalent to `fetch_child_roster`.
-    That is not a gap for `compute_manifest_orphans` below: #1183 measured
-    card-only == 0 across the org (no persona has a card but no entry in that
-    child's own `roster.json`), so the already-fetched child rosters are a
-    complete substitute for child cards without a second network round-trip.
+    This is the PARENT-repo-only half of the #1181 card union: this script
+    runs in CI with just the `noorinalabs-main` checkout, so a child repo's
+    card directory is never on disk here — only a NETWORK fetch can see it.
+    `fetch_child_card_names` below is that fetch — it exists precisely
+    because #1183's "card-only == 0" assumption (no persona has a card but no
+    entry in that child's own `roster.json`) turned out to be false (see the
+    module docstring § "The reverse direction: manifest orphans" for the live
+    Mei-Lin Chang / Aisha Idrissi counterexamples). `compute_manifest_orphans`
+    is called with `local_card_names(repo_root)` unioned with every fetched
+    child's card set, never with this function's return value alone.
     """
     roster_dir = repo_root / ".claude" / "team" / "roster"
     names: set[str] = set()

--- a/.claude/lib/roster_union_sync.py
+++ b/.claude/lib/roster_union_sync.py
@@ -80,16 +80,41 @@ break its own commit identity (the annunaki-attack skill commits AS
 `Annunaki`), and `Steven French` is the owner's bare-principal mapping
 `verify_commit_identity.py` special-cases on purpose. The remaining
 persona-shaped orphans ARE an open reconciliation question (prune the row, or
-onboard the persona with a real card) and are what moves the exit code.
+onboard the persona with a real card) — but their disposition is explicitly
+OUT of #1181's scope (still undecided), so this check reports them loudly
+without gating on them; see "Exit codes" below for why.
 
-Same posture as the forward gate: continue-on-error, advisory, never a hard
-block. Unlike the forward direction, an INCOMPLETE fetch (any roster.json OR
-card-directory SKIPPED) makes the orphan report unreliable in the unsafe
-direction — a name backed only by something we failed to read would
-misreport as an orphan — so the orphan check does not run at all in that
-case, rather than risk a false "prune this" instruction. The card fetch pass
-only runs once the roster.json pass is already clean (no point fetching
-cards for a run that is already disqualified).
+An INCOMPLETE fetch (any roster.json OR card-directory SKIPPED) makes the
+orphan report unreliable in the unsafe direction — a name backed only by
+something we failed to read would misreport as an orphan — so the orphan
+check does not run at all in that case, rather than risk a false "prune
+this" instruction. The card fetch pass only runs once the roster.json pass
+is already clean (no point fetching cards for a run that is already
+disqualified).
+
+The orphan check NEVER moves the exit code (owner correction, PR #1240 review)
+=================================================================================
+The forward direction (#634) above predates this reverse check and keeps its
+established `continue-on-error` contract: the WORKFLOW run stays green even
+when it exits 1, because a single PR cannot deterministically reconcile a
+name a sibling repo just added. That contract does NOT extend cleanly to a
+non-zero exit from a check whose findings are individually out of THIS PR's
+scope to fix: `continue-on-error: true` only protects the workflow RUN's own
+conclusion — it does not change what the JOB itself reports into the PR's
+`statusCheckRollup`, which is exactly the surface `pr_ci_state.py` /
+`validate_pr_ci_status.py` (the org's actual merge-readiness oracle) reads.
+Measured: the reverse check returning exit 1 for the (already-known,
+disposition-still-open) 16 unreconciled names turned this job FAILING on
+every PR in the repo, not just this one — a permanently-red check that no
+amount of continue-on-error hides from the tooling that actually gates merges,
+which is precisely the state the org's "a red check is a stop, not a speed
+bump" rule exists to prevent (charter, owner directive). So the orphan branch
+below reports loudly (stderr, unabbreviated) but deliberately never sets
+`exit_code` — only a genuine forward-direction violation (#634: a child
+persona entirely missing from the parent) can fail this job. A future
+disposition of the 16 (§ above) could reasonably promote them to blocking;
+that is a separate, explicit decision, not a side effect of this check
+existing.
 
 Input Language
 ==============
@@ -99,10 +124,12 @@ CLI:  roster_union_sync.py [--repo-root <dir>] [--repos a,b,c] [--owner <org>]
 network). `--owner` defaults to `noorinalabs`.
 
 Exit codes (CLI):
-    0 — no drift AND no unreconciled manifest orphan (or every child fetch was
-        skipped, so neither check had enough data to assert anything)
-    1 — drift (a child persona is missing from the parent), OR at least one
-        persona-shaped manifest orphan has no backing card/child-roster entry
+    0 — no forward drift (#634). The reverse orphan report (#1181) is ALWAYS
+        advisory-only and never affects this — see "The orphan check NEVER
+        moves the exit code" above. Printed output still names every
+        unreconciled/non-persona orphan found; only the process exit stays 0.
+    1 — forward drift ONLY: a child persona positively observed in a child
+        `roster.json` is missing from the committed parent roster (#634)
     2 — usage / parent-roster load error
 """
 
@@ -469,16 +496,29 @@ def main(argv: list[str] | None = None) -> int:
             for name in orphans["non_persona"]:
                 print(f'  - "{name}"')
         if orphans["unreconciled"]:
+            # Advisory ONLY (owner correction, PR #1240 review): this must NOT
+            # move exit_code. continue-on-error at the WORKFLOW level does not
+            # make the JOB's conclusion advisory — `pr_ci_state.py` /
+            # `validate_pr_ci_status.py` (the org's actual merge-readiness
+            # oracle) read the per-check rollup, not the run conclusion, so a
+            # non-zero exit here would mark every future PR in this repo
+            # "failing" until the (explicitly out-of-scope-for-#1181)
+            # disposition of these names is resolved — exactly the
+            # permanently-red state the "red is a stop" rule exists to
+            # prevent. Reported loudly (stderr) precisely so it stays visible
+            # without blocking. Only the forward direction (#634) above,
+            # which predates this reverse check and has its own established
+            # contract, may set exit_code — see module docstring.
             print(
-                "\nMANIFEST ORPHAN (#1181): persona-shaped parent-roster entry with NO backing "
-                "card or child roster.json observed anywhere in the org. Pick one:\n"
+                "\nMANIFEST ORPHAN (#1181, advisory — does not fail this job): "
+                "persona-shaped parent-roster entry with NO backing card or child "
+                "roster.json observed anywhere in the org. Pick one:\n"
                 "  (a) onboard the persona — add a real roster card in the repo it belongs to, or\n"
                 "  (b) the persona is retired — remove the row from .claude/team/roster.json.",
                 file=sys.stderr,
             )
             for name in orphans["unreconciled"]:
                 print(f'  - "{name}"', file=sys.stderr)
-            exit_code = 1
         else:
             print(
                 "\nManifest-orphan check (#1181): every persona-shaped manifest entry is backed "

--- a/.claude/lib/roster_union_sync.py
+++ b/.claude/lib/roster_union_sync.py
@@ -39,6 +39,58 @@ CI token cannot read, or a transient API error contributes no names and is
 reported as SKIPPED — never a drift failure on its own. Drift is only ever
 asserted on names we positively observed in a child roster.
 
+The reverse direction: manifest orphans (#1181)
+================================================
+The gate above answers "is the parent roster MISSING anyone a child vouches
+for?" — one-directional. #1181 measured the org's actual state and found the
+other direction rotting silently: `roster.json` (78 entries) carries 18 names
+backed by NO card anywhere in the org (union of every repo's roster cards:
+60), and nothing ever prunes an entry once its card is deleted — an offboarded
+persona's manifest row outlives the persona indefinitely (#1181's "liveness"
+framing). Compounding it, #1178 (#1162) made the manifest a resolution
+authority for review-class scope slots, so an unbacked entry is not merely
+stale bookkeeping — it can resolve as a live reviewer.
+
+`compute_manifest_orphans` is the reverse assertion: manifest ⊆ (this repo's
+own roster cards) ∪ (every child's own roster CARD directory) ∪ (every
+successfully-fetched child `roster.json`). #1183 independently measured the
+same 18 names checking against child `roster.json`s directly instead of child
+cards and reported `card-only == 0` (no persona has a card but no entry in
+that child's own roster.json) — but that measurement itself drifted: a live
+re-check while building this gate found `noorinalabs-isnad-graph/roster/
+data_scientist_mei.md` (Mei-Lin Chang) absent from that SAME repo's own
+`roster.json`, and `noorinalabs-deploy` has NO `roster.json` at all (its
+`sre_engineer_aisha.md` persona is invisible to every roster.json-only check).
+Trusting `card-only == 0` as a standing invariant would have shipped an
+orphan check that immediately false-positives on two real, carded people, so
+`fetch_child_card_names` fetches every child's card directory directly (one
+`gh api` directory listing + one fetch per `.md` file) rather than relying on
+that assumption staying true. See `DEFAULT_CARD_REPOS` for why the repo list
+here is NOT the same as `DEFAULT_CHILD_REPOS`.
+
+Two of the 18 are not a reconciliation question at all — `Annunaki` (the
+error-monitor's own commit identity) and `Steven French` (the bare
+`parametrization@gmail.com` principal, no `+alias`) are DEFINITIONALLY not
+personas, matched by `_PERSONA_ALIAS_RE` the same way
+`.claude/hooks/validate_pr_review.py` and
+`.claude/skills/wave-scope/validate_matrix_names.py` already exclude them from
+review-class resolution (#1179/#1181). Those two are reported separately, as
+information, not as something to prune or onboard: pruning `Annunaki` would
+break its own commit identity (the annunaki-attack skill commits AS
+`Annunaki`), and `Steven French` is the owner's bare-principal mapping
+`verify_commit_identity.py` special-cases on purpose. The remaining
+persona-shaped orphans ARE an open reconciliation question (prune the row, or
+onboard the persona with a real card) and are what moves the exit code.
+
+Same posture as the forward gate: continue-on-error, advisory, never a hard
+block. Unlike the forward direction, an INCOMPLETE fetch (any roster.json OR
+card-directory SKIPPED) makes the orphan report unreliable in the unsafe
+direction — a name backed only by something we failed to read would
+misreport as an orphan — so the orphan check does not run at all in that
+case, rather than risk a false "prune this" instruction. The card fetch pass
+only runs once the roster.json pass is already clean (no point fetching
+cards for a run that is already disqualified).
+
 Input Language
 ==============
 CLI:  roster_union_sync.py [--repo-root <dir>] [--repos a,b,c] [--owner <org>]
@@ -47,9 +99,10 @@ CLI:  roster_union_sync.py [--repo-root <dir>] [--repos a,b,c] [--owner <org>]
 network). `--owner` defaults to `noorinalabs`.
 
 Exit codes (CLI):
-    0 — no drift (parent roster covers every observed child persona), or every
-        child fetch was skipped (nothing positively observed to compare against)
-    1 — drift: at least one observed child persona is missing from the parent
+    0 — no drift AND no unreconciled manifest orphan (or every child fetch was
+        skipped, so neither check had enough data to assert anything)
+    1 — drift (a child persona is missing from the parent), OR at least one
+        persona-shaped manifest orphan has no backing card/child-roster entry
     2 — usage / parent-roster load error
 """
 
@@ -58,6 +111,7 @@ from __future__ import annotations
 import argparse
 import base64
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -79,15 +133,109 @@ DEFAULT_CHILD_REPOS: tuple[str, ...] = (
 
 ROSTER_PATH_IN_REPO = ".claude/team/roster.json"
 
+# A manifest entry is a PERSONA only if its address is a charter-conformant
+# per-persona commit identity: `<principal>+<First>.<Last>@<domain>`. Same
+# matcher as `.claude/hooks/validate_pr_review.py::_PERSONA_ALIAS_RE` (#1179)
+# and `.claude/skills/wave-scope/validate_matrix_names.py::_PERSONA_ALIAS_RE`
+# (#1181) — a third small duplicate rather than an import across the
+# lib/hook/skill boundary, the established pattern for this regex (see either
+# sibling's own docstring for why).
+_PERSONA_ALIAS_RE = re.compile(r"^[^\s@+]+\+[^\s@+]+\.[^\s@+]+@[^\s@]+\.[^\s@]+$")
 
-def parent_roster_names(repo_root: Path) -> set[str]:
-    """Names in the committed parent roster — the union manifest under test."""
+# Card name extractors — mirrors
+# `.claude/skills/wave-scope/validate_matrix_names._load_roster_names` (#1010:
+# both the OLD verbose `**Name:**` card field and the NEW slim H1 template are
+# matched, so a mixed-format roster dir mid-transition resolves every card).
+_CARD_NAME_RE = re.compile(r"\*\*Name:\*\*\s+(.+?)\s*$", re.MULTILINE)
+_CARD_H1_RE = re.compile(r"^#\s+(.+?)\s+[—–-]\s+.+$", re.MULTILINE)
+
+
+def parent_roster_map(repo_root: Path) -> dict[str, str]:
+    """Raw `{name: email}` from the committed parent `roster.json`, or `{}` on failure."""
     roster = repo_root / ".claude" / "team" / "roster.json"
     try:
         data = json.loads(roster.read_text(encoding="utf-8"))
     except (FileNotFoundError, json.JSONDecodeError, OSError):
-        return set()
-    return set(data.keys()) if isinstance(data, dict) else set()
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def parent_roster_names(repo_root: Path) -> set[str]:
+    """Names in the committed parent roster — the union manifest under test."""
+    return set(parent_roster_map(repo_root).keys())
+
+
+def local_card_names(repo_root: Path) -> set[str]:
+    """Parse member names from the LOCAL repo's own `.claude/team/roster/*.md` cards.
+
+    Local-only by design (#1181): this script runs in CI with just the
+    `noorinalabs-main` checkout, so a child repo's card directory is never on
+    disk here — there is no card-fetch equivalent to `fetch_child_roster`.
+    That is not a gap for `compute_manifest_orphans` below: #1183 measured
+    card-only == 0 across the org (no persona has a card but no entry in that
+    child's own `roster.json`), so the already-fetched child rosters are a
+    complete substitute for child cards without a second network round-trip.
+    """
+    roster_dir = repo_root / ".claude" / "team" / "roster"
+    names: set[str] = set()
+    if not roster_dir.is_dir():
+        return names
+    for md_file in roster_dir.glob("*.md"):
+        try:
+            text = md_file.read_text()
+        except OSError:
+            continue
+        for match in list(_CARD_NAME_RE.finditer(text)) + list(_CARD_H1_RE.finditer(text)):
+            name = match.group(1).strip()
+            name = re.sub(r"\s*\(.*?\)\s*$", "", name)
+            if name:
+                names.add(name)
+    return names
+
+
+def compute_manifest_orphans(
+    parent_map: dict[str, str],
+    card_names: set[str],
+    child_rosters: dict[str, dict[str, str]],
+) -> dict[str, list[str]]:
+    """Reverse of `compute_drift` (#1181): manifest entries backed by NOTHING.
+
+    Pure: given the already-loaded parent manifest, local card names, and the
+    already-fetched child rosters, returns
+
+        {"unreconciled": [...], "non_persona": [...]}
+
+    sorted lexicographically. `"unreconciled"` is a persona-shaped manifest
+    entry with no backing card or child-roster entry anywhere observed — an
+    open disposition question (prune the row, or onboard the persona with a
+    real card), and what the caller treats as actionable. `"non_persona"` is
+    a manifest entry whose address does not match `_PERSONA_ALIAS_RE` at all
+    (`Annunaki`, `Steven French`) — also unbacked, but definitionally not a
+    reviewer regardless of a card, so it is reported for visibility only and
+    never treated as something to reconcile.
+
+    A name present in ANY backing source (card or ANY child roster) is not an
+    orphan, matching #1183's broader measurement methodology (manifest vs.
+    union of cards ∪ every child `roster.json`).
+    """
+    backing: set[str] = set(card_names)
+    for roster in child_rosters.values():
+        backing |= set(roster)
+    orphans: dict[str, list[str]] = {"unreconciled": [], "non_persona": []}
+    for name, address in parent_map.items():
+        if not isinstance(name, str) or not name.strip():
+            continue
+        if name in backing:
+            continue
+        bucket = (
+            "unreconciled"
+            if isinstance(address, str) and _PERSONA_ALIAS_RE.match(address.strip())
+            else "non_persona"
+        )
+        orphans[bucket].append(name)
+    orphans["unreconciled"].sort()
+    orphans["non_persona"].sort()
+    return orphans
 
 
 def fetch_child_roster(owner: str, repo: str) -> dict[str, str] | None:
@@ -123,6 +271,80 @@ def fetch_child_roster(owner: str, repo: str) -> dict[str, str] | None:
     return data if isinstance(data, dict) else None
 
 
+CARD_PATH_IN_REPO = ".claude/team/roster"
+
+# Repos whose CARD directories the #1181 reverse (orphan) check fetches —
+# DEFAULT_CHILD_REPOS plus `noorinalabs-deploy`. Measured live (#1181): a
+# repo's own `roster.json` aggregate can itself lag its own card directory
+# (`noorinalabs-isnad-graph/roster/data_scientist_mei.md` names `Mei-Lin
+# Chang`, absent from that SAME repo's `roster.json`), so fetching only
+# `roster.json` false-positives the orphan check on a genuinely-carded
+# persona. `noorinalabs-deploy` has NO `roster.json` at all (see
+# DEFAULT_CHILD_REPOS comment above) so it is invisible to `fetch_child_roster`
+# entirely, but it DOES keep a card directory (`sre_engineer_aisha.md` names
+# `Aisha Idrissi`) — without fetching it, deploy's every persona would
+# misreport as an orphan.
+DEFAULT_CARD_REPOS: tuple[str, ...] = (*DEFAULT_CHILD_REPOS, "noorinalabs-deploy")
+
+
+def fetch_child_card_names(owner: str, repo: str) -> set[str] | None:
+    """Fetch a child repo's roster CARD names via `gh api`, or None if unavailable.
+
+    Complements `fetch_child_roster` for the #1181 reverse check — see
+    `DEFAULT_CARD_REPOS` above for why the aggregate `roster.json` is not a
+    safe substitute for the card directory here, unlike for the forward drift
+    check (which is deliberately asymmetric: a card genuinely NOT yet folded
+    into `roster.json` is that repo's own bookkeeping lag, not evidence a
+    persona from a THIRD repo is missing from the PARENT manifest).
+
+    Two `gh api` calls per repo with content (a directory listing, then one
+    fetch per `.md` file) — the parsed card-name union, or `None` when the
+    directory is missing/unreadable or every per-file fetch failed. Fail-open,
+    same posture as `fetch_child_roster`: the ORPHAN check (the only consumer)
+    already treats ANY skip — roster.json or cards — as "cannot compute
+    reliably" and does not run at all (see `main`), so a false SKIPPED here
+    never manufactures a false orphan; it can only suppress the whole check.
+    """
+    try:
+        listing = subprocess.run(
+            ["gh", "api", f"repos/{owner}/{repo}/contents/{CARD_PATH_IN_REPO}", "--jq", ".[].name"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+    filenames = [
+        line.strip() for line in listing.stdout.splitlines() if line.strip().endswith(".md")
+    ]
+    if not filenames:
+        return None
+    names: set[str] = set()
+    for filename in filenames:
+        try:
+            content = subprocess.run(
+                [
+                    "gh",
+                    "api",
+                    f"repos/{owner}/{repo}/contents/{CARD_PATH_IN_REPO}/{filename}",
+                    "--jq",
+                    ".content",
+                ],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            text = base64.b64decode(content.stdout.strip()).decode("utf-8")
+        except (subprocess.CalledProcessError, FileNotFoundError, ValueError):
+            continue
+        for match in list(_CARD_NAME_RE.finditer(text)) + list(_CARD_H1_RE.finditer(text)):
+            name = match.group(1).strip()
+            name = re.sub(r"\s*\(.*?\)\s*$", "", name)
+            if name:
+                names.add(name)
+    return names if names else None
+
+
 def compute_drift(
     parent_names: set[str], child_rosters: dict[str, dict[str, str]]
 ) -> dict[str, list[str]]:
@@ -152,7 +374,8 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     repo_root = Path(args.repo_root).expanduser().resolve()
-    parent_names = parent_roster_names(repo_root)
+    parent_map = parent_roster_map(repo_root)
+    parent_names = set(parent_map.keys())
     if not parent_names:
         print(
             f"ERROR: no parent roster names loaded from {repo_root}/{ROSTER_PATH_IN_REPO}.",
@@ -177,6 +400,9 @@ def main(argv: list[str] | None = None) -> int:
             child_rosters[repo] = roster
             print(f"OK      {repo}: {len(roster)} persona(s).")
 
+    exit_code = 0
+
+    # Forward direction (#634): parent roster ⊇ every observed child persona.
     drift = compute_drift(parent_names, child_rosters)
     if drift:
         print(
@@ -188,20 +414,78 @@ def main(argv: list[str] | None = None) -> int:
         )
         for name, owners in drift.items():
             print(f'  - "{name}"  (canonical in: {", ".join(owners)})', file=sys.stderr)
-        return 1
+        exit_code = 1
+    else:
+        observed = sum(len(r) for r in child_rosters.values())
+        if not child_rosters:
+            print(
+                f"\nNo child roster could be read ({len(skipped)} skipped); "
+                "nothing to cross-check for drift. Passing (advisory)."
+            )
+        else:
+            print(
+                f"\nParent roster covers all {observed} observed child persona(s) "
+                f"across {len(child_rosters)} repo(s). No drift."
+            )
 
-    observed = sum(len(r) for r in child_rosters.values())
-    if not child_rosters:
+    # Reverse direction (#1181): manifest ⊆ (this repo's cards) ∪ (every
+    # child's own card directory) ∪ (every successfully-fetched child
+    # roster.json). Skipped entirely when any roster.json OR card fetch
+    # failed — an orphan report over partial data could misreport a name
+    # backed only by a repo/directory we failed to fetch (see module
+    # docstring). The card fetch only runs at all once the roster.json pass
+    # is already clean, since a skip there already disqualifies the check.
+    card_skipped: list[str] = []
+    child_cards: dict[str, set[str]] = {}
+    if not skipped:
+        card_repos = list(dict.fromkeys([*repos, *DEFAULT_CARD_REPOS[len(DEFAULT_CHILD_REPOS) :]]))
+        for repo in card_repos:
+            names = fetch_child_card_names(args.owner, repo)
+            if names is None:
+                card_skipped.append(repo)
+                print(f"SKIPPED {repo}: no readable {CARD_PATH_IN_REPO}/*.md (fail-open).")
+            else:
+                child_cards[repo] = names
+                print(f"OK      {repo}: {len(names)} card(s).")
+
+    if skipped or card_skipped:
+        unreadable = len(skipped) + len(card_skipped)
         print(
-            f"\nNo child roster could be read ({len(skipped)} skipped); "
-            "nothing to cross-check. Passing (advisory)."
+            f"\nManifest-orphan check (#1181) SKIPPED: {unreadable} repo/directory fetch(es) "
+            "unreadable — an orphan report over partial data could wrongly flag a name backed "
+            "only by something we failed to fetch."
         )
-        return 0
-    print(
-        f"\nParent roster covers all {observed} observed child persona(s) "
-        f"across {len(child_rosters)} repo(s). No drift."
-    )
-    return 0
+    else:
+        card_names = local_card_names(repo_root)
+        for names in child_cards.values():
+            card_names |= names
+        orphans = compute_manifest_orphans(parent_map, card_names, child_rosters)
+        if orphans["non_persona"]:
+            print(
+                "\nManifest carries non-persona entrie(s) (#1181) — informational only, never "
+                "a reconciliation target (pruning would break their own use, e.g. the "
+                "annunaki-attack skill's own commit identity):"
+            )
+            for name in orphans["non_persona"]:
+                print(f'  - "{name}"')
+        if orphans["unreconciled"]:
+            print(
+                "\nMANIFEST ORPHAN (#1181): persona-shaped parent-roster entry with NO backing "
+                "card or child roster.json observed anywhere in the org. Pick one:\n"
+                "  (a) onboard the persona — add a real roster card in the repo it belongs to, or\n"
+                "  (b) the persona is retired — remove the row from .claude/team/roster.json.",
+                file=sys.stderr,
+            )
+            for name in orphans["unreconciled"]:
+                print(f'  - "{name}"', file=sys.stderr)
+            exit_code = 1
+        else:
+            print(
+                "\nManifest-orphan check (#1181): every persona-shaped manifest entry is backed "
+                "by a card or a child roster.json. No unreconciled orphans."
+            )
+
+    return exit_code
 
 
 if __name__ == "__main__":

--- a/.claude/lib/tests/test_roster_union_sync.py
+++ b/.claude/lib/tests/test_roster_union_sync.py
@@ -1,28 +1,52 @@
-"""Tests for roster_union_sync — the parent-roster ⊇ child-union drift gate (#634).
+"""Tests for roster_union_sync — the parent-roster <-> child-union sync gate.
 
 Verifies:
-  1. The pure drift computation: a child persona absent from the parent roster
-     is reported (with the child repos that carry it); a covered union is clean.
-  2. parent_roster_names reads the committed parent roster keys.
-  3. CLI wiring with an injected (monkeypatched) fetcher so tests never touch
+  1. The pure drift computation (#634): a child persona absent from the parent
+     roster is reported (with the child repos that carry it); a covered union
+     is clean.
+  2. parent_roster_names / parent_roster_map read the committed parent roster.
+  3. local_card_names parses this repo's own roster cards (#1181).
+  4. compute_manifest_orphans (#1181): the reverse assertion — a persona-shaped
+     manifest entry with no backing card/child-roster anywhere is
+     "unreconciled"; a non-persona-shaped one (Annunaki/Steven-French shape)
+     is "non_persona" and never actionable.
+  5. CLI wiring with an injected (monkeypatched) fetcher so tests never touch
      the network: clean union → exit 0, drift → exit 1, all-skipped → exit 0,
-     missing parent roster → exit 2.
+     missing parent roster → exit 2, orphan drift → exit 1, orphan check
+     skipped when any child fetch failed.
+  6. A non-vacuous regression pinned to the ACTUAL #1181 measurement: the
+     exact 18 manifest-only names, real emails, real "18 unbacked" count are
+     reproduced verbatim from the issue as a frozen fixture (not a live
+     filesystem read against the org dir — this file's own docstring
+     convention, matched by `test_validate_matrix_names.py`, is to avoid
+     coupling tests to the real org-dir state, which changes wave-to-wave).
+     This proves `compute_manifest_orphans` classifies the REAL, filed defect
+     correctly (2 non_persona + 16 unreconciled) rather than only ever
+     exercising a contrived example (#1181 acceptance: "a test that passes
+     today proves nothing").
 """
 
 from __future__ import annotations
 
+import base64
 import json
+import subprocess
 import sys
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 import roster_union_sync  # noqa: E402
 from roster_union_sync import (  # noqa: E402
     compute_drift,
+    compute_manifest_orphans,
+    fetch_child_card_names,
+    local_card_names,
     main,
+    parent_roster_map,
     parent_roster_names,
 )
 
@@ -31,6 +55,14 @@ def _write_parent_roster(repo_root: Path, roster: dict[str, str]) -> None:
     path = repo_root / ".claude" / "team" / "roster.json"
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(roster), encoding="utf-8")
+
+
+def _write_roster_card(roster_dir: Path, filename: str, name: str) -> None:
+    """Verbose-template card — mirrors the shape `local_card_names` parses."""
+    roster_dir.mkdir(parents=True, exist_ok=True)
+    (roster_dir / filename).write_text(
+        f"# Team Member Roster Card\n\n## Identity\n- **Name:** {name}\n- **Status:** Active\n"
+    )
 
 
 class ComputeDrift(unittest.TestCase):
@@ -70,18 +102,40 @@ class ParentRosterNames(unittest.TestCase):
 
 
 class CliWithInjectedFetcher(unittest.TestCase):
-    """Drive main() with fetch_child_roster monkeypatched — no network."""
+    """Drive main() with fetch_child_roster/fetch_child_card_names monkeypatched — no network.
 
-    def _run(self, parent: dict[str, str], fetched: dict[str, dict | None], repos: str) -> int:
+    BOTH fetchers must be patched for every test that reaches the child-repo
+    loop: `main` unconditionally attempts the #1181 card fetch once the
+    roster.json pass is clean, so leaving `fetch_child_card_names`
+    unpatched makes a real `gh api` subprocess call per card repo — slow, and
+    a hard requirement violation (tests must be hermetic / no network).
+    `card_fetched` defaults to `{}`, meaning every card repo — including the
+    always-added `noorinalabs-deploy` — reads as SKIPPED (`None`), which
+    fails the orphan check safely closed (never a surprise exit change) for
+    every test that does not care about the orphan path.
+    """
+
+    def _run(
+        self,
+        parent: dict[str, str],
+        fetched: dict[str, dict | None],
+        repos: str,
+        card_fetched: dict[str, set[str] | None] | None = None,
+    ) -> int:
         with TemporaryDirectory() as td:
             repo = Path(td)
             _write_parent_roster(repo, parent)
-            orig = roster_union_sync.fetch_child_roster
+            orig_roster = roster_union_sync.fetch_child_roster
+            orig_cards = roster_union_sync.fetch_child_card_names
             roster_union_sync.fetch_child_roster = lambda owner, r: fetched.get(r)  # type: ignore[assignment]
+            roster_union_sync.fetch_child_card_names = lambda owner, r: (  # type: ignore[assignment]
+                card_fetched or {}
+            ).get(r)
             try:
                 return main(["--repo-root", str(repo), "--repos", repos])
             finally:
-                roster_union_sync.fetch_child_roster = orig
+                roster_union_sync.fetch_child_roster = orig_roster
+                roster_union_sync.fetch_child_card_names = orig_cards
 
     def test_clean_union_exit_0(self) -> None:
         rc = self._run(
@@ -115,6 +169,294 @@ class CliWithInjectedFetcher(unittest.TestCase):
             empty.mkdir()
             rc = main(["--repo-root", str(empty), "--repos", "noorinalabs-isnad-graph"])
             self.assertEqual(rc, 2)
+
+    def test_orphan_drift_exit_1(self) -> None:
+        """#1181: a persona-shaped, uncarded manifest entry is a hard advisory exit 1."""
+        rc = self._run(
+            {"Persona X": "parametrization+Persona.X@gmail.com"},
+            {"noorinalabs-isnad-graph": {}},
+            "noorinalabs-isnad-graph",
+            card_fetched={"noorinalabs-isnad-graph": set(), "noorinalabs-deploy": set()},
+        )
+        self.assertEqual(rc, 1)
+
+    def test_card_only_child_persona_is_not_a_false_positive_orphan(self) -> None:
+        """#1181: a card whose OWN repo's roster.json aggregate lags it is not an orphan.
+
+        Real instance measured live: `noorinalabs-isnad-graph` carries
+        `data_scientist_mei.md` (Mei-Lin Chang) but her name is absent from
+        that repo's OWN `roster.json` — fetching only roster.json would
+        false-positive her as unbacked.
+        """
+        rc = self._run(
+            {"Mei-Lin Chang": "parametrization+Mei-Lin.Chang@gmail.com"},
+            {"noorinalabs-isnad-graph": {}},  # absent from the repo's own aggregate
+            "noorinalabs-isnad-graph",
+            card_fetched={
+                "noorinalabs-isnad-graph": {"Mei-Lin Chang"},  # but her CARD exists
+                "noorinalabs-deploy": set(),
+            },
+        )
+        self.assertEqual(rc, 0)
+
+    def test_deploy_cards_seen_even_though_deploy_has_no_roster_json(self) -> None:
+        """`noorinalabs-deploy` is excluded from --repos (no roster.json to fetch,
+        DEFAULT_CHILD_REPOS comment) but the #1181 orphan check must still see
+        its card directory — it is always added for the card-fetch pass.
+        """
+        rc = self._run(
+            {"Aisha Idrissi": "parametrization+Aisha.Idrissi@gmail.com"},
+            {"noorinalabs-isnad-graph": {}},
+            "noorinalabs-isnad-graph",
+            card_fetched={
+                "noorinalabs-isnad-graph": set(),
+                "noorinalabs-deploy": {"Aisha Idrissi"},
+            },
+        )
+        self.assertEqual(rc, 0)
+
+    def test_orphan_check_skipped_when_card_fetch_incomplete(self) -> None:
+        """A card-fetch skip (here: `noorinalabs-deploy` unreadable) also suppresses
+        the orphan check, same as a roster.json skip — never a false positive."""
+        rc = self._run(
+            {"Persona X": "parametrization+Persona.X@gmail.com"},
+            {"noorinalabs-isnad-graph": {}},
+            "noorinalabs-isnad-graph",
+            card_fetched={"noorinalabs-isnad-graph": set()},  # deploy missing -> None -> skip
+        )
+        self.assertEqual(rc, 0)
+
+    def test_orphan_check_skipped_when_any_child_fetch_fails(self) -> None:
+        """#1181: an incomplete fetch must not produce a false-positive orphan report.
+
+        `Amara Diallo` would be "unreconciled" if the orphan check ran — but
+        `noorinalabs-user-service` is unreadable, so the check does not run at
+        all (fail-open, same posture as the forward direction) and the run
+        stays exit 0 (forward drift is separately clean).
+        """
+        rc = self._run(
+            {"Amara Diallo": "parametrization+Amara.Diallo@gmail.com"},
+            {"noorinalabs-isnad-graph": {}, "noorinalabs-user-service": None},
+            "noorinalabs-isnad-graph,noorinalabs-user-service",
+        )
+        self.assertEqual(rc, 0)
+
+
+class FetchChildCardNamesTests(unittest.TestCase):
+    """#1181: unit coverage of the (list dir, then fetch each file) parse logic,
+    with `subprocess.run` mocked — no network."""
+
+    def test_parses_names_from_two_card_files_and_skips_non_md(self) -> None:
+        card_1 = base64.b64encode(b"## Identity\n- **Name:** Alpha One\n").decode()
+        card_2 = base64.b64encode(
+            "# Beta Two — Engineer\n\n- **Status:** Active\n".encode()
+        ).decode()
+
+        def fake_run(cmd, **kwargs):
+            result = subprocess.CompletedProcess(cmd, 0)
+            if cmd[-1] == ".[].name":
+                result.stdout = "alpha.md\nbeta.md\nNOTES.txt\n"
+            elif cmd[2].endswith("/alpha.md"):
+                result.stdout = card_1
+            elif cmd[2].endswith("/beta.md"):
+                result.stdout = card_2
+            else:
+                raise AssertionError(f"unexpected command {cmd}")
+            return result
+
+        with patch("subprocess.run", side_effect=fake_run):
+            names = fetch_child_card_names("noorinalabs", "noorinalabs-deploy")
+        self.assertEqual(names, {"Alpha One", "Beta Two"})
+
+    def test_missing_directory_returns_none(self) -> None:
+        def fake_run(cmd, **kwargs):
+            raise subprocess.CalledProcessError(1, cmd)
+
+        with patch("subprocess.run", side_effect=fake_run):
+            self.assertIsNone(fetch_child_card_names("noorinalabs", "noorinalabs-does-not-exist"))
+
+    def test_empty_directory_returns_none(self) -> None:
+        def fake_run(cmd, **kwargs):
+            result = subprocess.CompletedProcess(cmd, 0)
+            result.stdout = ""
+            return result
+
+        with patch("subprocess.run", side_effect=fake_run):
+            self.assertIsNone(fetch_child_card_names("noorinalabs", "noorinalabs-empty"))
+
+    def test_one_file_fetch_failure_does_not_abort_the_others(self) -> None:
+        card_2 = base64.b64encode(
+            "# Beta Two — Engineer\n\n- **Status:** Active\n".encode()
+        ).decode()
+
+        def fake_run(cmd, **kwargs):
+            if cmd[-1] == ".[].name":
+                result = subprocess.CompletedProcess(cmd, 0)
+                result.stdout = "alpha.md\nbeta.md\n"
+                return result
+            if cmd[2].endswith("/alpha.md"):
+                raise subprocess.CalledProcessError(1, cmd)
+            result = subprocess.CompletedProcess(cmd, 0)
+            result.stdout = card_2
+            return result
+
+        with patch("subprocess.run", side_effect=fake_run):
+            names = fetch_child_card_names("noorinalabs", "noorinalabs-deploy")
+        self.assertEqual(names, {"Beta Two"})
+
+
+class ParentRosterMapTests(unittest.TestCase):
+    def test_reads_raw_map(self) -> None:
+        with TemporaryDirectory() as td:
+            repo = Path(td)
+            _write_parent_roster(repo, {"Aino Virtanen": "a@x"})
+            self.assertEqual(parent_roster_map(repo), {"Aino Virtanen": "a@x"})
+
+    def test_missing_roster_returns_empty_dict(self) -> None:
+        with TemporaryDirectory() as td:
+            self.assertEqual(parent_roster_map(Path(td)), {})
+
+
+class LocalCardNamesTests(unittest.TestCase):
+    """#1181: parses THIS repo's own roster cards — never a child repo's."""
+
+    def test_reads_verbose_cards(self) -> None:
+        with TemporaryDirectory() as td:
+            repo = Path(td)
+            roster_dir = repo / ".claude" / "team" / "roster"
+            _write_roster_card(roster_dir, "tpm_wanjiku.md", "Wanjiku Mwangi")
+            _write_roster_card(roster_dir, "pd_nadia.md", "Nadia Khoury")
+            self.assertEqual(local_card_names(repo), {"Wanjiku Mwangi", "Nadia Khoury"})
+
+    def test_reads_slim_h1_cards(self) -> None:
+        """#1010 slim template: H1 `# Name — Role`, no `**Name:**` field."""
+        with TemporaryDirectory() as td:
+            repo = Path(td)
+            roster_dir = repo / ".claude" / "team" / "roster"
+            roster_dir.mkdir(parents=True)
+            (roster_dir / "eng_aino.md").write_text(
+                "# Aino Virtanen — Standards Lead\n\n- **Status:** Active\n"
+            )
+            self.assertEqual(local_card_names(repo), {"Aino Virtanen"})
+
+    def test_no_roster_dir_returns_empty(self) -> None:
+        with TemporaryDirectory() as td:
+            self.assertEqual(local_card_names(Path(td)), set())
+
+
+class ComputeManifestOrphansTests(unittest.TestCase):
+    """#1181: the reverse assertion — manifest ⊆ cards ∪ child rosters."""
+
+    def test_card_backed_name_is_not_an_orphan(self) -> None:
+        parent = {"Wanjiku Mwangi": "parametrization+Wanjiku.Mwangi@gmail.com"}
+        orphans = compute_manifest_orphans(parent, {"Wanjiku Mwangi"}, {})
+        self.assertEqual(orphans, {"unreconciled": [], "non_persona": []})
+
+    def test_child_roster_backed_name_is_not_an_orphan(self) -> None:
+        parent = {"Imelda Santos": "parametrization+Imelda.Santos@gmail.com"}
+        children = {"noorinalabs-isnad-ingest-platform": {"Imelda Santos": "i@x"}}
+        orphans = compute_manifest_orphans(parent, set(), children)
+        self.assertEqual(orphans, {"unreconciled": [], "non_persona": []})
+
+    def test_persona_shaped_unbacked_name_is_unreconciled(self) -> None:
+        parent = {"Amara Diallo": "parametrization+Amara.Diallo@gmail.com"}
+        orphans = compute_manifest_orphans(parent, set(), {})
+        self.assertEqual(orphans, {"unreconciled": ["Amara Diallo"], "non_persona": []})
+
+    def test_non_persona_shaped_unbacked_name_is_non_persona(self) -> None:
+        """Annunaki-shape (no `.` after the `+`): flagged, never actionable."""
+        parent = {"Annunaki": "parametrization+Annunaki@gmail.com"}
+        orphans = compute_manifest_orphans(parent, set(), {})
+        self.assertEqual(orphans, {"unreconciled": [], "non_persona": ["Annunaki"]})
+
+    def test_bare_principal_unbacked_is_non_persona(self) -> None:
+        """Steven-French-shape (no `+` at all): flagged, never actionable."""
+        parent = {"Steven French": "parametrization@gmail.com"}
+        orphans = compute_manifest_orphans(parent, set(), {})
+        self.assertEqual(orphans, {"unreconciled": [], "non_persona": ["Steven French"]})
+
+    def test_results_sorted(self) -> None:
+        parent = {
+            "Zeta Persona": "parametrization+Zeta.Persona@gmail.com",
+            "Alpha Persona": "parametrization+Alpha.Persona@gmail.com",
+        }
+        orphans = compute_manifest_orphans(parent, set(), {})
+        self.assertEqual(orphans["unreconciled"], ["Alpha Persona", "Zeta Persona"])
+
+
+class RealMeasuredDriftRegressionTests(unittest.TestCase):
+    """Pinned to the ACTUAL #1181/#1183 measurement (2026-07-29, main checkout).
+
+    Real names + the real `.claude/team/roster.json` email values for the
+    exact 18 manifest-only entries #1181 found, copied verbatim from the issue
+    body, plus a couple of genuinely BACKED real names (present on an actual
+    parent roster card) to prove the classification isn't accidentally
+    over-broad. This is a frozen snapshot rather than a live read of the org
+    dir — this module's other tests already avoid coupling to the real
+    org-dir state, which changes wave-to-wave — but the VALUES are the real
+    ones, so a regression on the actual filed defect fails this test, which a
+    purely synthetic example cannot demonstrate (#1181 acceptance: "a test
+    that passes today proves nothing").
+    """
+
+    REAL_UNBACKED_18: dict[str, str] = {
+        "Amara Diallo": "parametrization+Amara.Diallo@gmail.com",
+        "Annunaki": "parametrization+Annunaki@gmail.com",
+        "Carolina Méndez-Ríos": "parametrization+Carolina.Mendez-Rios@gmail.com",
+        "Cedric Novak": "parametrization+Cedric.Novak@gmail.com",
+        "Dmitri Volkov": "parametrization+Dmitri.Volkov@gmail.com",
+        "Elena Petrova": "parametrization+Elena.Petrova@gmail.com",
+        "Fatima Okonkwo": "parametrization+Fatima.Okonkwo@gmail.com",
+        "Hiro Tanaka": "parametrization+Hiro.Tanaka@gmail.com",
+        "Kwame Asante": "parametrization+Kwame.Asante@gmail.com",
+        "Mei Chen": "parametrization+Mei.Chen@gmail.com",
+        "Priya Nair": "parametrization+Priya.Nair@gmail.com",
+        "Rashid Osei-Mensah": "parametrization+Rashid.Osei-Mensah@gmail.com",
+        "Renaud Tremblay": "parametrization+Renaud.Tremblay@gmail.com",
+        "Sable Nakamura-Whitfield": "parametrization+Sable.Nakamura-Whitfield@gmail.com",
+        "Steven French": "parametrization@gmail.com",
+        "Sunita Krishnamurthy": "parametrization+Sunita.Krishnamurthy@gmail.com",
+        "Tomasz Wójcik": "parametrization+Tomasz.Wojcik@gmail.com",
+        "Yara Hadid": "parametrization+Yara.Hadid@gmail.com",
+    }
+
+    # Real personas, real parent-repo roster cards (main#634 onboarding).
+    REAL_BACKED: dict[str, str] = {
+        "Wanjiku Mwangi": "parametrization+Wanjiku.Mwangi@gmail.com",
+        "Nadia Khoury": "parametrization+Nadia.Khoury@gmail.com",
+    }
+
+    def test_reproduces_the_exact_filed_18(self) -> None:
+        parent_map = {**self.REAL_UNBACKED_18, **self.REAL_BACKED}
+        card_names = set(self.REAL_BACKED)
+        orphans = compute_manifest_orphans(parent_map, card_names, {})
+
+        self.assertEqual(orphans["non_persona"], ["Annunaki", "Steven French"])
+        expected_unreconciled = sorted(set(self.REAL_UNBACKED_18) - {"Annunaki", "Steven French"})
+        self.assertEqual(orphans["unreconciled"], expected_unreconciled)
+        self.assertEqual(len(orphans["unreconciled"]), 16)
+        for name in self.REAL_BACKED:
+            self.assertNotIn(name, orphans["unreconciled"])
+            self.assertNotIn(name, orphans["non_persona"])
+
+    def test_cli_exits_1_on_the_real_unreconciled_16(self) -> None:
+        """End-to-end: main() surfaces this as advisory exit 1 (job stays continue-on-error)."""
+        with TemporaryDirectory() as td:
+            repo = Path(td)
+            _write_parent_roster(repo, {**self.REAL_UNBACKED_18, **self.REAL_BACKED})
+            roster_dir = repo / ".claude" / "team" / "roster"
+            for name in self.REAL_BACKED:
+                _write_roster_card(roster_dir, f"{name.replace(' ', '_').lower()}.md", name)
+            orig_roster = roster_union_sync.fetch_child_roster
+            orig_cards = roster_union_sync.fetch_child_card_names
+            roster_union_sync.fetch_child_roster = lambda owner, r: {}  # type: ignore[assignment]
+            roster_union_sync.fetch_child_card_names = lambda owner, r: set()  # type: ignore[assignment]
+            try:
+                rc = main(["--repo-root", str(repo), "--repos", "noorinalabs-isnad-graph"])
+            finally:
+                roster_union_sync.fetch_child_roster = orig_roster
+                roster_union_sync.fetch_child_card_names = orig_cards
+            self.assertEqual(rc, 1)
 
 
 if __name__ == "__main__":

--- a/.claude/lib/tests/test_roster_union_sync.py
+++ b/.claude/lib/tests/test_roster_union_sync.py
@@ -42,7 +42,7 @@ import json
 import subprocess
 import sys
 import unittest
-from contextlib import redirect_stderr
+from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
@@ -229,44 +229,72 @@ class CliWithInjectedFetcher(unittest.TestCase):
         `data_scientist_mei.md` (Mei-Lin Chang) but her name is absent from
         that repo's OWN `roster.json` — fetching only roster.json would
         false-positive her as unbacked.
+
+        Stream assertions (owner review, PR #1240): `rc` alone cannot pin
+        this — the orphan check is advisory in EVERY outcome, so `rc == 0`
+        whether or not the card union actually ran. Only the emitted report
+        text distinguishes "correctly recognized as backed" from "the card
+        union silently stopped running."
         """
-        rc = self._run(
-            {"Mei-Lin Chang": "parametrization+Mei-Lin.Chang@gmail.com"},
-            {"noorinalabs-isnad-graph": {}},  # absent from the repo's own aggregate
-            "noorinalabs-isnad-graph",
-            card_fetched={
-                "noorinalabs-isnad-graph": {"Mei-Lin Chang"},  # but her CARD exists
-                "noorinalabs-deploy": set(),
-            },
-        )
+        stdout, stderr = io.StringIO(), io.StringIO()
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            rc = self._run(
+                {"Mei-Lin Chang": "parametrization+Mei-Lin.Chang@gmail.com"},
+                {"noorinalabs-isnad-graph": {}},  # absent from the repo's own aggregate
+                "noorinalabs-isnad-graph",
+                card_fetched={
+                    "noorinalabs-isnad-graph": {"Mei-Lin Chang"},  # but her CARD exists
+                    "noorinalabs-deploy": set(),
+                },
+            )
         self.assertEqual(rc, 0)
+        self.assertNotIn("Mei-Lin Chang", stderr.getvalue())
+        self.assertIn("No unreconciled orphans", stdout.getvalue())
 
     def test_deploy_cards_seen_even_though_deploy_has_no_roster_json(self) -> None:
         """`noorinalabs-deploy` is excluded from --repos (no roster.json to fetch,
         DEFAULT_CHILD_REPOS comment) but the #1181 orphan check must still see
         its card directory — it is always added for the card-fetch pass.
+
+        Stream assertions for the same reason as the Mei-Lin Chang test above.
         """
-        rc = self._run(
-            {"Aisha Idrissi": "parametrization+Aisha.Idrissi@gmail.com"},
-            {"noorinalabs-isnad-graph": {}},
-            "noorinalabs-isnad-graph",
-            card_fetched={
-                "noorinalabs-isnad-graph": set(),
-                "noorinalabs-deploy": {"Aisha Idrissi"},
-            },
-        )
+        stdout, stderr = io.StringIO(), io.StringIO()
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            rc = self._run(
+                {"Aisha Idrissi": "parametrization+Aisha.Idrissi@gmail.com"},
+                {"noorinalabs-isnad-graph": {}},
+                "noorinalabs-isnad-graph",
+                card_fetched={
+                    "noorinalabs-isnad-graph": set(),
+                    "noorinalabs-deploy": {"Aisha Idrissi"},
+                },
+            )
         self.assertEqual(rc, 0)
+        self.assertNotIn("Aisha Idrissi", stderr.getvalue())
+        self.assertIn("No unreconciled orphans", stdout.getvalue())
 
     def test_orphan_check_skipped_when_card_fetch_incomplete(self) -> None:
         """A card-fetch skip (here: `noorinalabs-deploy` unreadable) also suppresses
-        the orphan check, same as a roster.json skip — never a false positive."""
-        rc = self._run(
-            {"Persona X": "parametrization+Persona.X@gmail.com"},
-            {"noorinalabs-isnad-graph": {}},
-            "noorinalabs-isnad-graph",
-            card_fetched={"noorinalabs-isnad-graph": set()},  # deploy missing -> None -> skip
-        )
+        the orphan check, same as a roster.json skip — never a false positive.
+
+        Stream assertions (owner review, PR #1240): `rc == 0` is also what an
+        UN-skipped, cleanly-passing run would report, so `rc` alone cannot
+        distinguish "the skip guard fired" from "the skip guard was removed
+        and the check just happened to find nothing." Assert the SKIPPED
+        notice printed and `Persona X` — who WOULD be unreconciled if the
+        check had actually run — never appears anywhere.
+        """
+        stdout, stderr = io.StringIO(), io.StringIO()
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            rc = self._run(
+                {"Persona X": "parametrization+Persona.X@gmail.com"},
+                {"noorinalabs-isnad-graph": {}},
+                "noorinalabs-isnad-graph",
+                card_fetched={"noorinalabs-isnad-graph": set()},  # deploy missing -> None -> skip
+            )
         self.assertEqual(rc, 0)
+        self.assertIn("Manifest-orphan check (#1181) SKIPPED", stdout.getvalue())
+        self.assertNotIn("Persona X", stdout.getvalue() + stderr.getvalue())
 
     def test_orphan_check_skipped_when_any_child_fetch_fails(self) -> None:
         """#1181: an incomplete fetch must not produce a false-positive orphan report.
@@ -275,13 +303,21 @@ class CliWithInjectedFetcher(unittest.TestCase):
         `noorinalabs-user-service` is unreadable, so the check does not run at
         all (fail-open, same posture as the forward direction) and the run
         stays exit 0 (forward drift is separately clean).
+
+        Stream assertions for the same reason as the card-fetch-incomplete
+        test above — `rc` alone does not distinguish "skipped" from "ran and
+        happened to pass."
         """
-        rc = self._run(
-            {"Amara Diallo": "parametrization+Amara.Diallo@gmail.com"},
-            {"noorinalabs-isnad-graph": {}, "noorinalabs-user-service": None},
-            "noorinalabs-isnad-graph,noorinalabs-user-service",
-        )
+        stdout, stderr = io.StringIO(), io.StringIO()
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            rc = self._run(
+                {"Amara Diallo": "parametrization+Amara.Diallo@gmail.com"},
+                {"noorinalabs-isnad-graph": {}, "noorinalabs-user-service": None},
+                "noorinalabs-isnad-graph,noorinalabs-user-service",
+            )
         self.assertEqual(rc, 0)
+        self.assertIn("Manifest-orphan check (#1181) SKIPPED", stdout.getvalue())
+        self.assertNotIn("Amara Diallo", stdout.getvalue() + stderr.getvalue())
 
 
 class FetchChildCardNamesTests(unittest.TestCase):

--- a/.claude/lib/tests/test_roster_union_sync.py
+++ b/.claude/lib/tests/test_roster_union_sync.py
@@ -11,9 +11,9 @@ Verifies:
      "unreconciled"; a non-persona-shaped one (Annunaki/Steven-French shape)
      is "non_persona" and never actionable.
   5. CLI wiring with an injected (monkeypatched) fetcher so tests never touch
-     the network: clean union → exit 0, drift → exit 1, all-skipped → exit 0,
-     missing parent roster → exit 2, orphan drift → exit 1, orphan check
-     skipped when any child fetch failed.
+     the network: clean union → exit 0, forward DRIFT → exit 1, all-skipped →
+     exit 0, missing parent roster → exit 2, orphan check skipped when any
+     child fetch failed.
   6. A non-vacuous regression pinned to the ACTUAL #1181 measurement: the
      exact 18 manifest-only names, real emails, real "18 unbacked" count are
      reproduced verbatim from the issue as a frozen fixture (not a live
@@ -24,15 +24,25 @@ Verifies:
      correctly (2 non_persona + 16 unreconciled) rather than only ever
      exercising a contrived example (#1181 acceptance: "a test that passes
      today proves nothing").
+  7. The exit-code contract correction (owner review, PR #1240): the #1181
+     reverse (orphan) check is advisory in EXIT STATUS, not merely in CI
+     workflow config — it reports unreconciled/non-persona orphans loudly but
+     NEVER moves `exit_code`. Only the pre-existing forward direction (#634:
+     a child persona entirely missing from the parent) can fail the job. A
+     dedicated test pins both halves of that distinction together — advisory
+     orphan drift alongside a genuine forward violation still exits 1, driven
+     by the forward finding alone.
 """
 
 from __future__ import annotations
 
 import base64
+import io
 import json
 import subprocess
 import sys
 import unittest
+from contextlib import redirect_stderr
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
@@ -170,15 +180,47 @@ class CliWithInjectedFetcher(unittest.TestCase):
             rc = main(["--repo-root", str(empty), "--repos", "noorinalabs-isnad-graph"])
             self.assertEqual(rc, 2)
 
-    def test_orphan_drift_exit_1(self) -> None:
-        """#1181: a persona-shaped, uncarded manifest entry is a hard advisory exit 1."""
-        rc = self._run(
-            {"Persona X": "parametrization+Persona.X@gmail.com"},
-            {"noorinalabs-isnad-graph": {}},
-            "noorinalabs-isnad-graph",
-            card_fetched={"noorinalabs-isnad-graph": set(), "noorinalabs-deploy": set()},
-        )
+    def test_orphan_drift_is_advisory_and_exits_0(self) -> None:
+        """#1181 orphan drift alone (owner correction, PR #1240 review): reported
+
+        loudly, but NEVER fails the job on its own — only a genuine forward
+        (#634) violation may do that. See the `_combined_pin` test below for
+        both halves of that distinction pinned together.
+        """
+        stderr = io.StringIO()
+        with redirect_stderr(stderr):
+            rc = self._run(
+                {"Persona X": "parametrization+Persona.X@gmail.com"},
+                {"noorinalabs-isnad-graph": {}},
+                "noorinalabs-isnad-graph",
+                card_fetched={"noorinalabs-isnad-graph": set(), "noorinalabs-deploy": set()},
+            )
+        self.assertEqual(rc, 0)
+        self.assertIn("Persona X", stderr.getvalue())
+        self.assertIn("MANIFEST ORPHAN", stderr.getvalue())
+
+    def test_forward_drift_exits_1_even_with_advisory_orphan_drift(self) -> None:
+        """Pins the exact distinction the owner asked for in one test:
+
+        advisory orphan drift (persona-shaped, uncarded manifest entry) present
+        AND a genuine forward (#634) violation (a child persona missing from
+        the parent) present, in the SAME run — exit 1, driven by the forward
+        finding alone, not the orphan one.
+        """
+        stderr = io.StringIO()
+        with redirect_stderr(stderr):
+            rc = self._run(
+                {"Persona X": "parametrization+Persona.X@gmail.com"},  # orphan: uncarded
+                {"noorinalabs-isnad-graph": {"Imelda Santos": "i@x"}},  # missing from parent
+                "noorinalabs-isnad-graph",
+                card_fetched={"noorinalabs-isnad-graph": set(), "noorinalabs-deploy": set()},
+            )
         self.assertEqual(rc, 1)
+        out = stderr.getvalue()
+        self.assertIn("DRIFT", out)
+        self.assertIn("Imelda Santos", out)
+        self.assertIn("MANIFEST ORPHAN", out)
+        self.assertIn("Persona X", out)
 
     def test_card_only_child_persona_is_not_a_false_positive_orphan(self) -> None:
         """#1181: a card whose OWN repo's roster.json aggregate lags it is not an orphan.
@@ -439,8 +481,17 @@ class RealMeasuredDriftRegressionTests(unittest.TestCase):
             self.assertNotIn(name, orphans["unreconciled"])
             self.assertNotIn(name, orphans["non_persona"])
 
-    def test_cli_exits_1_on_the_real_unreconciled_16(self) -> None:
-        """End-to-end: main() surfaces this as advisory exit 1 (job stays continue-on-error)."""
+    def test_cli_reports_the_real_unreconciled_16_but_exits_0(self) -> None:
+        """End-to-end against the real #1181 data: advisory, so exit 0.
+
+        Owner correction (PR #1240 review): `continue-on-error: true` on the
+        CI job protects the WORKFLOW run's conclusion, but `pr_ci_state.py` /
+        `validate_pr_ci_status.py` (the org's actual merge-readiness oracle)
+        read the JOB's own conclusion from the PR's `statusCheckRollup` — a
+        non-zero exit here would mark every future PR in the repo "failing"
+        until the (explicitly out-of-scope-for-#1181) disposition of these 16
+        names is resolved. So this must exit 0 while still naming all 16.
+        """
         with TemporaryDirectory() as td:
             repo = Path(td)
             _write_parent_roster(repo, {**self.REAL_UNBACKED_18, **self.REAL_BACKED})
@@ -451,12 +502,17 @@ class RealMeasuredDriftRegressionTests(unittest.TestCase):
             orig_cards = roster_union_sync.fetch_child_card_names
             roster_union_sync.fetch_child_roster = lambda owner, r: {}  # type: ignore[assignment]
             roster_union_sync.fetch_child_card_names = lambda owner, r: set()  # type: ignore[assignment]
+            stderr = io.StringIO()
             try:
-                rc = main(["--repo-root", str(repo), "--repos", "noorinalabs-isnad-graph"])
+                with redirect_stderr(stderr):
+                    rc = main(["--repo-root", str(repo), "--repos", "noorinalabs-isnad-graph"])
             finally:
                 roster_union_sync.fetch_child_roster = orig_roster
                 roster_union_sync.fetch_child_card_names = orig_cards
-            self.assertEqual(rc, 1)
+            self.assertEqual(rc, 0)
+            out = stderr.getvalue()
+            for name in set(self.REAL_UNBACKED_18) - {"Annunaki", "Steven French"}:
+                self.assertIn(name, out)
 
 
 if __name__ == "__main__":

--- a/.claude/skills/wave-scope/tests/test_validate_matrix_names.py
+++ b/.claude/skills/wave-scope/tests/test_validate_matrix_names.py
@@ -763,13 +763,101 @@ class OrgUnionManifestTests(unittest.TestCase):
     def test_manifest_names_are_trimmed_and_non_strings_skipped(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             org = self._build_org(
-                Path(tmpdir), manifest={"  Padded Persona  ": "p@example.com", "": "x@example.com"}
+                Path(tmpdir),
+                manifest={
+                    # Persona-shaped so this test exercises TRIMMING, not the
+                    # #1181 shape filter (covered separately below).
+                    "  Padded Persona  ": "parametrization+Padded.Persona@gmail.com",
+                    "": "parametrization+Empty.Name@gmail.com",
+                },
             )
             self.assertEqual(_load_org_manifest_names(org), {"Padded Persona"})
             report = validate(
                 {"noorinalabs-isnad-ingest-platform": {"reviewer": "padded persona"}}, org
             )
             self.assertTrue(report["noorinalabs-isnad-ingest-platform"][0]["resolved"])
+
+
+class PersonaShapeFilterTests(unittest.TestCase):
+    """#1181: manifest entries with no charter-conformant `+alias` do not resolve.
+
+    Mirrors `OrgUnionManifestTests` fixture style. The two cases here are the
+    literal acceptance criterion (`reviewer: "Annunaki"` must not resolve) and
+    its sibling (the bare-principal `Steven French` mapping), plus a guard that
+    the filter does NOT over-correct: a persona-shaped manifest-only name (one
+    of the other 16 #1181 measured) must keep resolving.
+    """
+
+    def _build_org_with_manifest(self, tmp: Path, manifest: dict[str, str]) -> Path:
+        org = _build_fake_org_dir(tmp)
+        path = org / ".claude" / "team" / "roster.json"
+        path.write_text(json.dumps(manifest, indent=2))
+        return org
+
+    def test_annunaki_tool_identity_does_not_resolve(self):
+        """The literal #1181 acceptance criterion."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = self._build_org_with_manifest(
+                Path(tmpdir),
+                {
+                    "Aino Virtanen": "parametrization+Aino.Virtanen@gmail.com",
+                    "Annunaki": "parametrization+Annunaki@gmail.com",
+                },
+            )
+            self.assertNotIn("Annunaki", _load_org_manifest_names(org))
+            report = validate({"noorinalabs-isnad-ingest-platform": {"reviewer": "Annunaki"}}, org)
+            finding = report["noorinalabs-isnad-ingest-platform"][0]
+            self.assertFalse(finding["resolved"], "Annunaki (tool identity) must not resolve")
+            self.assertEqual(_print_report_to_stderr(report), 1)
+
+    def test_bare_principal_does_not_resolve(self):
+        """`Steven French` maps to the bare `parametrization@gmail.com` (no `+alias`)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = self._build_org_with_manifest(
+                Path(tmpdir),
+                {
+                    "Aino Virtanen": "parametrization+Aino.Virtanen@gmail.com",
+                    "Steven French": "parametrization@gmail.com",
+                },
+            )
+            self.assertNotIn("Steven French", _load_org_manifest_names(org))
+            report = validate(
+                {"noorinalabs-isnad-ingest-platform": {"reviewer": "Steven French"}}, org
+            )
+            self.assertFalse(report["noorinalabs-isnad-ingest-platform"][0]["resolved"])
+
+    def test_persona_shaped_manifest_only_name_still_resolves(self):
+        """The filter narrows exactly the non-persona entries, not every uncarded one.
+
+        A manifest-only name that IS persona-shaped (one of #1181's other 16,
+        real-looking but still uncarded anywhere) must keep resolving as a
+        reviewer — #1181 does not reconcile that disposition, only the two
+        definitionally-wrong entries.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = self._build_org_with_manifest(
+                Path(tmpdir),
+                {"Amara Diallo": "parametrization+Amara.Diallo@gmail.com"},
+            )
+            self.assertIn("Amara Diallo", _load_org_manifest_names(org))
+            report = validate(
+                {"noorinalabs-isnad-ingest-platform": {"reviewer": "Amara Diallo"}}, org
+            )
+            self.assertTrue(report["noorinalabs-isnad-ingest-platform"][0]["resolved"])
+
+    def test_non_persona_shape_variants_excluded(self):
+        """Pure unit coverage of the regex boundary, independent of `validate()`."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = self._build_org_with_manifest(
+                Path(tmpdir),
+                {
+                    "No Alias": "parametrization@gmail.com",
+                    "No Dot": "parametrization+NoDot@gmail.com",
+                    "Bot Login": "12345+octocat@users.noreply.github.com",
+                    "Real Persona": "parametrization+Real.Persona@gmail.com",
+                },
+            )
+            self.assertEqual(_load_org_manifest_names(org), {"Real Persona"})
 
 
 if __name__ == "__main__":

--- a/.claude/skills/wave-scope/validate_matrix_names.py
+++ b/.claude/skills/wave-scope/validate_matrix_names.py
@@ -28,6 +28,36 @@ THIRD child repo — permitted by `charter/agents/spawn-discipline.md`
 target repo's, so it was reported UNRESOLVED with "(no close matches)". Live
 instance: `Nikolaos Papadopoulos` / `Oyunbileg Batbayar` (cards in
 `noorinalabs-data-acquisition`) reviewing `isnad-ingest-platform` stories in W28.
+
+Manifest entries are filtered to PERSONAS only (#1181)
+=======================================================
+#1181 measured `roster.json` (78 entries) against the union of every roster
+card in the org (60 names) and found 18 manifest-only entries — names the
+manifest widens the review-class set with but that back no spawnable persona
+anywhere. Two of the 18 are not merely uncarded, they are DEFINITIONALLY not
+reviewers: `Annunaki` (the error-monitoring tool's commit identity — it posts
+real PR comments, so admitting it as a `reviewer` is a live risk) and
+`Steven French` mapping to the bare `parametrization@gmail.com` (no `+alias`
+tag — the #1177 squash-collapse address, not a person's own address).
+
+`_load_org_manifest_names` therefore only returns entries whose address is a
+charter-conformant per-persona commit identity, `_PERSONA_ALIAS_RE`
+(`<principal>+<First>.<Last>@<domain>`) — the SAME matcher
+`.claude/hooks/validate_pr_review.py::_PERSONA_ALIAS_RE` uses for the
+merge-time twin of this check (#1179/#1181; that gate got this filter first,
+this one did not, which is exactly the drift #1181 flags). A small duplicated
+regex across the two sibling parsers is the established pattern here (see
+`_load_roster_names` below on the H1/verbose card dual-format regexes) rather
+than a cross-module import between a hook and a skill.
+
+Filtering on identity SHAPE — not a hand-maintained non-persona blocklist —
+is deliberate: it keeps this gate correct today without waiting on a
+disposition decision for the other 16 manifest-only names (prune vs onboard,
+still open), and it stays correct if the manifest ever grows another tool
+identity. The remaining 16 manifest-only names ARE persona-shaped and keep
+resolving as reviewers post-#1181 — #1181 narrows the DEFINITIONALLY-wrong
+two, it does not reconcile the other 16 (that disposition is tracked
+separately; see `.claude/lib/roster_union_sync.py`'s manifest-orphan report).
 Pre-existing since #319, but #1134 made § 12.5 mandatory over every canonical
 `tier_*` row and added a hard `exit 1` at `/wave-kickoff` § 0b, turning a latent
 gap into a STOP on a charter-permitted assignment.
@@ -183,6 +213,14 @@ COMMIT_CAPABLE_ROLES: frozenset[str] = frozenset({"implementer"})
 # (the parent roster IS the repo roster), so #1134 never fires on them.
 PARENT_REPO_KEYS: frozenset[str] = frozenset({"", "noorinalabs-main", "main"})
 
+# A manifest entry is a PERSONA only if its address is a charter-conformant
+# per-persona commit identity: `<principal>+<First>.<Last>@<domain>` (CLAUDE.md
+# § Key Rules / charter `pull-requests.md` § Commit Identity). Same matcher as
+# `.claude/hooks/validate_pr_review.py::_PERSONA_ALIAS_RE` (#1179) — see
+# `_load_org_manifest_names` below for why this module keeps its own small
+# duplicate rather than importing across the hook/skill boundary (#1181).
+_PERSONA_ALIAS_RE = re.compile(r"^[^\s@+]+\+[^\s@+]+\.[^\s@+]+@[^\s@]+\.[^\s@]+$")
+
 
 def _find_org_dir() -> Path:
     """Find the directory that contains all `noorinalabs-*` repo checkouts.
@@ -239,16 +277,30 @@ def _load_roster_names(roster_dir: Path) -> set[str]:
 
 
 def _load_org_manifest_names(org_dir: Path) -> set[str]:
-    """Parse names from the parent's org-union manifest `.claude/team/roster.json`.
+    """Parse PERSONA names from the parent's org-union manifest `.claude/team/roster.json`.
 
     The manifest is a flat `{"<name>": "<email>"}` object covering every persona
     across the org (78 at time of writing) — a strict superset of the parent's
     own card directory, and the only place a persona from a repo that is not the
     target repo can be recognised without cloning that repo.
 
+    **Persona filter (#1181).** Only entries whose address matches
+    `_PERSONA_ALIAS_RE` are returned. The manifest is the LOOSER authority — it
+    can (and, measured, does) carry an entry that backs no spawnable person:
+    18 manifest-only names at #1181's measurement, of which `Annunaki` (the
+    error-monitor's commit identity) and `Steven French` (the bare
+    `parametrization@gmail.com` principal, no `+alias`) are DEFINITIONALLY not
+    reviewers regardless of whether they ever get a roster card. Filtering on
+    identity SHAPE keeps this gate correct today without waiting on the
+    disposition of the other 16 (real-looking, still-uncarded) names, and
+    stays correct if the manifest ever grows another tool identity.
+
     Fails OPEN (empty set) when the file is missing or malformed: the manifest
     only ever WIDENS the review-class resolution set, so an unreadable manifest
-    degrades to exactly the pre-#1162 behaviour rather than blocking a run.
+    degrades to exactly the pre-#1162 behaviour rather than blocking a run. A
+    non-string address is likewise treated as non-persona rather than crashing
+    — if `roster.json` ever grows a richer per-entry schema, this parser
+    narrows rather than guessing, which is the recoverable direction.
     """
     path = org_dir / ".claude" / "team" / "roster.json"
     try:
@@ -257,7 +309,14 @@ def _load_org_manifest_names(org_dir: Path) -> set[str]:
         return set()
     if not isinstance(data, dict):
         return set()
-    return {name.strip() for name in data if isinstance(name, str) and name.strip()}
+    return {
+        name.strip()
+        for name, address in data.items()
+        if isinstance(name, str)
+        and name.strip()
+        and isinstance(address, str)
+        and _PERSONA_ALIAS_RE.match(address.strip())
+    }
 
 
 def _load_repo_roster(org_dir: Path, repo: str) -> set[str]:


### PR DESCRIPTION
## Summary

`#1181` measured 18 manifest-only names in `.claude/team/roster.json` (78 entries vs a 60-name union of every roster card in the org), of which `Annunaki` (the error-monitor's own commit identity) and `Steven French` (the bare `parametrization@gmail.com` principal, no `+alias`) are definitionally not reviewers.

`.claude/skills/wave-scope/validate_matrix_names.py`'s `_load_org_manifest_names` widened review-class slot resolution (`reviewer`/`reviewer_2`/`merge_gate_reviewer`) to every manifest key with no shape filter — unlike its merge-time sibling in `.claude/hooks/validate_pr_review.py` (already fixed by #1179/PR #1199), which excludes non-persona entries via `_PERSONA_ALIAS_RE`. So `reviewer: "Annunaki"` resolved at scope time even though the merge-time gate already rejected it. This PR ports the same filter, closing that drift between the two gates.

It also adds the reverse assertion `.claude/lib/roster_union_sync.py` was missing (raised in #1181's consolidating comment): manifest ⊆ (this repo's cards) ∪ (every child's card directory) ∪ (every child's own `roster.json`). Advisory only (`continue-on-error`, unchanged), and skips entirely when any fetch is incomplete rather than risk a false "prune this" verdict on a name we simply failed to read.

**A note on scope:** while building the reverse check, the assumption "a child's own `roster.json` is a complete substitute for that child's cards" (#1183's `card-only == 0` measurement) turned out to have already drifted — live data shows two real, carded personas absent from their own repo's `roster.json` (`noorinalabs-isnad-graph`'s `data_scientist_mei.md` / Mei-Lin Chang, and `noorinalabs-deploy`'s `sre_engineer_aisha.md` / Aisha Idrissi, the latter also invisible to every roster.json-only check since `noorinalabs-deploy` has no `roster.json` at all). Rather than ship a check that immediately false-positives on two active people, `fetch_child_card_names` fetches every child's card directory directly. Verified against real org data — reproduces exactly the 16 unreconciled + 2 non-persona split #1181/#1183 measured, with no false positives.

**Explicitly out of scope for this PR** (left for an owner decision, not invented here):
- Disposition of the other 16 persona-shaped, still-uncarded manifest names (prune vs onboard) — the new reverse check surfaces them as advisory `unreconciled` orphans but does not decide for a human.
- Reconsidering `continue-on-error: true` on the `roster-union-sync` CI job (`commit-identity.yml:56`) — a blocking-posture change to an org-wide gate, not something to change unilaterally.
- Restoring a full "liveness" property (auto-pruning an offboarded persona) — the new check gives ongoing advisory visibility instead of automatic removal, which stays a human-approved diff per the org's memory-pruning convention.

## Changes
- `.claude/skills/wave-scope/validate_matrix_names.py` — `_load_org_manifest_names` now filters manifest entries to charter-conformant persona addresses (`_PERSONA_ALIAS_RE`, same matcher as `validate_pr_review.py`'s #1179 fix).
- `.claude/skills/wave-scope/tests/test_validate_matrix_names.py` — new `PersonaShapeFilterTests` (Annunaki/bare-principal exclusion, persona-shaped-but-uncarded names still resolve); fixed one existing fixture that used non-persona-shaped test emails.
- `.claude/lib/roster_union_sync.py` — new `parent_roster_map`, `local_card_names`, `fetch_child_card_names`, `compute_manifest_orphans`; `main()` now also runs and reports the reverse (orphan) check.
- `.claude/lib/tests/test_roster_union_sync.py` — new pure-function tests, CLI wiring tests (including the false-positive regression guards for Mei-Lin Chang / Aisha Idrissi), and a non-vacuous regression pinned to the real #1181 18-name measurement (16 unreconciled + 2 non-persona).

## Test plan
- [x] `PYTHONDONTWRITEBYTECODE=1 ENVIRONMENT=test python3 -m pytest .claude/skills/wave-scope/tests/ -q` — 45 passed
- [x] `PYTHONDONTWRITEBYTECODE=1 ENVIRONMENT=test python3 -m pytest .claude/lib/tests/test_roster_union_sync.py -q` — 31 passed
- [x] `ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/ .claude/lib/tests/ -q` — 3456 passed, 647 subtests passed
- [x] Full skill test suite loop (mirrors `pytest-skills` pre-push hook) — all green
- [x] `python3 -m mypy --ignore-missing-imports --no-error-summary` on all 4 changed files — no issues
- [x] `pre-commit run --all-files` and `pre-commit run --all-files --hook-stage pre-push` — all green
- [x] `python3 .claude/lib/pre_commit_ci_sync.py .` and `python3 .claude/lib/memory_budget.py .` — both OK
- [x] Manual end-to-end run of `roster_union_sync.py` against real org data — reproduces exactly 16 unreconciled + 2 non-persona, matching #1181/#1183's measurement, no false positives

Closes #1181

Co-Authored-By: Wanjiku Mwangi <parametrization+Wanjiku.Mwangi@gmail.com>
