### PR TITLE
audit(G10): per-edit ledger IO: skip no-op writes, cache check-ignore per directory

### DIFF
--- a/.claude/hooks/ontology_tracker.py
+++ b/.claude/hooks/ontology_tracker.py
@@ -335,13 +335,29 @@ def _run_check_ignore(git_root: Path, pathspecs: list[str]) -> set[str]:
     is what introduced the exposure, so the pin restores the property that
     change gave up. Do not remove it without replacing the matching scheme.
 
-    ``encoding="utf-8", errors="replace"`` rather than ``text=True`` for the
-    same reason: with the pin in place raw UTF-8 bytes now reach the decoder,
-    and ``text=True`` would decode with the locale encoding under
-    ``errors='strict'`` — so a ``LC_ALL=C`` runner would raise
-    ``UnicodeDecodeError``, which is NOT in the ``except`` clause below and
-    would escape ``check()``, breaking this hook's "exit 0 — always"
-    contract. ``errors="replace"`` makes that unraisable.
+    ``encoding="utf-8", errors="surrogateescape"`` rather than ``text=True``,
+    and the reason is the FILENAME BYTES, not the locale (main#1263 review,
+    Weronika Zielinska — an earlier version of this docstring blamed a
+    ``LC_ALL=C`` runner raising ``UnicodeDecodeError``; that is false, PEP 538
+    C-locale coercion yields UTF-8 anyway, and reverting to ``text=True``
+    leaves the suite green under ``LC_ALL=C``. Do not restore that rationale).
+
+    The real trigger: a POSIX filename is a byte string and need not be valid
+    UTF-8. The caller's pathspec comes from ``os.fsdecode``, which maps
+    undecodable bytes to lone surrogates (``b"\\xe9.log"`` -> ``"\\udce9.log"``).
+    For set-membership below to work, git's echoed stdout must decode back to
+    that SAME string. Only ``surrogateescape`` does:
+
+    - ``text=True`` (strict) can raise ``UnicodeDecodeError``, which is not in
+      the ``except`` clause and would escape ``check()``, breaking this hook's
+      "exit 0 — always" contract.
+    - ``errors="replace"`` cannot raise but is lossy — the byte decodes to
+      U+FFFD, which does not equal the caller's surrogate, so a genuinely
+      ignored file reads as NOT ignored. That is the same fail-open defect the
+      ``core.quotePath`` pin above exists to fix, one level narrower, and it
+      was shipped here briefly before review caught it.
+    - ``surrogateescape`` is non-raising AND byte-exact round-trips, so it
+      strictly dominates both.
 
     Deliberately omits ``-q`` (which would suppress that stdout) so a single
     call can answer more than one question at once (#1122) — the caller
@@ -365,7 +381,7 @@ def _run_check_ignore(git_root: Path, pathspecs: list[str]) -> set[str]:
             timeout=5,
             env=_hermetic_git_env(),
             encoding="utf-8",
-            errors="replace",
+            errors="surrogateescape",
         )
     except (OSError, subprocess.TimeoutExpired):
         return set()  # Subprocess failed — fail open.

--- a/.claude/hooks/ontology_tracker.py
+++ b/.claude/hooks/ontology_tracker.py
@@ -322,12 +322,31 @@ def _run_check_ignore(git_root: Path, pathspecs: list[str]) -> set[str]:
     """Run ``git check-ignore`` for one or more pathspecs against ``git_root``.
 
     Returns the subset of ``pathspecs`` that ARE ignored, as the exact
-    strings passed in (git echoes back whichever supplied pathspec matched,
-    one per line, preserving the caller's original string — verified against
-    real git, not assumed). Deliberately omits ``-q`` (which would suppress
-    that stdout) so a single call can answer more than one question at once
-    (#1122) — the caller distinguishes "ignored" from "not ignored" by
-    set-membership instead of by exit code alone.
+    strings passed in: git echoes back whichever supplied pathspec matched,
+    one per line, and ``core.quotePath=false`` is pinned on the invocation
+    so that echo is the caller's ORIGINAL string rather than a C-quoted
+    rendering of it. That pin is load-bearing, not cosmetic (main#1265):
+    under git's default ``core.quotePath=true`` any pathspec containing a
+    non-ASCII byte comes back quoted and escaped (``سند.md`` echoes as
+    ``"\\330\\263\\331\\206\\330\\257.md"``), which equals nothing the
+    caller passed in, so set-membership below reports a genuinely-ignored
+    path as NOT ignored. The pre-#1122 code read only ``-q``'s exit status
+    and was encoding-independent by construction; matching on echoed text
+    is what introduced the exposure, so the pin restores the property that
+    change gave up. Do not remove it without replacing the matching scheme.
+
+    ``encoding="utf-8", errors="replace"`` rather than ``text=True`` for the
+    same reason: with the pin in place raw UTF-8 bytes now reach the decoder,
+    and ``text=True`` would decode with the locale encoding under
+    ``errors='strict'`` — so a ``LC_ALL=C`` runner would raise
+    ``UnicodeDecodeError``, which is NOT in the ``except`` clause below and
+    would escape ``check()``, breaking this hook's "exit 0 — always"
+    contract. ``errors="replace"`` makes that unraisable.
+
+    Deliberately omits ``-q`` (which would suppress that stdout) so a single
+    call can answer more than one question at once (#1122) — the caller
+    distinguishes "ignored" from "not ignored" by set-membership instead of
+    by exit code alone.
 
     Fails OPEN — returns an empty set (nothing reported ignored) — on any
     subprocess error or timeout, or on any exit code other than 0 (at least
@@ -340,12 +359,13 @@ def _run_check_ignore(git_root: Path, pathspecs: list[str]) -> set[str]:
     """
     try:
         result = subprocess.run(
-            ["git", "check-ignore", "--", *pathspecs],
+            ["git", "-c", "core.quotePath=false", "check-ignore", "--", *pathspecs],
             cwd=str(git_root),
             capture_output=True,
             timeout=5,
             env=_hermetic_git_env(),
-            text=True,
+            encoding="utf-8",
+            errors="replace",
         )
     except (OSError, subprocess.TimeoutExpired):
         return set()  # Subprocess failed — fail open.

