### PR TITLE
tech-debt(session-start): stream check_worktree_merged's log|patch-id pipeline

### DIFF
--- a/.claude/lib/check_worktree_merged.py
+++ b/.claude/lib/check_worktree_merged.py
@@ -48,8 +48,11 @@ internal commit ordering:**
      (the branch's *entire* accumulated change, computed once, over the
      full range — never an intermediate prefix) is compared by patch-id
      against every commit `remote_ref` has gained since `merge_base`
-     (`git log -p --first-parent merge_base..remote_ref` fed through
-     `git patch-id --stable`). A match means some single commit on
+     (`git log -p --first-parent merge_base..remote_ref` streamed directly
+     into `git patch-id --stable` over an OS pipe — `_git_log_patch_id`,
+     #1214 — rather than buffered into a Python string first; this is a
+     memory-profile change only, the comparison result is unaffected). A
+     match means some single commit on
      `remote_ref` — the squash, or a single-commit rebase/cherry-pick — *is*
      the landed form of `head`'s entire accumulated content. Because this
      only ever looks at `merge_base` and `head`'s final trees, it is
@@ -177,9 +180,15 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 GitRunner = Callable[[Sequence[str], Path], "subprocess.CompletedProcess[str]"]
-# A second runner shape for the two commands that need to feed a diff/log
-# stream to `git patch-id` on stdin rather than take a rev-range argument.
+# A second runner shape for the one command that needs to feed a diff stream
+# to `git patch-id` on stdin (the branch's own, bounded-size diff).
 PipeRunner = Callable[[Sequence[str], Path, str], "subprocess.CompletedProcess[str]"]
+# A third runner shape for `git log -p ... | git patch-id --stable` (#1214):
+# unlike PipeRunner, this one never receives the log text as a Python string
+# at all — see `_git_log_patch_id`. Same call shape as GitRunner (a git
+# argv + cwd in, a CompletedProcess-shaped result out) since the caller never
+# needs to supply input text; only the *implementation* streams internally.
+LogPatchIdRunner = Callable[[Sequence[str], Path], "subprocess.CompletedProcess[str]"]
 
 
 def _git(args: Sequence[str], cwd: Path) -> subprocess.CompletedProcess[str]:
@@ -201,6 +210,67 @@ def _git_pipe(args: Sequence[str], cwd: Path, input_text: str) -> subprocess.Com
         text=True,
         check=False,
     )
