### PR TITLE
fix(hook4/#1211): disclose an unavailable self-review exclusion on the ALLOW path

### DIFF
--- a/.claude/hooks/tests/test_validate_pr_review.py
+++ b/.claude/hooks/tests/test_validate_pr_review.py
@@ -1109,10 +1109,20 @@ class CheckEndToEndTests(_NoContentBindingHarness):
             ) as ccr_mock,
         ):
             result = hook.check(self._input("gh pr merge 100 --squash"))
-        self.assertIsNone(
-            result,
+        # The merge is ALLOWED, which is what #294 is about. As of #1211 a
+        # wave-merge ref — a no-branch-author ref by construction — carries the
+        # scan-mode disclosure with that allow, so the outcome is an explicit
+        # `{"decision": "allow", …}` rather than the bare `None` this test
+        # originally used as its proxy for "allowed". Assert the decision, not
+        # the proxy; asserting `is None` here would now be asserting the ABSENCE
+        # of the #1211 disclosure, which is not this test's subject.
+        assert result is not None, "wave-merge PR with 2 Approveds must not block"
+        self.assertEqual(
+            result["decision"],
+            "allow",
             "wave-merge PR with 2 charter-format Approveds should allow merge",
         )
+        self.assertIn("WITHOUT self-review exclusion", result["systemMessage"])
         ccr_mock.assert_called_once()
         # Empty-string sentinel is what permits any non-empty reviewer name.
         call_args = ccr_mock.call_args
@@ -5058,6 +5068,216 @@ class CommitAuthorBlockDiagnosticTests(_ResolveOverFakeCommentsHarness):
         self.assertNotIn("COMMIT IDENTITY", unavailable)
         self.assertIn("WITHOUT self-review exclusion", unavailable)
         self.assertNotIn("WITHOUT self-review exclusion", excluded)
+
+
+class AllowPathScanDisclosureTests(_ResolveOverFakeCommentsHarness):
+    """#1211: the ALLOW path must say when self-review exclusion was unavailable.
+
+    #1206/#1210 made the scan mode loud on the paths that STOP a merge — the
+    paths where the missing discriminator did not change the outcome. The
+    exposure only bites when the gate PASSES: a persona's own verdict plus one
+    genuine reviewer reaches 2/2 on a ref naming nobody, and pre-#1211 the hook
+    returned `None` and said nothing. These pin that the disclosure now rides
+    the allow path, that it does NOT fire when exclusion was actually applied,
+    and — the case a naive fix silently breaks — that it COMPOSES with the
+    main#1055 unparseable-TechDebt advisory instead of racing it.
+    """
+
+    HEAD_REF = "dependabot/docker/x-1.2.3"
+
+    def _allow_result(self, verdicts, head_ref=None):
+        input_data = {
+            "tool_name": "Bash",
+            "tool_input": {"command": "gh pr merge 691 --repo noorinalabs/noorinalabs-main"},
+        }
+        with (
+            mock.patch.object(
+                hook, "get_pr_data", return_value=self._pr_data(head_ref or self.HEAD_REF)
+            ),
+            mock.patch.object(hook, "resolve_review_verdicts", return_value=verdicts),
+            mock.patch.object(hook, "log_pretooluse_block") as mock_log,
+        ):
+            result = hook.check(input_data)
+        # A merge that passes the threshold must never be logged as a block, no
+        # matter how many advisories rode along with it.
+        mock_log.assert_not_called()
+        return result
+
+    def _verdicts(self, comment_scan, *, unparseable=(), identities=(), head_ref=None):
+        """Two distinct roster reviewers, nothing missing — a clean 2/2 ALLOW.
+
+        Only `comment_scan` / `tech_debt_unparseable` vary, so any difference in
+        the returned message is attributable to those and nothing else.
+        """
+        return hook.ReviewVerdicts(
+            number=691,
+            head_ref=head_ref or self.HEAD_REF,
+            labels=[],
+            branch_author_lastname=None,
+            content_sha="837c272a",
+            content_ts=None,
+            formal_reviewers=set(),
+            comment_reviewers={"aino virtanen", "nino kavtaradze"},
+            non_roster_requestors=set(),
+            roster_comment_reviewers={"aino virtanen", "nino kavtaradze"},
+            roster_names=set(self.ROSTER),
+            distinct_reviewers={"aino virtanen", "nino kavtaradze"},
+            stale_verdicts_comment=[],
+            stale_verdicts_formal=[],
+            reviews_missing_tech_debt=[],
+            tech_debt_issue_numbers=[],
+            tech_debt_unparseable=list(unparseable),
+            wave_bootstrap_exception=False,
+            comment_scan=comment_scan,
+            commit_author_identities=identities,
+        )
+
+    def test_allowed_merge_discloses_that_exclusion_was_unavailable(self):
+        """The core #1211 fix: a passing gate on a no-branch-author ref must
+        return an ALLOW carrying the disclosure, not a bare `None`.
+
+        Pre-fix this returned `None` — the `assertIsNotNone` alone is the
+        kill-shot, and the content assertions pin WHAT is disclosed so a future
+        edit cannot satisfy the test with an empty or unrelated message.
+        """
+        result = self._allow_result(self._verdicts(hook.COMMENT_SCAN_NO_BRANCH_AUTHOR))
+
+        self.assertIsNotNone(
+            result, "an allowed merge with no self-review exclusion must disclose that"
+        )
+        assert result is not None  # narrow `dict | None` for mypy
+        self.assertEqual(result["decision"], "allow", "the disclosure must NOT block the merge")
+        message = result["systemMessage"]
+        # Names the ref, so the operator can check the classification themselves.
+        self.assertIn(self.HEAD_REF, message)
+        # States the fact that matters: no verdict was excluded as a self-review.
+        self.assertIn("WITHOUT self-review exclusion", message)
+        self.assertIn("including any posted by whoever wrote this branch", message)
+        # Reports the count the missing discriminator applied to.
+        self.assertIn("2/2", message)
+        # Proportionate: an advisory, not a verdict on the PR's validity.
+        self.assertNotIn("BLOCKED", message)
+        self.assertNotIn("WARNING", message)
+
+    def test_exclusion_applied_modes_stay_silent_on_the_allow_path(self):
+        """The negative control the positive test cannot supply on its own.
+
+        Applying exclusion can only REMOVE verdicts, so it can never manufacture
+        a pass — there is nothing to disclose. Both exclusion-active modes must
+        return `None`, so a change that emitted the note unconditionally fails
+        here just as loudly as one that emitted it never.
+        """
+        by_ref = self._allow_result(
+            self._verdicts(hook.COMMENT_SCAN_AUTHOR_EXCLUDED, head_ref="A.Virtanen/1211-x"),
+            head_ref="A.Virtanen/1211-x",
+        )
+        by_commit = self._allow_result(
+            self._verdicts(
+                hook.COMMENT_SCAN_COMMIT_AUTHOR_EXCLUDED,
+                identities=(
+                    hook.CommitAuthorIdentity(
+                        lastname="Virtanen", initial="a", display="Aino Virtanen"
+                    ),
+                ),
+            )
+        )
+        self.assertIsNone(by_ref, "ref-derived exclusion was applied — nothing to disclose")
+        self.assertIsNone(by_commit, "commit-derived exclusion was applied — nothing to disclose")
+
+    def test_both_advisories_survive_when_both_conditions_hold(self):
+        """THE composition test — the case a second early `return` breaks.
+
+        `check()` may emit exactly one `systemMessage`. main#1055's
+        unparseable-TechDebt note and #1211's scan disclosure are independent
+        facts that can both be true of one PR, so bolting the new advisory on as
+        its own early return would make whichever ran first silently swallow the
+        other. Both texts must appear in the single returned message.
+        """
+        result = self._allow_result(
+            self._verdicts(
+                hook.COMMENT_SCAN_NO_BRANCH_AUTHOR,
+                unparseable=[("Nino Kavtaradze", "filed later")],
+            )
+        )
+
+        assert result is not None, "both advisories must produce a message"
+        self.assertEqual(result["decision"], "allow")
+        message = result["systemMessage"]
+        # main#1055 advisory survived, verbatim payload included.
+        self.assertIn("not parseable as issue reference(s)", message)
+        self.assertIn("filed later", message)
+        self.assertIn("Nino Kavtaradze", message)
+        # #1211 advisory survived alongside it.
+        self.assertIn("WITHOUT self-review exclusion", message)
+        self.assertIn(self.HEAD_REF, message)
+        # Two distinct advisories, joined — not one truncated or overwritten.
+        self.assertEqual(message.count("NOTE: PR"), 2, f"expected 2 joined advisories: {message!r}")
+
+    def test_each_advisory_still_stands_alone(self):
+        """Composition must not have made either advisory depend on the other.
+
+        The TechDebt note must be emitted with the scan mode exclusion-active
+        (so only it fires), and its text must be exactly what it was before the
+        accumulator — pinning that #1211 refactored the return shape without
+        rewording main#1055's message.
+        """
+        td_only = self._allow_result(
+            self._verdicts(
+                hook.COMMENT_SCAN_AUTHOR_EXCLUDED,
+                unparseable=[("Nino Kavtaradze", "filed later")],
+                head_ref="A.Virtanen/1211-x",
+            ),
+            head_ref="A.Virtanen/1211-x",
+        )
+        assert td_only is not None, "main#1055 advisory must still fire on its own"
+        self.assertEqual(td_only["decision"], "allow")
+        self.assertIn("filed later", td_only["systemMessage"])
+        self.assertEqual(td_only["systemMessage"].count("NOTE: PR"), 1)
+        self.assertNotIn("self-review exclusion", td_only["systemMessage"])
+
+        scan_only = self._allow_result(self._verdicts(hook.COMMENT_SCAN_NO_BRANCH_AUTHOR))
+        assert scan_only is not None, "#1211 advisory must still fire on its own"
+        self.assertEqual(scan_only["systemMessage"].count("NOTE: PR"), 1)
+        self.assertNotIn("filed later", scan_only["systemMessage"])
+
+    def test_clean_pr_still_returns_none(self):
+        """No advisory condition, no message. The accumulator must not have
+        turned every allowed merge into a chatty one — `None` is the contract
+        `main()` reads as 'exit 0, say nothing'."""
+        self.assertIsNone(
+            self._allow_result(
+                self._verdicts(hook.COMMENT_SCAN_AUTHOR_EXCLUDED, head_ref="A.Virtanen/1211-x"),
+                head_ref="A.Virtanen/1211-x",
+            )
+        )
+
+    def test_disclosure_never_relaxes_or_tightens_the_gate(self):
+        """The advisory is orthogonal to the decision (#1211's stated scope).
+
+        Same NO_BRANCH_AUTHOR ref, two counts: 1/2 must still BLOCK and 2/2 must
+        still ALLOW. Without this, a disclosure implemented as a `decision` key
+        on the wrong branch could pass every content assertion above while
+        letting a 1/2 PR through.
+        """
+        short = self._verdicts(hook.COMMENT_SCAN_NO_BRANCH_AUTHOR)
+        short.distinct_reviewers = {"aino virtanen"}
+        input_data = {
+            "tool_name": "Bash",
+            "tool_input": {"command": "gh pr merge 691 --repo noorinalabs/noorinalabs-main"},
+        }
+        with (
+            mock.patch.object(hook, "get_pr_data", return_value=self._pr_data(self.HEAD_REF)),
+            mock.patch.object(hook, "resolve_review_verdicts", return_value=short),
+            mock.patch.object(hook, "log_pretooluse_block"),
+        ):
+            blocked = hook.check(input_data)
+        assert blocked is not None
+        self.assertEqual(blocked["decision"], "block")
+        self.assertIn("1/2 required peer reviews", blocked["reason"])
+
+        allowed = self._allow_result(self._verdicts(hook.COMMENT_SCAN_NO_BRANCH_AUTHOR))
+        assert allowed is not None
+        self.assertEqual(allowed["decision"], "allow")
 
 
 if __name__ == "__main__":

--- a/.claude/hooks/validate_pr_review.py
+++ b/.claude/hooks/validate_pr_review.py
@@ -2073,7 +2073,17 @@ def resolve_review_verdicts(pr_data: dict, repo: str | None = None) -> ReviewVer
 
 
 def check(input_data: dict) -> dict | None:
-    """Check PR review requirements. Returns result dict if blocking/warning, None if allowed."""
+    """Check PR review requirements.
+
+    Returns a `{"decision": "block", "reason": …}` dict when the merge is
+    stopped, a `{"decision": "allow", "systemMessage": …}` dict when the merge
+    proceeds but something is worth stating (see the allow-path advisories at
+    the tail — main#1055 unparseable TechDebt, #1211 scan-mode disclosure), and
+    `None` when the merge proceeds with nothing to report.
+
+    Callers must therefore NOT read a non-`None` return as "blocked": `main()`
+    branches on `decision`, and an advisory exits 0.
+    """
     tool_name = input_data.get("tool_name", "")
     if tool_name != "Bash":
         return None
@@ -2531,23 +2541,69 @@ def check(input_data: dict) -> dict | None:
         if board_repo_name:
             ensure_issues_on_board(board_repo_name, td_issues)
 
-    # Non-blocking observability (main#1055): a TechDebt line that is present,
-    # not "none", but parsed to ZERO issue numbers used to vanish silently —
-    # neither flagged as missing nor recorded as filed. Surface it as an
-    # advisory `systemMessage` so the gap is visible without blocking merge.
+    # ---- Non-blocking allow-path advisories (#1211) -------------------------
+    #
+    # ACCUMULATE, never early-return. Every condition below is independently
+    # true or false of the same PR, and a PreToolUse hook may emit exactly ONE
+    # `systemMessage`. Before #1211 the main#1055 advisory `return`ed inline,
+    # so any advisory added after it would have been unreachable whenever an
+    # unparseable TechDebt value was also present — the two would race, and the
+    # loser would be silently dropped on precisely the PRs that had the most to
+    # report. Appending to `advisories` and joining once before the single
+    # `return` is what makes them compose. Do not reintroduce an early return
+    # here; add to the list instead.
+    advisories: list[str] = []
+
+    # main#1055: a TechDebt line that is present, not "none", but parsed to
+    # ZERO issue numbers used to vanish silently — neither flagged as missing
+    # nor recorded as filed. Surface it so the gap is visible without blocking.
     unparseable = verdicts.tech_debt_unparseable
     if unparseable:
         detail = "; ".join(f"{name}: {value!r}" for name, value in unparseable)
-        return {
-            "decision": "allow",
-            "systemMessage": (
-                f"NOTE: PR {pr_display} has {len(unparseable)} verdict(s) with a "
-                "TechDebt line present but not parseable as issue reference(s) — "
-                f"recorded as ZERO tech-debt refs, not blocked: {detail}. Charter "
-                "format: `TechDebt: none` or `TechDebt: #15, #16` (a bare `15, 16` "
-                "is also accepted); free text is not."
-            ),
-        }
+        advisories.append(
+            f"NOTE: PR {pr_display} has {len(unparseable)} verdict(s) with a "
+            "TechDebt line present but not parseable as issue reference(s) — "
+            f"recorded as ZERO tech-debt refs, not blocked: {detail}. Charter "
+            "format: `TechDebt: none` or `TechDebt: #15, #16` (a bare `15, 16` "
+            "is also accepted); free text is not."
+        )
+
+    # #1211: disclose the scan mode on the ALLOW path too.
+    #
+    # The block path has named the mode since #1206/#1210, but that is the path
+    # where the missing discriminator did NOT change the outcome. It is when
+    # the gate PASSES that "self-review exclusion was unavailable" is load-
+    # bearing: a persona's own verdict plus one genuine reviewer can reach 2/2
+    # on a ref that names nobody, and the operator would see no trace of it.
+    # Disclosing only on block told them the one thing they did not need.
+    #
+    # Scoped deliberately to NO_BRANCH_AUTHOR:
+    #   - AUTHOR_EXCLUDED / COMMIT_AUTHOR_EXCLUDED — exclusion WAS applied.
+    #     Applying it can only REMOVE verdicts, so it can never manufacture a
+    #     pass; the block path already names those subtractions, which is where
+    #     they matter.
+    #   - NOT_RUN — `resolve_review_verdicts` hard-blocks upstream, so it is
+    #     unreachable here; it is left alone rather than given wording that
+    #     could only ever fire on a regression already caught elsewhere.
+    #
+    # Wording is proportionate on purpose: an allowed merge is a correct
+    # outcome under the charter threshold, and this states which discriminator
+    # was unavailable — it is not a warning about the PR's validity.
+    if verdicts.comment_scan == COMMENT_SCAN_NO_BRANCH_AUTHOR:
+        advisories.append(
+            f"NOTE: PR {pr_display} reached {total_distinct}/2 WITHOUT self-review "
+            f"exclusion. Head ref `{verdicts.head_ref or '(unknown)'}` carries no "
+            "`{Initial}.{Lastname}` branch-author prefix and the PR's commits named no "
+            "roster persona either (a bot author, a merge-only branch, or a squashed "
+            "commit re-authored to the bare principal — #1177/#1210), so no verdict was "
+            "excluded as a self-review: every roster-valid Approved Requestor was "
+            "counted, including any posted by whoever wrote this branch. The scan DID "
+            "run and the charter threshold is unchanged — this states which "
+            "discriminator was unavailable, not a defect (#1206/#1211)."
+        )
+
+    if advisories:
+        return {"decision": "allow", "systemMessage": "\n\n".join(advisories)}
 
     return None
 


### PR DESCRIPTION
Closes #1211

## The gap

#1207 made a skipped comment scan loud — but only on the paths that **stop** a merge.
`check()` emitted the scan-mode note inside the *block* `reason`, and
`pr_review_state._describe_comment_scan` renders it only in a report an operator has to run
deliberately. On the path where `check()` **allows**, the hook returned `None` (or, for the
main#1055 unparseable-TechDebt case only, an unrelated advisory) and said nothing about scan
mode.

That is inverted relative to the risk. The exposure only bites when the gate **passes**: on a
head ref naming no persona whose commits name no persona either, a branch author's own verdict
plus one genuine reviewer reaches 2/2 with nothing subtracted — a silent allow. Pre-fix, the
operator was told "no self-review exclusion was applied" in every case *except* the one where
it changed the outcome.

## The fix

On the allow path, when `verdicts.comment_scan == COMMENT_SCAN_NO_BRANCH_AUTHOR`, `check()`
returns `{"decision": "allow", "systemMessage": …}` naming the head ref and stating that
exclusion was not applied to the counted verdicts.

**Why it is not a one-liner — the advisories must compose, not race.** A PreToolUse hook may
emit exactly ONE `systemMessage`, and `check()` already `return`ed one inline for main#1055.
The unparseable-TechDebt fact and the scan-mode fact are independent and can both hold of the
same PR, so a second early return would make whichever ran first silently swallow the other —
on precisely the PRs with the most to report. `check()` now appends to an `advisories` list and
joins once before a single `return`. The in-code comment says so explicitly, because the shape
is load-bearing and the obvious future edit is to add another early return.

**Scoped deliberately to `NO_BRANCH_AUTHOR`:**

- `AUTHOR_EXCLUDED` / `COMMIT_AUTHOR_EXCLUDED` — exclusion **was** applied. Applying it can only
  *remove* verdicts, so it can never manufacture a pass; the block path already names those
  subtractions, which is where they matter.
- `NOT_RUN` — `resolve_review_verdicts` hard-blocks upstream, so it is unreachable here.

**The gate is untouched.** Same threshold, same roster filtering, same block paths. The wording
is proportionate on purpose: it states which discriminator was unavailable, not that the PR is
suspect. `test_disclosure_never_relaxes_or_tightens_the_gate` pins that a 1/2 PR on the same ref
still blocks.

What an operator sees when both advisories fire (verified end-to-end through `main()`, exit 0):

```
NOTE: PR #691 has 1 verdict(s) with a TechDebt line present but not parseable as issue
reference(s) — recorded as ZERO tech-debt refs, not blocked: Nino Kavtaradze: 'will file'. …

NOTE: PR #691 reached 2/2 WITHOUT self-review exclusion. Head ref
`deployments/phase-10/wave-29` carries no `{Initial}.{Lastname}` branch-author prefix and the
PR's commits named no roster persona either … so no verdict was excluded as a self-review …
The scan DID run and the charter threshold is unchanged — this states which discriminator was
unavailable, not a defect (#1206/#1211).
```

## Relationship to #1210 — this is not obsoleted by it

#1210 (already on `main`) removes the **cause**: it derives the branch author from commit
identity, restoring exclusion on non-persona refs via `COMMIT_AUTHOR_EXCLUDED`. #1211 closes the
**disclosure** gap and **keeps residual value afterwards**: `NO_BRANCH_AUTHOR` stays reachable
for genuine bot branches, merge-only branches, and commits whose authors match no roster
persona, so "exclusion was not applied here" remains worth saying. `refine_comment_scan_scope`
returns `NO_BRANCH_AUTHOR` unchanged whenever no identity was derived — that residual is exactly
what this advisory reports.

## One pre-existing test updated

`CheckEndToEndTests::test_wave_merge_head_ref_runs_comment_review` asserted `result is None` as
its proxy for "the merge is allowed". A wave-merge ref (`deployments/phase-N/wave-M`) is a
no-branch-author ref *by construction*, so post-fix it carries the disclosure. Keeping `is None`
would have turned that test into an assertion about the **absence** of the #1211 disclosure,
which is not its subject (#294: the wave-merge ref must not silently skip the scan). It now
asserts `decision == "allow"` plus the disclosure text — strictly stronger, same intent.

## Mutation testing

Assertion-only tests are not evidence. Each new branch was deleted or weakened and the run
re-executed; every mutation is killed by a **named** test. Harness:
`/tmp/claude-1000/-home-parameterization-code-noorinalabs-main/f59882d5-3c72-4f52-b53f-e1d9a8016471/scratchpad/mutate_1211.py`
(applies the mutation, runs the suite, restores byte-identical).

| # | Mutation | Result | Killed by |
|---|---|---|---|
| M1 | Delete the whole `NO_BRANCH_AUTHOR` advisory branch (pre-fix behaviour) | 5 failed, 313 passed | `AllowPathScanDisclosureTests::test_allowed_merge_discloses_that_exclusion_was_unavailable`, `::test_both_advisories_survive_when_both_conditions_hold`, `::test_disclosure_never_relaxes_or_tightens_the_gate`, `::test_each_advisory_still_stands_alone`, `CheckEndToEndTests::test_wave_merge_head_ref_runs_comment_review` |
| M2 | **The naive fix** — revert main#1055 to an early `return`, keep the new append (the two race) | 1 failed, 317 passed | `AllowPathScanDisclosureTests::test_both_advisories_survive_when_both_conditions_hold` — **only** the combined test |
| M3 | Drop the `NO_BRANCH_AUTHOR` guard (emit unconditionally) | 19 failed, 299 passed | `AllowPathScanDisclosureTests::test_exclusion_applied_modes_stay_silent_on_the_allow_path`, `::test_clean_pr_still_returns_none`, `::test_each_advisory_still_stands_alone` + 16 pre-existing allow-path tests |
| M4 | `join(advisories[:1])` — accumulator present, second advisory dropped | 1 failed, 317 passed | `AllowPathScanDisclosureTests::test_both_advisories_survive_when_both_conditions_hold` |
| M5 | Advisory returns `decision: "block"` (disproportionate) | 6 failed, 312 passed | `AllowPathScanDisclosureTests::test_allowed_merge_discloses_that_exclusion_was_unavailable`, `::test_both_advisories_survive_when_both_conditions_hold`, `::test_disclosure_never_relaxes_or_tightens_the_gate`, `::test_each_advisory_still_stands_alone`, `ResolveReviewVerdictsSharedBoundaryTests::test_check_surfaces_unparseable_tech_debt_as_nonblocking_advisory`, `CheckEndToEndTests::test_wave_merge_head_ref_runs_comment_review` |
| M6 | Stop naming the head ref in the message | 2 failed, 316 passed | `AllowPathScanDisclosureTests::test_allowed_merge_discloses_that_exclusion_was_unavailable`, `::test_both_advisories_survive_when_both_conditions_hold` |
| M7 | Stop reporting the `{n}/2` count | 1 failed, 317 passed | `AllowPathScanDisclosureTests::test_allowed_merge_discloses_that_exclusion_was_unavailable` |

**M2 is the one that matters.** It is precisely the shape the issue warns against, it passes the
whole rest of the suite, and it is caught by exactly one test — the combined case. Without that
test the naive fix ships green.

Additionally, the new tests were run against the **genuine pre-fix hook** (`git show
origin/main:.claude/hooks/validate_pr_review.py`), not just a mutation: 5 failed, 2 passed. The 2
that pass are the negative controls (`test_exclusion_applied_modes_stay_silent_on_the_allow_path`,
`test_clean_pr_still_returns_none`) — they *should* pass pre-fix, since pre-fix emitted nothing;
their kill-shot is M3.

## Vacuity (per #1203)

No bare `assertIn("1/2", reason)`-style assertions were added. Every new assertion names specific
advisory content (`"WITHOUT self-review exclusion"`, `"including any posted by whoever wrote this
branch"`, the literal head ref, the `filed later` payload), and the combined case asserts
`message.count("NOTE: PR") == 2` — a structural count that a truncated or overwritten join
cannot satisfy. Both directions are asserted: the exclusion-active modes must be **silent**
(`assertIsNone`), and each advisory must NOT contain the other's text when only one condition
holds.

## Verification

- `ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/ .claude/lib/tests/ -q` → **3526 passed,
  647 subtests passed** (re-run after rebase onto `origin/main` @ `f915d68`).
- Both pre-commit stages green: commit-stage and `--hook-stage pre-push --all-files` (ruff-format,
  ruff-lint, actionlint, cspell, mypy ×2, pytest ×2, memory-budget, headcount-budget,
  doc-freshness, office-drift, mermaid-render, checksums-ascii, fixture-realism,
  skill-graphql-pagination).
- `python3 .claude/lib/pre_commit_ci_sync.py .` → `OK: pre-commit config mirrors all CI-enforced
  checks.`
- End-to-end smoke through `main()` over real stdin JSON: exit code **0** (advisory, not the
  block path's 2), `decision: allow`, both advisory texts present in one `systemMessage`.

Rebased on `origin/main` and the full suite re-run afterwards. No changes to
`extract_branch_author_lastname` or its imports (concurrent #1175 work); the diff is confined to
the tail of `check()` plus its docstring, and to the test file.

## Files

- `.claude/hooks/validate_pr_review.py` — advisory accumulator at the tail of `check()`; `check()`
  docstring now states the three-way return contract (block dict / allow dict / `None`), since
  "non-`None` means blocked" is now wrong.
- `.claude/hooks/tests/test_validate_pr_review.py` — `AllowPathScanDisclosureTests` (6 cases); one
  pre-existing assertion updated as described above.
