### PR TITLE
fix(#1180): invert the wave-scope role seam — REVIEW class is the allowlist

### DIFF
--- a/.claude/skills/wave-kickoff/SKILL.md
+++ b/.claude/skills/wave-kickoff/SKILL.md
@@ -64,7 +64,8 @@ python3 "$REPO_ROOT/.claude/skills/wave-scope/validate_matrix_names.py" \
     --scope "$REPO_ROOT/cross-repo-status.json" --wave {M}
 RC=$?
 if [ "$RC" -ne 0 ]; then
-  echo "ERROR: wave_{M}_scope has unresolved names or cross-repo implementer(s)."
+  echo "ERROR: wave_{M}_scope has unresolved names, cross-repo implementer(s),"
+  echo "  or an unclassified role slot key (#1180)."
   echo "  Fix the scope rows (reassign, onboard, or record a roster_union_override"
   echo "  with a rationale) and re-run. See /wave-scope SKILL.md § 12.5."
   exit 1
@@ -72,6 +73,8 @@ fi
 ```
 
 Deterministic and hermetic by default — reads only local rosters and `cross-repo-status.json`, no GitHub API calls. A child repo not cloned locally is reported `unverified` and does not block; add `--fetch-missing` to resolve those over the network. Charter rule: `charter/skills.md` § Wave Scoping — Child-Repo Implementer Must Be a Repo-Roster Member.
+
+Since #1180 this step also fails on an **unclassified role slot key** — a row slot in neither `COMMIT_CAPABLE_ROLES` nor `REVIEW_CLASS_ROLES`. Adding a new role slot to the scope schema is a code change: classify the key in `validate_matrix_names.py` so both the resolution set and the membership check are chosen deliberately rather than inherited from a fall-through.
 
 ### 0. Derive wave repos in scope (Mandatory first step)
 

--- a/.claude/skills/wave-scope/SKILL.md
+++ b/.claude/skills/wave-scope/SKILL.md
@@ -530,14 +530,15 @@ Do NOT delete the original body — copy it (or post the pre-update version as a
 
 If any step surfaced a process gap (stale memory, missing meta-issue, vague reference), include a `**Process gaps surfaced**` section so the next retro can address them.
 
-### 12.5. Validate implementer/reviewer names + child-repo membership (#319, #1134) — MANDATORY
+### 12.5. Validate implementer/reviewer names + child-repo membership (#319, #1134, #1180) — MANDATORY
 
-Validate every declared name against the relevant roster BEFORE `/wave-kickoff` fan-out. The validator runs **two independent checks**:
+Validate every declared name against the relevant roster BEFORE `/wave-kickoff` fan-out. The validator runs **three independent checks** — any one alone exits 1:
 
 | # | Check | Applies to | Failure |
 |---|---|---|---|
 | #319 | **Name resolution** — does the name exist at all? | every slot, but the candidate set differs by slot class (#1162 — see Resolution rules) | unresolved name + fuzzy suggestions |
-| #1134 | **Repo membership** — is the implementer on the TARGET repo's roster? | `implementer` on a child repo | cross-repo implementer with no recorded override |
+| #1134 | **Repo membership** — is the implementer on the TARGET repo's roster? | every non-review-class slot on a child repo | cross-repo implementer with no recorded override |
+| #1180 | **Slot classification** — is this slot key classified at all? | every slot key the row carries | `UNCLASSIFIED role slot(s)` — classify it in `validate_matrix_names.py` |
 
 **#319 (name resolution).** Pre-#319 a stale alias like "Anya Volkov" (canonical: "Anya Kowalczyk") would propagate through scope and only surface at first-spawn time — P3W7 retro recorded TWO such substitutions in `wave_7_decisions.implementer_substitutions`.
 
@@ -546,9 +547,11 @@ Validate every declared name against the relevant roster BEFORE `/wave-kickoff` 
 **Resolution rules:**
 - Name resolution — **the candidate set depends on the slot class (#1162):**
   - **Review-class slots** (`reviewer`, `reviewer_2`, `merge_gate_reviewer`): child-repo roster (`<repo>/.claude/team/roster/*.md`) UNION parent roster UNION the **org-union manifest** `.claude/team/roster.json`. The manifest is what makes a reviewer drawn from a **third child repo** valid — e.g. a `noorinalabs-data-acquisition` persona reviewing an `isnad-ingest-platform` story. **A third-child reviewer is a correct assignment, not drift: do not "fix" one by reassigning it.** Before #1162 the parent side was the parent's *card directory* only (9 names, not the manifest's 78), so such a reviewer resolved against neither roster and hard-blocked this step and `/wave-kickoff` § 0b.
-  - **`implementer`**: child-repo roster UNION parent roster only — **the manifest is deliberately excluded.** Including it would loosen the #1134 membership check in the `unverified` case below: when the target roster is unreadable, membership fails open, so a manifest-only implementer would resolve, be reported `unverified`, and pass. Keeping the set narrow means that slot only passes on a name the target repo (or the parent) can vouch for.
+  - **`implementer` — and every slot that is not review-class (#1180):** child-repo roster UNION parent roster only — **the manifest is deliberately excluded.** Including it would loosen the #1134 membership check in the `unverified` case below: when the target roster is unreadable, membership fails open, so a manifest-only implementer would resolve, be reported `unverified`, and pass. Keeping the set narrow means that slot only passes on a name the target repo (or the parent) can vouch for.
   - Both sets let org-level coordinators (Aino, Nadia, Wanjiku, Santiago) fill child-repo slots without duplicating roster entries.
-- Repo membership: the **target repo's roster only**, and **only for the `implementer` slot**. Reviewers keep the wider resolution set above and are never membership-gated — cross-team reviewers are explicitly permitted by `charter/agents/spawn-discipline.md` § Child-Repo Implementer Rule step 5. The implementer is the only role that must produce a commit in the target repo.
+  - **`REVIEW_CLASS_ROLES` is the allowlist, not `COMMIT_CAPABLE_ROLES` (#1180).** The wide set and the membership exemption are both justified only for a slot that *provably never commits*, so an unrecognised slot key defaults to the strict side and fails loudly. Pre-#1180 the seam ran the other way: a `co_implementer` slot silently inherited the manifest widening AND the membership exemption, and a matrix of `co_implementer` / `pair_implementer` / `fixer` reported "all 3 names resolved", exit 0.
+- Repo membership: the **target repo's roster only**, and **for every non-review-class slot** (`implementer` today). Review-class slots keep the wider resolution set above and are never membership-gated — cross-team reviewers are explicitly permitted by `charter/agents/spawn-discipline.md` § Child-Repo Implementer Rule step 5. The implementer is the only role that must produce a commit in the target repo.
+- **Slot classification (#1180).** Scope mode discovers slots from `KNOWN_ROLE_SLOTS` (= `COMMIT_CAPABLE_ROLES | REVIEW_CLASS_ROLES`) plus any agentive-shaped row key (`_ROLE_SLOT_KEY_RE`) not denied in `NON_ROLE_ROW_KEYS` — it no longer iterates a hardcoded 4-slot tuple that skipped an unrecognised key outright. An admitted-but-unclassified key is a **third failure class**: `UNCLASSIFIED role slot(s) (#1180)`, exit 1. **Adding a role slot to the scope schema is therefore a code change**, not just a data change — classify the key in one of the three frozensets in `validate_matrix_names.py`.
 - Parent entries (`noorinalabs-main` or empty repo key) → parent-only roster; membership is vacuous there and never fires.
 - Match is case-insensitive; trailing parenthetical role suffix (`Aino Virtanen (Standards & Quality Lead)`) is stripped before comparison.
 - On a name miss: fuzzy-match via difflib SequenceMatcher; surface the top-3 closest matches to the operator.

--- a/.claude/skills/wave-scope/tests/test_validate_matrix_names.py
+++ b/.claude/skills/wave-scope/tests/test_validate_matrix_names.py
@@ -15,14 +15,20 @@ import json
 import sys
 import tempfile
 import unittest
+import unittest.mock
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
+import validate_matrix_names  # noqa: E402
 from validate_matrix_names import (  # noqa: E402
+    COMMIT_CAPABLE_ROLES,
+    KNOWN_ROLE_SLOTS,
+    REVIEW_CLASS_ROLES,
     _load_org_manifest_names,
     _override_rationale,
     _print_report_to_stderr,
+    is_role_slot_key,
     repo_of_row,
     validate,
     validate_scope,
@@ -858,6 +864,337 @@ class PersonaShapeFilterTests(unittest.TestCase):
                 },
             )
             self.assertEqual(_load_org_manifest_names(org), {"Real Persona"})
+
+
+class UnclassifiedRoleSlotTests(unittest.TestCase):
+    """#1180: an unclassified slot key takes the STRICT path and fails loudly.
+
+    Pre-#1180 the seam was `combined if role in COMMIT_CAPABLE_ROLES else
+    review_combined` — an allowlist of the NARROW side, so an unclassified role
+    inherited BOTH review-class loosenings: the org-union manifest widened its
+    resolution set, and the #1134 membership check was skipped. Measured on the
+    pre-fix code, a matrix of `co_implementer` / `pair_implementer` / `fixer`
+    reported "all 3 names resolved", exit 0.
+
+    Every test here goes RED against the pre-#1180 module.
+    """
+
+    THIRD_CHILD_REVIEWER = "Nikolaos Papadopoulos"
+    # A commit-capable-by-meaning slot key nobody has classified — the #1180
+    # example. It would have to COMMIT in the target repo.
+    UNCLASSIFIED_SLOT = "co_implementer"
+
+    def _build_org(self, tmp: Path) -> Path:
+        """Fake org: parent cards, two child rosters, a third-child reviewer, a manifest."""
+        org = _build_fake_org_dir(tmp)
+        _write_roster_card(
+            org / "noorinalabs-data-acquisition" / ".claude" / "team" / "roster",
+            "data_engineer_nikolaos",
+            self.THIRD_CHILD_REVIEWER,
+        )
+        manifest = {
+            name: f"parametrization+{name.replace(' ', '.')}@gmail.com"
+            for name in (
+                "Nadia Khoury",
+                "Wanjiku Mwangi",
+                "Aino Virtanen",
+                "Anya Kowalczyk",
+                self.THIRD_CHILD_REVIEWER,
+            )
+        }
+        (org / ".claude" / "team" / "roster.json").write_text(json.dumps(manifest, indent=2))
+        return org
+
+    # ---- the seam itself -------------------------------------------------
+
+    def test_unclassified_slot_resolves_against_the_narrow_set(self):
+        """The literal acceptance criterion: manifest-only name in an unclassified slot → exit 1.
+
+        `Nikolaos Papadopoulos` is manifest-resolvable and is a real persona in a
+        THIRD child repo, so he resolves in a `reviewer` slot (#1162). In an
+        unclassified slot he must NOT — the manifest widens review-class only.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = self._build_org(Path(tmpdir))
+            matrix = {
+                "noorinalabs-isnad-graph": {self.UNCLASSIFIED_SLOT: self.THIRD_CHILD_REVIEWER}
+            }
+            report = validate(matrix, org)
+            finding = report["noorinalabs-isnad-graph"][0]
+            self.assertFalse(
+                finding["resolved"],
+                "manifest must not widen an unclassified slot's resolution set",
+            )
+            self.assertEqual(_print_report_to_stderr(report), 1)
+
+    def test_same_name_still_resolves_in_a_review_slot(self):
+        """The paired control: only the SLOT CLASS differs between this and the test above.
+
+        Without this pair, `test_unclassified_slot_resolves_against_the_narrow_set`
+        would also pass if the manifest had simply stopped being loaded at all.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = self._build_org(Path(tmpdir))
+            report = validate(
+                {"noorinalabs-isnad-graph": {"reviewer": self.THIRD_CHILD_REVIEWER}}, org
+            )
+            self.assertTrue(report["noorinalabs-isnad-graph"][0]["resolved"])
+
+    def test_unclassified_slot_gets_the_membership_check(self):
+        """The second loosening: #1134 membership must apply to an unclassified slot.
+
+        `Nadia Khoury` is on the parent cards, so she RESOLVES on the narrow set
+        too — the resolution seam alone would let this pass. She is not on the
+        isnad-graph roster, and a `co_implementer` commits there.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = self._build_org(Path(tmpdir))
+            report = validate(
+                {"noorinalabs-isnad-graph": {self.UNCLASSIFIED_SLOT: "Nadia Khoury"}}, org
+            )
+            finding = report["noorinalabs-isnad-graph"][0]
+            self.assertTrue(finding["resolved"], "parent-card name resolves on the narrow set")
+            self.assertEqual(finding["membership"], "cross-repo")
+            self.assertEqual(_print_report_to_stderr(report), 1)
+
+    def test_unclassified_slot_fails_even_when_fully_valid(self):
+        """A resolvable, repo-member name in an unclassified slot is STILL exit 1.
+
+        Neither the #319 nor the #1134 class fires here — only the #1180 slot
+        class does. This is the test that pins the classification failure as its
+        own signal rather than a side effect of a name miss.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = self._build_org(Path(tmpdir))
+            report = validate(
+                {"noorinalabs-isnad-graph": {self.UNCLASSIFIED_SLOT: "Anya Kowalczyk"}}, org
+            )
+            finding = report["noorinalabs-isnad-graph"][0]
+            self.assertTrue(finding["resolved"])
+            self.assertEqual(finding["membership"], "member")
+            self.assertEqual(finding["slot_class"], "unclassified")
+            self.assertEqual(_print_report_to_stderr(report), 1)
+
+    def test_known_slots_are_marked_known(self):
+        """All four live slots stay `slot_class="known"` — no false unclassified."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = self._build_org(Path(tmpdir))
+            matrix = {
+                "noorinalabs-isnad-graph": {
+                    "implementer": "Anya Kowalczyk",
+                    "reviewer": "Aino Virtanen",
+                    "reviewer_2": "Nadia Khoury",
+                    "merge_gate_reviewer": "Wanjiku Mwangi",
+                }
+            }
+            report = validate(matrix, org)
+            for f in report["noorinalabs-isnad-graph"]:
+                self.assertEqual(f["slot_class"], "known", f"{f['role']} must be classified")
+            self.assertEqual(_print_report_to_stderr(report), 0)
+
+    def test_every_review_class_role_keeps_the_wide_set(self):
+        """Regression anchor for the inversion: drop a name from REVIEW_CLASS_ROLES and this reds.
+
+        Each review slot is checked INDEPENDENTLY with a manifest-only name, so
+        losing any single member of the frozenset is caught, not just losing all
+        three (which a combined-matrix assertion would also catch).
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = self._build_org(Path(tmpdir))
+            for role in ("reviewer", "reviewer_2", "merge_gate_reviewer"):
+                with self.subTest(role=role):
+                    report = validate(
+                        {"noorinalabs-isnad-graph": {role: self.THIRD_CHILD_REVIEWER}}, org
+                    )
+                    finding = report["noorinalabs-isnad-graph"][0]
+                    self.assertTrue(finding["resolved"], f"{role} must keep the manifest union")
+                    self.assertEqual(finding["membership"], "n/a", f"{role} must not be gated")
+                    self.assertEqual(finding["slot_class"], "known")
+                    self.assertEqual(_print_report_to_stderr(report), 0)
+
+    def test_role_classes_are_disjoint(self):
+        """A slot cannot be both commit-capable and review-class — the seam would be ambiguous."""
+        self.assertEqual(COMMIT_CAPABLE_ROLES & REVIEW_CLASS_ROLES, frozenset())
+        self.assertEqual(KNOWN_ROLE_SLOTS, COMMIT_CAPABLE_ROLES | REVIEW_CLASS_ROLES)
+
+
+class SlotKeyRecognitionTests(unittest.TestCase):
+    """#1180: `is_role_slot_key` — which scope-row keys name a PERSON.
+
+    Scope rows mix role slots with free-form metadata, so scope mode cannot
+    treat every string key as a person. The recogniser admits the known slots
+    plus any agentive-shaped key not explicitly denied.
+    """
+
+    # Every non-role key measured across all 293 rows of every `wave_*_scope`
+    # in cross-repo-status.json (2026-08-02). Snapshotted rather than read from
+    # the live file so the guard cannot rot when the wave data changes.
+    LIVE_METADATA_KEYS = (
+        "batch",
+        "blocked_by",
+        "blocked_on",
+        "blocks",
+        "blocks_next_wave_scope",
+        "bundle",
+        "coupled_with",
+        "follow_on_to",
+        "found_by",
+        "id",
+        "merged_sha",
+        "note",
+        "open_risk",
+        "pair_with",
+        "pr",
+        "pre_kickoff_blocker",
+        "priority",
+        "reassigned_from",
+        "ref",
+        "role",
+        "scope_note",
+        "sequence",
+        "slate_note",
+        "spawn",
+        "status",
+    )
+
+    def test_known_slots_are_recognised(self):
+        for key in sorted(KNOWN_ROLE_SLOTS):
+            with self.subTest(key=key):
+                self.assertTrue(is_role_slot_key(key))
+
+    def test_no_live_metadata_key_is_mistaken_for_a_slot(self):
+        """Zero false positives over the measured live key census.
+
+        `pre_kickoff_blocker` IS agentive-shaped (`_blocker`) and is caught only
+        by the `NON_ROLE_ROW_KEYS` denylist — delete that branch and this reds.
+        """
+        for key in self.LIVE_METADATA_KEYS:
+            with self.subTest(key=key):
+                self.assertFalse(is_role_slot_key(key), f"{key} is metadata, not a person slot")
+
+    def test_unclassified_agentive_keys_are_recognised(self):
+        """The #1180 examples plus plausible neighbours — all must be SEEN, then flagged."""
+        for key in ("co_implementer", "pair_implementer", "fixer", "author", "owner", "reviewer_3"):
+            with self.subTest(key=key):
+                self.assertTrue(is_role_slot_key(key))
+
+    def test_override_key_is_not_a_slot(self):
+        """`roster_union_override` is the #1134 escape hatch, not a person's name."""
+        self.assertFalse(is_role_slot_key("roster_union_override"))
+
+    def test_recognition_is_case_and_whitespace_insensitive(self):
+        self.assertTrue(is_role_slot_key("  Implementer  "))
+        self.assertFalse(is_role_slot_key("  Pre_Kickoff_Blocker  "))
+
+
+class ScopeModeSlotDiscoveryTests(unittest.TestCase):
+    """#1180: scope mode must not silently SKIP an unrecognised slot key.
+
+    Pre-fix, `validate_scope` iterated a hardcoded
+    `("implementer", "reviewer", "reviewer_2", "merge_gate_reviewer")` tuple —
+    a third place a role had to be listed. Measured on the pre-fix code, the
+    3-slot row below reported "all 2 names resolved", exit 0: the third slot was
+    never looked at, so neither the resolution seam nor the membership check
+    could have caught it.
+    """
+
+    def _build_org(self, tmp: Path) -> Path:
+        return _build_fake_org_dir(tmp)
+
+    def _row(self, **extra: object) -> dict[str, object]:
+        row: dict[str, object] = {
+            "id": "noorinalabs-isnad-graph#9999",
+            "ref": "isnad-graph#9999",
+            "priority": "P1",
+            "implementer": "Anya Kowalczyk",
+            "reviewer": "Aino Virtanen",
+        }
+        row.update(extra)
+        return row
+
+    def test_unrecognised_slot_key_is_not_skipped(self):
+        """The reproducer: 3 slots in, 3 findings out, exit 1 (was 2 findings, exit 0)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = self._build_org(Path(tmpdir))
+            scope = {"tier_1_core": [self._row(co_implementer="Nadia Khoury")]}
+            report = validate_scope(scope, org)
+            findings = report["noorinalabs-isnad-graph (isnad-graph#9999)"]
+            roles = sorted(f["role"] for f in findings)
+            self.assertEqual(roles, ["co_implementer", "implementer", "reviewer"])
+            extra = next(f for f in findings if f["role"] == "co_implementer")
+            self.assertEqual(extra["slot_class"], "unclassified")
+            self.assertEqual(_print_report_to_stderr(report), 1)
+
+    def test_metadata_keys_are_still_ignored_in_scope_mode(self):
+        """Walking the row must not start validating `note` / `found_by` as names.
+
+        Weaken `is_role_slot_key` to `return True` and this reds — the guard that
+        the widened discovery did not become "every string key is a person".
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = self._build_org(Path(tmpdir))
+            row = self._row(
+                note="a long prose annotation about sequencing",
+                found_by="Weronika Zielinska (PR #1143 adversarial pass)",
+                reassigned_from="Jean-Claude Habimana (da-roster)",
+                blocked_on="noorinalabs-main#870",
+                status="completed",
+                pre_kickoff_blocker="yes",
+            )
+            report = validate_scope({"tier_1_core": [row]}, org)
+            findings = report["noorinalabs-isnad-graph (isnad-graph#9999)"]
+            self.assertEqual(sorted(f["role"] for f in findings), ["implementer", "reviewer"])
+            self.assertEqual(_print_report_to_stderr(report), 0)
+
+    def test_scope_mode_covers_every_known_slot(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = self._build_org(Path(tmpdir))
+            row = self._row(reviewer_2="Nadia Khoury", merge_gate_reviewer="Wanjiku Mwangi")
+            report = validate_scope({"tier_1_core": [row]}, org)
+            findings = report["noorinalabs-isnad-graph (isnad-graph#9999)"]
+            self.assertEqual(sorted(f["role"] for f in findings), sorted(KNOWN_ROLE_SLOTS))
+            self.assertEqual(_print_report_to_stderr(report), 0)
+
+    def test_scope_mode_slot_list_is_driven_by_the_frozensets(self):
+        """Single source of truth: classifying a role reaches scope mode with no second edit.
+
+        `co_lead` is deliberately NOT agentive-shaped, so the only way scope mode
+        can see it is via `KNOWN_ROLE_SLOTS`. Under the old hardcoded tuple this
+        row's third slot stayed invisible no matter what the frozensets said.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = self._build_org(Path(tmpdir))
+            self.assertFalse(is_role_slot_key("co_lead"), "fixture premise: not agentive-shaped")
+            scope = {"tier_1_core": [self._row(co_lead="Aino Virtanen")]}
+
+            before = validate_scope(scope, org)["noorinalabs-isnad-graph (isnad-graph#9999)"]
+            self.assertNotIn("co_lead", [f["role"] for f in before])
+
+            widened = REVIEW_CLASS_ROLES | {"co_lead"}
+            with unittest.mock.patch.multiple(
+                validate_matrix_names,
+                REVIEW_CLASS_ROLES=widened,
+                KNOWN_ROLE_SLOTS=COMMIT_CAPABLE_ROLES | widened,
+            ):
+                after = validate_scope(scope, org)["noorinalabs-isnad-graph (isnad-graph#9999)"]
+                entry = next(f for f in after if f["role"] == "co_lead")
+                self.assertEqual(entry["slot_class"], "known")
+                self.assertTrue(entry["resolved"])
+
+    def test_override_key_still_applies_in_scope_mode(self):
+        """The widened row walk must not swallow or re-validate the override key."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = self._build_org(Path(tmpdir))
+            row = self._row(
+                implementer="Nadia Khoury",  # parent-only → cross-repo without the override
+                roster_union_override={"rationale": "intended, owner-approved"},
+            )
+            report = validate_scope({"tier_1_core": [row]}, org)
+            findings = report["noorinalabs-isnad-graph (isnad-graph#9999)"]
+            self.assertNotIn("roster_union_override", [f["role"] for f in findings])
+            impl = next(f for f in findings if f["role"] == "implementer")
+            self.assertEqual(impl["membership"], "overridden")
+            self.assertEqual(_print_report_to_stderr(report), 0)
 
 
 if __name__ == "__main__":

--- a/.claude/skills/wave-scope/validate_matrix_names.py
+++ b/.claude/skills/wave-scope/validate_matrix_names.py
@@ -88,10 +88,25 @@ membership check not applying — hang off the REVIEW class, so `REVIEW_CLASS_RO
 is the allowlist and everything else, *including a role nobody has classified*,
 takes the commit-capable path. The seam was originally written the other way
 round (`COMMIT_CAPABLE_ROLES` as the allowlist, review as the fall-through),
-which meant an unclassified slot silently inherited BOTH loosenings. Measured on
-`main` at #1180: a matrix row with `co_implementer` / `pair_implementer` /
-`fixer` reported "all 3 names resolved", exit 0 — and `co_implementer` is
-semantically commit-capable, it would have to commit in the target repo.
+which meant an unclassified slot silently inherited BOTH loosenings.
+
+Measured against the pre-fix module, on a `co_implementer` slot — a name that is
+semantically commit-capable, it would have to commit in the target repo:
+
+    {"noorinalabs-user-service": {"co_implementer": "Nikolaos Papadopoulos"}}
+        -> "all 1 names resolved", exit 0   (loosening 1: the manifest widened
+           a commit-capable slot; his cards live in a THIRD child repo)
+
+    {"noorinalabs-user-service": {"co_implementer": "Nurul Hakim"}}
+        -> "all 1 names resolved", exit 0   (loosening 2: #1134 membership
+           skipped — this is the W27/W28 cross-repo-implementer failure exactly,
+           re-admitted by nothing more than renaming the slot key)
+
+Note the FIRST measurement is what the `#1180` issue body approximated with a
+three-slot matrix (`co_implementer` / `pair_implementer` / `fixer`); that matrix
+also names `Annunaki` and `Steven French`, which #1181's persona-shape filter
+already rejects, so it exits 1 for reasons unrelated to this seam and MASKS the
+one slot that actually passes. Isolate the slot when re-measuring.
 
 The asymmetry is the same consequence argument as § Why the manifest is
 acceptable HERE: a slot wrongly treated as review-class fails silently and

--- a/.claude/skills/wave-scope/validate_matrix_names.py
+++ b/.claude/skills/wave-scope/validate_matrix_names.py
@@ -81,6 +81,34 @@ third-child implementer that newly *resolved* would exit 0 where today it exits
 1 as an unresolved name. Keeping the commit-capable resolution set narrow means
 the only way that slot passes is a name the target repo can actually vouch for.
 
+Unknown role slots default to the STRICT side (#1180)
+=====================================================
+Both loosenings above — the manifest widening the resolution set, and the
+membership check not applying — hang off the REVIEW class, so `REVIEW_CLASS_ROLES`
+is the allowlist and everything else, *including a role nobody has classified*,
+takes the commit-capable path. The seam was originally written the other way
+round (`COMMIT_CAPABLE_ROLES` as the allowlist, review as the fall-through),
+which meant an unclassified slot silently inherited BOTH loosenings. Measured on
+`main` at #1180: a matrix row with `co_implementer` / `pair_implementer` /
+`fixer` reported "all 3 names resolved", exit 0 — and `co_implementer` is
+semantically commit-capable, it would have to commit in the target repo.
+
+The asymmetry is the same consequence argument as § Why the manifest is
+acceptable HERE: a slot wrongly treated as review-class fails silently and
+expensively (the W28 mechanical merge-commit re-attribution); a slot wrongly
+treated as commit-capable fails loudly and cheaply at scope time, and the fix is
+one line in `REVIEW_CLASS_ROLES`. Default to the failure you can see.
+
+The same reasoning drives slot DISCOVERY. Scope mode used to iterate a hardcoded
+tuple of the four live slots, a third place a role had to be listed, so an
+unrecognised key there was not mis-classified but skipped outright (measured: a
+3-slot row reported "all 2 names resolved", exit 0). It now walks the row via
+`is_role_slot_key`, which admits `KNOWN_ROLE_SLOTS` plus any agentive-shaped key
+(`_ROLE_SLOT_KEY_RE`) not explicitly denied in `NON_ROLE_ROW_KEYS`. An admitted
+but unclassified key is reported `slot_class="unclassified"` and fails the run —
+NOT merely warned about, because a warning printed inside an otherwise-green job
+is exactly the advisory posture § Hard fail already records as insufficient.
+
 Why check 2 is implementer-only. The implementer is the only role that must
 produce a **commit in the target repo**, where `validate_commit_identity`
 (Hook 5) resolves the author against that repo's roster. Reviewers never
@@ -159,10 +187,11 @@ matrix — the repo is derived from each row's `id` (`noorinalabs-user-service#2
 copy a row into the matrix.
 
 Exit codes:
-    0 — all names resolve, and every child-repo implementer is a repo member
-        (or carries a recorded override)
+    0 — all names resolve, every child-repo implementer is a repo member (or
+        carries a recorded override), and every slot key is classified
     1 — one or more names don't resolve, OR a child-repo implementer is not on
-        that repo's roster and has no recorded override
+        that repo's roster and has no recorded override, OR a slot key is in
+        neither `COMMIT_CAPABLE_ROLES` nor `REVIEW_CLASS_ROLES` (#1180)
     2 — invalid input
 
 Resolution:
@@ -204,10 +233,21 @@ import re
 import sys
 from pathlib import Path
 
-# Role slots that must be able to COMMIT in the target repo. Only these are
-# subject to the #1134 repo-membership check; every other slot is review-class
-# and keeps the parent-union resolution (#319 semantics).
+# Role slots that must be able to COMMIT in the target repo: narrow (#319 card)
+# resolution + the #1134 repo-membership check.
 COMMIT_CAPABLE_ROLES: frozenset[str] = frozenset({"implementer"})
+
+# Review-class slots: the org-union manifest widens their resolution set (#1162)
+# and the #1134 membership check does NOT apply to them (charter
+# `spawn-discipline.md` § Child-Repo Implementer Rule step 5 permits cross-team
+# reviewers). THIS is the allowlist the two loosenings hang off (#1180) — see
+# § Unknown role slots default to the STRICT side in the module docstring.
+REVIEW_CLASS_ROLES: frozenset[str] = frozenset({"reviewer", "reviewer_2", "merge_gate_reviewer"})
+
+# Every slot key the validator knows how to classify. Scope mode drives its slot
+# list off THIS union rather than a second hardcoded tuple, so adding a role to
+# either frozenset above is the single edit that makes both modes see it (#1180).
+KNOWN_ROLE_SLOTS: frozenset[str] = COMMIT_CAPABLE_ROLES | REVIEW_CLASS_ROLES
 
 # Repo keys that mean "the parent repo itself" — membership is vacuous there
 # (the parent roster IS the repo roster), so #1134 never fires on them.
@@ -220,6 +260,51 @@ PARENT_REPO_KEYS: frozenset[str] = frozenset({"", "noorinalabs-main", "main"})
 # `_load_org_manifest_names` below for why this module keeps its own small
 # duplicate rather than importing across the hook/skill boundary (#1181).
 _PERSONA_ALIAS_RE = re.compile(r"^[^\s@+]+\+[^\s@+]+\.[^\s@+]+@[^\s@]+\.[^\s@]+$")
+
+# Scope rows carry role slots alongside free-form metadata (`id`, `ref`, `note`,
+# `found_by`, `blocked_on`, ...), so scope mode cannot simply treat every string
+# key as a person slot. Role slots in this schema are named after the AGENT that
+# fills them, so the key's last `_`-component is agentive — ends in `-er`/`-or`,
+# optionally with a `_<n>` ordinal (`reviewer_2`). Measured over all 293 rows in
+# every `wave_*_scope` of `cross-repo-status.json` (2026-08-02) this matches the
+# four known slots plus `pre_kickoff_blocker` and NOTHING else — the other 24
+# metadata keys (`found_by`, `reassigned_from`, `blocked_by`, `coupled_with`,
+# `follow_on_to`, `pair_with`, `scope_note`, `slate_note`, `open_risk`,
+# `merged_sha`, `sequence`, `bundle`, `spawn`, `status`, `role`, ...) do not end
+# in an agentive component.
+_ROLE_SLOT_KEY_RE = re.compile(r"(?:^|_)[a-z]+(?:er|or)(?:_\d+)?$")
+
+# Agentive-SHAPED row keys that are explicitly NOT person slots. This is the
+# escape hatch that keeps `_ROLE_SLOT_KEY_RE`'s generosity cheap: a false
+# positive costs one reviewable line here, not a redesign. `pre_kickoff_blocker`
+# is the one live instance (a bool flag, `wave_29_scope`).
+NON_ROLE_ROW_KEYS: frozenset[str] = frozenset({"pre_kickoff_blocker"})
+
+# Not a role slot and not metadata — the recorded #1134 escape hatch, consumed
+# by `_override_rationale` rather than validated as a name.
+OVERRIDE_KEY = "roster_union_override"
+
+
+def is_role_slot_key(key: str) -> bool:
+    """Is `key` a scope-row key that names a PERSON filling a role slot? (#1180)
+
+    Used by scope mode to decide which row keys to hand to `validate()`. A key is
+    a role slot if it is one of `KNOWN_ROLE_SLOTS`, or — so a slot nobody has
+    classified yet cannot be silently skipped — if it is agentive-shaped
+    (`_ROLE_SLOT_KEY_RE`) and not explicitly denied in `NON_ROLE_ROW_KEYS`.
+
+    An unknown agentive key is deliberately admitted rather than ignored:
+    `validate()` then marks it `slot_class="unclassified"`, which is a hard
+    exit-1 telling the operator to classify it. Ignoring it is the #1180 bug in
+    its scope-mode form (measured: a 3-slot row reported "all 2 names resolved",
+    exit 0 — the third slot was never looked at).
+    """
+    lowered = key.strip().lower()
+    if lowered in KNOWN_ROLE_SLOTS:
+        return True
+    if lowered in NON_ROLE_ROW_KEYS or lowered == OVERRIDE_KEY:
+        return False
+    return bool(_ROLE_SLOT_KEY_RE.search(lowered))
 
 
 def _find_org_dir() -> Path:
@@ -411,6 +496,12 @@ def validate(
                            cannot decide, so does not fail
       - ``"n/a"``        — review-class slot, parent-repo row, or unresolved name
 
+    `slot_class` (#1180) is ``"known"`` when the slot key is in
+    `KNOWN_ROLE_SLOTS`, else ``"unclassified"`` — a hard failure in
+    `_print_report_to_stderr`. It is orthogonal to `resolved` / `membership`:
+    an unclassified slot is ALSO validated (on the strict path), so a run can
+    report both "this name does not resolve" and "this slot key is unknown".
+
     A per-repo `roster_union_override` may be supplied as a slot key alongside
     the role names; scope mode maps each row's own override onto its repo.
     """
@@ -436,29 +527,34 @@ def validate(
         # § Review-class slots for why the manifest must not widen this one).
         combined = parent_roster | repo_roster
         review_combined = combined | org_manifest
-        override = _override_rationale(slots.get("roster_union_override"))
+        override = _override_rationale(slots.get(OVERRIDE_KEY))
         repo_findings: list[dict[str, object]] = []
         for role, raw in slots.items():
-            if role == "roster_union_override":
+            if role == OVERRIDE_KEY:
                 continue
             if not raw or not isinstance(raw, str):
                 continue
             declared = raw
             declared_clean = re.sub(r"\s*\(.*?\)\s*$", "", declared).strip()
-            candidates = combined if role in COMMIT_CAPABLE_ROLES else review_combined
+            # #1180: REVIEW class is the allowlist. Anything else — including a
+            # role nobody has classified — takes the strict commit-capable path:
+            # narrow resolution AND the #1134 membership check.
+            is_review_class = role in REVIEW_CLASS_ROLES
+            candidates = review_combined if is_review_class else combined
             resolved = any(declared_clean.lower() == known.lower() for known in candidates)
             entry: dict[str, object] = {
                 "role": role,
                 "declared": declared,
                 "resolved": resolved,
                 "membership": "n/a",
+                "slot_class": "known" if role in KNOWN_ROLE_SLOTS else "unclassified",
             }
             if not resolved:
                 entry["suggestions"] = _suggest(declared_clean, candidates)
                 repo_findings.append(entry)
                 continue
             # #1134: commit-capable slots on a child repo must be repo members.
-            if role in COMMIT_CAPABLE_ROLES and not is_parent_repo:
+            if not is_review_class and not is_parent_repo:
                 if not membership_decidable:
                     entry["membership"] = "unverified"
                 elif any(declared_clean.lower() == known.lower() for known in repo_roster):
@@ -519,17 +615,26 @@ def validate_scope(
     several stories reports — and overrides — each story independently. Rows
     with no parsable repo are treated as parent-repo rows, matching the
     `/wave-scope` convention that a bare `main#N` lives in `noorinalabs-main`.
+
+    Slot discovery is `is_role_slot_key` (#1180), NOT a hardcoded tuple. The old
+    tuple was a THIRD place a role had to be listed, so an unrecognised slot key
+    was not merely mis-classified here, it was skipped outright — measured on a
+    3-slot row: "all 2 names resolved", exit 0. Now every key in
+    `KNOWN_ROLE_SLOTS` is covered automatically, and an agentive-shaped key in
+    neither frozenset is still handed to `validate()`, which flags it
+    `slot_class="unclassified"` and fails the run.
     """
     report: dict[str, list[dict[str, object]]] = {}
     for row in _iter_tier_rows(scope):
         repo = repo_of_row(row) or "noorinalabs-main"
         slots: dict[str, object] = {}
-        for role in ("implementer", "reviewer", "reviewer_2", "merge_gate_reviewer"):
-            value = row.get(role)
+        for role, value in row.items():
+            if not is_role_slot_key(role):
+                continue
             if isinstance(value, str) and value:
                 slots[role] = value
-        if "roster_union_override" in row:
-            slots["roster_union_override"] = row["roster_union_override"]
+        if OVERRIDE_KEY in row:
+            slots[OVERRIDE_KEY] = row[OVERRIDE_KEY]
         if not slots:
             continue
         ref = row.get("ref") or row.get("id") or "?"
@@ -541,19 +646,22 @@ def validate_scope(
 def _print_report_to_stderr(report: dict[str, list[dict[str, object]]]) -> int:
     """Pretty-print the report to stderr; return exit code.
 
-    Two independent failure classes (#319 name resolution, #1134 repo
-    membership). Either one alone returns 1.
+    Three independent failure classes (#319 name resolution, #1134 repo
+    membership, #1180 slot classification). Any one alone returns 1.
     """
     total = 0
     unresolved = 0
     cross_repo = 0
     overridden = 0
     unverified = 0
+    unclassified = 0
     for findings in report.values():
         for f in findings:
             total += 1
             if not f["resolved"]:
                 unresolved += 1
+            if f.get("slot_class") == "unclassified":
+                unclassified += 1
             membership = f.get("membership")
             if membership == "cross-repo":
                 cross_repo += 1
@@ -623,7 +731,36 @@ def _print_report_to_stderr(report: dict[str, list[dict[str, object]]]) -> int:
             file=sys.stderr,
         )
 
-    if unresolved or cross_repo:
+    if unclassified:
+        print(
+            f"\nvalidate_matrix_names: {unclassified}/{total} UNCLASSIFIED role slot(s) (#1180).",
+            file=sys.stderr,
+        )
+        for repo, findings in report.items():
+            bad = [f for f in findings if f.get("slot_class") == "unclassified"]
+            if not bad:
+                continue
+            print(f"\n  {repo}:", file=sys.stderr)
+            for f in bad:
+                print(
+                    f"    - {f['role']}: {f['declared']!r} — slot key is in neither "
+                    "COMMIT_CAPABLE_ROLES nor REVIEW_CLASS_ROLES.",
+                    file=sys.stderr,
+                )
+        print(
+            "\n  An unclassified slot is validated on the STRICT path (narrow #319\n"
+            "  resolution + the #1134 membership check) — the safe default, since the\n"
+            "  loosenings (org-union manifest, membership exemption) are justified only\n"
+            "  for a slot that provably never commits.\n"
+            "\n  Classify the key in .claude/skills/wave-scope/validate_matrix_names.py:\n"
+            "    COMMIT_CAPABLE_ROLES — the slot must COMMIT in the target repo\n"
+            "    REVIEW_CLASS_ROLES   — review-only; never commits (manifest widens it,\n"
+            "                           #1134 membership does not apply)\n"
+            "    NON_ROLE_ROW_KEYS    — the key is row metadata, not a person slot",
+            file=sys.stderr,
+        )
+
+    if unresolved or cross_repo or unclassified:
         return 1
 
     detail = []

--- a/.claude/team/charter/skills.md
+++ b/.claude/team/charter/skills.md
@@ -50,7 +50,8 @@ This is the scope-time twin of `charter/agents/spawn-discipline.md` § Child-Rep
 
 ### Scope
 
-- Applies to the **`implementer` slot only**. Reviewer / `reviewer_2` / `merge_gate_reviewer` slots keep the parent-union resolution — cross-team reviewers are explicitly permitted (spawn-discipline § step 5). The implementer is the only role that must produce a commit in the target repo.
+- Applies to **every slot that is not review-class**. `reviewer` / `reviewer_2` / `merge_gate_reviewer` are the review class and keep the wider parent-union-plus-manifest resolution with no membership check — cross-team reviewers are explicitly permitted (spawn-discipline § step 5). `implementer` is the only commit-capable slot today, so in practice this is the implementer slot; the rule is written around the *class* because **the review class is the allowlist, not the commit-capable one (#1180)**. A slot key nobody has classified takes the strict path and fails loudly rather than silently inheriting the reviewer exemption.
+- **Adding a role slot to the wave-scope schema is a code change, not a data change.** A new slot key must be classified in `validate_matrix_names.py` (`COMMIT_CAPABLE_ROLES`, `REVIEW_CLASS_ROLES`, or `NON_ROLE_ROW_KEYS` for a non-person row key); an unclassified key is its own hard STOP (#1180). Scoping a row with an unclassified slot is not permitted, because neither the resolution set nor the membership decision for that slot would have been made deliberately.
 - Does not apply to `noorinalabs-main` rows (membership is vacuous — the parent roster *is* the repo roster).
 - A child repo whose roster cannot be read (not cloned locally) is reported `unverified` and does **not** fail the run. Fail-open on unverifiable, never fail-closed.
 


### PR DESCRIPTION
Closes #1180.

> **Correction (see the pinned comment).** The first version of this description reported the matrix-mode differential as `main` → "all 3 names resolved, exit 0". That was carried over from the issue body, not measured by me. Re-measured, it is wrong — and the corrected measurement below is a *sharper* statement of the defect, not a weaker one.

## What was wrong

`validate_matrix_names.py` chose a role slot's candidate set with

```python
candidates = combined if role in COMMIT_CAPABLE_ROLES else review_combined
```

`COMMIT_CAPABLE_ROLES = frozenset({"implementer"})` is an allowlist of the **narrow** side, so the fall-through for any unclassified role was the **wide** side. Two loosenings ride on that fall-through, and both are justified only for a slot that *provably never commits*:

1. the org-union manifest widens the resolution set (#1162), and
2. the #1134 repo-membership check does not apply.

The module docstring argues at length that `implementer` must stay narrow so a failure is a loud exit-1 rather than a silent pass. That reasoning was never applied to the default branch.

**Latent — no current instance. All four live slots are classified**, so nothing in any shipped wave behaved incorrectly. This closes the seam before a new role slot lands on it.

A related pre-existing gap sat one layer up: `validate_scope` iterated a hardcoded `("implementer", "reviewer", "reviewer_2", "merge_gate_reviewer")` tuple — a *third* place a role had to be listed — so in scope mode an unrecognised slot key was not merely mis-classified, it was never looked at.

## What changed

- **`REVIEW_CLASS_ROLES` is now the allowlist.** `candidates = review_combined if role in REVIEW_CLASS_ROLES else combined`. Unknown ⇒ narrow ⇒ loud exit 1. The membership branch is inverted the same way (`if not is_review_class and not is_parent_repo`), so an unclassified slot no longer inherits the #1134 exemption either — the issue names that exemption as part of the defect.
- **`KNOWN_ROLE_SLOTS = COMMIT_CAPABLE_ROLES | REVIEW_CLASS_ROLES` is the single source of truth.** `validate_scope` walks each row via a new `is_role_slot_key` instead of the hardcoded tuple, so classifying a role in either frozenset is the one edit that makes both modes see it.
- **Third failure class: `slot_class="unclassified"`, exit 1**, with a message naming the three frozensets to classify the key into. Chosen over a warning deliberately — a warning printed inside an otherwise-green job is exactly the advisory posture the module's own § Hard fail section already records as insufficient.

### Why `is_role_slot_key` is shaped the way it is

Scope rows mix role slots with free-form metadata, so scope mode cannot treat every string key as a person — `note`, `id`, `priority`, `scope_note` would all become bogus name checks. Nor can it hard-fail on every unrecognised key: the live data carries 25 distinct metadata keys that grow ad hoc wave to wave (`open_risk`, `slate_note`, `merged_sha`, `sequence`, …), and a gate that reds on the next ad-hoc annotation is one operators route around.

The recogniser instead uses the schema's own naming convention: **role slots are named after the agent that fills them**, so the key ends in an agentive `-er`/`-or` component, optionally with an ordinal (`reviewer_2`). Measured across **all 293 rows of every `wave_*_scope`** in `cross-repo-status.json`, that matches the four known slots plus `pre_kickoff_blocker` (a bool flag) and nothing else. `pre_kickoff_blocker` is pre-classified in `NON_ROLE_ROW_KEYS`, which is the escape hatch that keeps the regex's generosity cheap — a future false positive costs one reviewable line, and the failure is self-documenting rather than silent.

**Known limit, stated plainly:** a non-agentive unclassified slot key (say `co_lead`) is still skipped in scope mode — filed as #1278. It is caught in matrix mode by the inverted seam, and classifying it in either frozenset makes scope mode pick it up with no second edit, which is pinned by `test_scope_mode_slot_list_is_driven_by_the_frozensets`. Closing the non-agentive case would need either a metadata denylist (unbounded, given the 25 free-form keys) or a value-shape heuristic that false-positives on `found_by` / `reassigned_from`, both of which trade a real gate for a noisy one.

## The measured differential (corrected)

**The issue's own three-slot example masks the defect.** That matrix names `Annunaki` and `Steven French` alongside `Nikolaos Papadopoulos`; #1181's persona-shape filter already rejects the first two, so on today's `origin/main` the run exits **1** — on those two names — while the one slot the issue is actually about resolves silently. Isolating each loosening:

| Case (matrix mode, `noorinalabs-user-service`) | `origin/main` | this branch |
|---|---|---|
| `{"co_implementer": "Nikolaos Papadopoulos"}` — his cards live in a **third child repo**, so he is manifest-only here | `all 1 names resolved`, exit **0** | `1/1 names UNRESOLVED` + `1/1 UNCLASSIFIED`, exit **1** |
| `{"co_implementer": "Nurul Hakim"}` — on the parent roster, **not** on the user-service roster | `all 1 names resolved`, exit **0** | `1/1 CROSS-REPO IMPLEMENTER assignment(s)`, exit **1** |
| the issue's 3-slot matrix verbatim | `2/3 UNRESOLVED`, exit 1 — but `co_implementer` **passes** | `3/3 UNRESOLVED` + `3/3 UNCLASSIFIED`, exit 1 |

The second row is the sharpest statement of the risk: **it is the W27/W28 cross-repo-implementer failure — the one that cost a mechanical merge-commit re-attribution — re-admitted by nothing more than renaming the slot key.** `Nurul Hakim` on `user-service` is blocked as `implementer` and waved through as `co_implementer`.

Scope mode, a 3-slot row (`implementer` + `reviewer` + `co_implementer`):

| | result |
|---|---|
| `origin/main` | `all 2 names resolved`, exit **0** — the third slot was never looked at |
| this branch | `1/3 names UNRESOLVED` + `1/3 UNCLASSIFIED role slot(s)`, exit **1** |

## Regression anchors — measured against real wave data

`origin/main`'s validator and this branch's were run over **every** `wave_*_scope` in `cross-repo-status.json`, comparing **stdout+stderr byte-for-byte and the exit code**:

| Wave | Before | After | Output |
|---|---|---|---|
| **28** | exit **1**, `2/30 CROSS-REPO IMPLEMENTER assignment(s)` (`Nurul Hakim`, `Weronika Zielinska`) | exit **1**, identical | byte-identical |
| **29** | exit **0**, `all 165 names resolved across 51 entries` | exit **0**, identical | byte-identical |
| 1–7, 16–27 | — | — | byte-identical, exit codes unchanged |

**21 waves / 293 rows, zero differences.** Note the W29 count is 165, not the 85 quoted in the issue: `wave_29_scope` has been amended since #1180 was filed. The load-bearing anchor is the before/after equality on today's data, which is exact.

## Testing — mutation-tested, not assertion-only

62 tests pass (45 pre-existing + 17 new) plus 38 subtests. Each new branch was deleted or weakened in turn and the suite re-run; **0 of 9 mutations survived**. The harness asserts a green baseline before mutating and re-asserts a green tree after restoring.

| # | Mutation | Named test(s) that go red |
|---|---|---|
| M1 | Seam reverted to `combined if role in COMMIT_CAPABLE_ROLES else review_combined` | `test_unclassified_slot_resolves_against_the_narrow_set`, `test_unclassified_slot_gets_the_membership_check`, `test_unclassified_slot_fails_even_when_fully_valid` |
| M2 | Membership branch reverted to `role in COMMIT_CAPABLE_ROLES` | `test_unclassified_slot_gets_the_membership_check`, `test_unclassified_slot_fails_even_when_fully_valid` |
| M3 | `slot_class` marking deleted (everything reported `known`) | `test_unclassified_slot_fails_even_when_fully_valid`, `test_unrecognised_slot_key_is_not_skipped` |
| M4 | `unclassified` dropped from the exit-code condition | `test_unclassified_slot_fails_even_when_fully_valid` |
| M5 | Scope-mode discovery reverted to the hardcoded 4-slot tuple | `test_unrecognised_slot_key_is_not_skipped`, `test_scope_mode_slot_list_is_driven_by_the_frozensets` |
| M6 | `is_role_slot_key` weakened to `return True` | 36 red, incl. `test_metadata_keys_are_still_ignored_in_scope_mode`, `test_no_live_metadata_key_is_mistaken_for_a_slot` (25 subtests), `test_non_tier_keys_and_null_slots_ignored` |
| M7 | `NON_ROLE_ROW_KEYS` denylist branch deleted | `test_no_live_metadata_key_is_mistaken_for_a_slot(key='pre_kickoff_blocker')`, `test_recognition_is_case_and_whitespace_insensitive`, `test_metadata_keys_are_still_ignored_in_scope_mode` |
| M8 | Agentive recogniser deleted (unknown keys never admitted) | `test_unclassified_agentive_keys_are_recognised` (6 subtests), `test_unrecognised_slot_key_is_not_skipped` |
| M9 | `merge_gate_reviewer` dropped from `REVIEW_CLASS_ROLES` | `test_every_review_class_role_keeps_the_wide_set(role='merge_gate_reviewer')`, `test_reviewer_slots_keep_parent_union`, `test_third_child_reviewer_resolves_and_implementer_stays_gated`, +3 |

Three design notes on the tests:

- `test_unclassified_slot_fails_even_when_fully_valid` uses a name that **resolves and is a repo member**, so neither the #319 nor the #1134 class fires. It is the only test that isolates the #1180 class as its own signal rather than a side effect of a name miss — which is why it is the sole anchor for M4.
- `test_same_name_still_resolves_in_a_review_slot` is a deliberate paired control: without it, the narrow-set test would also pass if the manifest had simply stopped being loaded at all. Only the slot class differs between the two.
- `test_no_live_metadata_key_is_mistaken_for_a_slot` snapshots the measured 25-key census rather than reading `cross-repo-status.json`, so the guard cannot rot when the wave data changes.

## Docs

`/wave-scope` § 12.5, `/wave-kickoff` § 0b and `charter/skills.md` all described the membership rule as "the `implementer` slot only". Restated in the class terms the code now uses, with the new rule made explicit: **adding a role slot to the scope schema is a code change, not a data change.** The module docstring now carries the corrected, isolated measurements and a note that the issue's example matrix masks the slot it is about.

## Gates

`pre-commit run --hook-stage pre-push --all-files` fully green (17 hooks). `pre_commit_ci_sync.py` reports parity. All 21 CI checks passed on the prior head; re-running on `aee3d94`. No `--no-verify`, no failing check.

## Follow-up

- #1278 — the non-agentive unclassified slot key residual (`tech-debt` / `process` / `phase-10`, no wave label).

## Reviewers

Two per charter. Not for merge by me — the orchestrator drives the review gate.