+
+
+def _git_log_patch_id(log_args: Sequence[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    """Run ``git <log_args>`` piped directly into ``git patch-id --stable``
+    over an OS-level pipe, without ever materializing the (potentially large,
+    O(worktree staleness)) patch text as a Python string (#1214).
+
+    Behaviourally identical to::
+
+        log = _git(log_args, cwd)
+        return _git_pipe(["patch-id", "--stable"], cwd, log.stdout)
+
+    — same combined exit-code/stdout/stderr contract from the caller's point
+    of view — but `git log`'s stdout file descriptor is connected straight to
+    `git patch-id`'s stdin via `Popen(stdin=<the other process's stdout
+    pipe>)`, so this process never holds more than `git patch-id`'s own
+    output resident (one short line per commit, not the full diff text).
+
+    Only `git patch-id`'s stdout is meaningful on success (the same
+    ``<patch-id> [<sha>]`` lines `_parse_patch_ids` expects); the combined
+    ``returncode`` is 0 only if *both* stages exited 0, so a `git log`
+    failure degrades exactly like a `git patch-id` failure did before this
+    change — the caller does not need to know which stage failed.
+    """
+    log_proc = subprocess.Popen(
+        ["git", *log_args],
+        cwd=str(cwd),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    assert log_proc.stdout is not None  # guaranteed by stdout=PIPE above
+    patch_id_proc = subprocess.Popen(
+        ["git", "patch-id", "--stable"],
+        cwd=str(cwd),
+        stdin=log_proc.stdout,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    # Standard Popen -> Popen pipe idiom: release our copy of the read end so
+    # patch_id_proc's own (already-duplicated) fd is what keeps it open, and
+    # `git log` gets a normal EOF/SIGPIPE signal once patch-id is done.
+    log_proc.stdout.close()
+
+    patch_stdout, patch_stderr = patch_id_proc.communicate()
+    log_proc.wait()
+    log_stderr = log_proc.stderr.read() if log_proc.stderr is not None else ""
+    if log_proc.stderr is not None:
+        log_proc.stderr.close()
+
+    argv_desc = ["git", *log_args, "|", "git", "patch-id", "--stable"]
+    if log_proc.returncode != 0:
+        return subprocess.CompletedProcess(
+            args=argv_desc, returncode=log_proc.returncode, stdout="", stderr=log_stderr
+        )
+    if patch_id_proc.returncode != 0:
+        return subprocess.CompletedProcess(
+            args=argv_desc, returncode=patch_id_proc.returncode, stdout="", stderr=patch_stderr
+        )
+    return subprocess.CompletedProcess(args=argv_desc, returncode=0, stdout=patch_stdout, stderr="")
 
 
 @dataclass
@@ -268,6 +338,7 @@ def classify_merged(
     *,
     runner: GitRunner = _git,
     pipe_runner: PipeRunner = _git_pipe,
+    log_patch_id_runner: LogPatchIdRunner = _git_log_patch_id,
 ) -> MergeClassification:
     """Classify whether ``head`` is fully merged into ``remote_ref``. See module docs."""
     root = Path(repo_root)
@@ -337,20 +408,20 @@ def classify_merged(
         )
     own_patch_id = own_pairs[0][0]
 
-    main_log = runner(["log", "-p", "--first-parent", f"{merge_base}..{remote_ref}"], root)
-    if main_log.returncode != 0:
-        return _degrade(
-            "content-check-failed",
-            f"git log -p --first-parent {merge_base}..{remote_ref} failed "
-            f"(exit {main_log.returncode}): {main_log.stderr.strip()} "
-            f"— degraded to ancestry-only result",
-        )
-    main_pid_res = pipe_runner(["patch-id", "--stable"], root, main_log.stdout)
+    # Streamed (#1214): `git log -p ...` is piped straight into `git patch-id`
+    # over an OS pipe rather than buffered into a Python string first — see
+    # `_git_log_patch_id`. Same net effect as the old two-step
+    # runner(["log", ...]) + pipe_runner(["patch-id", ...], log.stdout)
+    # sequence, just without the O(patch size) resident string in between.
+    main_pid_res = log_patch_id_runner(
+        ["log", "-p", "--first-parent", f"{merge_base}..{remote_ref}"], root
+    )
     if main_pid_res.returncode != 0:
         return _degrade(
             "content-check-failed",
-            f"git patch-id (main range) failed (exit {main_pid_res.returncode}): "
-            f"{main_pid_res.stderr.strip()} — degraded to ancestry-only result",
+            f"git log -p --first-parent {merge_base}..{remote_ref} | git patch-id --stable "
+            f"failed (exit {main_pid_res.returncode}): {main_pid_res.stderr.strip()} "
+            f"— degraded to ancestry-only result",
         )
     main_pids = dict(_parse_patch_ids(main_pid_res.stdout))
 

--- a/.claude/lib/check_worktree_merged.py
+++ b/.claude/lib/check_worktree_merged.py
@@ -175,6 +175,7 @@ from __future__ import annotations
 
 import subprocess
 import sys
+import tempfile
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -233,33 +234,53 @@ def _git_log_patch_id(log_args: Sequence[str], cwd: Path) -> subprocess.Complete
     ``returncode`` is 0 only if *both* stages exited 0, so a `git log`
     failure degrades exactly like a `git patch-id` failure did before this
     change — the caller does not need to know which stage failed.
-    """
-    log_proc = subprocess.Popen(
-        ["git", *log_args],
-        cwd=str(cwd),
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-    )
-    assert log_proc.stdout is not None  # guaranteed by stdout=PIPE above
-    patch_id_proc = subprocess.Popen(
-        ["git", "patch-id", "--stable"],
-        cwd=str(cwd),
-        stdin=log_proc.stdout,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-    )
-    # Standard Popen -> Popen pipe idiom: release our copy of the read end so
-    # patch_id_proc's own (already-duplicated) fd is what keeps it open, and
-    # `git log` gets a normal EOF/SIGPIPE signal once patch-id is done.
-    log_proc.stdout.close()
 
-    patch_stdout, patch_stderr = patch_id_proc.communicate()
-    log_proc.wait()
-    log_stderr = log_proc.stderr.read() if log_proc.stderr is not None else ""
-    if log_proc.stderr is not None:
-        log_proc.stderr.close()
+    **Why `git log`'s stderr goes to a `tempfile`, not a pipe (#1249).**
+    `patch_id_proc.communicate()` below drains `patch_id_proc`'s own
+    stdout+stderr concurrently (that is what `communicate()` is for), but it
+    knows nothing about `log_proc`'s stderr. If `log_proc`'s stderr were
+    `subprocess.PIPE` (as it originally was), nobody drains that pipe until
+    *after* `communicate()` returns — and `communicate()` doesn't return
+    until `git log` finishes writing its stdout. A `git log` that writes more
+    than one OS pipe-buffer's worth of stderr (~64KiB on Linux — plausible
+    across a large `merge_base..remote_ref` range, e.g. a per-commit warning
+    repeated many times) blocks mid-write on the full stderr pipe, which
+    stalls its stdout too, which stalls `patch_id_proc` waiting on stdin —
+    the classic "multiple pipes into one drain point, only one drained"
+    deadlock `communicate()` exists to avoid for a *single* process, just
+    relocated to the *other* process's stderr in a two-`Popen` pipeline.
+    Routing it to an unbounded-capacity `tempfile.TemporaryFile` instead
+    means a write there can never block on a reader, so this hazard cannot
+    reoccur regardless of how much `git log` writes to stderr.
+    """
+    with tempfile.TemporaryFile() as log_stderr_file:
+        log_proc = subprocess.Popen(
+            ["git", *log_args],
+            cwd=str(cwd),
+            stdout=subprocess.PIPE,
+            stderr=log_stderr_file,
+            text=True,
+        )
+        assert log_proc.stdout is not None  # guaranteed by stdout=PIPE above
+        patch_id_proc = subprocess.Popen(
+            ["git", "patch-id", "--stable"],
+            cwd=str(cwd),
+            stdin=log_proc.stdout,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        # Standard Popen -> Popen pipe idiom: release our copy of the read
+        # end so patch_id_proc's own (already-duplicated) fd is what keeps it
+        # open, and `git log` gets a normal EOF/SIGPIPE signal once patch-id
+        # is done — dropping this leaves our copy open, so `git log` never
+        # sees EOF/SIGPIPE if `patch-id` exits early (hang risk + fd leak).
+        log_proc.stdout.close()
+
+        patch_stdout, patch_stderr = patch_id_proc.communicate()
+        log_proc.wait()
+        log_stderr_file.seek(0)
+        log_stderr = log_stderr_file.read().decode("utf-8", errors="replace")
 
     argv_desc = ["git", *log_args, "|", "git", "patch-id", "--stable"]
     if log_proc.returncode != 0:

--- a/.claude/lib/tests/test_check_worktree_merged.py
+++ b/.claude/lib/tests/test_check_worktree_merged.py
@@ -743,17 +743,31 @@ class CheckWorktreeMergedTest(unittest.TestCase):
         OTHER helper in this module (`_git`, `_git_pipe`) goes through
         `subprocess.run` (`capture_output=True` / `input=<str>`, which
         necessarily buffers); `_git_log_patch_id` must never call
-        `subprocess.run` at all, only `Popen`, and the second `Popen`'s
-        `stdin` must be the first `Popen`'s own stdout pipe object (not a
-        string) — `input=` never appears in its kwargs."""
+        `subprocess.run` at all, only `Popen`.
+
+        Strengthened per #1251 finding 2: the ORIGINAL version of this test
+        (checking only `stdin is not None` and `not isinstance(stdin, str)`)
+        passed for a mutant that fully buffers `log_proc`'s output via
+        `log_proc.communicate()` and then feeds the buffered string to
+        `patch_id_proc.communicate(input=...)` with `stdin=subprocess.PIPE`
+        — `subprocess.PIPE` is an `int`, not a `str`, so the old assertions
+        were blind to it. The second `Popen`'s `stdin` must therefore be
+        checked to be neither `None` NOR the `subprocess.PIPE` sentinel, AND
+        must expose `fileno()` (a real OS-level pipe/file object, not the
+        "please give me a pipe" request constant) — verified to be exactly
+        the first `Popen`'s own `stdout` pipe object by identity, and that
+        object must end up closed (the fd-release idiom, #1251 finding 3)."""
         self._multi_commit_squash()
 
         popen_calls: list[dict[str, object]] = []
+        created_procs: list[subprocess.Popen[str]] = []
         real_popen = subprocess.Popen
 
         def recording_popen(*args: Any, **kwargs: Any) -> subprocess.Popen[str]:
             popen_calls.append(kwargs)
-            return real_popen(*args, **kwargs)
+            proc = real_popen(*args, **kwargs)
+            created_procs.append(proc)
+            return proc
 
         with (
             unittest.mock.patch("subprocess.run") as mock_run,
@@ -764,11 +778,25 @@ class CheckWorktreeMergedTest(unittest.TestCase):
         mock_run.assert_not_called()
         self.assertEqual(result.returncode, 0)
         self.assertEqual(len(popen_calls), 2)
+        self.assertEqual(len(created_procs), 2)
         log_kwargs, patch_kwargs = popen_calls
+        log_proc, _patch_id_proc = created_procs
         self.assertEqual(log_kwargs["stdout"], subprocess.PIPE)
         self.assertNotIn("input", patch_kwargs)
         self.assertIsNotNone(patch_kwargs.get("stdin"))
         self.assertNotIsInstance(patch_kwargs["stdin"], str)
+        # #1251 finding 2: PIPE is an int sentinel meaning "give me a new
+        # pipe" -- a mutant that fully buffers and re-feeds via
+        # `communicate(input=...)` would set stdin=subprocess.PIPE here, not
+        # an actual stream object. Must be a real pipe/file-like object AND
+        # the exact one log_proc itself produced (identity, not just shape).
+        self.assertNotEqual(patch_kwargs["stdin"], subprocess.PIPE)
+        self.assertTrue(hasattr(patch_kwargs["stdin"], "fileno"))
+        self.assertIs(patch_kwargs["stdin"], log_proc.stdout)
+        # #1251 finding 3: our copy of the read end must be released (closed)
+        # so `git log` gets a normal EOF/SIGPIPE once patch-id is done.
+        assert log_proc.stdout is not None
+        self.assertTrue(log_proc.stdout.closed)
 
     def test_git_log_patch_id_output_matches_manual_buffer_then_pipe(self) -> None:
         """Correctness pin (#1214): the streamed helper's output must be
@@ -797,6 +825,100 @@ class CheckWorktreeMergedTest(unittest.TestCase):
             self.repo,
         )
         self.assertNotEqual(result.returncode, 0)
+
+    def test_git_log_patch_id_patch_id_stage_failure_returns_nonzero(self) -> None:
+        """#1251 finding 1: the `git patch-id`-stage failure branch
+        (`if patch_id_proc.returncode != 0: ...`) was the only uncovered
+        line in the helper — the consolidated `test_main_log_patch_id_
+        failure_degrades` injects a fake at the whole `log_patch_id_runner`
+        seam (covers `classify_merged`'s degrade path, not this helper's own
+        two internal branches), and the log-stage-failure test above only
+        exercises the OTHER branch. Real `git patch-id --stable` essentially
+        never fails on well-formed stdin, so this exercises the branch by
+        substituting a failing command for the second `Popen` call only,
+        while the first (`git log`) call runs for real and unmodified."""
+        self._multi_commit_squash()
+        real_popen = subprocess.Popen
+
+        def failing_patch_id_popen(*args: Any, **kwargs: Any) -> subprocess.Popen[str]:
+            argv = args[0] if args else kwargs.pop("args", None)
+            if isinstance(argv, list) and "patch-id" in argv:
+                argv = ["false"]  # always exits 1, ignores stdin
+            return real_popen(argv, **kwargs)
+
+        with unittest.mock.patch("subprocess.Popen", failing_patch_id_popen):
+            result = _git_log_patch_id(["log", "-p", "--first-parent", "main"], self.repo)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "")
+
+    # ---- streaming (#1249): log-stage stderr must never deadlock the pipe ----
+
+    def test_git_log_patch_id_log_stderr_routed_off_bounded_pipe(self) -> None:
+        """#1249, fast structural pin: `_git_log_patch_id`'s FIRST `Popen`
+        call (`git log`) must not set `stderr=subprocess.PIPE` — a bounded OS
+        pipe that nobody drains until AFTER `patch_id_proc.communicate()`
+        returns, which cannot happen until `git log` itself finishes (see
+        the real-process reproduction below and the module docstring). A
+        real file object (has `fileno()`, unbounded by pipe-buffer size) is
+        required instead."""
+        self._multi_commit_squash()
+        popen_calls: list[dict[str, object]] = []
+        real_popen = subprocess.Popen
+
+        def recording_popen(*args: Any, **kwargs: Any) -> subprocess.Popen[str]:
+            popen_calls.append(kwargs)
+            return real_popen(*args, **kwargs)
+
+        with unittest.mock.patch("subprocess.Popen", recording_popen):
+            _git_log_patch_id(["log", "-p", "--first-parent", "main"], self.repo)
+
+        log_kwargs, _patch_kwargs = popen_calls
+        self.assertNotEqual(log_kwargs["stderr"], subprocess.PIPE)
+        self.assertTrue(hasattr(log_kwargs["stderr"], "fileno"))
+
+    def test_git_log_patch_id_large_log_stderr_does_not_deadlock(self) -> None:
+        """#1249, real-process reproduction: a `git log -p` whose diff driver
+        (`.gitattributes` `textconv`) writes well over one OS pipe-buffer's
+        worth (~64KiB on Linux) of STDERR across the range must not hang the
+        pipeline. Run in a genuinely separate process with a hard wall-clock
+        timeout so an actual regression fails this test FAST (seconds)
+        rather than hanging the whole suite indefinitely."""
+        noisy = self.repo / "noisy_textconv.sh"
+        noisy.write_text('#!/usr/bin/env bash\nyes x | head -c 20000 >&2\ncat "$1"\n')
+        noisy.chmod(0o755)
+        _git(["config", "diff.noisy.textconv", str(noisy)], self.repo)
+        _write(self.repo, ".gitattributes", "noisy.dat diff=noisy\n")
+        _git(["add", ".gitattributes"], self.repo)
+        _git(["commit", "-m", "add noisy.dat textconv driver"], self.repo)
+        for i in range(4):
+            _commit(self.repo, "noisy.dat", f"payload {i}\n" * 50, f"noisy commit {i}")
+
+        script = (
+            "import sys\n"
+            f"sys.path.insert(0, {str(Path(__file__).resolve().parent.parent)!r})\n"
+            "from pathlib import Path\n"
+            "from check_worktree_merged import _git_log_patch_id\n"
+            "result = _git_log_patch_id(\n"
+            "    ['log', '-p', '--first-parent', 'main'],\n"
+            f"    Path({str(self.repo)!r}),\n"
+            ")\n"
+            "print(result.returncode)\n"
+        )
+        try:
+            proc = subprocess.run(
+                [sys.executable, "-c", script],
+                capture_output=True,
+                text=True,
+                timeout=20,
+            )
+        except subprocess.TimeoutExpired:
+            self.fail(
+                "_git_log_patch_id deadlocked on a large git-log stderr stream "
+                "(#1249 regression) -- did not return within 20s"
+            )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(proc.stdout.strip(), "0")
 
     def test_cherry_failure_degrades(self) -> None:
         """Cherry is only reached when test 1 (net-content) does not match —

--- a/.claude/lib/tests/test_check_worktree_merged.py
+++ b/.claude/lib/tests/test_check_worktree_merged.py
@@ -836,14 +836,26 @@ class CheckWorktreeMergedTest(unittest.TestCase):
         exercises the OTHER branch. Real `git patch-id --stable` essentially
         never fails on well-formed stdin, so this exercises the branch by
         substituting a failing command for the second `Popen` call only,
-        while the first (`git log`) call runs for real and unmodified."""
+        while the first (`git log`) call runs for real and unmodified.
+
+        Must DRAIN stdin before exiting, not just exit immediately: a
+        command that exits without reading stdin (the original `["false"]`
+        here) makes `git log` take SIGPIPE while still writing, which sends
+        `log_proc.returncode` negative — and `_git_log_patch_id` checks
+        `log_proc.returncode != 0` FIRST, so the test would silently pass
+        through the OTHER (log-stage) branch instead of the one it names
+        and claims to isolate (caught in merge-gate review of PR #1247:
+        `log_proc.returncode` went to -13, line 290 — the target branch —
+        was never reached, yet the assertions still passed on the wrong
+        branch). `sh -c "cat >/dev/null; exit 1"` reads stdin to EOF (so
+        `git log` finishes writing and exits 0 normally) before failing."""
         self._multi_commit_squash()
         real_popen = subprocess.Popen
 
         def failing_patch_id_popen(*args: Any, **kwargs: Any) -> subprocess.Popen[str]:
             argv = args[0] if args else kwargs.pop("args", None)
             if isinstance(argv, list) and "patch-id" in argv:
-                argv = ["false"]  # always exits 1, ignores stdin
+                argv = ["sh", "-c", "cat >/dev/null; exit 1"]
             return real_popen(argv, **kwargs)
 
         with unittest.mock.patch("subprocess.Popen", failing_patch_id_popen):

--- a/.claude/lib/tests/test_check_worktree_merged.py
+++ b/.claude/lib/tests/test_check_worktree_merged.py
@@ -63,10 +63,16 @@ piped through `git patch-id --stable`, and `git cherry`). Coverage:
     -> merged / content-equivalent
   * every internal git-command failure/unexpected-result site degrades to
     unmerged, never merged: own diff, own diff patch-id, own diff patch-id
-    producing no output for a non-empty diff (fail-open guard), main log,
-    main patch-id, git cherry, the per-"+"-candidate empty-commit diff
-    check, the merges rev-list enumeration, and the evil-merge
-    diff-tree --cc check
+    producing no output for a non-empty diff (fail-open guard), the
+    streamed main-range log|patch-id pipeline (either stage), git cherry,
+    the per-"+"-candidate empty-commit diff check, the merges rev-list
+    enumeration, and the evil-merge diff-tree --cc check
+  * streaming (#1214): `_git_log_patch_id` connects `git log -p`'s stdout
+    directly to `git patch-id`'s stdin over an OS pipe instead of buffering
+    the full patch text into a Python string first — pinned structurally
+    (no `subprocess.run`/`input=` call site, `stdin` is a pipe object) and
+    for output-equivalence against the old buffer-then-pipe two-step, with
+    a dedicated failure case for the `git log` stage itself
   * CLI exit code mirrors `.merged` (0 iff merged, 1 otherwise)
 """
 
@@ -75,9 +81,11 @@ from __future__ import annotations
 import subprocess
 import sys
 import unittest
+import unittest.mock
 from collections.abc import Sequence
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from typing import Any
 
 # Helper lives at .claude/lib/check_worktree_merged.py; this test is at
 # .claude/lib/tests/.
@@ -85,7 +93,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from check_worktree_merged import (  # noqa: E402
     GitRunner,
+    LogPatchIdRunner,
     PipeRunner,
+    _git_log_patch_id,
     classify_merged,
 )
 from check_worktree_merged import (
@@ -164,6 +174,25 @@ def _runner_intercepting(subcommand: str, occurrence: int, *, mode: str = "fail"
             if seen["n"] == occurrence:
                 return _fail(args) if mode == "fail" else _empty_ok(args)
         return _git_ok(list(args), cwd)
+
+    return wrapper
+
+
+def _log_patch_id_failing(
+    returncode: int = 128, stderr: str = "simulated failure"
+) -> LogPatchIdRunner:
+    """A LogPatchIdRunner fake that fails unconditionally — stands in for
+    EITHER of the two stages `_git_log_patch_id` pipes together (`git log`
+    or `git patch-id`) failing, since #1214 merged both into one seam that
+    classify_merged only ever sees a single combined pass/fail result from."""
+
+    def wrapper(log_args: Sequence[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args=["git", *log_args, "|", "git", "patch-id", "--stable"],
+            returncode=returncode,
+            stdout="",
+            stderr=stderr,
+        )
 
     return wrapper
 
@@ -686,25 +715,88 @@ class CheckWorktreeMergedTest(unittest.TestCase):
         self.assertFalse(result.merged)
         self.assertIn("produced no output", result.detail)
 
-    def test_main_log_failure_degrades(self) -> None:
+    def test_main_log_patch_id_failure_degrades(self) -> None:
+        """Covers BOTH failure surfaces `_git_log_patch_id` pipes together
+        (`git log` itself failing, or `git patch-id` itself failing) — #1214
+        merged the two into one streamed seam, so classify_merged only ever
+        sees a single combined pass/fail result from `log_patch_id_runner`
+        regardless of which internal stage actually failed."""
         feature_tip = self._multi_commit_squash()
-        runner = _runner_intercepting("log", occurrence=1, mode="fail")
         result = classify_merged(
-            self.repo, feature_tip, "main", runner=runner, pipe_runner=_git_pipe_real
+            self.repo,
+            feature_tip,
+            "main",
+            runner=_git_ok,
+            pipe_runner=_git_pipe_real,
+            log_patch_id_runner=_log_patch_id_failing(),
         )
         self.assertEqual(result.status, "unmerged")
         self.assertEqual(result.reason, "content-check-failed")
         self.assertFalse(result.merged)
 
-    def test_main_patch_id_failure_degrades(self) -> None:
-        feature_tip = self._multi_commit_squash()
-        pipe_runner = _pipe_intercepting(occurrence=2, mode="fail")
-        result = classify_merged(
-            self.repo, feature_tip, "main", runner=_git_ok, pipe_runner=pipe_runner
+    # ---- streaming (#1214): no full patch-text buffering ---------------------
+
+    def test_git_log_patch_id_streams_without_buffering_full_text(self) -> None:
+        """The actual point of #1214: `git log`'s stdout must be connected
+        directly to `git patch-id`'s stdin via an OS pipe, never fully
+        materialized as a Python string first. Proven structurally: every
+        OTHER helper in this module (`_git`, `_git_pipe`) goes through
+        `subprocess.run` (`capture_output=True` / `input=<str>`, which
+        necessarily buffers); `_git_log_patch_id` must never call
+        `subprocess.run` at all, only `Popen`, and the second `Popen`'s
+        `stdin` must be the first `Popen`'s own stdout pipe object (not a
+        string) — `input=` never appears in its kwargs."""
+        self._multi_commit_squash()
+
+        popen_calls: list[dict[str, object]] = []
+        real_popen = subprocess.Popen
+
+        def recording_popen(*args: Any, **kwargs: Any) -> subprocess.Popen[str]:
+            popen_calls.append(kwargs)
+            return real_popen(*args, **kwargs)
+
+        with (
+            unittest.mock.patch("subprocess.run") as mock_run,
+            unittest.mock.patch("subprocess.Popen", recording_popen),
+        ):
+            result = _git_log_patch_id(["log", "-p", "--first-parent", "main"], self.repo)
+
+        mock_run.assert_not_called()
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(len(popen_calls), 2)
+        log_kwargs, patch_kwargs = popen_calls
+        self.assertEqual(log_kwargs["stdout"], subprocess.PIPE)
+        self.assertNotIn("input", patch_kwargs)
+        self.assertIsNotNone(patch_kwargs.get("stdin"))
+        self.assertNotIsInstance(patch_kwargs["stdin"], str)
+
+    def test_git_log_patch_id_output_matches_manual_buffer_then_pipe(self) -> None:
+        """Correctness pin (#1214): the streamed helper's output must be
+        byte-identical to the old buffer-then-pipe two-step it replaces —
+        proving the memory-profile change did not alter WHAT is computed,
+        only how much text is held resident in this process at once."""
+        self._multi_commit_squash()
+        merge_base = _git(["merge-base", "feature", "main"], self.repo).stdout.strip()
+        log_args = ["log", "-p", "--first-parent", f"{merge_base}..main"]
+
+        streamed = _git_log_patch_id(log_args, self.repo)
+        manual_log = _git_ok(log_args, self.repo)
+        manual = _git_pipe_real(["patch-id", "--stable"], self.repo, manual_log.stdout)
+
+        self.assertEqual(streamed.returncode, 0)
+        self.assertEqual(manual.returncode, 0)
+        self.assertEqual(streamed.stdout, manual.stdout)
+
+    def test_git_log_patch_id_log_stage_failure_returns_nonzero(self) -> None:
+        """When the `git log` stage itself fails (bad range), the combined
+        helper must report failure, not silently succeed with empty patch-id
+        output — which `classify_merged` would otherwise misread as "no
+        commits on the range" rather than "the command failed"."""
+        result = _git_log_patch_id(
+            ["log", "-p", "--first-parent", "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef..main"],
+            self.repo,
         )
-        self.assertEqual(result.status, "unmerged")
-        self.assertEqual(result.reason, "content-check-failed")
-        self.assertFalse(result.merged)
+        self.assertNotEqual(result.returncode, 0)
 
     def test_cherry_failure_degrades(self) -> None:
         """Cherry is only reached when test 1 (net-content) does not match —


### PR DESCRIPTION
## Summary

`check_worktree_merged.py`'s test 1 (net-content match) buffered the full
`git log -p --first-parent merge_base..remote_ref` patch text into a
single Python string, then handed it to `git patch-id` via `input=` —
peak resident cost roughly 2x the patch size, growing with worktree
staleness on this mandatory session-start check (#1212's cost lives on
a hot path that must stay fast).

## Change

`_git_log_patch_id()` (new) connects `git log`'s stdout directly to
`git patch-id`'s stdin over an OS pipe (`Popen -> Popen`), so this
process only ever holds `git patch-id`'s own short output resident —
never the full diff text. `classify_merged` gains a third injectable
seam, `log_patch_id_runner`, alongside the existing `runner`/`pipe_runner`
seams; the two-stage combined result degrades exactly like the old
two-call sequence did (a `git log` failure or a `git patch-id` failure
both surface as one `content-check-failed` degrade — same as before).

**Behaviour is unchanged — memory profile only.** No test 1/test 2
logic, ordering, or verdict changed.

## Verification

- `PYTHONDONTWRITEBYTECODE=1 ENVIRONMENT=test python3 -m pytest .claude/lib/tests/test_check_worktree_merged.py -v` — 29/29 pass, including the full existing merged/unmerged/order-independence/degrade-path suite plus 3 new tests:
  - `test_git_log_patch_id_streams_without_buffering_full_text` — structural proof: `subprocess.run` (the buffered `capture_output`/`input=` idiom) is never called for this path, only `Popen`, and the second `Popen`'s `stdin` is the first `Popen`'s own stdout pipe object.
  - `test_git_log_patch_id_output_matches_manual_buffer_then_pipe` — output-equivalence pin: the streamed helper's stdout is byte-identical to the old manual buffer-then-pipe two-step, on a real multi-commit fixture.
  - `test_git_log_patch_id_log_stage_failure_returns_nonzero` — the `git log` stage itself failing (bad range) is reported, not silently swallowed.
  - `test_main_log_patch_id_failure_degrades` replaces the two prior log-failure/patch-id-failure tests (now a single seam) — **mutation-verified**: reverting `classify_merged`'s call site back to the old two-runner buffered form makes this test fail (`'merged' != 'unmerged'`), confirming it is non-vacuous.
- `ENVIRONMENT=test python3 -m mypy .claude/lib/check_worktree_merged.py .claude/lib/tests/test_check_worktree_merged.py` — clean.
- `python3 -m ruff format --check` / `ruff check` — clean.
- `ENVIRONMENT=test pre-commit run --all-files` and `--hook-stage pre-push` — all hooks pass (ruff-format, ruff-lint, actionlint, cspell, checksums-ascii, mypy, pytest, pytest-skills, memory-budget, headcount-budget, doc-freshness, office-drift, mermaid-render).
- `ENVIRONMENT=test python3 .claude/lib/pre_commit_ci_sync.py .` — `OK: pre-commit config mirrors all CI-enforced checks.`
- Ad hoc memory check (300-commit synthetic history, outside the repo, not committed): streamed `_git_log_patch_id` output byte-identical to the old buffer-then-pipe two-step, with lower peak Python-heap usage (585KB vs 750KB via `tracemalloc`) at this size — the gap widens with history size per the issue's own measurement table.

Closes #1214

🤖 Generated with [Claude Code](https://claude.com/claude-code)