### PR TITLE
audit(G8): session handoff: one search call instead of 8 serial subprocesses

### DIFF
--- a/.claude/hooks/session_handoff.py
+++ b/.claude/hooks/session_handoff.py
@@ -20,12 +20,13 @@ import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import NamedTuple
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
 _LIB_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "lib")
 sys.path.insert(0, os.path.abspath(_LIB_DIR))
-from org_repos import ALL_REPOS  # noqa: E402
+from org_repos import ALL_REPOS, ORG  # noqa: E402
 
 # Project memory is version-controlled in-repo (#732 relocation) so it travels
 # with a git pull. The handoff file itself stays gitignored — it's per-session
@@ -68,27 +69,111 @@ def _get_git_state() -> dict:
     }
 
 
-def _get_open_prs() -> list[str]:
-    """Get open PRs across all repos.
+# GitHub's search API pages at 100 results/request and caps at 1000 total.
+# We stay at exactly one page (--limit == the page max) so "one search call"
+# is literally one HTTP request, not gh silently paginating under the hood.
+PR_SEARCH_LIMIT = 100
 
-    Queries org_repos.ALL_REPOS (main#1118 / audit G6) — the previous hand-copied
-    list here omitted noorinalabs-isnad-ingest-platform (BUG-08), silently
-    querying only 7 of 8 org repos.
+
+class PrQueryResult(NamedTuple):
+    """Outcome of the single org-wide open-PR search.
+
+    `failed` and an empty `lines` list are DISTINCT states — a failed query
+    must never render the same as "the org genuinely has zero open PRs"
+    (main#1120). `truncated` flags a possible partial result: the result set
+    hit PR_SEARCH_LIMIT, so PRs beyond the cap (e.g. a large repo crowding
+    out others under `--sort updated`) may be missing without any command
+    error. `unknown_repos` are repos the search returned that are NOT in
+    org_repos.ALL_REPOS — the inverse of BUG-08 (a repo added org-side that
+    the SSOT list doesn't know about yet), something the old per-repo loop
+    could structurally never detect since it only ever queried repos already
+    in its list.
     """
-    prs = []
-    for repo in ALL_REPOS:
-        raw = _run(
-            f"gh pr list --repo noorinalabs/{repo} --state open --json number,title --limit 5",
-            timeout=15,
+
+    lines: list[str]
+    failed: bool
+    truncated: bool
+    unknown_repos: tuple[str, ...]
+
+
+def _get_open_prs() -> PrQueryResult:
+    """Get open PRs across the whole org in a single search call.
+
+    Replaces the previous 7-serial (pre-#1238) / 8-serial (post-#1238) loop
+    of `gh pr list --repo ...` subprocesses — worst case ~120s against a 30s
+    Stop-hook timeout (main#1120 / audit G8) — with one `gh search prs
+    --owner noorinalabs` call spanning all repos the token can see, so it no
+    longer needs a repo list to construct the query at all (pairs with G6).
+
+    Collapsing 8 independent calls into 1 changes the failure shape: before,
+    one repo's `gh pr list` timing out only dropped that repo's PRs (still
+    silently — `_run()` swallows failures into ""), leaving the other 7
+    repos' results intact. Now a single failed call drops the WHOLE org's PR
+    list in one shot. `_run()` returns "" on any failure, which is
+    byte-for-byte different from a genuine empty result ("[]" parses to an
+    empty list, not ""), so that distinction is preserved explicitly here
+    and surfaced up through `failed` — main() must render "query failed",
+    never "None", when `failed` is True.
+    """
+    raw = _run(
+        f"gh search prs --owner {ORG} --state open --sort updated "
+        f"--json number,title,repository --limit {PR_SEARCH_LIMIT}",
+        timeout=15,
+    )
+    if not raw:
+        return PrQueryResult(lines=[], failed=True, truncated=False, unknown_repos=())
+    try:
+        items = json.loads(raw)
+    except json.JSONDecodeError:
+        return PrQueryResult(lines=[], failed=True, truncated=False, unknown_repos=())
+
+    lines = []
+    repos_seen: set[str] = set()
+    for item in items:
+        try:
+            repo = item["repository"]["name"]
+            lines.append(f"  - {repo}#{item['number']}: {item['title']}")
+            repos_seen.add(repo)
+        except (KeyError, TypeError):
+            continue
+
+    truncated = len(items) >= PR_SEARCH_LIMIT
+    unknown_repos = tuple(sorted(repos_seen - set(ALL_REPOS)))
+    return PrQueryResult(
+        lines=lines, failed=False, truncated=truncated, unknown_repos=unknown_repos
+    )
+
+
+def _render_prs_section(result: PrQueryResult) -> list[str]:
+    """Build the '### Open PRs' markdown block from a PrQueryResult.
+
+    A failed query is never rendered as "None" — that would misreport an
+    unknown PR state as "the org has zero open PRs". Truncation at the
+    search cap and unexpected repos are both surfaced as explicit notes
+    rather than silently folded into (or dropped from) the list.
+    """
+    section = ["### Open PRs"]
+    if result.failed:
+        section.append(
+            "  - QUERY FAILED (gh search prs errored or timed out) — PR state "
+            "unknown, NOT confirmed empty"
         )
-        if raw:
-            try:
-                items = json.loads(raw)
-                for item in items:
-                    prs.append(f"  - {repo}#{item['number']}: {item['title']}")
-            except (json.JSONDecodeError, KeyError):
-                pass
-    return prs
+        return section
+    if not result.lines:
+        section.append("  - None")
+    else:
+        section.extend(result.lines)
+    if result.truncated:
+        section.append(
+            f"  - NOTE: hit the {PR_SEARCH_LIMIT}-result search cap — some open "
+            "PRs may be missing from this list"
+        )
+    if result.unknown_repos:
+        section.append(
+            "  - NOTE: PR(s) found in repo(s) not in org_repos.ALL_REPOS: "
+            f"{', '.join(result.unknown_repos)} — SSOT list may be stale"
+        )
+    return section
 
 
 def _get_open_issues() -> list[str]:
@@ -184,7 +269,7 @@ def main() -> None:
     date_str = now.strftime("%Y-%m-%d %H:%M UTC")
 
     git = _get_git_state()
-    prs = _get_open_prs()
+    pr_result = _get_open_prs()
     issues = _get_open_issues()
     ontology = _get_ontology_staleness()
     wave = _get_wave_status()
@@ -216,10 +301,7 @@ def main() -> None:
         "",
     ]
 
-    if prs:
-        lines.extend(["### Open PRs", *prs, ""])
-    else:
-        lines.extend(["### Open PRs", "  - None", ""])
+    lines.extend([*_render_prs_section(pr_result), ""])
 
     if issues:
         lines.extend(["### Open issues (noorinalabs-main)", *issues, ""])
@@ -254,9 +336,16 @@ def main() -> None:
         f"Branch: {git['branch']} | Uncommitted: {'Yes' if git['uncommitted'] else 'No'}",
         f"Wave: {wave} | Ontology: {ontology}",
     ]
-    if prs:
-        display_lines.append(f"Open PRs: {len(prs)}")
-        display_lines.extend(prs[:5])
+    if pr_result.failed:
+        display_lines.append("Open PRs: QUERY FAILED — see handoff file, NOT confirmed empty")
+    else:
+        suffix = " (truncated at cap)" if pr_result.truncated else ""
+        display_lines.append(f"Open PRs: {len(pr_result.lines)}{suffix}")
+        display_lines.extend(pr_result.lines[:5])
+        if pr_result.unknown_repos:
+            display_lines.append(
+                f"Unknown repos in PR results: {', '.join(pr_result.unknown_repos)}"
+            )
     if issues:
         display_lines.append(f"Open issues (main): {len(issues)}")
         display_lines.extend(issues[:5])

--- a/.claude/hooks/tests/test_session_handoff.py
+++ b/.claude/hooks/tests/test_session_handoff.py
@@ -109,35 +109,139 @@ class GetWaveStatusTests(unittest.TestCase):
         self.assertEqual(result, "No cross-repo-status.json found")
 
 
-class GetOpenPrsQueriesAllOrgReposTests(unittest.TestCase):
-    """main#1118 / audit G6, BUG-08 regression: `_get_open_prs()` used to iterate
-    a hand-copied 7-repo list that silently omitted
-    noorinalabs-isnad-ingest-platform. It now iterates org_repos.ALL_REPOS, so
-    this asserts all 8 org repos are queried (non-vacuous: fails if the count
-    regresses to 7, or if a caller reintroduces a hand-copied list)."""
+class GetOpenPrsSingleSearchCallTests(unittest.TestCase):
+    """main#1120 / audit G8: `_get_open_prs()` used to iterate ALL_REPOS with
+    one `gh pr list` subprocess per repo (7 serial pre-#1238, 8 post-#1238) —
+    worst case ~120s against a 30s Stop-hook timeout. It now issues exactly
+    ONE `gh search prs --owner noorinalabs` call spanning the whole org."""
 
-    def test_queries_all_eight_repos(self) -> None:
+    def test_issues_exactly_one_search_call(self) -> None:
         from unittest.mock import patch
 
-        queried: list[str] = []
+        calls: list[str] = []
 
         def _fake_run(cmd: str, cwd: str | None = None, timeout: int = 10) -> str:
-            for repo in hook.ALL_REPOS:
-                if f"noorinalabs/{repo}" in cmd:
-                    queried.append(repo)
-                    break
+            calls.append(cmd)
             return "[]"
 
         with patch.object(hook, "_run", side_effect=_fake_run):
             hook._get_open_prs()
 
-        self.assertEqual(sorted(queried), sorted(hook.ALL_REPOS))
-        self.assertEqual(len(queried), 8)
-        self.assertIn("noorinalabs-isnad-ingest-platform", queried)
+        # Non-vacuous shape assertion (the issue's own "Verify" ask): exactly
+        # one subprocess, and it's a single org-scoped search — not a
+        # per-repo `gh pr list`.
+        self.assertEqual(len(calls), 1)
+        self.assertIn("gh search prs", calls[0])
+        self.assertIn("--owner noorinalabs", calls[0])
+        self.assertNotIn("gh pr list", calls[0])
+
+    def test_parses_items_across_repos(self) -> None:
+        from unittest.mock import patch
+
+        raw = json.dumps(
+            [
+                {"number": 42, "title": "Fix thing", "repository": {"name": "noorinalabs-main"}},
+                {
+                    "number": 7,
+                    "title": "Add feature",
+                    "repository": {"name": "noorinalabs-isnad-ingest-platform"},
+                },
+            ]
+        )
+        with patch.object(hook, "_run", return_value=raw):
+            result = hook._get_open_prs()
+
+        self.assertFalse(result.failed)
+        self.assertFalse(result.truncated)
+        self.assertEqual(result.unknown_repos, ())
+        self.assertEqual(
+            result.lines,
+            [
+                "  - noorinalabs-main#42: Fix thing",
+                "  - noorinalabs-isnad-ingest-platform#7: Add feature",
+            ],
+        )
+
+    def test_failed_query_is_distinct_from_empty_result(self) -> None:
+        """A failed command (`_run` returns "") must NOT collapse into the same
+        state as a genuinely empty PR list ("[]") — that would misreport an
+        unknown PR state as "the org has zero open PRs" (main#1120)."""
+        from unittest.mock import patch
+
+        with patch.object(hook, "_run", return_value=""):
+            failed_result = hook._get_open_prs()
+        with patch.object(hook, "_run", return_value="[]"):
+            empty_result = hook._get_open_prs()
+
+        self.assertTrue(failed_result.failed)
+        self.assertFalse(empty_result.failed)
+        self.assertEqual(failed_result.lines, [])
+        self.assertEqual(empty_result.lines, [])
+        # The two must render differently even though `lines` is identical.
+        self.assertNotEqual(
+            hook._render_prs_section(failed_result),
+            hook._render_prs_section(empty_result),
+        )
+        self.assertIn("QUERY FAILED", "\n".join(hook._render_prs_section(failed_result)))
+
+    def test_malformed_json_treated_as_failure(self) -> None:
+        from unittest.mock import patch
+
+        with patch.object(hook, "_run", return_value="not json"):
+            result = hook._get_open_prs()
+
+        self.assertTrue(result.failed)
+
+    def test_truncation_detected_at_cap(self) -> None:
+        from unittest.mock import patch
+
+        items = [
+            {"number": i, "title": f"PR {i}", "repository": {"name": "noorinalabs-main"}}
+            for i in range(hook.PR_SEARCH_LIMIT)
+        ]
+        with patch.object(hook, "_run", return_value=json.dumps(items)):
+            result = hook._get_open_prs()
+
+        self.assertTrue(result.truncated)
+        rendered = "\n".join(hook._render_prs_section(result))
+        self.assertIn(f"{hook.PR_SEARCH_LIMIT}-result search cap", rendered)
+
+    def test_no_truncation_below_cap(self) -> None:
+        from unittest.mock import patch
+
+        items = [
+            {"number": 1, "title": "Only one", "repository": {"name": "noorinalabs-main"}},
+        ]
+        with patch.object(hook, "_run", return_value=json.dumps(items)):
+            result = hook._get_open_prs()
+
+        self.assertFalse(result.truncated)
+
+    def test_unknown_repo_flagged(self) -> None:
+        from unittest.mock import patch
+
+        raw = json.dumps(
+            [
+                {
+                    "number": 1,
+                    "title": "New repo PR",
+                    "repository": {"name": "noorinalabs-not-in-ssot"},
+                },
+            ]
+        )
+        with patch.object(hook, "_run", return_value=raw):
+            result = hook._get_open_prs()
+
+        self.assertEqual(result.unknown_repos, ("noorinalabs-not-in-ssot",))
+        rendered = "\n".join(hook._render_prs_section(result))
+        self.assertIn("noorinalabs-not-in-ssot", rendered)
+        self.assertIn("SSOT list may be stale", rendered)
 
     def test_all_repos_is_org_repos_ssot(self) -> None:
         # session_handoff.ALL_REPOS must BE org_repos.ALL_REPOS (imported, not
-        # re-derived) so the two can never drift apart again.
+        # re-derived) so the two can never drift apart again (kept intact
+        # across main#1120 — #1243 flags the sibling validate_wave_audit.py
+        # module for lacking this same guard, not this one).
         import org_repos
 
         self.assertIs(hook.ALL_REPOS, org_repos.ALL_REPOS)


### PR DESCRIPTION
## Summary
- Replaces `_get_open_prs()`'s per-repo `gh pr list` loop (7 serial pre-#1238, 8 post-#1238; worst case ~120s against a 30s Stop-hook timeout) with one `gh search prs --owner noorinalabs` call spanning the whole org. No longer needs a repo list to build the query at all (pairs with G6).
- Failure-shape change addressed head-on: a single failed call now drops the whole org's PR list at once instead of just one repo's silently-dropped slice. `_get_open_prs()` returns a `PrQueryResult` that keeps "query failed" (`_run()` returned `""`) strictly distinct from "genuinely zero open PRs" (`"[]"` parses to an empty list) — a failed query always renders as an explicit `QUERY FAILED` line in both the handoff file and the systemMessage, never silently as "None".
- Also flags truncation at the 100-result search-page cap (`PR_SEARCH_LIMIT`, chosen to match the search API's per-page max so "one search call" is literally one HTTP request), and flags any PR-bearing repo not in `org_repos.ALL_REPOS` — the inverse of BUG-08 (a repo the SSOT list doesn't know about yet), something the old per-repo loop could never detect since it only ever queried repos already in its own list.
- `org_repos.ALL_REPOS` stays imported (not re-derived) in `session_handoff.py`, keeping the existing `test_all_repos_is_org_repos_ssot` identity guard intact, per the caution that #1243 flags the *sibling* `validate_wave_audit.py` module for lacking the equivalent guard (that module is untouched by this PR).

Closes #1120

## Test plan
- [x] `PYTHONDONTWRITEBYTECODE=1 ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/test_session_handoff.py -v` — 18 passed
- [x] `PYTHONDONTWRITEBYTECODE=1 ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/ .claude/lib/tests/ -q` — 3489 passed, 647 subtests passed (full suite, no regressions)
- [x] Mutation-killed the three load-bearing new assertions by hand (confirmed each new test fails without the corresponding code): (1) collapsing `failed`/empty-result into the same state, (2) hardcoding `truncated = False`, (3) hardcoding `unknown_repos = ()`
- [x] `pre-commit run --all-files` — all commit-stage hooks pass
- [x] `pre-commit run --all-files --hook-stage pre-push` — mypy, pytest, pytest-skills, memory-budget, headcount-budget, doc-freshness, office-drift, mermaid-render all pass
- [x] `python3 .claude/lib/pre_commit_ci_sync.py .` — OK, pre-commit config mirrors CI
- [x] Manually ran `gh search prs --owner noorinalabs --state open --json number,title,repository --limit 100` against the live org to confirm the command shape and JSON schema used in the implementation

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>