--- a/.claude/hooks/ontology_tracker.py
+++ b/.claude/hooks/ontology_tracker.py
@@ -337,10 +337,21 @@ def _run_check_ignore(git_root: Path, pathspecs: list[str]) -> set[str]:
 
     ``encoding="utf-8", errors="surrogateescape"`` rather than ``text=True``,
     and the reason is the FILENAME BYTES, not the locale (main#1263 review,
-    Weronika Zielinska — an earlier version of this docstring blamed a
-    ``LC_ALL=C`` runner raising ``UnicodeDecodeError``; that is false, PEP 538
-    C-locale coercion yields UTF-8 anyway, and reverting to ``text=True``
-    leaves the suite green under ``LC_ALL=C``. Do not restore that rationale).
+    Weronika Zielinska). An earlier version of this docstring blamed a
+    ``LC_ALL=C`` runner raising ``UnicodeDecodeError``. That was false, and
+    for a subtler reason than "coercion": ``LC_ALL=C python3`` auto-enables
+    **UTF-8 Mode (PEP 540)** — ``sys.flags.utf8_mode == 1`` while ``LC_CTYPE``
+    stays ``C`` — so PEP 538 C-locale *coercion* never runs at all. That is
+    why ``PYTHONCOERCECLOCALE=0`` does not restore ASCII either; it defeats
+    538, not 540. Only ``PYTHONUTF8=0 PYTHONCOERCECLOCALE=0`` yields
+    ``ANSI_X3.4-1968``. Do not restore the locale rationale.
+
+    Historical note on how that was caught, because it dates: when measured
+    at ``2c113e7`` the suite was green under ``LC_ALL=C`` with ``text=True``,
+    which is what falsified the claim. That is no longer reproducible —
+    ``test_invalid_utf8_filename_is_detected`` below now catches ``text=True``
+    at ANY locale, because the trigger is the filename bytes rather than the
+    environment. The fixture, not the locale, is what pins this line.
 
     The real trigger: a POSIX filename is a byte string and need not be valid
     UTF-8. The caller's pathspec comes from ``os.fsdecode``, which maps

--- a/.claude/hooks/ontology_tracker.py
+++ b/.claude/hooks/ontology_tracker.py
@@ -123,7 +123,28 @@ Owning-repo check-ignore (#1039):
   pathspecs matched, so the FIRST file seen in a directory pays one
   subprocess call that answers "is this file ignored" AND "is its directory
   ignored" simultaneously — no additional subprocess versus the pre-#1122
-  single-file check. Invalidation: none needed — both caches are
+  single-file check.
+
+  The directory pathspec passed to ``git check-ignore`` is the BARE relative
+  directory name, with NO trailing slash (main#1263 review finding, fixed
+  before merge). A trailing slash turns the pathspec into a literal STRING
+  that a contents-only pattern like ``data/raw/*`` matches directly (git
+  echoes back the exact string ``"data/raw/"`` as a match), which is a
+  different fact from the directory ITSELF being excluded — the bare
+  ``"data/raw"`` does not match that same pattern. Using the slash version
+  would cache a false "directory ignored" and silently mis-skip any file a
+  ``!`` rule re-includes inside it (e.g. the ``dir/*`` + ``!dir/**/.gitkeep``
+  idiom used by ``noorinalabs-isnad-ingest-platform``) — under-tracking,
+  the one direction this function must never risk. The bare name still
+  correctly answers "ignored" for a genuinely directory-excluding pattern
+  (``build/`` matches ``"build"`` too) and for a NESTED directory swept up
+  by a contents-only parent pattern (gitignore(5)'s no-re-include-under-an-
+  excluded-parent rule then really does apply to everything beneath it), so
+  the cache short-circuit stays sound in both directions — see
+  ``GitCheckIgnoreDirectoryCacheTests`` in the test module for the exact
+  fixtures.
+
+  Invalidation: none needed — both caches are
   module-level dicts scoped to this one short-lived process (a fresh
   Edit/Write hook invocation starts with empty caches), and the on-disk
   ``.gitignore`` rules cannot change mid-invocation, so nothing can go stale
@@ -388,7 +409,27 @@ def _is_git_ignored(resolved_path: Path) -> bool:
     # Neither the file nor its directory is cached yet: one subprocess call
     # answers both questions and seeds both caches, so every LATER file
     # under this same directory is a cache hit instead of a new subprocess.
-    dir_spec = f"{dir_rel_str}/"
+    #
+    # NO trailing slash on the directory pathspec (main#1263 review finding):
+    # a pattern like `data/raw/*` matches the literal STRING "data/raw/" —
+    # `git check-ignore -- data/raw/ ...` echoes it back as ignored even
+    # though the directory itself is not excluded, only its immediate
+    # contents are (minus whatever a later `!` re-include exempts). That
+    # false "directory ignored" verdict would then be cached and wrongly
+    # applied to every later file in the directory, INCLUDING one a `!`
+    # rule legitimately re-includes — a silent under-tracking regression.
+    # Querying the bare directory name instead asks git the real question
+    # ("is `data/raw` itself excluded?"): a genuinely directory-excluding
+    # pattern (`build/`) still matches the bare name, but a
+    # contents-only pattern (`data/raw/*`) does not, so `dir_ignored` stays
+    # False and each file is still checked on its own merits (same
+    # subprocess cost as before this cache existed). A NESTED directory
+    # whose own path is swept up by the contents-only pattern (e.g.
+    # `data/raw/sub` under `data/raw/*`) still correctly comes back
+    # ignored — gitignore(5)'s no-re-include-under-an-excluded-parent rule
+    # then genuinely applies to everything beneath it, so the cached True
+    # is not a false positive there.
+    dir_spec = dir_rel_str
     matched = _run_check_ignore(git_root, [dir_spec, rel_str])
     dir_ignored = dir_spec in matched
     file_ignored = rel_str in matched

