### PR TITLE
ci(base-pin): validate the digest value and registry host, not just the FROM shape (#1204 item 1)

### DIFF
--- a/.claude/lib/check_dockerfile_base_pin.py
+++ b/.claude/lib/check_dockerfile_base_pin.py
@@ -13,6 +13,11 @@ What this gate enforces (verbatim from the section's distro table)
 For every `FROM` that is not exempt:
 
 1. The image reference MUST carry an `@sha256:` digest pin.
+1a. The digest VALUE must be well-formed — `sha256:` followed by exactly 64
+    lowercase hex characters (noorinalabs-main#1204). Shape-only checking let
+    `@sha256:deadbeef` and `@sha256:` through the gate.
+1b. The registry host the reference resolves to must be in the allowed set
+    (see "Registry allowlist" below) — also #1204.
 2. The stage MUST run the package-manager upgrade matching the base distro:
 
    | Family      | Pin shape               | Upgrade command                                 |
@@ -37,16 +42,50 @@ Exemptions honored (verbatim from the section)
   upstream stage's pin, so it is not re-checked (the named stage was checked at
   its defining `FROM`).
 - **Vendor images** documented with an inline `# RATIONALE:` comment on the
-  `FROM` line (or the comment line immediately above it).
+  `FROM` line (or the comment line immediately above it). This remains the full
+  escape hatch: a RATIONALE-documented `FROM` skips *every* rule below,
+  including the digest-value and registry rules, because the exemption is
+  visible and reviewed in the diff.
+
+Registry allowlist — what "expected registry" means (#1204)
+==========================================================
+There is no single expected hostname to hardcode: this file is an org-wide
+template vendored into every child repo, and a repo may legitimately pull a base
+image from a registry another repo never touches. "Expected" is therefore a
+**declared policy set**, layered, with the narrow/loud default the org's
+standing stance on classifier defaults requires (unknown ⇒ narrow ⇒ loud exit-1):
+
+1. `DEFAULT_ALLOWED_REGISTRIES` — the built-in org floor below. Every entry is
+   evidence-grounded (see the per-entry comments); a registry that no repo pulls
+   a base image from is deliberately NOT here.
+2. `--allow-registry HOST` (repeatable) — a per-repo extension, declared in that
+   repo's `.pre-commit-config.yaml` `args:` and its CI step, so the widening is
+   itself a reviewed, diffable line rather than a silent default.
+3. `# RATIONALE:` on the `FROM` — the per-statement escape hatch.
+
+Anything outside (1) ∪ (2), not covered by (3), is a violation. A legitimate but
+unanticipated registry therefore FAILS LOUDLY with a message naming the flag —
+it is never silently permitted. Two deliberate non-widenings:
+
+- **No alias canonicalization.** `index.docker.io` / `registry-1.docker.io` are
+  not silently folded into `docker.io`; a ref naming a different literal host
+  must be allowlisted explicitly.
+- **Ports are part of the host.** `registry.example.com:5000` must be
+  allowlisted with its port; the bare hostname does not cover it.
+
+A reference whose registry component is a build-arg/variable (`FROM
+${REGISTRY}/img@sha256:...`) is not statically determinable and is flagged
+rather than assumed to be Docker Hub.
 
 CLI
 ===
-    python3 .claude/lib/check_dockerfile_base_pin.py <Dockerfile> [<Dockerfile> ...]
+    python3 .claude/lib/check_dockerfile_base_pin.py [--allow-registry HOST]... \
+        <Dockerfile> [<Dockerfile> ...]
 
 Exit codes:
     0 — every FROM in every file is compliant (or exempt)
     1 — at least one violation (each printed as `path:line: FROM <image> — <why>`)
-    2 — usage / file-not-found error
+    2 — usage / unknown-flag / file-not-found error
 
 This is a reusable template (same CLI/exit-code shape as
 `.claude/lib/pre_commit_ci_sync.py`) so it wires identically into a repo's
@@ -59,7 +98,47 @@ from __future__ import annotations
 
 import re
 import sys
+from collections.abc import Iterable
 from pathlib import Path
+
+# --- Digest value (#1204) ---------------------------------------------------
+# An OCI content digest is `sha256:` + exactly 64 LOWERCASE hex characters. The
+# registry spec's grammar is lowercase-only, so uppercase hex is rejected rather
+# than normalized — a ref Docker itself would refuse must not pass the lint.
+_DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+# --- Registry host (#1204) --------------------------------------------------
+# A ref with no explicit registry component resolves to Docker Hub. This is the
+# host such a ref is checked against; it is NOT an alias table (see the module
+# docstring — `index.docker.io` is a different literal host and must be
+# allowlisted on its own).
+_IMPLICIT_REGISTRY = "docker.io"
+
+# The org floor. Narrow by construction: each entry is a registry some repo in
+# this org actually pulls a base image from, or that the charter's own distro
+# table names. A registry used only for `image:` refs in compose (e.g.
+# `quay.io/prometheuscommunity/postgres-exporter`) is NOT here — this gate reads
+# `FROM` lines, and widening the default on non-evidence is the same defect as
+# permitting `evil.example.com`. Repos that legitimately need more declare it
+# with `--allow-registry`.
+DEFAULT_ALLOWED_REGISTRIES: frozenset[str] = frozenset(
+    {
+        # Every real base image across all seven repos is an un-prefixed Docker
+        # Hub ref (python:*-slim, node:*-alpine, nginx:*-alpine, neo4j, ubuntu).
+        _IMPLICIT_REGISTRY,
+        # The org's own registry — every child repo publishes to it via its
+        # `ghcr-publish.yml`, so a `FROM ghcr.io/noorinalabs/...` base built by
+        # us is an anticipated pattern.
+        "ghcr.io",
+        # Distroless is a family the charter's own distro table names as
+        # supported, and it is published only under `gcr.io/distroless/...`.
+        "gcr.io",
+    }
+)
+
+# A `$VAR` / `${VAR}` occurrence — used only against the registry component, to
+# tell "statically Docker Hub" apart from "we cannot know".
+_VARIABLE_RE = re.compile(r"\$\{?\w")
 
 # `FROM` is the only keyword we parse; Dockerfile keywords are case-insensitive.
 _FROM_RE = re.compile(r"^\s*FROM\s+(?P<rest>\S.*?)\s*$", re.IGNORECASE)
@@ -127,6 +206,48 @@ def parse_froms(text: str) -> list[FromStatement]:
     return froms
 
 
+def digest_of(image: str) -> str | None:
+    """Return the digest component of an image ref, or None if it carries none.
+
+    Everything after the FIRST `@` is the digest, so a ref with a stray second
+    `@` yields a value that fails `_DIGEST_RE` rather than being silently
+    truncated to a well-formed prefix.
+    """
+    if "@" not in image:
+        return None
+    return image.split("@", 1)[1]
+
+
+def registry_host(image: str) -> str | None:
+    """Return the ref's explicit registry host, or None for implicit Docker Hub.
+
+    Docker's own rule: the first `/`-separated component is a registry iff it
+    contains a `.` or a `:`, or is exactly `localhost`. Otherwise it is a Hub
+    namespace (`myorg/myimage`), and a ref with no `/` at all is a Hub library
+    image (`python:3.14-slim`).
+    """
+    ref = image.split("@", 1)[0]
+    if "/" not in ref:
+        return None
+    head = ref.split("/", 1)[0]
+    if head == "localhost" or "." in head or ":" in head:
+        return head
+    return None
+
+
+def _registry_component_is_variable(image: str) -> bool:
+    """True if the ref has a registry component that is a build arg/variable.
+
+    Only the component before the first `/` is inspected: a variable in the
+    NAME or TAG (`FROM neo4j:${NEO4J_VERSION}`) leaves the registry statically
+    known (Docker Hub), whereas `FROM ${REGISTRY}/img@sha256:...` does not.
+    """
+    ref = image.split("@", 1)[0]
+    if "/" not in ref:
+        return False
+    return bool(_VARIABLE_RE.search(ref.split("/", 1)[0]))
+
+
 def _stage_body(text: str, from_lineno: int, next_from_lineno: int | None) -> str:
     """Return the text between a `FROM` (exclusive) and the next `FROM`/EOF."""
     lines = text.splitlines()
@@ -135,8 +256,20 @@ def _stage_body(text: str, from_lineno: int, next_from_lineno: int | None) -> st
     return "\n".join(lines[start:end])
 
 
-def check_dockerfile_text(path: str, text: str) -> list[str]:
-    """Return a list of human-readable violation strings for one Dockerfile."""
+def check_dockerfile_text(
+    path: str,
+    text: str,
+    allowed_registries: Iterable[str] | None = None,
+) -> list[str]:
+    """Return a list of human-readable violation strings for one Dockerfile.
+
+    `allowed_registries` defaults to `DEFAULT_ALLOWED_REGISTRIES`; callers pass
+    the repo's declared set (default ∪ `--allow-registry` values).
+    """
+    allowed = {
+        h.lower()
+        for h in (DEFAULT_ALLOWED_REGISTRIES if allowed_registries is None else allowed_registries)
+    }
     violations: list[str] = []
     froms = parse_froms(text)
     defined_stages: set[str] = set()
@@ -153,11 +286,39 @@ def check_dockerfile_text(path: str, text: str) -> list[str]:
         if is_exempt:
             continue
 
-        if "@sha256:" not in stmt.image:
+        # Rule 1 — a digest pin is present, and (1a, #1204) its VALUE is a
+        # well-formed sha256 content digest. Shape-only checking passed
+        # `@sha256:deadbeef` and `@sha256:`.
+        digest = digest_of(stmt.image)
+        if digest is None:
             violations.append(
                 f"{path}:{stmt.lineno}: FROM {stmt.image} — not digest-pinned "
                 f"(require image:tag@sha256:<digest>)"
             )
+        elif _DIGEST_RE.match(digest) is None:
+            violations.append(
+                f"{path}:{stmt.lineno}: FROM {stmt.image} — malformed digest "
+                f"'{digest}' (require sha256: followed by exactly 64 lowercase "
+                f"hex characters)"
+            )
+
+        # Rule 1b (#1204) — the ref must resolve to an allowed registry host.
+        if _registry_component_is_variable(stmt.image):
+            violations.append(
+                f"{path}:{stmt.lineno}: FROM {stmt.image} — registry host is not "
+                f"statically determinable (it is a build arg/variable); use a "
+                f"literal registry host so the allowlist can be enforced"
+            )
+        else:
+            host = registry_host(stmt.image) or _IMPLICIT_REGISTRY
+            if host.lower() not in allowed:
+                violations.append(
+                    f"{path}:{stmt.lineno}: FROM {stmt.image} — registry "
+                    f"'{host}' is not in the allowed set "
+                    f"({', '.join(sorted(allowed))}); if this registry is "
+                    f"legitimate for this repo, declare it with "
+                    f"--allow-registry {host} in .pre-commit-config.yaml and CI"
+                )
 
         body = _stage_body(text, stmt.lineno, next_lineno)
         if "distroless" in image_l:
@@ -176,17 +337,59 @@ def check_dockerfile_text(path: str, text: str) -> list[str]:
     return violations
 
 
-def check_file(path: Path) -> list[str]:
-    return check_dockerfile_text(str(path), path.read_text(encoding="utf-8"))
+def check_file(path: Path, allowed_registries: Iterable[str] | None = None) -> list[str]:
+    return check_dockerfile_text(str(path), path.read_text(encoding="utf-8"), allowed_registries)
+
+
+_USAGE = (
+    "usage: check_dockerfile_base_pin.py [--allow-registry HOST]... <Dockerfile> [<Dockerfile> ...]"
+)
+
+
+def parse_args(argv: list[str]) -> tuple[list[str], set[str]] | None:
+    """Split argv into (paths, allowed registries), or None on a usage error.
+
+    Hand-rolled rather than argparse so `main` keeps returning its exit code
+    instead of raising SystemExit. An unrecognized `--flag` is a usage error,
+    never a path — a typo'd `--allow-registy` must not be silently swallowed
+    into the file list and leave the default allowlist quietly in force.
+    """
+    paths: list[str] = []
+    allowed = set(DEFAULT_ALLOWED_REGISTRIES)
+    i = 0
+    while i < len(argv):
+        arg = argv[i]
+        if arg == "--allow-registry":
+            if i + 1 >= len(argv):
+                print("ERROR: --allow-registry requires a HOST argument", file=sys.stderr)
+                return None
+            allowed.add(argv[i + 1])
+            i += 2
+            continue
+        if arg.startswith("--allow-registry="):
+            value = arg.split("=", 1)[1]
+            if not value:
+                print("ERROR: --allow-registry requires a HOST argument", file=sys.stderr)
+                return None
+            allowed.add(value)
+            i += 1
+            continue
+        if arg.startswith("-"):
+            print(f"ERROR: unknown option: {arg}", file=sys.stderr)
+            return None
+        paths.append(arg)
+        i += 1
+    return paths, allowed
 
 
 def main(argv: list[str]) -> int:
-    paths = argv[1:]
+    parsed = parse_args(argv[1:])
+    if parsed is None:
+        print(_USAGE, file=sys.stderr)
+        return 2
+    paths, allowed = parsed
     if not paths:
-        print(
-            "usage: check_dockerfile_base_pin.py <Dockerfile> [<Dockerfile> ...]",
-            file=sys.stderr,
-        )
+        print(_USAGE, file=sys.stderr)
         return 2
 
     all_violations: list[str] = []
@@ -195,17 +398,19 @@ def main(argv: list[str]) -> int:
         if not path.is_file():
             print(f"ERROR: not a file: {p}", file=sys.stderr)
             return 2
-        all_violations.extend(check_file(path))
+        all_violations.extend(check_file(path, allowed))
 
     if all_violations:
         print("Base Image Pinning violations (tech-decisions.md § Base Image Pinning, #735):")
         for v in all_violations:
             print(f"  {v}")
         print(
-            "\nEvery FROM must be digest-pinned (image:tag@sha256:<digest>) AND carry "
-            "the matching distro upgrade (apk/apt). Exemptions: scratch, distroless "
-            "(pin-only), a FROM that references an earlier stage, or a vendor image with "
-            "an inline `# RATIONALE:` comment on the FROM line."
+            "\nEvery FROM must be digest-pinned with a well-formed digest "
+            "(image:tag@sha256:<64 lowercase hex>), resolve to an allowed registry "
+            f"({', '.join(sorted(allowed))}), AND carry the matching distro upgrade "
+            "(apk/apt). Exemptions: scratch, distroless (pin-only), a FROM that "
+            "references an earlier stage, or a vendor image with an inline "
+            "`# RATIONALE:` comment on the FROM line."
         )
         return 1
 

--- a/.claude/lib/tests/test_check_dockerfile_base_pin.py
+++ b/.claude/lib/tests/test_check_dockerfile_base_pin.py
@@ -17,14 +17,29 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from check_dockerfile_base_pin import (  # noqa: E402
+    DEFAULT_ALLOWED_REGISTRIES,
     check_dockerfile_text,
+    digest_of,
     main,
+    parse_args,
     parse_froms,
+    registry_host,
 )
 
-# A real digest (truncated only for readability is NOT allowed by the checker —
-# it needs the literal `@sha256:` marker, which these carry in full shape).
-_DIGEST = "@sha256:0272e4609f1b5f3a2d8c9e1a4b6c8d0e2f4a6b8c0d2e4f6a8b0c2d4e6f8a0b2c4"
+# A well-formed digest: `sha256:` + exactly 64 lowercase hex characters.
+#
+# NOTE (#1204): this constant carried 65 hex characters until the digest-VALUE
+# rule landed — a digest no registry would accept, undetected because the gate
+# only checked for the `@sha256:` substring. The new rule flagged the test
+# suite's own fixture. Kept charter-example-derived (`0272e460...`), corrected
+# to the real 64-character length.
+_DIGEST = "@sha256:0272e4609f1b5f3a2d8c9e1a4b6c8d0e2f4a6b8c0d2e4f6a8b0c2d4e6f8a0b2c"
+
+# The real digest from the #1204 mutation corpus — the head of
+# noorinalabs-deploy `integration-tests/fake_oauth/Dockerfile`.
+_REAL_DIGEST = "@sha256:d3400aa122fa42cf0af0dbe8ec3091b047eac5c8f7e3539f7135e86d855dc015"
+
+_APT_UPGRADE = "RUN apt-get update && apt-get -y upgrade && apt-get clean"
 
 
 class CompliantFromsPass(unittest.TestCase):
@@ -161,6 +176,212 @@ FROM scratch
         self.assertEqual(check_dockerfile_text("Dockerfile", df), [])
 
 
+class DigestValueValidated(unittest.TestCase):
+    """#1204 item 1a — the digest VALUE, not just the `@sha256:` shape.
+
+    Cases are the silent mutants from the issue's mutation table, run against
+    the real head of noorinalabs-deploy `integration-tests/fake_oauth/Dockerfile`.
+    """
+
+    def test_short_hex_digest_is_malformed(self) -> None:
+        # Mutant 4 from #1204: `@sha256:deadbeef` — 8 hex chars, was silent.
+        df = f"FROM python:3.14-slim@sha256:deadbeef\n{_APT_UPGRADE}\n"
+        violations = check_dockerfile_text("Dockerfile", df)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("malformed digest", violations[0])
+        self.assertIn("sha256:deadbeef", violations[0])
+
+    def test_empty_digest_is_malformed(self) -> None:
+        # Mutant 5 from #1204: `@sha256:` with no value — was silent.
+        df = f"FROM python:3.14-slim@sha256:\n{_APT_UPGRADE}\n"
+        violations = check_dockerfile_text("Dockerfile", df)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("malformed digest", violations[0])
+
+    def test_bare_at_with_no_algorithm_is_malformed(self) -> None:
+        df = f"FROM python:3.14-slim@\n{_APT_UPGRADE}\n"
+        violations = check_dockerfile_text("Dockerfile", df)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("malformed digest", violations[0])
+
+    def test_uppercase_hex_digest_is_malformed(self) -> None:
+        # The registry grammar is lowercase-only; a ref Docker would refuse
+        # must not pass the lint.
+        df = f"FROM python:3.14-slim@sha256:{'A' * 64}\n{_APT_UPGRADE}\n"
+        violations = check_dockerfile_text("Dockerfile", df)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("malformed digest", violations[0])
+
+    def test_sixty_three_hex_digest_is_malformed(self) -> None:
+        # Off-by-one on the length: 63 hex chars, everything else well-formed.
+        df = f"FROM python:3.14-slim@sha256:{'a' * 63}\n{_APT_UPGRADE}\n"
+        violations = check_dockerfile_text("Dockerfile", df)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("malformed digest", violations[0])
+
+    def test_sixty_five_hex_digest_is_malformed(self) -> None:
+        df = f"FROM python:3.14-slim@sha256:{'a' * 65}\n{_APT_UPGRADE}\n"
+        violations = check_dockerfile_text("Dockerfile", df)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("malformed digest", violations[0])
+
+    def test_non_sha256_algorithm_is_malformed(self) -> None:
+        df = f"FROM python:3.14-slim@sha512:{'a' * 64}\n{_APT_UPGRADE}\n"
+        violations = check_dockerfile_text("Dockerfile", df)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("malformed digest", violations[0])
+
+    def test_second_at_sign_is_not_truncated_away(self) -> None:
+        # Everything after the FIRST `@` is the digest, so a well-formed prefix
+        # followed by junk still fails rather than matching a truncated head.
+        df = f"FROM python:3.14-slim@sha256:{'a' * 64}@evil\n{_APT_UPGRADE}\n"
+        violations = check_dockerfile_text("Dockerfile", df)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("malformed digest", violations[0])
+
+    def test_real_deploy_head_digest_passes(self) -> None:
+        # Mutant 1 from #1204 (unmodified head) must still pass — the new rule
+        # is not a blanket reject.
+        df = f"FROM python:3.14-slim{_REAL_DIGEST}\n{_APT_UPGRADE}\n"
+        self.assertEqual(check_dockerfile_text("Dockerfile", df), [])
+
+    def test_missing_digest_keeps_the_not_pinned_message(self) -> None:
+        # A ref with no `@` at all is still "not digest-pinned", not "malformed".
+        violations = check_dockerfile_text("Dockerfile", "FROM nginx:alpine\n")
+        self.assertTrue(any("not digest-pinned" in v for v in violations))
+        self.assertFalse(any("malformed digest" in v for v in violations))
+
+    def test_digest_of_helper(self) -> None:
+        self.assertIsNone(digest_of("python:3.14-slim"))
+        self.assertEqual(digest_of("python:3.14-slim@sha256:abc"), "sha256:abc")
+        self.assertEqual(digest_of("python@sha256:a@b"), "sha256:a@b")
+
+
+class KnownGapRollbackStillPasses(unittest.TestCase):
+    """The #1204 scope boundary, asserted rather than only described in prose.
+
+    Item 1 (this change) is no-network validation. Item 2 — forward-monotonicity
+    via the images' config-blob `created` timestamps — needs registry access and
+    is tracked separately. Mutant 6 of the #1204 table (a rollback to an older
+    but perfectly well-formed digest on the expected registry) is therefore
+    STILL not caught, and nothing here should be read as closing it.
+
+    This test fails the day monotonicity lands, which is the point: it forces
+    the follow-up to delete it consciously rather than leaving a stale claim.
+    """
+
+    def test_rollback_to_an_older_valid_digest_is_not_detected(self) -> None:
+        # Both are real digests of python:3.14-slim from the deploy repo's
+        # history; `older` predates `newer`. Statically they are indistinguishable.
+        older = "@sha256:44dd04494ee8f3b538294360e7c4b3acb87c8268e4d0a4828a6500b1eff50061"
+        newer = _REAL_DIGEST
+        for digest in (older, newer):
+            df = f"FROM python:3.14-slim{digest}\n{_APT_UPGRADE}\n"
+            self.assertEqual(
+                check_dockerfile_text("Dockerfile", df),
+                [],
+                "item 1 is no-network validation; digest ORDERING is item 2",
+            )
+
+
+class RegistryAllowlistEnforced(unittest.TestCase):
+    """#1204 item 1b — the ref must resolve to a declared registry host."""
+
+    def test_evil_registry_is_flagged(self) -> None:
+        # Mutant 7 from #1204: registry swapped to evil.example.com with an
+        # otherwise valid digest — was silent.
+        df = f"FROM evil.example.com/python:3.14-slim{_REAL_DIGEST}\n{_APT_UPGRADE}\n"
+        violations = check_dockerfile_text("Dockerfile", df)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("registry 'evil.example.com' is not in the allowed set", violations[0])
+        self.assertIn("--allow-registry evil.example.com", violations[0])
+
+    def test_unprefixed_ref_is_implicit_docker_hub_and_allowed(self) -> None:
+        df = f"FROM python:3.14-slim{_DIGEST}\n{_APT_UPGRADE}\n"
+        self.assertEqual(check_dockerfile_text("Dockerfile", df), [])
+
+    def test_docker_hub_user_namespace_is_not_a_registry(self) -> None:
+        # `myorg/myimage` — the first component has no dot/colon, so it is a Hub
+        # namespace, not a registry host.
+        df = f"FROM myorg/myimage:1.0{_DIGEST}\n{_APT_UPGRADE}\n"
+        self.assertEqual(check_dockerfile_text("Dockerfile", df), [])
+
+    def test_ghcr_and_gcr_are_in_the_default_floor(self) -> None:
+        df = f"FROM ghcr.io/noorinalabs/base:1.0{_DIGEST}\n{_APT_UPGRADE}\n"
+        self.assertEqual(check_dockerfile_text("Dockerfile", df), [])
+        self.assertEqual(
+            check_dockerfile_text(
+                "Dockerfile", f"FROM gcr.io/distroless/static-debian12{_DIGEST}\n"
+            ),
+            [],
+        )
+
+    def test_default_floor_is_narrow_not_a_catch_all(self) -> None:
+        # The default must NOT quietly include registries the org only uses for
+        # compose `image:` refs. quay.io is the live example.
+        self.assertEqual(set(DEFAULT_ALLOWED_REGISTRIES), {"docker.io", "ghcr.io", "gcr.io"})
+        df = f"FROM quay.io/prometheus/busybox:latest{_DIGEST}\n{_APT_UPGRADE}\n"
+        violations = check_dockerfile_text("Dockerfile", df)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("registry 'quay.io' is not in the allowed set", violations[0])
+
+    def test_explicit_allowlist_extension_permits_the_registry(self) -> None:
+        df = f"FROM quay.io/prometheus/busybox:latest{_DIGEST}\n{_APT_UPGRADE}\n"
+        allowed = set(DEFAULT_ALLOWED_REGISTRIES) | {"quay.io"}
+        self.assertEqual(check_dockerfile_text("Dockerfile", df, allowed), [])
+
+    def test_docker_hub_alias_is_not_silently_canonicalized(self) -> None:
+        # `index.docker.io` is a different literal host; folding it into
+        # docker.io would be a silent widening.
+        df = f"FROM index.docker.io/library/python:3.14-slim{_DIGEST}\n{_APT_UPGRADE}\n"
+        violations = check_dockerfile_text("Dockerfile", df)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("registry 'index.docker.io' is not in the allowed set", violations[0])
+
+    def test_port_is_part_of_the_host(self) -> None:
+        # Allowlisting the bare hostname must not cover a ported ref.
+        df = f"FROM ghcr.io:5000/noorinalabs/base:1.0{_DIGEST}\n{_APT_UPGRADE}\n"
+        violations = check_dockerfile_text("Dockerfile", df)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("registry 'ghcr.io:5000' is not in the allowed set", violations[0])
+
+    def test_localhost_registry_is_flagged(self) -> None:
+        df = f"FROM localhost:5000/base:1.0{_DIGEST}\n{_APT_UPGRADE}\n"
+        violations = check_dockerfile_text("Dockerfile", df)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("registry 'localhost:5000' is not in the allowed set", violations[0])
+
+    def test_variable_registry_component_is_flagged(self) -> None:
+        # `${REGISTRY}` is not statically determinable — it must not be assumed
+        # to be Docker Hub just because it carries no dot.
+        df = f"FROM ${{REGISTRY}}/python:3.14-slim{_DIGEST}\n{_APT_UPGRADE}\n"
+        violations = check_dockerfile_text("Dockerfile", df)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("not statically determinable", violations[0])
+
+    def test_variable_in_tag_only_is_not_a_registry_problem(self) -> None:
+        # `FROM neo4j:${NEO4J_VERSION}` (a real child-repo shape): the registry
+        # IS statically known (Docker Hub); only the pin rule should fire.
+        violations = check_dockerfile_text("Dockerfile", "FROM neo4j:${NEO4J_VERSION}\n")
+        self.assertFalse(any("statically determinable" in v for v in violations))
+        self.assertTrue(any("not digest-pinned" in v for v in violations))
+
+    def test_rationale_exemption_still_covers_the_registry_rule(self) -> None:
+        # The documented, reviewed escape hatch remains total.
+        df = (
+            "# RATIONALE: vendor image, only published on the vendor registry\n"
+            "FROM vendor.example.com/proprietary:1.4\n"
+        )
+        self.assertEqual(check_dockerfile_text("Dockerfile", df), [])
+
+    def test_registry_host_helper(self) -> None:
+        self.assertIsNone(registry_host("python:3.14-slim"))
+        self.assertIsNone(registry_host("myorg/myimage:1.0"))
+        self.assertEqual(registry_host("gcr.io/distroless/static"), "gcr.io")
+        self.assertEqual(registry_host("localhost:5000/base"), "localhost:5000")
+        self.assertEqual(registry_host("evil.example.com/x@sha256:abc"), "evil.example.com")
+
+
 class CliBehavior(unittest.TestCase):
     def test_clean_file_exits_zero(self) -> None:
         import tempfile
@@ -189,6 +410,58 @@ class CliBehavior(unittest.TestCase):
 
     def test_missing_file_is_error(self) -> None:
         self.assertEqual(main(["check_dockerfile_base_pin.py", "/no/such/Dockerfile"]), 2)
+
+    def _write(self, body: str) -> str:
+        import tempfile
+
+        with tempfile.NamedTemporaryFile("w", suffix=".dockerfile", delete=False) as fh:
+            fh.write(body)
+            self.addCleanup(Path(fh.name).unlink)
+            return fh.name
+
+    def test_disallowed_registry_exits_one_by_default(self) -> None:
+        name = self._write(f"FROM quay.io/prometheus/busybox:1.0{_DIGEST}\n{_APT_UPGRADE}\n")
+        self.assertEqual(main(["check_dockerfile_base_pin.py", name]), 1)
+
+    def test_allow_registry_flag_makes_it_pass(self) -> None:
+        name = self._write(f"FROM quay.io/prometheus/busybox:1.0{_DIGEST}\n{_APT_UPGRADE}\n")
+        self.assertEqual(
+            main(["check_dockerfile_base_pin.py", "--allow-registry", "quay.io", name]), 0
+        )
+
+    def test_allow_registry_equals_form_makes_it_pass(self) -> None:
+        name = self._write(f"FROM quay.io/prometheus/busybox:1.0{_DIGEST}\n{_APT_UPGRADE}\n")
+        self.assertEqual(
+            main(["check_dockerfile_base_pin.py", "--allow-registry=quay.io", name]), 0
+        )
+
+    def test_unknown_option_is_usage_error_not_a_path(self) -> None:
+        # A typo'd flag must stop the run, never be silently skipped leaving the
+        # default allowlist quietly in force. The `=` form is used deliberately:
+        # with the separate-value form a fall-through would still exit 2 (the
+        # orphaned "quay.io" fails the is-a-file check), so the test would pass
+        # for the wrong reason and not detect the missing guard.
+        name = self._write(f"FROM python:3.14-slim{_DIGEST}\n{_APT_UPGRADE}\n")
+        self.assertEqual(main(["check_dockerfile_base_pin.py", "--allow-registy=quay.io", name]), 2)
+
+    def test_allow_registry_without_value_is_usage_error(self) -> None:
+        self.assertEqual(main(["check_dockerfile_base_pin.py", "--allow-registry"]), 2)
+
+    def test_parse_args_defaults_to_the_org_floor(self) -> None:
+        parsed = parse_args(["Dockerfile"])
+        assert parsed is not None
+        paths, allowed = parsed
+        self.assertEqual(paths, ["Dockerfile"])
+        self.assertEqual(allowed, set(DEFAULT_ALLOWED_REGISTRIES))
+
+    def test_parse_args_extends_rather_than_replaces(self) -> None:
+        parsed = parse_args(["--allow-registry", "quay.io", "Dockerfile"])
+        assert parsed is not None
+        _, allowed = parsed
+        self.assertEqual(allowed, set(DEFAULT_ALLOWED_REGISTRIES) | {"quay.io"})
+
+    def test_parse_args_rejects_unknown_flag(self) -> None:
+        self.assertIsNone(parse_args(["--nope", "Dockerfile"]))
 
 
 if __name__ == "__main__":

--- a/.claude/team/charter/tech-decisions.md
+++ b/.claude/team/charter/tech-decisions.md
@@ -56,12 +56,26 @@ FROM nginx:alpine
 RUN apk upgrade --no-cache
 ```
 
+**The digest VALUE and the registry host are part of the rule (noorinalabs-main#1204):**
+
+A pin is only a pin if the thing it names is real and comes from where we expect. Two additional requirements, both statically checkable with no network access:
+
+- **Well-formed digest.** The digest MUST be `sha256:` followed by exactly **64 lowercase hex characters**. `@sha256:deadbeef` and `@sha256:` are not pins — they are the *shape* of a pin. (Uppercase hex is rejected rather than normalized: the OCI grammar is lowercase-only, so a ref Docker itself would refuse must not pass our lint.)
+- **Allowed registry host.** The reference MUST resolve to a registry in the repo's **declared** allowed set. "Expected" is a declared policy set, not one hardcoded hostname, because different repos legitimately pull from different registries:
+  1. the org floor built into the gate (`docker.io`, `ghcr.io`, `gcr.io` — each grounded in a registry some repo actually pulls a base image from, or that the distro table above names);
+  2. a per-repo extension via `--allow-registry HOST`, declared in that repo's `.pre-commit-config.yaml` `args:` and its CI step, so the widening is itself a reviewed line;
+  3. the `# RATIONALE:` exemption below, which remains total.
+
+  Anything outside that set **fails loudly (exit 1)** and names the flag to declare it. A legitimate-but-unanticipated registry is never silently permitted — an unrecognized registry is treated as unknown, and unknown means narrow and loud, not waved through. For the same reason the gate does not canonicalize Docker Hub aliases (`index.docker.io` must be allowlisted on its own), treats a port as part of the host, and flags a registry component that is a build arg (`FROM ${REGISTRY}/img@sha256:…`) rather than assuming Docker Hub.
+
+**What this does NOT cover:** the *ordering* of a pin change. A refresh that moves **backwards** to an older-but-well-formed digest on an allowed registry passes every check above, silently losing the distro updates the refresh existed to pick up. Forward-monotonicity requires resolving both images' config blobs over the network and is tracked separately (see the follow-up on #1204). Reviewers of a digest-bump PR still verify the direction of the move by hand.
+
 **Acceptable exemptions:**
 
 - `scratch` final layer in a multi-stage build — final image has no package manager; the upstream stages still follow this rule.
-- Vendor-supplied images that are not redistributable as digest-pinned (rare; document the exemption inline as a `# RATIONALE:` comment on the `FROM` line).
+- Vendor-supplied images that are not redistributable as digest-pinned (rare; document the exemption inline as a `# RATIONALE:` comment on the `FROM` line). A documented `RATIONALE` exempts the `FROM` from *every* rule in this section, including the digest-value and registry rules — the exemption is acceptable precisely because it is visible and reviewed in the diff.
 
-**Reviewer enforcement:** Absence of a digest pin OR absence of the upgrade step on a `Dockerfile` PR is grounds for `ChangesRequested`. The pattern is mechanical; reviewers cite this section.
+**Reviewer enforcement:** Absence of a digest pin, a malformed digest value, an undeclared registry host, OR absence of the upgrade step on a `Dockerfile` PR is grounds for `ChangesRequested`. The pattern is mechanical; reviewers cite this section.
 
 **Promotion path:** This is step 1 + 2 (charter + memory) of the [enforcement hierarchy](hooks.md). A future `validate_dockerfile_base_pin` PreToolUse hook (step 3) is filed if the convention proves load-bearing across multiple Dockerfile PRs without manual reviewer reminders.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,8 +183,12 @@ jobs:
         with:
           python-version: "3.12"
       # Charter-prose→code gate (#735, tech-decisions.md § Base Image Pinning).
-      # Discovers every Dockerfile and asserts each FROM is digest-pinned with the
-      # matching distro upgrade. Mirrors the `dockerfile-base-pin` pre-commit hook
+      # Discovers every Dockerfile and asserts each FROM is digest-pinned with a
+      # well-formed digest value, resolves to a declared registry host (#1204),
+      # and carries the matching distro upgrade. A repo needing a registry
+      # outside the built-in floor appends `--allow-registry HOST` here and in
+      # the matching pre-commit hook entry.
+      # Mirrors the `dockerfile-base-pin` pre-commit hook
       # (sync-drift gate classifies the kind). The parent ships no Dockerfiles, so
       # this is a no-op template here; child repos inherit it to scan their real
       # Dockerfiles (#735 follow-up rollout).

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -103,6 +103,12 @@ repos:
     hooks:
       - id: dockerfile-base-pin
         name: dockerfile-base-pin
+        # A repo that legitimately pulls a base image from a registry outside
+        # the gate's built-in floor (docker.io/ghcr.io/gcr.io) declares it here
+        # AND in the matching CI step, e.g.
+        #   entry: python3 .claude/lib/check_dockerfile_base_pin.py --allow-registry quay.io
+        # An undeclared registry is an exit-1 violation, never a silent pass
+        # (#1204).
         entry: python3 .claude/lib/check_dockerfile_base_pin.py
         language: system
         files: ((^|/)Dockerfile(\.[^/]+)?$|\.dockerfile$)


### PR DESCRIPTION
Closes #1204 (item 1 only — see **Deliberately out of scope** below; this PR does **not** close the rollback gap).

## The defect

`check_dockerfile_base_pin.py` enforced the *shape* of a pin and nothing about its value. The entire digest check in `check_dockerfile_text` was:

```python
if "@sha256:" not in stmt.image:
```

A substring test. So `@sha256:deadbeef`, `@sha256:`, and a swap to `evil.example.com/python:3.14-slim@<valid digest>` all passed the gate green.

## What this adds

**1a — digest well-formedness.** `^sha256:[0-9a-f]{64}$`. Lowercase-only, matching the OCI grammar, so a ref Docker itself would refuse cannot pass our lint. `digest_of` splits on the **first** `@`, so a well-formed prefix followed by junk fails rather than being silently truncated to something valid.

**1b — registry-host allowlist.** The interesting design question, and the one the issue asked to be answered explicitly rather than by hardcoding a hostname.

"Expected" cannot be one hostname: this file is an org-wide template vendored into seven repos that legitimately pull from different places. So it is a **declared policy set**, layered:

1. `DEFAULT_ALLOWED_REGISTRIES` — the built-in org floor;
2. repeatable `--allow-registry HOST` — a per-repo extension, declared in that repo's `.pre-commit-config.yaml` `args:` **and** its CI step, so the widening is itself a reviewed, diffable line rather than a silent default;
3. the existing `# RATIONALE:` comment — still the total per-`FROM` escape hatch, acceptable precisely because it is visible in the diff.

Anything outside (1) ∪ (2), uncovered by (3), is **exit 1** with a message naming the flag needed to declare it. A legitimate-but-unanticipated registry fails loudly; it is never silently permitted. That is the standing unknown ⇒ narrow ⇒ loud stance (cf. #1180).

The floor is narrow **by evidence**, not by taste. I surveyed every `FROM` line in all seven repos before choosing it:

| Host | In the floor? | Why |
|---|---|---|
| `docker.io` | yes | Every real base image in the org is an un-prefixed Docker Hub ref (`python:*-slim`, `node:*-alpine`, `nginx:*-alpine`, `neo4j`, `ubuntu`). |
| `ghcr.io` | yes | The org's own registry — every child repo publishes to it via `ghcr-publish.yml`, so a `FROM ghcr.io/noorinalabs/...` base built by us is anticipated. |
| `gcr.io` | yes | Distroless is a family the charter's own distro table names as supported, and it is published only under `gcr.io/distroless/...`. |
| `quay.io` | **no** | Appears only in compose `image:` refs (`quay.io/prometheuscommunity/postgres-exporter`), never in a `FROM`. This gate reads `FROM` lines. Widening a default on non-evidence is the same class of defect as permitting `evil.example.com`. |

Three deliberate non-widenings, each with a test:

- **No alias canonicalization** — `index.docker.io` is a different literal host and must be allowlisted on its own; folding it into `docker.io` would be a silent widening.
- **A port is part of the host** — `ghcr.io:5000` is not covered by allowlisting `ghcr.io`.
- **A build-arg registry component is flagged**, not assumed — `FROM ${REGISTRY}/img@sha256:...` is not statically determinable, so it fails rather than being treated as Docker Hub. A variable in the *tag* only (`FROM neo4j:${NEO4J_VERSION}`, a real child-repo shape) is correctly left alone: the registry there **is** statically known.

**CLI.** Flag parsing is hand-rolled rather than argparse so `main` keeps returning its exit code instead of raising `SystemExit` (the existing tests depend on that contract). An unrecognized `--flag` is a usage error, never a path — a typo'd `--allow-registy` must not be swallowed into the file list, leaving the default allowlist quietly in force.

**Charter.** `tech-decisions.md § Base Image Pinning` gains the matching prose. This is a prose→code gate; the code must not enforce policy the section does not state.

## A real defect the new rule found immediately

The test suite's own `_DIGEST` fixture had carried **65** hex characters since #735 — a digest no registry would accept, invisible to a substring check, sitting in the file that exists to prove the gate works. The new rule flagged it on the first run. Corrected to 64.

## Verification

### The original #1204 seven-mutant corpus, re-run through the real CLI

Old gate vs. this branch, actual exit codes:

| Mutant | old gate | this PR |
|---|---|---|
| 1 unmodified head | pass (correct) | pass (correct) |
| 2 digest stripped → floating tag | **caught** | **caught** |
| 3 upgrade downgraded to `apt-get update` | **caught** | **caught** |
| 4 malformed digest `@sha256:deadbeef` | silent | **caught** (exit 1) |
| 5 empty digest `@sha256:` | silent | **caught** (exit 1) |
| 6 **rollback to an older digest** | silent | **still silent — out of scope, see below** |
| 7 registry swapped to `evil.example.com` | silent | **caught** (exit 1) |

Real output on mutant 7:

```
Base Image Pinning violations (tech-decisions.md § Base Image Pinning, #735):
  7.dockerfile:1: FROM evil.example.com/python:3.14-slim@sha256:d3400aa122fa42cf0af0dbe8ec3091b047eac5c8f7e3539f7135e86d855dc015 — registry 'evil.example.com' is not in the allowed set (docker.io, gcr.io, ghcr.io); if this registry is legitimate for this repo, declare it with --allow-registry evil.example.com in .pre-commit-config.yaml and CI
```

and on mutant 4:

```
  4.dockerfile:1: FROM python:3.14-slim@sha256:deadbeef — malformed digest 'sha256:deadbeef' (require sha256: followed by exactly 64 lowercase hex characters)
```

### Mutation table — my own gate held to the standard that produced the finding

The #1204 finding came from mutation-testing someone else's green gate, so this one gets the same treatment. Each row weakens or deletes exactly **one** new rule in a copy of the script and runs the real suite against the mutant. All test names and verdicts below are actual harness output, not claims.

| Mutation | What it weakens | Verdict | Failing tests |
|---|---|---|---|
| M1 | digest length quantifier `{64}` → `+` (any number of hex chars) | KILLED | `DigestValueValidated::test_short_hex_digest_is_malformed`<br>`DigestValueValidated::test_sixty_five_hex_digest_is_malformed`<br>`DigestValueValidated::test_sixty_three_hex_digest_is_malformed` |
| M2 | digest charset `[0-9a-f]` → `[0-9a-fA-F]` (accept uppercase hex) | KILLED | `DigestValueValidated::test_uppercase_hex_digest_is_malformed` |
| M3 | delete the digest-value branch entirely (revert to shape-only) | KILLED | `DigestValueValidated::test_bare_at_with_no_algorithm_is_malformed`<br>`DigestValueValidated::test_empty_digest_is_malformed`<br>`DigestValueValidated::test_non_sha256_algorithm_is_malformed`<br>`DigestValueValidated::test_second_at_sign_is_not_truncated_away`<br>`DigestValueValidated::test_short_hex_digest_is_malformed`<br>`DigestValueValidated::test_sixty_five_hex_digest_is_malformed`<br>`DigestValueValidated::test_sixty_three_hex_digest_is_malformed`<br>`DigestValueValidated::test_uppercase_hex_digest_is_malformed` |
| M4 | `digest_of` splits on the LAST `@` (silently truncates trailing junk) | KILLED | `DigestValueValidated::test_digest_of_helper` |
| M5 | delete the registry allowlist check (never flag a host) | KILLED | `CliBehavior::test_disallowed_registry_exits_one_by_default`<br>`RegistryAllowlistEnforced::test_default_floor_is_narrow_not_a_catch_all`<br>`RegistryAllowlistEnforced::test_docker_hub_alias_is_not_silently_canonicalized`<br>`RegistryAllowlistEnforced::test_evil_registry_is_flagged`<br>`RegistryAllowlistEnforced::test_localhost_registry_is_flagged`<br>`RegistryAllowlistEnforced::test_port_is_part_of_the_host` |
| M6 | `registry_host` always returns `None` (every ref treated as Docker Hub) | KILLED | `CliBehavior::test_disallowed_registry_exits_one_by_default`<br>`RegistryAllowlistEnforced::test_default_floor_is_narrow_not_a_catch_all`<br>`RegistryAllowlistEnforced::test_docker_hub_alias_is_not_silently_canonicalized`<br>`RegistryAllowlistEnforced::test_evil_registry_is_flagged`<br>`RegistryAllowlistEnforced::test_localhost_registry_is_flagged`<br>`RegistryAllowlistEnforced::test_port_is_part_of_the_host`<br>`RegistryAllowlistEnforced::test_registry_host_helper` |
| M7 | widen the default floor with an unevidenced registry (`quay.io`) | KILLED | `CliBehavior::test_disallowed_registry_exits_one_by_default`<br>`RegistryAllowlistEnforced::test_default_floor_is_narrow_not_a_catch_all` |
| M8 | canonicalize Docker Hub aliases (silent widening) | KILLED | `RegistryAllowlistEnforced::test_docker_hub_alias_is_not_silently_canonicalized` |
| M9 | drop the variable-registry check (assume Docker Hub when unknown) | KILLED | `RegistryAllowlistEnforced::test_variable_registry_component_is_flagged` |
| M10 | CLI: unknown `--flag` falls through to the path list instead of erroring | KILLED | `CliBehavior::test_parse_args_rejects_unknown_flag`<br>`CliBehavior::test_unknown_option_is_usage_error_not_a_path` |
| M11 | CLI: `--allow-registry` parsed but discarded (extension is inert) | KILLED | `CliBehavior::test_allow_registry_flag_makes_it_pass`<br>`CliBehavior::test_parse_args_extends_rather_than_replaces` |
| M12 | `allowed_registries` parameter ignored; always the built-in default | KILLED | `CliBehavior::test_allow_registry_equals_form_makes_it_pass`<br>`CliBehavior::test_allow_registry_flag_makes_it_pass`<br>`RegistryAllowlistEnforced::test_explicit_allowlist_extension_permits_the_registry` |

**12/12 mutants killed.**

M10 is worth calling out: the first version of `test_unknown_option_is_usage_error_not_a_path` used the separate-value form (`--allow-registy quay.io`) and **passed under the mutant** — with the guard removed the orphaned `quay.io` failed the is-a-file check and the CLI still exited 2, so the test was green for the wrong reason. The mutation run is what exposed that; the test now uses `--allow-registy=quay.io`, where a fall-through genuinely exits 0. That is the mutation harness catching a weak test of mine, which is exactly what it is for.

### No false positives on real content

Old vs. new verdicts compared across **all 13 real Dockerfiles** in the org (`.claude/lib/`, all seven child repos, excluding vendored/`.venv`/`data/raw`): **zero files changed verdict.** The new rules add strictness without re-flagging anything currently compliant.

### Gates

Full local suite green, both stages, no `--no-verify`:

- `54 passed` in the gate's own suite; `3553 passed, 647 subtests passed` across `.claude/lib/tests/` + `.claude/hooks/tests/`
- commit stage: ruff-format, ruff-lint, actionlint, cspell, checksums-ascii — all Passed
- push stage: mypy, mypy-skills, pytest, pytest-skills, memory-budget, headcount-budget, doc-freshness, office-drift, mermaid-render — all Passed
- `pre_commit_ci_sync.py` — `OK: pre-commit config mirrors all CI-enforced checks`
- markdownlint-cli2 on the charter edit — `0 issues`

## Deliberately out of scope

**1. Forward-monotonicity (item 2 of #1204) → #1266.** Needs network access to both images' config blobs and is a PR-scoped check, not a per-file lint; putting network I/O in this hermetic script would make every local commit depend on registry reachability.

**This PR does not close the rollback gap.** Mutant 6 — a rollback to an older but perfectly well-formed digest on an allowed registry — still passes everything here, and monotonicity is the only thing that catches it. That boundary is asserted in code, not just in prose: `KnownGapRollbackStillPasses::test_rollback_to_an_older_valid_digest_is_not_detected` feeds the gate two real `python:3.14-slim` digests, one older, and asserts both are clean. It is written to **fail** when #1266 lands, forcing that PR to delete the stale claim consciously.

**2. The child-repo rollout → #1267.** The same script is vendored in five child repos (`deploy`, `isnad-graph`, `user-service`, `data-acquisition`, `isnad-ingest-platform`). This PR lands the **template only**. I implemented from an isolated parent worktree, where the harness blocks git operations against nested child repos, and five child PRs with their own CI is a different unit of work regardless. **Until #1267 lands, the child copies still accept the mutants this PR closes** — and since the parent repo ships no Dockerfiles, the template change protects nothing at runtime on its own. #1267 also carries the same 65-hex fixture fix, which was copied into every vendored test file.

Both follow-ups are labelled `tech-debt` / `process` / `phase-10`, no wave label.

## Files

- `.claude/lib/check_dockerfile_base_pin.py` — `_DIGEST_RE`, `DEFAULT_ALLOWED_REGISTRIES`, `digest_of`, `registry_host`, `_registry_component_is_variable`, `parse_args`; `check_dockerfile_text`/`check_file` take an optional `allowed_registries`
- `.claude/lib/tests/test_check_dockerfile_base_pin.py` — `DigestValueValidated`, `RegistryAllowlistEnforced`, `KnownGapRollbackStillPasses`, extended `CliBehavior`; `_DIGEST` fixture corrected
- `.claude/team/charter/tech-decisions.md` — § Base Image Pinning gains the digest-value + registry-host rules and an explicit statement of what is *not* covered
- `.pre-commit-config.yaml`, `.github/workflows/ci.yml` — comments documenting `--allow-registry` for child repos (both must match, per the parity rule)