--- a/.claude/hooks/ontology_tracker.py
+++ b/.claude/hooks/ontology_tracker.py
@@ -101,6 +101,34 @@ Owning-repo check-ignore (#1039):
   calls within a single test run or a future batch invocation, not
   cross-invocation caching (there is no daemon to cache across).
 
+  ``_DIR_CHECK_IGNORE_CACHE`` (#1122) additionally memoizes the *containing
+  directory's* own check-ignore verdict, per (repo, relative-directory), same
+  process lifetime. Per gitignore(5) — "It is not possible to re-include a
+  file if a parent directory of that file is excluded" — a directory that
+  ``git check-ignore`` reports as ignored makes EVERY file beneath it ignored
+  too, no exceptions possible. So once a directory resolves to ignored, any
+  later file under it is a cache hit with zero subprocess calls: real
+  savings within a burst of edits/tests touching the same generated or
+  vendored subtree (e.g. a child repo's own ``.venv/``/``dist/``/``coverage/``
+  that ``SKIP_PATTERNS`` doesn't already substring-catch). A directory
+  verdict of NOT-ignored is not similarly reusable — it says nothing about a
+  specific file, since a filename pattern (``*.secret``) can still exclude
+  one file inside an otherwise-untouched directory — so that case still
+  falls through to a per-file check, same subprocess cost as before this
+  cache existed.
+
+  The directory verdict is resolved for free alongside the file's own
+  verdict: ``git check-ignore`` (without ``-q``) accepts more than one
+  pathspec and echoes back on stdout exactly which of the supplied
+  pathspecs matched, so the FIRST file seen in a directory pays one
+  subprocess call that answers "is this file ignored" AND "is its directory
+  ignored" simultaneously — no additional subprocess versus the pre-#1122
+  single-file check. Invalidation: none needed — both caches are
+  module-level dicts scoped to this one short-lived process (a fresh
+  Edit/Write hook invocation starts with empty caches), and the on-disk
+  ``.gitignore`` rules cannot change mid-invocation, so nothing can go stale
+  within the cache's own lifetime.
+
 Input Language:
   Fires on:      PostToolUse Edit, Write
   Matches:       Edit/Write whose `file_path` is non-empty AND resides inside
@@ -129,6 +157,12 @@ CHECKSUMS_FILE = REPO_ROOT / "ontology" / "checksums.json"
 # Memoizes (git_root, repo_relative_path) -> ignored? for the life of this
 # process. See "Owning-repo check-ignore (#1039)" in the module docstring.
 _GIT_CHECK_IGNORE_CACHE: dict[tuple[str, str], bool] = {}
+
+# Memoizes (git_root, repo_relative_directory) -> ignored? for the life of
+# this process (#1122). See "Owning-repo check-ignore (#1039)" in the module
+# docstring for why a directory-ignored verdict is authoritative for every
+# file beneath it, and why a not-ignored verdict is NOT similarly reusable.
+_DIR_CHECK_IGNORE_CACHE: dict[tuple[str, str], bool] = {}
 
 # Shared read/write helpers (#1042): both this hook and the /ontology-rebuild
 # resolver's `mark-resolved` CLI go through checksums_io so neither has to
@@ -263,6 +297,44 @@ def _hermetic_git_env() -> dict[str, str]:
     return {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
 
 
+def _run_check_ignore(git_root: Path, pathspecs: list[str]) -> set[str]:
+    """Run ``git check-ignore`` for one or more pathspecs against ``git_root``.
+
+    Returns the subset of ``pathspecs`` that ARE ignored, as the exact
+    strings passed in (git echoes back whichever supplied pathspec matched,
+    one per line, preserving the caller's original string — verified against
+    real git, not assumed). Deliberately omits ``-q`` (which would suppress
+    that stdout) so a single call can answer more than one question at once
+    (#1122) — the caller distinguishes "ignored" from "not ignored" by
+    set-membership instead of by exit code alone.
+
+    Fails OPEN — returns an empty set (nothing reported ignored) — on any
+    subprocess error or timeout, or on any exit code other than 0 (at least
+    one match) / 1 (no match, e.g. every pathspec is genuinely not ignored).
+    Exit 128 is a fatal git error (e.g. not actually a git repo); folding it
+    into "nothing ignored" fails open the same way a single-path check
+    always has. See "Owning-repo check-ignore (#1039)" in the module
+    docstring for why fail-open (never skip on doubt) is the deliberate,
+    one-sided policy here.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "check-ignore", "--", *pathspecs],
+            cwd=str(git_root),
+            capture_output=True,
+            timeout=5,
+            env=_hermetic_git_env(),
+            text=True,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return set()  # Subprocess failed — fail open.
+
+    if result.returncode not in (0, 1):
+        return set()  # Fatal git error — fail open.
+
+    return {line for line in result.stdout.splitlines() if line}
+
+
 def _is_git_ignored(resolved_path: Path) -> bool:
     """True if ``resolved_path`` is gitignored BY ITS OWN REPO.
 
@@ -270,7 +342,9 @@ def _is_git_ignored(resolved_path: Path) -> bool:
     full rationale. Summary: resolve the nearest ``.git`` ancestor of the
     file (its OWNING repo, which may be a child repo nested under
     ``REPO_ROOT``, not ``REPO_ROOT`` itself), then run ``git check-ignore``
-    there against the path relative to that repo.
+    there against the path relative to that repo — checking the per-file AND
+    per-directory caches first (#1122; see the module docstring's cache
+    section for exactly what each caches and why both are sound).
 
     Fails OPEN (returns False -> file gets tracked) on every error case: no
     ``.git`` ancestor, a path that doesn't resolve relative to its own
@@ -287,28 +361,40 @@ def _is_git_ignored(resolved_path: Path) -> bool:
     except ValueError:
         return False  # Shouldn't happen (git_root is an ancestor), fail open anyway.
 
-    cache_key = (str(git_root), str(rel))
-    cached = _GIT_CHECK_IGNORE_CACHE.get(cache_key)
+    rel_str = str(rel)
+    file_key = (str(git_root), rel_str)
+    cached = _GIT_CHECK_IGNORE_CACHE.get(file_key)
     if cached is not None:
         return cached
 
-    try:
-        result = subprocess.run(
-            ["git", "check-ignore", "-q", "--", str(rel)],
-            cwd=str(git_root),
-            capture_output=True,
-            timeout=5,
-            env=_hermetic_git_env(),
-        )
-        # `git check-ignore -q` exit codes: 0 = ignored, 1 = not ignored,
-        # 128 = fatal error (e.g. not a git repo after all). Only 0 counts
-        # as ignored; anything else — including the fatal case — fails open.
-        ignored = result.returncode == 0
-    except (OSError, subprocess.TimeoutExpired):
-        ignored = False  # Subprocess failed — fail open.
+    dir_rel_str = str(rel.parent)
+    dir_key = (str(git_root), dir_rel_str)
+    dir_cached = _DIR_CHECK_IGNORE_CACHE.get(dir_key)
 
-    _GIT_CHECK_IGNORE_CACHE[cache_key] = ignored
-    return ignored
+    if dir_cached is True:
+        # gitignore(5): a file cannot be re-included once a parent directory
+        # is excluded — authoritative without a subprocess call.
+        _GIT_CHECK_IGNORE_CACHE[file_key] = True
+        return True
+
+    if dir_cached is False:
+        # Directory itself isn't excluded — that says nothing about THIS
+        # file (a filename pattern can still match inside it), so fall
+        # through to a per-file check, same subprocess cost as before #1122.
+        ignored = rel_str in _run_check_ignore(git_root, [rel_str])
+        _GIT_CHECK_IGNORE_CACHE[file_key] = ignored
+        return ignored
+
+    # Neither the file nor its directory is cached yet: one subprocess call
+    # answers both questions and seeds both caches, so every LATER file
+    # under this same directory is a cache hit instead of a new subprocess.
+    dir_spec = f"{dir_rel_str}/"
+    matched = _run_check_ignore(git_root, [dir_spec, rel_str])
+    dir_ignored = dir_spec in matched
+    file_ignored = rel_str in matched
+    _DIR_CHECK_IGNORE_CACHE[dir_key] = dir_ignored
+    _GIT_CHECK_IGNORE_CACHE[file_key] = file_ignored
+    return file_ignored
 
 
 def _should_skip(file_path: str) -> bool:
@@ -402,6 +488,20 @@ def check(input_data: dict) -> dict | None:
     files = data.setdefault("files", {})
 
     existing = files.get(rel_path, {})
+    if existing.get("last_tracked") == sha:
+        # No-op re-save (#1122): the file's content hash is byte-for-byte
+        # what's already recorded — e.g. an edit that reverts to prior
+        # content, or a Write that rewrites identical bytes. `sha` is always
+        # a real 64-hex-char digest here (the `sha is None` case already
+        # returned above), so this only matches an EXISTING entry whose
+        # tracked hash is unchanged — never a brand-new path (`existing`
+        # empty -> `.get("last_tracked")` is `None`, which can't equal a
+        # real digest). Dirty-ness is driven by `last_tracked !=
+        # last_resolved`, not by `tracked_at`, so re-writing the full 103 KB
+        # file here would change zero meaningful state — skip the write
+        # (the read above still had to happen, to learn this).
+        return {"action": "skip_noop", "path": rel_path}
+
     files[rel_path] = {
         "last_tracked": sha,
         "last_resolved": existing.get("last_resolved", ""),

--- a/.claude/hooks/ontology_tracker.py
+++ b/.claude/hooks/ontology_tracker.py
@@ -449,6 +449,15 @@ def _is_git_ignored(resolved_path: Path) -> bool:
     # ignored — gitignore(5)'s no-re-include-under-an-excluded-parent rule
     # then genuinely applies to everything beneath it, so the cached True
     # is not a false positive there.
+    #
+    # Why no `--no-index` (main#1263 review, Weronika Zielinska): git's
+    # index-masking applies to the DIRECTORY pathspec too, not just to
+    # files. `git check-ignore -- dist dist/manifest.json` exits 1 when
+    # `dist` holds force-added tracked files, where `--no-index` would
+    # report both as matched. The practical consequence is a useful
+    # invariant rather than a bug: `dir_ignored` can only ever cache True
+    # for a directory that holds ZERO tracked files, so the short-circuit
+    # can never suppress tracking of a path git already knows about.
     dir_spec = dir_rel_str
     matched = _run_check_ignore(git_root, [dir_spec, rel_str])
     dir_ignored = dir_spec in matched

--- a/.claude/hooks/tests/test_ontology_tracker.py
+++ b/.claude/hooks/tests/test_ontology_tracker.py
@@ -793,11 +793,26 @@ class GitCheckIgnoreExcludeThenReincludeTests(_FakeRepoRootMixin, unittest.TestC
         self.assertTrue(hook._DIR_CHECK_IGNORE_CACHE[(str(self._fake_root), "data/raw/sub")])
 
     def test_trailing_slash_is_unsound_bare_name_is_not(self):
-        """Direct guard on the exact mechanism, independent of
-        ``_is_git_ignored``'s call sequence: proves the trap AND the fix in
-        one place, so a future re-introduction of the trailing slash fails
-        immediately rather than needing the fuller scenario above to
-        surface it."""
+        """Characterization of GIT's behavior — the PREMISE the fix rests
+        on — not a regression guard on our code.
+
+        Read the scope carefully (main#1263 review, Weronika Zielinska).
+        An earlier version of this docstring claimed a future
+        re-introduction of the trailing slash would "fail immediately"
+        here. **That is false**, and was measured false: this test calls
+        ``_run_check_ignore`` with literal strings, so it never touches
+        ``_is_git_ignored``'s ``dir_spec`` at all and passes unchanged when
+        the trailing slash is reinstated. The test that actually catches
+        that mutation is ``test_untracked_reincluded_keeper_is_not_skipped``
+        in the class above — and only that one.
+
+        What this DOES pin is worth keeping: that real git treats a
+        trailing-slash pathspec as a literal string matched by a
+        contents-only pattern while the bare name is not. If git ever
+        changed that, the fix's rationale would evaporate silently and
+        every other test here would still pass. Keeping it labeled
+        honestly is the point — a test that overstates what it guards is
+        how a suite comes to look stronger than it is (cf. main#1215)."""
         raw = self._fake_root / "data" / "raw"
         raw.mkdir(parents=True)
         (raw / "dump.parquet").write_text("x\n", encoding="utf-8")
@@ -933,12 +948,29 @@ class RunCheckIgnoreFailOpenTests(_FakeRepoRootMixin, unittest.TestCase):
         self.assertEqual(matched, set())
 
     def test_real_fatal_returncode_also_fails_open(self):
-        """Not mocked: a real ``git check-ignore`` invocation with an
-        out-of-repo pathspec genuinely exits 128 (verified: real git prints
-        ``fatal: ... is outside repository`` and returns 128 for this
-        exact input) — must also fail open, end to end through the real
-        subprocess path."""
-        outside = "/etc/hostname"  # universally readable on Linux test runners
+        """Not mocked: a real ``git check-ignore`` with an out-of-repo
+        pathspec genuinely exits 128 (real git prints ``fatal: ... is
+        outside repository``) and must fail open end to end.
+
+        **This test is vacuous with respect to the guard it appears to
+        cover** (main#1263 review, Weronika Zielinska — measured, not
+        assumed). A real fatal exit also produces EMPTY stdout, so the
+        function returns an empty set with or without the
+        ``returncode not in (0, 1)`` branch: deleting that branch leaves
+        this test passing. ``test_mocked_fatal_returncode_fails_open`` is
+        the only test that catches it, which is exactly why that one feeds
+        deliberately NON-empty stdout.
+
+        Kept because it pins the PREMISE the mocked test is built on — that
+        128 is really what git returns here, rather than a return code we
+        invented for a fixture. Labeled so the pair is never miscounted as
+        two guards on the same branch (cf. main#1215: an anti-vacuity
+        assertion can itself be vacuous).
+
+        Not a flake risk despite naming a system path: any absolute
+        out-of-repo pathspec exits 128 whether or not the file exists
+        (verified against a nonexistent path)."""
+        outside = "/etc/hostname"  # any absolute out-of-repo path works
         matched = hook._run_check_ignore(self._fake_root, [outside])
         self.assertEqual(matched, set())
 

--- a/.claude/hooks/tests/test_ontology_tracker.py
+++ b/.claude/hooks/tests/test_ontology_tracker.py
@@ -814,6 +814,78 @@ class GitCheckIgnoreExcludeThenReincludeTests(_FakeRepoRootMixin, unittest.TestC
         self.assertIn("data/raw/", matched_slash)
 
 
+class GitCheckIgnoreNonAsciiTests(_FakeRepoRootMixin, unittest.TestCase):
+    """main#1265: matching on git's ECHOED pathspec is encoding-sensitive.
+
+    Under git's default ``core.quotePath=true`` a pathspec containing any
+    non-ASCII byte is C-quoted on the way out (``عربي.log`` echoes as
+    ``"\\330\\271\\330\\261\\330\\250\\331\\212.log"``), so exact-string
+    membership against what we passed in never matches and a genuinely
+    ignored file is reported NOT ignored. That is a behavioural regression
+    versus the pre-#1122 code, which read only ``check-ignore -q``'s exit
+    status and was encoding-independent by construction.
+
+    The failure direction is the safe one (fail-open -> over-track, never
+    under-track) and no repo currently holds a non-ASCII path, so it was
+    latent. It is pinned here anyway because this org's domain is
+    Arabic-language scholarly data and the over-tracked entries land in the
+    COMMITTED ``ontology/checksums.json`` — the #1038 phantom-drift-forever
+    shape.
+    """
+
+    def setUp(self):
+        super().setUp()
+        hook._GIT_CHECK_IGNORE_CACHE.clear()
+        hook._DIR_CHECK_IGNORE_CACHE.clear()
+        subprocess.run(
+            ["git", "init", "-q", str(self._fake_root)],
+            check=True,
+            capture_output=True,
+            env=hook._hermetic_git_env(),
+        )
+        (self._fake_root / ".gitignore").write_text("*.log\nبناء/\n", encoding="utf-8")
+
+    def tearDown(self):
+        hook._GIT_CHECK_IGNORE_CACHE.clear()
+        hook._DIR_CHECK_IGNORE_CACHE.clear()
+        super().tearDown()
+
+    def test_non_ascii_ignored_file_is_detected(self):
+        """The core case: removing the ``core.quotePath=false`` pin makes
+        this return False."""
+        target = self._fake_root / "عربي.log"
+        target.write_text("x\n", encoding="utf-8")
+
+        self.assertTrue(hook._is_git_ignored(target.resolve()))
+
+    def test_ascii_sibling_still_detected(self):
+        """Control: the ASCII path was never affected, so a passing
+        non-ASCII test alone would not prove the pin is what fixed it."""
+        target = self._fake_root / "plain.log"
+        target.write_text("x\n", encoding="utf-8")
+
+        self.assertTrue(hook._is_git_ignored(target.resolve()))
+
+    def test_non_ascii_ignored_directory_is_detected(self):
+        """The directory-cache half: a non-ASCII directory excluded by a
+        genuine directory pattern must cache True, which it cannot do while
+        the echo is quoted."""
+        d = self._fake_root / "بناء"
+        d.mkdir()
+        target = d / "a.md"
+        target.write_text("x\n", encoding="utf-8")
+
+        self.assertTrue(hook._is_git_ignored(target.resolve()))
+
+    def test_echo_round_trips_the_caller_string(self):
+        """Direct guard on the mechanism, independent of ``_is_git_ignored``:
+        what git echoes back must be exactly what we passed in."""
+        (self._fake_root / "عربي.log").write_text("x\n", encoding="utf-8")
+
+        matched = hook._run_check_ignore(self._fake_root, ["عربي.log"])
+        self.assertEqual(matched, {"عربي.log"})
+
+
 class RunCheckIgnoreFailOpenTests(_FakeRepoRootMixin, unittest.TestCase):
     """main#1263 review: the ``returncode not in (0, 1)`` fail-open branch
     in ``_run_check_ignore`` had no test pinning it — a mutation deleting it

--- a/.claude/hooks/tests/test_ontology_tracker.py
+++ b/.claude/hooks/tests/test_ontology_tracker.py
@@ -442,6 +442,7 @@ class GitCheckIgnoreGeneralizationTests(_FakeRepoRootMixin, unittest.TestCase):
     def setUp(self):
         super().setUp()
         hook._GIT_CHECK_IGNORE_CACHE.clear()
+        hook._DIR_CHECK_IGNORE_CACHE.clear()
         # `env=hook._hermetic_git_env()` is load-bearing (main#719): the
         # pre-push pytest hook is itself invoked by `git push`, which exports
         # GIT_DIR/GIT_WORK_TREE for the real repo into every subprocess this
@@ -458,6 +459,7 @@ class GitCheckIgnoreGeneralizationTests(_FakeRepoRootMixin, unittest.TestCase):
 
     def tearDown(self):
         hook._GIT_CHECK_IGNORE_CACHE.clear()
+        hook._DIR_CHECK_IGNORE_CACHE.clear()
         super().tearDown()
 
     def test_child_repo_file_ignored_by_parent_is_still_tracked(self):
@@ -597,6 +599,183 @@ class GitCheckIgnoreGeneralizationTests(_FakeRepoRootMixin, unittest.TestCase):
             self.assertEqual(checksums.read_bytes(), before)
         finally:
             hook.CHECKSUMS_FILE = orig_checksums_file
+
+    def _counting_run(self):
+        """Wrap ``subprocess.run`` with a call counter, returning
+        ``(wrapped_fn, get_count)``. Callers swap ``subprocess.run`` in and
+        restore it in a ``finally``."""
+        call_count = 0
+        orig_run = subprocess.run
+
+        def _wrapped(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return orig_run(*args, **kwargs)
+
+        return _wrapped, (lambda: call_count)
+
+    def test_first_file_in_a_directory_resolves_both_in_one_subprocess_call(self):
+        """#1122: the directory verdict is resolved for free alongside the
+        file's own verdict — no extra subprocess versus the pre-#1122
+        single-file check."""
+        (self._fake_root / ".gitignore").write_text("scratch/\n", encoding="utf-8")
+        scratch = self._fake_root / "scratch"
+        scratch.mkdir()
+        f = scratch / "a.md"
+        f.write_text("a\n", encoding="utf-8")
+
+        wrapped, get_count = self._counting_run()
+        orig_run = subprocess.run
+        subprocess.run = wrapped
+        try:
+            ignored = hook._is_git_ignored(f.resolve())
+        finally:
+            subprocess.run = orig_run
+
+        self.assertTrue(ignored)
+        self.assertEqual(get_count(), 1)
+
+    def test_second_file_in_same_ignored_directory_is_a_cache_hit(self):
+        """#1122's actual win: a LATER, DIFFERENT file under an
+        already-known-ignored directory costs zero subprocess calls."""
+        (self._fake_root / ".gitignore").write_text("scratch/\n", encoding="utf-8")
+        scratch = self._fake_root / "scratch"
+        scratch.mkdir()
+        a = scratch / "a.md"
+        a.write_text("a\n", encoding="utf-8")
+        b = scratch / "b.md"
+        b.write_text("b\n", encoding="utf-8")
+
+        self.assertTrue(hook._is_git_ignored(a.resolve()))  # seeds the dir cache
+
+        wrapped, get_count = self._counting_run()
+        orig_run = subprocess.run
+        subprocess.run = wrapped
+        try:
+            ignored = hook._is_git_ignored(b.resolve())
+        finally:
+            subprocess.run = orig_run
+
+        self.assertTrue(ignored)
+        self.assertEqual(get_count(), 0)
+
+    def test_second_file_in_a_not_ignored_directory_is_still_checked_individually(self):
+        """Mutation guard for #1122's directory cache: a not-ignored
+        DIRECTORY verdict must never be used to declare a DIFFERENT file
+        not-ignored — a filename pattern can still exclude that one file.
+        Without this guard (e.g. a broadened predicate that trusts a False
+        directory-cache hit as "file not ignored"), this test fails because
+        ``x.secret`` would wrongly come back as tracked.
+        """
+        (self._fake_root / ".gitignore").write_text("*.secret\n", encoding="utf-8")
+        kept = self._fake_root / "kept"
+        kept.mkdir()
+        plain = kept / "plain.md"
+        plain.write_text("plain\n", encoding="utf-8")
+        secret = kept / "x.secret"
+        secret.write_text("s\n", encoding="utf-8")
+
+        # Directory resolves to NOT ignored (seeds `_DIR_CHECK_IGNORE_CACHE`
+        # False for `kept`).
+        self.assertFalse(hook._is_git_ignored(plain.resolve()))
+
+        wrapped, get_count = self._counting_run()
+        orig_run = subprocess.run
+        subprocess.run = wrapped
+        try:
+            ignored = hook._is_git_ignored(secret.resolve())
+        finally:
+            subprocess.run = orig_run
+
+        self.assertTrue(ignored)
+        self.assertEqual(get_count(), 1)  # still had to ask, just for this one file
+
+
+class SkipNoopWriteTests(_FakeRepoRootMixin, unittest.TestCase):
+    """#1122: skip the ``checksums.json`` write when the SHA is unchanged.
+
+    Exercises the skip PREDICATE directly (by counting calls to
+    ``checksums_io.write_checksums``), not just its byte-stability side
+    effect (``ChecksumsSerializationTests`` already covers that) — these
+    fail if the predicate is dropped, inverted, or broadened to compare the
+    wrong field.
+    """
+
+    def setUp(self):
+        super().setUp()
+        checksums = self._fake_root / "ontology" / "checksums.json"
+        checksums.parent.mkdir(parents=True, exist_ok=True)
+        checksums.write_text('{"version": 1, "files": {}}\n', encoding="utf-8")
+        self._checksums = checksums
+        self._orig_checksums_file = hook.CHECKSUMS_FILE
+        hook.CHECKSUMS_FILE = checksums
+
+    def tearDown(self):
+        hook.CHECKSUMS_FILE = self._orig_checksums_file
+        super().tearDown()
+
+    def test_first_track_of_a_new_path_always_writes(self):
+        """A never-before-seen path has no `last_tracked` to compare against
+        (`existing.get("last_tracked")` is `None`, never equal to a real
+        64-hex-char digest) — must never be mistaken for a no-op."""
+        f = self._fake_root / "ontology" / "domain.yaml"
+        f.parent.mkdir(parents=True, exist_ok=True)
+        f.write_text("entities: []\n", encoding="utf-8")
+
+        with mock.patch.object(hook.checksums_io, "write_checksums") as m:
+            result = hook.check({"tool_name": "Write", "tool_input": {"file_path": str(f)}})
+
+        self.assertEqual(result, {"action": "tracked", "path": "ontology/domain.yaml"})
+        m.assert_called_once()
+
+    def test_unchanged_content_reedit_skips_the_write(self):
+        """The exact no-op case #1122 targets: an edit that re-saves
+        byte-identical content must skip the 103 KB write entirely."""
+        f = self._fake_root / "ontology" / "domain.yaml"
+        f.parent.mkdir(parents=True, exist_ok=True)
+        f.write_text("entities: []\n", encoding="utf-8")
+        payload = {"tool_name": "Write", "tool_input": {"file_path": str(f)}}
+        hook.check(payload)  # real track — establishes last_tracked
+
+        with mock.patch.object(hook.checksums_io, "write_checksums") as m:
+            result = hook.check(payload)  # identical content re-saved
+
+        self.assertEqual(result, {"action": "skip_noop", "path": "ontology/domain.yaml"})
+        m.assert_not_called()
+
+    def test_changed_content_after_a_noop_still_writes(self):
+        """Mutation guard: the predicate must not be too broad. A genuine
+        content change immediately after a no-op must still write — proves
+        the skip isn't sticky/state-leaking and isn't comparing the wrong
+        field (e.g. always True, or comparing `tracked_at`)."""
+        f = self._fake_root / "ontology" / "domain.yaml"
+        f.parent.mkdir(parents=True, exist_ok=True)
+        f.write_text("entities: []\n", encoding="utf-8")
+        payload = {"tool_name": "Write", "tool_input": {"file_path": str(f)}}
+        hook.check(payload)
+        hook.check(payload)  # no-op — establishes the skip path was taken
+
+        f.write_text("entities: [foo]\n", encoding="utf-8")
+        with mock.patch.object(hook.checksums_io, "write_checksums") as m:
+            result = hook.check(payload)
+
+        self.assertEqual(result["action"], "tracked")
+        m.assert_called_once()
+
+    def test_skip_leaves_the_on_disk_entry_byte_identical(self):
+        """A skipped no-op write must leave the committed entry untouched —
+        not drop it, not corrupt it, not merely "similar"."""
+        f = self._fake_root / "ontology" / "domain.yaml"
+        f.parent.mkdir(parents=True, exist_ok=True)
+        f.write_text("entities: []\n", encoding="utf-8")
+        payload = {"tool_name": "Write", "tool_input": {"file_path": str(f)}}
+        hook.check(payload)
+        before = self._checksums.read_bytes()
+
+        hook.check(payload)  # no-op re-save, write skipped
+        after = self._checksums.read_bytes()
+
+        self.assertEqual(before, after)
 
 
 class LinkedWorktreeTests(_FakeRepoRootMixin, unittest.TestCase):

--- a/.claude/hooks/tests/test_ontology_tracker.py
+++ b/.claude/hooks/tests/test_ontology_tracker.py
@@ -995,14 +995,31 @@ class RunCheckIgnoreFailOpenTests(_FakeRepoRootMixin, unittest.TestCase):
 
         Kept because it pins the PREMISE the mocked test is built on — that
         128 is really what git returns here, rather than a return code we
-        invented for a fixture. Labeled so the pair is never miscounted as
-        two guards on the same branch (cf. main#1215: an anti-vacuity
-        assertion can itself be vacuous).
+        invented for a fixture. **That premise is now asserted directly**
+        (main#1263 review, Weronika Zielinska, second pass): the earlier
+        version claimed to pin it while asserting only ``matched == set()``,
+        an observable identical for simulated exits 0, 1 and 128 with empty
+        stdout — so a change to exit 1 would have evaporated the premise
+        silently. Claiming to guard a premise while measuring something else
+        is the same #1215 mode this docstring invokes, one level in.
 
         Not a flake risk despite naming a system path: any absolute
         out-of-repo pathspec exits 128 whether or not the file exists
         (verified against a nonexistent path)."""
         outside = "/etc/hostname"  # any absolute out-of-repo path works
+
+        # The premise, measured rather than asserted about: real git treats
+        # an out-of-repo pathspec as a FATAL error, not as "not ignored".
+        probe = subprocess.run(
+            ["git", "-c", "core.quotePath=false", "check-ignore", "--", outside],
+            cwd=str(self._fake_root),
+            capture_output=True,
+            env=hook._hermetic_git_env(),
+            encoding="utf-8",
+            errors="surrogateescape",
+        )
+        self.assertEqual(probe.returncode, 128, "premise gone: git no longer exits 128 here")
+
         matched = hook._run_check_ignore(self._fake_root, [outside])
         self.assertEqual(matched, set())
 

--- a/.claude/hooks/tests/test_ontology_tracker.py
+++ b/.claude/hooks/tests/test_ontology_tracker.py
@@ -892,6 +892,38 @@ class GitCheckIgnoreNonAsciiTests(_FakeRepoRootMixin, unittest.TestCase):
 
         self.assertTrue(hook._is_git_ignored(target.resolve()))
 
+    def test_invalid_utf8_filename_is_detected(self):
+        """main#1263 review, Weronika Zielinska: the decode setting was an
+        UNTESTED guard — reverting it broke nothing, so it could regress
+        silently.
+
+        A POSIX filename is a byte string and need not be valid UTF-8.
+        ``os.fsdecode`` maps undecodable bytes to lone surrogates
+        (``b"\\xe9.log"`` -> ``"\\udce9.log"``), which is the pathspec
+        ``_is_git_ignored`` passes; git echoes the raw bytes back. Only
+        ``errors="surrogateescape"`` round-trips those byte-exact.
+
+        This fixture fails against BOTH rejected alternatives, which is what
+        makes it a real guard rather than a happy-path test:
+        ``errors="replace"`` decodes to U+FFFD (silently not-matched,
+        fail-open), and ``text=True`` decodes strict (raises, or likewise
+        fails to match). Ground truth is ``check-ignore -q``'s exit code —
+        the encoding-independent pre-#1122 method — which reports ignored.
+        """
+        raw_name = os.fsdecode(b"\xe9.log")
+        target = self._fake_root / raw_name
+        target.write_bytes(b"x\n")
+
+        ground_truth = subprocess.run(
+            ["git", "check-ignore", "-q", "--", raw_name],
+            cwd=str(self._fake_root),
+            capture_output=True,
+            env=hook._hermetic_git_env(),
+        ).returncode
+        self.assertEqual(ground_truth, 0, "fixture is wrong: git does not ignore this")
+
+        self.assertTrue(hook._is_git_ignored(target.resolve()))
+
     def test_echo_round_trips_the_caller_string(self):
         """Direct guard on the mechanism, independent of ``_is_git_ignored``:
         what git echoes back must be exactly what we passed in."""

--- a/.claude/hooks/tests/test_ontology_tracker.py
+++ b/.claude/hooks/tests/test_ontology_tracker.py
@@ -691,6 +691,186 @@ class GitCheckIgnoreGeneralizationTests(_FakeRepoRootMixin, unittest.TestCase):
         self.assertEqual(get_count(), 1)  # still had to ask, just for this one file
 
 
+class GitCheckIgnoreExcludeThenReincludeTests(_FakeRepoRootMixin, unittest.TestCase):
+    """main#1263 review finding: a trailing-slash directory pathspec is
+    unsound for the `dir/*` + `!dir/**/keeper` idiom.
+
+    ``git check-ignore`` treats a trailing-slash pathspec (``"data/raw/"``)
+    as a literal STRING that a contents-only pattern like ``data/raw/*``
+    matches directly — git echoes that exact string back as "ignored". That
+    is a DIFFERENT fact from the directory itself being excluded, and it is
+    NOT true that every file inside is unconditionally ignored the way a
+    genuine directory-exclusion (``build/``) implies. Caching the
+    trailing-slash answer as ``dir_ignored=True`` therefore silently
+    mis-skips any file a ``!`` rule re-includes — this is the exact
+    ``data/raw/*`` + ``!data/**/.gitkeep`` idiom used by
+    ``noorinalabs-isnad-ingest-platform/.gitignore`` (four committed
+    ``.gitkeep`` files use it).
+
+    Reviewer correction that shaped these fixtures: a COMMITTED keeper is
+    masked by git's index (``check-ignore`` never flags a tracked path
+    regardless of pattern), so a test using an already-``git add``-ed
+    keeper passes for an unrelated reason and proves nothing about the
+    pattern-matching bug. The live bug surface is a keeper that is NOT YET
+    tracked (a newly created ``.gitkeep``, exactly the moment the tracker
+    hook would actually run on it) — that case is kept as its own,
+    explicitly-labeled test alongside the (also explicitly-labeled) tracked
+    case, per review, so nobody later mistakes the tracked test for
+    covering the fix it does not exercise.
+    """
+
+    def setUp(self):
+        super().setUp()
+        hook._GIT_CHECK_IGNORE_CACHE.clear()
+        hook._DIR_CHECK_IGNORE_CACHE.clear()
+        subprocess.run(
+            ["git", "init", "-q", str(self._fake_root)],
+            check=True,
+            capture_output=True,
+            env=hook._hermetic_git_env(),
+        )
+        (self._fake_root / ".gitignore").write_text(
+            "data/raw/*\n!data/**/.gitkeep\n", encoding="utf-8"
+        )
+
+    def tearDown(self):
+        hook._GIT_CHECK_IGNORE_CACHE.clear()
+        hook._DIR_CHECK_IGNORE_CACHE.clear()
+        super().tearDown()
+
+    def test_untracked_reincluded_keeper_is_not_skipped(self):
+        """THE live-bug case (untracked keeper — see class docstring). Seeds
+        the directory cache via the excluded sibling first, matching
+        production call order (whichever file ``check()`` sees first in a
+        directory), then proves the re-included keeper is still tracked."""
+        raw = self._fake_root / "data" / "raw"
+        raw.mkdir(parents=True)
+        dump = raw / "dump.parquet"
+        dump.write_text("binary-stand-in\n", encoding="utf-8")
+        keeper = raw / ".gitkeep"
+        keeper.write_text("", encoding="utf-8")
+
+        self.assertTrue(hook._is_git_ignored(dump.resolve()))  # genuinely excluded
+        self.assertFalse(hook._is_git_ignored(keeper.resolve()))  # re-included by `!`
+
+    def test_tracked_reincluded_keeper_is_not_skipped_for_index_reasons(self):
+        """The steady-state case once a keeper is committed. Passes for a
+        DIFFERENT reason than the fix above (git's index masks a tracked
+        path from check-ignore regardless of pattern matching) and would
+        pass even against the buggy trailing-slash code — see class
+        docstring. Kept only so the tracked case is covered too, and
+        labeled so it is never mistaken for covering the pattern fix."""
+        raw = self._fake_root / "data" / "raw"
+        raw.mkdir(parents=True)
+        dump = raw / "dump.parquet"
+        dump.write_text("binary-stand-in\n", encoding="utf-8")
+        keeper = raw / ".gitkeep"
+        keeper.write_text("", encoding="utf-8")
+        subprocess.run(
+            ["git", "add", "data/raw/.gitkeep"],
+            cwd=str(self._fake_root),
+            check=True,
+            capture_output=True,
+            env=hook._hermetic_git_env(),
+        )
+
+        self.assertTrue(hook._is_git_ignored(dump.resolve()))
+        self.assertFalse(hook._is_git_ignored(keeper.resolve()))
+
+    def test_nested_directory_swept_up_by_contents_pattern_is_still_ignored(self):
+        """A NESTED directory whose own bare name is itself matched by the
+        contents-only pattern (``data/raw/sub`` matches ``data/raw/*``) IS
+        genuinely excluded — gitignore(5)'s no-re-include-under-an-excluded-
+        parent rule then really does apply to everything beneath it, so the
+        directory-cache shortcut short-circuiting to True there is correct
+        behavior, not a regression of the fix above."""
+        sub = self._fake_root / "data" / "raw" / "sub"
+        sub.mkdir(parents=True)
+        nested_keeper = sub / ".gitkeep"
+        nested_keeper.write_text("", encoding="utf-8")
+
+        self.assertTrue(hook._is_git_ignored(nested_keeper.resolve()))
+        self.assertTrue(hook._DIR_CHECK_IGNORE_CACHE[(str(self._fake_root), "data/raw/sub")])
+
+    def test_trailing_slash_is_unsound_bare_name_is_not(self):
+        """Direct guard on the exact mechanism, independent of
+        ``_is_git_ignored``'s call sequence: proves the trap AND the fix in
+        one place, so a future re-introduction of the trailing slash fails
+        immediately rather than needing the fuller scenario above to
+        surface it."""
+        raw = self._fake_root / "data" / "raw"
+        raw.mkdir(parents=True)
+        (raw / "dump.parquet").write_text("x\n", encoding="utf-8")
+
+        # The fix: the bare directory name is NOT reported as matched by a
+        # contents-only pattern.
+        matched_bare = hook._run_check_ignore(self._fake_root, ["data/raw"])
+        self.assertNotIn("data/raw", matched_bare)
+
+        # The trap this guards against: WITH a trailing slash, git DOES
+        # echo the literal string back as matched, proving the slash
+        # version is unsound for this idiom (not merely untested).
+        matched_slash = hook._run_check_ignore(self._fake_root, ["data/raw/"])
+        self.assertIn("data/raw/", matched_slash)
+
+
+class RunCheckIgnoreFailOpenTests(_FakeRepoRootMixin, unittest.TestCase):
+    """main#1263 review: the ``returncode not in (0, 1)`` fail-open branch
+    in ``_run_check_ignore`` had no test pinning it — a mutation deleting it
+    survived the suite. Exit 128 is git's fatal-error code (e.g. an
+    out-of-repo or otherwise invalid pathspec); folding it into "nothing
+    ignored" must fail open (track the file), matching the single-path
+    behavior this module has always had for a subprocess failure.
+    """
+
+    def setUp(self):
+        super().setUp()
+        subprocess.run(
+            ["git", "init", "-q", str(self._fake_root)],
+            check=True,
+            capture_output=True,
+            env=hook._hermetic_git_env(),
+        )
+
+    def test_mocked_fatal_returncode_fails_open(self):
+        """The ``stdout`` here is deliberately NON-empty and formatted
+        exactly like a real ignored-pathspec echo — if the ``returncode not
+        in (0, 1)`` guard were deleted, the code would fall straight
+        through to parsing ``stdout`` and (wrongly) report ``some/path`` as
+        matched anyway, because an empty-stdout fatal error is
+        indistinguishable from "nothing ignored" without this guard. An
+        empty-``stdout`` version of this test would pass with or without
+        the guard and prove nothing (this is exactly the gap the reviewer
+        found survived undetected)."""
+        real_run = subprocess.run
+
+        def _fake_fatal(*args, **kwargs):
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=128,
+                stdout="some/path\n",
+                stderr="fatal: not a git repository\n",
+            )
+
+        subprocess.run = _fake_fatal
+        try:
+            matched = hook._run_check_ignore(self._fake_root, ["some/path"])
+        finally:
+            subprocess.run = real_run
+
+        self.assertEqual(matched, set())
+
+    def test_real_fatal_returncode_also_fails_open(self):
+        """Not mocked: a real ``git check-ignore`` invocation with an
+        out-of-repo pathspec genuinely exits 128 (verified: real git prints
+        ``fatal: ... is outside repository`` and returns 128 for this
+        exact input) — must also fail open, end to end through the real
+        subprocess path."""
+        outside = "/etc/hostname"  # universally readable on Linux test runners
+        matched = hook._run_check_ignore(self._fake_root, [outside])
+        self.assertEqual(matched, set())
+
+
 class SkipNoopWriteTests(_FakeRepoRootMixin, unittest.TestCase):
     """#1122: skip the ``checksums.json`` write when the SHA is unchanged.
 


### PR DESCRIPTION
## Summary

- `ontology_tracker.check()` skips the `checksums.json` write (not the read — still needed to compare) when the file's content SHA already equals `last_tracked`, i.e. a genuine no-op re-save. Previously every Edit/Write unconditionally rewrote the full 103 KB file.
- `_is_git_ignored`'s per-file `git check-ignore` cache (#1039) is extended with a per-directory cache. `git check-ignore` (without `-q`) accepts multiple pathspecs and echoes back which matched, so the FIRST file seen in a directory resolves both "is this file ignored" and "is its directory ignored" in one subprocess call — same cost as before. Per gitignore(5) ("It is not possible to re-include a file if a parent directory of that file is excluded"), a directory-ignored verdict is authoritative for every later file in that directory: zero subprocess calls. A not-ignored directory verdict is *not* reused for individual files (a filename pattern can still exclude one), so that case still checks per-file as before.
- Both caches are process-lifetime module dicts; nothing invalidates them mid-invocation (a PostToolUse hook is a fresh, short-lived, one-Edit-per-call subprocess, and `.gitignore` can't change mid-call).

Closes #1122

## Verification

- `pre-commit run --all-files` and `--hook-stage pre-push` both green (ruff-format/lint, actionlint, cspell, checksums-ascii, mypy, `pytest` incl. `.claude/hooks/tests` + `.claude/lib/tests` — 3493 passed, 647 subtests).
- Real (non-mocked) end-to-end exercise of the hook via stdin, run against a throwaway `git init` fixture repo *outside* this worktree (edits inside this worktree itself are filtered by the pre-existing linked-worktree skip, unrelated to this change):
  - First `Write` on a new tracked file → `exit 0`, `checksums.json` gains the new entry.
  - Identical re-`Write` (no-op) → `exit 0`, `checksums.json` byte-identical (write skipped).
  - Content actually changed → `exit 0`, `checksums.json` diffs again (`last_tracked` + `tracked_at` updated).
  - Directory-cache: a real, un-mocked Python process call showed 1 subprocess call for the first file in a gitignored directory and 0 for a second file in the same directory.
- Mutation-tested both new predicates directly against the source (not just the tests): an "always skip" mutation, an "ignore SHA, key on path presence" mutation, and an "over-broad directory cache" mutation were each applied in turn and confirmed to fail the corresponding new test, then reverted.

## Scope notes

- Does not touch `validate_edit_completion.py` or `post_dispatcher.py`'s logging path — no interaction with #1244 (missing Annunaki logging from `check()`) or #1245 (dispatcher discards advisories on a later block).

## Test plan

- [x] `pre-commit run --all-files`
- [x] `pre-commit run --all-files --hook-stage pre-push`
- [x] New/mutation tests in `.claude/hooks/tests/test_ontology_tracker.py`
- [x] Real synthetic PostToolUse exercise (exit codes measured, not reasoned about)

Co-Authored-By: Wanjiku Mwangi <parametrization+Wanjiku.Mwangi@gmail.com>