### PR TITLE
fix(commit-identity): heredoc written to a file, executed later in the same command, now blocks (#1167)

### DIFF
--- a/.claude/hooks/_shell_parse.py
+++ b/.claude/hooks/_shell_parse.py
@@ -748,6 +748,254 @@ def _opener_feeds_interpreter(line: str, pos: int, scan: _LineScan) -> bool:
     return False
 
 
+# ---------------------------------------------------------------------------
+# Cross-segment "write-then-exec" correlation (main#1167)
+# ---------------------------------------------------------------------------
+#
+# `_opener_feeds_interpreter` answers "is this heredoc's body consumed by an
+# interpreter reachable through a PIPE from the same physical line?" That is
+# the wrong question for a heredoc whose owning segment redirects the body
+# into a FILE (`cat > FILE <<'DELIM'`, or `tee FILE <<'DELIM'`) and a LATER
+# segment — connected by `;`, a newline, or anything else, not a pipe —
+# invokes an interpreter on that same file:
+#
+#     cat > /tmp/s.txt <<'DELIM'
+#     git -c user.name=X -c user.email=Y commit -m z
+#     DELIM
+#     bash /tmp/s.txt
+#
+# `cat` is a recognised data sink and nothing downstream of it on the SAME
+# line is a `|`-connected interpreter, so `_opener_feeds_interpreter` says
+# DATA — correctly, for the question it answers. But the body reaches a real
+# shell one command later. `_read_script_if_safe` (the OTHER existing defense,
+# in validate_commit_identity) is structurally blind to this too: the hook
+# fires PreToolUse, before `cat` has created the file, so reading it back
+# fails and no content is inspected either — see the #1167 issue body for the
+# full "why every matcher misses it" account. Belongs to the #1150 umbrella.
+#
+# The fix stays inside the classifier (the issue's preferred option 1):
+# record the file path(s) a heredoc's owning segment writes the body to, and
+# if ANY segment anywhere else in the same command later invokes a
+# `SHELL_INTERPRETERS` member with that same path as its script operand,
+# reclassify the body as CODE.
+#
+# Deliberately positionally-agnostic: a `bash /tmp/x` segment appearing
+# BEFORE `cat > /tmp/x <<...` in the command still counts. A real shell would
+# only execute meaningful content if the write happens first, but this is a
+# security gate — main#1152's own rule ("every ambiguity resolves toward
+# CODE") already commits this module to erring toward over-detection rather
+# than depending on textual ordering to save a rare false positive.
+#
+# Deliberately NOT resolved through `iter_interpreter_invocations`: that
+# helper's `strip_heredocs` call (the coarse, single-regex eraser — NOT the
+# per-line `classify_heredocs`/`strip_data_heredocs` machinery) consumes
+# everything from a heredoc opener through to its terminator in ONE pass,
+# INCLUDING any command chained onto the OPENER's own line with `;` before
+# the heredoc's first newline (`cat <<'DELIM' > /tmp/x; bash /tmp/x`, the
+# issue's stated semicolon-equivalent shape). Measured:
+# `_HEREDOC_RE.sub("", "cat <<'DELIM' > /tmp/x; bash /tmp/x\\n...")` erases
+# "; bash /tmp/x" along with the heredoc syntax, so a target scan built on
+# `iter_interpreter_invocations` would silently miss the semicolon variant
+# even though `_opener_write_targets`/`_scan_command_line` (the mechanism the
+# rest of this module already trusts) see it fine. This module's own per-line
+# scan is reused instead — see `_iter_non_heredoc_segments` — which has no
+# such erasure bug: it only ever skips a heredoc's OWN body lines, never
+# trailing text on the opener's own line.
+#
+# Explicit scope boundary — NOT covered, by deliberate decision, not oversight:
+#   - `source FILE` / `. FILE`: shell BUILTINS, not members of
+#     `SHELL_INTERPRETERS`. Reading a file into the CURRENT shell is a
+#     structurally different mechanism from spawning a new interpreter
+#     process on it, and folding them in would widen `SHELL_INTERPRETERS`
+#     itself — a set several OTHER matchers in this module and in
+#     validate_commit_identity key on. That is a broader decision than this
+#     fix and belongs in its own issue.
+#   - `env bash FILE`: no new work needed here — `parse_interpreter_invocation`
+#     already strips the `env` wrapper via `strip_command_prefixes` before
+#     resolving the interpreter, so this shape already correlates correctly
+#     through the same path as a bare `bash FILE`.
+#   - A redirect target given via an unexpanded shell variable is not
+#     RESOLVED — the hook cannot evaluate `$F` without running the shell, the
+#     same documented punt this module already makes for `eval "$cmd"`. Note
+#     the caveat: comparison here is by LITERAL TOKEN, not by value, so
+#     `cat > "$F" <<'DELIM' ...; bash "$F"` is still caught — not because `$F`
+#     was resolved, but because both sides spell the identical literal token
+#     `$F`. A rename between the two positions (`cat > "$OUT" ...; F=$OUT;
+#     bash "$F"`) or any other divergent spelling defeats it exactly as
+#     variable resolution in general would.
+#   - `bash < FILE` (script fed via stdin redirect rather than a positional
+#     argument) is a different execution mechanism than the positional
+#     `InterpreterInvocation.operands` this correlation reads, and is not
+#     resolved by the pre-existing shape-7 walker either — out of scope here.
+#   - The attached-operator redirect form with no surrounding whitespace
+#     (`cat>/tmp/x`, as opposed to `cat > /tmp/x`) is not recognised by
+#     `_segment_write_targets`'s tokenizer, which relies on shlex already
+#     splitting `>`/`>>` into their own token — shlex only does that when
+#     whitespace separates them. Every shape in the issue, and every heredoc
+#     redirect in this codebase's own conventions, uses the spaced form.
+
+# `tee`'s own value-less options. `tee` has no value-taking flags besides the
+# attached-`=` long form `--output-error[=MODE]`, which never starts a new
+# bare token and needs no entry here.
+_TEE_BOOL_FLAGS = frozenset({"-a", "--append", "-i", "--ignore-interrupts", "-p", "--output-error"})
+
+
+def _segment_write_targets(seg_text: str) -> list[str]:
+    """File paths the DATA-SINK head of `seg_text` could write a heredoc body to.
+
+    Two independent sources, both checked unconditionally:
+      - a `>`/`>>` shell redirect (any command may carry one);
+      - if the head command is `tee`, every non-flag positional argument
+        (`tee` writes to each of its own file arguments, with or without an
+        ADDITIONAL `>`/`>>` redirect).
+
+    `cat` never contributes a positional target: `cat FILE` READS FILE, it
+    does not write to it — only `cat`'s redirect (if any) is a write.
+    """
+    tokens = tokenize(_HEREDOC_OPENER_RE.sub(" ", seg_text))
+    if not tokens:
+        return []
+    head = tokens[0].rsplit("/", 1)[-1]
+    is_tee = head == "tee"
+    targets: list[str] = []
+    i = 1
+    n = len(tokens)
+    while i < n:
+        tok = tokens[i]
+        if tok in (">", ">>"):
+            if i + 1 < n:
+                targets.append(tokens[i + 1])
+                i += 2
+                continue
+            i += 1
+            continue
+        if tok.startswith(">>") and len(tok) > 2:
+            targets.append(tok[2:])
+            i += 1
+            continue
+        if tok.startswith(">") and len(tok) > 1 and tok[1] not in ("(", "&", ">"):
+            targets.append(tok[1:])
+            i += 1
+            continue
+        if is_tee and tok not in _TEE_BOOL_FLAGS and not _looks_like_flag(tok):
+            targets.append(tok)
+        i += 1
+    return targets
+
+
+def _opener_write_targets(line: str, pos: int, scan: _LineScan) -> list[str]:
+    """`_segment_write_targets` for the segment that OWNS the opener at `pos`."""
+    idx = next(
+        (k for k, (start, end, _sep) in enumerate(scan.segments) if start <= pos < end),
+        None,
+    )
+    if idx is None:
+        return []
+    start, end, _sep = scan.segments[idx]
+    return _segment_write_targets(line[start:end])
+
+
+def _normalize_path_for_compare(path: str) -> str:
+    """Loose normalization so `./x` and `x` — or a doubled slash — written two
+    ways still compare equal. Deliberately narrow: `os.path.normpath` collapses
+    redundant `.`/`//` segments only; it does NOT resolve against a cwd (the
+    write and the invocation share the same shell cwd, so this is the right
+    amount of normalization — resolving further would require knowing that
+    cwd, which this module deliberately does not read) and does NOT expand a
+    leading `~` (harmless either way here: `~/x` written identically on both
+    sides already compares equal as a plain string, and there is no realistic
+    same-command shape where the two sides spell a home-relative path
+    differently — expanding `~` would add a branch with no distinguishing
+    test, so it is left out).
+    """
+    try:
+        return os.path.normpath(path)
+    except (TypeError, ValueError):
+        return path
+
+
+def _iter_non_heredoc_segments(cmd: str) -> Iterator[str]:
+    """Every pipeline segment in `cmd` that is NOT inside a heredoc body.
+
+    Reuses the exact line-walk + terminator-search `_classify_heredocs_cached`
+    and `strip_data_heredocs` already use, so a heredoc BODY line is never
+    mistaken for a segment of the surrounding command (a body line containing
+    the word `bash` must not itself look like an interpreter invocation).
+    Deliberately NOT built on `iter_interpreter_invocations`/`strip_heredocs`
+    — see the module comment above `_segment_write_targets` for the measured
+    erasure bug that makes that helper unsuitable here.
+    """
+    lines = cmd.split("\n")
+    n = len(lines)
+    i = 0
+    while i < n:
+        line = lines[i]
+        i += 1
+        scan = _scan_command_line(line)
+        for start, end, _sep in scan.segments:
+            yield line[start:end]
+        for _pos, dash_form, delim in scan.openers:
+            j = i
+            while j < n:
+                candidate = lines[j].rstrip("\r")
+                if (candidate.lstrip("\t") if dash_form else candidate) == delim:
+                    i = j + 1
+                    break
+                j += 1
+            else:
+                i = n  # unterminated: nothing after this belongs to real command text
+
+
+@lru_cache(maxsize=256)
+def _script_invocation_targets(cmd: str) -> frozenset[str]:
+    """Normalized script-path operands of every interpreter invocation in `cmd`.
+
+    Used to correlate a heredoc's file-redirect target against a later (or
+    earlier — see the positional-agnostic note above) interpreter invocation
+    of that same file (main#1167). Memoized: pure in `cmd`, and both
+    `_classify_heredocs_cached` and `strip_data_heredocs` call it on the same
+    `cmd` within one hook invocation.
+    """
+    if not any(name in cmd for name in SHELL_INTERPRETERS):
+        return frozenset()
+    targets: set[str] = set()
+    for seg_text in _iter_non_heredoc_segments(cmd):
+        tokens = tokenize(_HEREDOC_OPENER_RE.sub(" ", seg_text))
+        if not tokens:
+            continue
+        invocation = parse_interpreter_invocation(tokens)
+        if invocation is None or invocation.has_command_string:
+            continue
+        if invocation.operands:
+            targets.add(_normalize_path_for_compare(invocation.operands[0]))
+    return frozenset(targets)
+
+
+def _is_opener_code(cmd: str, line: str, pos: int, scan: _LineScan) -> bool:
+    """Single source of truth: is the heredoc opened at `pos` on `line` (within
+    the larger command `cmd`) executed as shell code?
+
+    `classify_heredocs` and `strip_data_heredocs` MUST both call this rather
+    than reimplementing the decision. main#1152 already flagged the drift
+    hazard of two independent "is this body code" definitions; main#1167 is
+    exactly that hazard realized once — extending only one of the two
+    pre-existing call sites would silently leave the gap open in the other
+    (in practice: `strip_data_heredocs` feeds `validate_commit_identity`'s
+    `scanned` text, so a fix applied only to `classify_heredocs` would still
+    let the body's `git commit` text get stripped as data before any matcher
+    reading `scanned` ever saw it).
+    """
+    if _opener_feeds_interpreter(line, pos, scan):
+        return True
+    script_targets = _script_invocation_targets(cmd)
+    if not script_targets:
+        return False
+    return any(
+        _normalize_path_for_compare(target) in script_targets
+        for target in _opener_write_targets(line, pos, scan)
+    )
+
+
 def classify_heredocs(cmd: str) -> tuple[HeredocSpan, ...]:
     """Find every heredoc in `cmd` and say whether its body is code or data.
 
@@ -771,7 +1019,7 @@ def _classify_heredocs_cached(cmd: str) -> tuple[HeredocSpan, ...]:
         i += 1
         scan = _scan_command_line(line)
         for pos, dash_form, delim in scan.openers:
-            is_code = _opener_feeds_interpreter(line, pos, scan)
+            is_code = _is_opener_code(cmd, line, pos, scan)
             body: list[str] = []
             term = None
             j = i
@@ -816,7 +1064,7 @@ def strip_data_heredocs(cmd: str) -> str:
         i += 1
         scan = _scan_command_line(line)
         for pos, dash_form, delim in scan.openers:
-            is_code = _opener_feeds_interpreter(line, pos, scan)
+            is_code = _is_opener_code(cmd, line, pos, scan)
             term = None
             j = i
             while j < len(lines):

--- a/.claude/hooks/tests/test_heredoc_write_then_exec.py
+++ b/.claude/hooks/tests/test_heredoc_write_then_exec.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Regression tests for main#1167 — heredoc written to a file, executed later
+in the SAME command, bypasses the commit-identity gate. Sibling of the
+main#1150 under-matching umbrella (found by the PR #1155 merge-gate review,
+Aino Virtanen, while constructing bypass shapes outside that PR's own corpus).
+
+Shape
+=====
+
+    cat > /tmp/s.txt <<'DELIM'
+    git -c user.name="X" -c user.email="Y" commit -m z
+    DELIM
+    bash /tmp/s.txt
+
+Measured ALLOW at both `fea0dca` (main) and `e163320` (PR #1155 head) — a
+pre-existing gap, not a #1155 regression. Every existing matcher misses it for
+a distinct reason (see the #1167 issue body and the `main#1167` block comment
+in `_shell_parse.py` above `_segment_write_targets` for the full account):
+
+  - `_HEREDOC_RE` requires an interpreter textually BEFORE the `<<` — absent.
+  - `_shell_parse.classify_heredocs` resolved the owner to `cat` (a data
+    sink) and followed only `|` downstream; a `;`/newline-separated later
+    command is not in the pipeline, so the body was classified DATA.
+  - `_SCRIPT_INVOKE_RE` DOES match `bash /tmp/s.txt` and calls
+    `_read_script_if_safe`, but the hook fires PreToolUse, so the file does
+    not exist yet — the read fails and no content is inspected.
+
+The fix (issue's preferred option 1) stays inside the classifier: when a
+heredoc's owning segment redirects the body into a file (`cat > FILE`, or
+`tee FILE` as a positional argument), and ANY segment elsewhere in the same
+command later invokes a `SHELL_INTERPRETERS` member with that same file as its
+script operand, the body is reclassified as CODE.
+
+Run: python3 -m pytest .claude/hooks/tests/test_heredoc_write_then_exec.py -v
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_HOOKS_DIR = _HERE.parent
+sys.path.insert(0, str(_HOOKS_DIR))
+
+import validate_commit_identity as hook  # noqa: E402
+from _shell_parse import (  # noqa: E402
+    classify_heredocs,
+    strip_data_heredocs,
+)
+
+REAL_COMMIT = 'git -c user.name="X" -c user.email="Y" commit -m z'
+DOC_LINE = "the bypass shape looks like: bash -c 'git commit -m x'"
+
+
+def _bash(command: str) -> dict:
+    return {"tool_name": "Bash", "tool_input": {"command": command}}
+
+
+class WriteThenExecBypassBlocksTests(unittest.TestCase):
+    """The bypass shapes the fix exists to close, through the real `check()`."""
+
+    def _assert_blocked(self, cmd: str) -> None:
+        result = hook.check(_bash(cmd))
+        self.assertIsNotNone(result, f"write-then-exec must block: {cmd!r}")
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+        self.assertIn("indirect-exec", result["reason"])
+
+    def test_literal_issue_repro_newline_variant(self):
+        """The exact reproduction from the #1167 issue body."""
+        self._assert_blocked(f"cat > /tmp/s.txt <<'DELIM'\n{REAL_COMMIT}\nDELIM\nbash /tmp/s.txt")
+
+    def test_semicolon_variant(self):
+        """The issue's stated equivalent: `; bash FILE` chained onto the
+        OPENER line itself, before the heredoc's first newline. This is the
+        shape that defeats a naive fix built on `iter_interpreter_invocations`
+        (its `strip_heredocs` call erases same-line trailing text after a
+        heredoc opener) — see the module comment in `_shell_parse.py`."""
+        self._assert_blocked(f"cat <<'DELIM' > /tmp/x; bash /tmp/x\n{REAL_COMMIT}\nDELIM")
+
+    def test_append_redirect(self):
+        """`>>` append, not just `>`."""
+        self._assert_blocked(f"cat >> /tmp/s.txt <<'DELIM'\n{REAL_COMMIT}\nDELIM\nbash /tmp/s.txt")
+
+    def test_tee_sink(self):
+        """`tee` writes to its own positional argument, not via `>` redirect."""
+        self._assert_blocked(f"tee /tmp/s.txt <<'DELIM'\n{REAL_COMMIT}\nDELIM\nsh /tmp/s.txt")
+
+    def test_tee_sink_with_append_flag(self):
+        self._assert_blocked(f"tee -a /tmp/s.txt <<'DELIM'\n{REAL_COMMIT}\nDELIM\nbash /tmp/s.txt")
+
+    def test_zsh_interpreter(self):
+        self._assert_blocked(f"cat > /tmp/s.txt <<'DELIM'\n{REAL_COMMIT}\nDELIM\nzsh /tmp/s.txt")
+
+    def test_dash_interpreter(self):
+        self._assert_blocked(f"cat > /tmp/s.txt <<'DELIM'\n{REAL_COMMIT}\nDELIM\ndash /tmp/s.txt")
+
+    def test_env_prefixed_interpreter(self):
+        """`env bash FILE` — already correlates via the pre-existing
+        `strip_command_prefixes` wrapper-stripping, no new mechanism needed."""
+        self._assert_blocked(
+            f"cat > /tmp/s.txt <<'DELIM'\n{REAL_COMMIT}\nDELIM\nenv bash /tmp/s.txt"
+        )
+
+    def test_absolute_interpreter_path(self):
+        self._assert_blocked(
+            f"cat > /tmp/s.txt <<'DELIM'\n{REAL_COMMIT}\nDELIM\n/bin/bash /tmp/s.txt"
+        )
+
+    def test_dot_slash_prefix_normalization(self):
+        """Write target spelled `./s.txt`, invocation spelled `s.txt` — the
+        same file, different literal spelling. `_normalize_path_for_compare`
+        (`os.path.normpath`) unifies them without resolving against a cwd."""
+        self._assert_blocked(f"cat > ./s.txt <<'DELIM'\n{REAL_COMMIT}\nDELIM\nbash s.txt")
+
+    def test_positionally_agnostic_invocation_before_write(self):
+        """The correlation does not require the invocation to come AFTER the
+        write — a conservative, deliberate choice (see module comment)."""
+        self._assert_blocked(f"bash /tmp/s.txt\ncat > /tmp/s.txt <<'DELIM'\n{REAL_COMMIT}\nDELIM")
+
+    def test_identical_literal_variable_target(self):
+        """Not variable RESOLUTION — literal token equality. Both positions
+        spell the identical token `$F`, so it still correlates even though
+        the hook never evaluates what `$F` expands to."""
+        self._assert_blocked(f'cat > "$F" <<\'DELIM\'\n{REAL_COMMIT}\nDELIM\nbash "$F"')
+
+    def test_classifier_marks_the_span_code(self):
+        """Pinned at the primitive too, so a failure localises to the
+        classifier rather than only to the hook's verdict."""
+        (span,) = classify_heredocs(
+            f"cat > /tmp/s.txt <<'DELIM'\n{REAL_COMMIT}\nDELIM\nbash /tmp/s.txt"
+        )
+        self.assertTrue(span.is_code)
+
+    def test_strip_data_heredocs_keeps_the_body(self):
+        """The OTHER call site of the shared classification decision — pinned
+        independently so a fix applied to only one of the two duplicate
+        call sites (the main#1152 drift hazard) is caught here."""
+        cmd = f"cat > /tmp/s.txt <<'DELIM'\n{REAL_COMMIT}\nDELIM\nbash /tmp/s.txt"
+        out = strip_data_heredocs(cmd)
+        self.assertIn("commit", out)
+
+
+class WriteThenExecFalsePositiveTests(unittest.TestCase):
+    """A legitimate `cat > FILE <<'EOF' ... EOF` with no later interpreter
+    invocation on that file must still pass — the direction this fix must NOT
+    regress."""
+
+    def _assert_allowed(self, cmd: str) -> None:
+        result = hook.check(_bash(cmd))
+        self.assertIsNone(
+            result,
+            f"legitimate write with no later exec must not block: {cmd!r} "
+            f"(got: {result['reason'].splitlines()[0] if result else ''})",
+        )
+
+    def test_plain_write_no_later_invocation(self):
+        """The canonical legitimate shape named in the spawn brief."""
+        self._assert_allowed("cat > README.md <<'EOF'\nSome documentation.\nEOF")
+
+    def test_write_followed_by_unrelated_command(self):
+        self._assert_allowed("cat > /tmp/n.md <<'EOF'\nnot a commit\nEOF\nls -la")
+
+    def test_write_followed_by_invocation_of_a_different_file(self):
+        """A real interpreter invocation elsewhere in the command must not
+        make an UNRELATED heredoc's file target look executed — correlation
+        is per-path, not "any interpreter invocation anywhere flips
+        everything to code"."""
+        self._assert_allowed(
+            "cat > /tmp/s.txt <<'EOF'\nnot a commit\nEOF\nbash /tmp/other-script.sh"
+        )
+
+    def test_doc_line_written_then_unrelated_invocation(self):
+        self._assert_allowed(f"cat > /tmp/n.md <<'EOF'\n{DOC_LINE}\nEOF\nbash /tmp/build.sh")
+
+    def test_two_writes_only_one_later_invoked(self):
+        """Multi-heredoc command: only the SECOND file is later invoked, and
+        only its span must flip to code."""
+        cmd = (
+            "cat > /tmp/a.txt <<'E1'\njust prose, not code\nE1\n"
+            f"cat > /tmp/b.txt <<'E2'\n{REAL_COMMIT}\nE2\n"
+            "bash /tmp/b.txt"
+        )
+        first, second = classify_heredocs(cmd)
+        self.assertFalse(first.is_code, "the unreferenced /tmp/a.txt heredoc must stay data")
+        self.assertTrue(second.is_code, "the /tmp/b.txt heredoc, later invoked, must be code")
+
+    def test_tee_write_no_later_invocation(self):
+        self._assert_allowed("tee /tmp/n.md <<'EOF'\nnot a commit\nEOF")
+
+    def test_write_target_never_invoked_even_with_other_interpreters_present(self):
+        """A command that legitimately mentions/invokes bash for something
+        else entirely (a different script) must not implicate an unrelated
+        write."""
+        self._assert_allowed("cat > /tmp/notes.md <<'EOF'\nsome notes\nEOF\nbash -c 'echo hello'")
+
+
+class WriteThenExecMutationCoverageTests(unittest.TestCase):
+    """Targeted assertions that pin the SPECIFIC branch each mutation test in
+    the PR report exercises — see the report table for the paired
+    weaken-and-observe-failure evidence."""
+
+    def test_correlation_requires_write_AND_invocation_both(self):
+        """Neither half alone is sufficient: a write with no invocation is
+        data (already covered), and — pinned here — an invocation with no
+        corresponding write must not retroactively make an unrelated data
+        heredoc code."""
+        cmd = "cat > /tmp/a.txt <<'EOF'\nnot code\nEOF\nbash /tmp/never-written.sh"
+        (span,) = classify_heredocs(cmd)
+        self.assertFalse(span.is_code)
+
+    def test_append_and_plain_redirect_both_correlate(self):
+        plain = classify_heredocs(f"cat > /tmp/x <<'D'\n{REAL_COMMIT}\nD\nbash /tmp/x")[0]
+        append = classify_heredocs(f"cat >> /tmp/x <<'D'\n{REAL_COMMIT}\nD\nbash /tmp/x")[0]
+        self.assertTrue(plain.is_code)
+        self.assertTrue(append.is_code)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes #1167 — sibling of the **#1150 under-matching umbrella**, found during the PR #1155 merge-gate review (Aino Virtanen).

A heredoc body written to a file and **executed later in the same Bash command** reached a shell but the commit-identity gate allowed it:

```
cat > /tmp/s.txt <<'DELIM'
git -c user.name="X" -c user.email="Y" commit -m z
DELIM
bash /tmp/s.txt
```

Measured ALLOW at both `fea0dca` (main) and `e163320` (PR #1155 head) — pre-existing, not a #1155 regression. Every existing matcher missed it for a distinct reason (full account in the issue and in the new `_shell_parse.py` block comment above `_segment_write_targets`):

- `_HEREDOC_RE` requires an interpreter textually before `<<` — absent.
- `classify_heredocs` resolved the owner to `cat` (a data sink) and only followed `|` downstream — a `;`/newline-separated later command isn't in the pipeline.
- `_SCRIPT_INVOKE_RE` *does* match `bash /tmp/s.txt` and calls `_read_script_if_safe`, but the hook fires PreToolUse, before the file exists — the read fails and nothing is inspected.

## Fix — option 1 from the issue, stays inside the classifier

When a heredoc's owning segment writes the body to a file (`cat > FILE` / `>>` / `tee FILE` positional arg), and **any segment elsewhere in the command** later invokes a `SHELL_INTERPRETERS` member on that same file, the body is reclassified as CODE. The decision is centralized in one new `_is_opener_code`, called by **both** `classify_heredocs` and `strip_data_heredocs` — main#1152 already flagged the hazard of two independent "is this body code" definitions drifting apart; #1167 is exactly that hazard, since `strip_data_heredocs` is what actually feeds `validate_commit_identity`'s `scanned` text. Fixing only one call site would have left the gap open in the other (mutation-tested below).

**Deliberately not built on `iter_interpreter_invocations`.** That helper's `strip_heredocs` call erases same-line trailing text after a heredoc opener — measured directly against `cat <<'DELIM' > /tmp/x; bash /tmp/x\n...`, it strips `; bash /tmp/x` right along with the heredoc syntax. That's exactly the issue's stated semicolon-equivalent shape, so a target scan built on that helper would silently miss it. A new `_iter_non_heredoc_segments` walk reuses this module's own per-line terminator search instead, which has no such erasure bug (mutation-tested below — swapping in `iter_interpreter_invocations` breaks exactly `test_semicolon_variant`).

## Shapes covered

- Newline variant (the issue's literal repro) and the **semicolon variant** stated as equivalent in the issue
- `>>` append, not just `>`
- `tee FILE` as a sink (positional target, not a `>` redirect)
- Every `SHELL_INTERPRETERS` member (`bash`, `sh`, `zsh`, `dash`, `ksh`)
- `env bash FILE` (already correlates for free — `parse_interpreter_invocation` already strips the `env` wrapper)
- Absolute interpreter paths (`/bin/bash FILE`)
- `./FILE` vs bare `FILE` spelling (`os.path.normpath`)
- Positionally-agnostic ordering: the invocation may appear *before* the write in the command text — deliberate, since main#1152's own rule is "every ambiguity resolves toward CODE," and this is a security gate, not a scheduler
- Identical *literal* shell-variable tokens on both sides (`cat > "$F" ...; bash "$F"`) — this is literal-token equality, **not** variable resolution (see scope note below)

## Deliberately NOT covered (stated, not silent)

- **`source FILE` / `. FILE`** — shell builtins, not members of `SHELL_INTERPRETERS`. Reading a file into the *current* shell is a structurally different mechanism than spawning a new interpreter on it, and folding them in would widen `SHELL_INTERPRETERS` itself — a set several *other* matchers in this module and in `validate_commit_identity` key on. That's a broader decision than this fix; filing a follow-up issue.
- **Unexpanded shell-variable redirect targets** — not resolved by evaluation (same documented punt this module already makes for `eval "$cmd"`). The literal-token case above is a side effect of plain string comparison, not a variable-resolution feature — a rename between the write and invoke positions (`cat > "$OUT" ...; F=$OUT; bash "$F"`) defeats it exactly as true variable resolution in general would.
- **`bash < FILE`** (stdin-redirect execution) — a different execution mechanism than the positional `InterpreterInvocation.operands` this correlation reads; not resolved by the pre-existing shape-7 walker either.
- **Unspaced redirect form** (`cat>/tmp/x`, no surrounding whitespace) — `_segment_write_targets` relies on shlex already splitting `>`/`>>` into their own token, which only happens when whitespace separates them. Every shape in the issue, and every heredoc redirect in this codebase's own conventions, uses the spaced form.

## False-positive verification

`WriteThenExecFalsePositiveTests` in the new test file pins the not-over-blocking direction directly through `check()`:
- A plain `cat > README.md <<'EOF' ... EOF` with no later invocation anywhere → still allowed (the canonical legitimate shape named in the spawn brief).
- A write followed by an unrelated command, or by a *different* file's invocation → still allowed (correlation is per-path, not "any interpreter invocation anywhere flips everything to code").
- A multi-heredoc command where only ONE of two written files is later invoked → only that span flips to code; the other stays data.

Additionally, the full pre-existing `test_heredoc_target_scope.py` (101 tests/subtests, main#1152's own false-positive suite) still passes unchanged, and the full hooks+lib suite is green (2456 + 1087 passed).

## Mutation table

Each row: weaken/delete the named branch in `_shell_parse.py`, then run `test_heredoc_write_then_exec.py`, and confirm a specific named test fails (not just "something fails").

| # | Mutation | Named test(s) that fail | Result |
|---|---|---|---|
| 1 | `_is_opener_code` — remove the correlation entirely, fall back to `_opener_feeds_interpreter` only | `test_literal_issue_repro_newline_variant` + 15 others | 16 failed, 7 passed |
| 2 | `_segment_write_targets` — drop `>>` handling, keep only bare `>` | `test_append_redirect`, `test_append_and_plain_redirect_both_correlate` | 2 failed, 21 passed |
| 3 | `_segment_write_targets` — drop the `tee` positional-argument branch | `test_tee_sink`, `test_tee_sink_with_append_flag` | 2 failed, 21 passed |
| 4 | `_normalize_path_for_compare` — drop `os.path.normpath` (no normalization) | `test_dot_slash_prefix_normalization` | 1 failed, 22 passed |
| 5 | `_script_invocation_targets` — swap `_iter_non_heredoc_segments` for `iter_interpreter_invocations` (the rejected design) | `test_semicolon_variant` | 1 failed, 22 passed |
| 6a | `_classify_heredocs_cached` call site reverted to `_opener_feeds_interpreter` (leave `strip_data_heredocs` fixed) | `test_literal_issue_repro_newline_variant` + 14 others (including `test_classifier_marks_the_span_code`) | 15 failed, 8 passed |
| 6b | `strip_data_heredocs` call site reverted to `_opener_feeds_interpreter` (leave `classify_heredocs` fixed) | `test_literal_issue_repro_newline_variant` + 12 others (including `test_strip_data_heredocs_keeps_the_body`) — `test_classifier_marks_the_span_code` stays green, correctly localizing to the reverted site | 13 failed, 10 passed |

Rows 6a/6b are the empirical demonstration of the main#1152 drift hazard this PR explicitly guards against by centralizing the decision in `_is_opener_code`.

All mutations were reverted before the final commit; `git diff` against the committed state is clean.

## Verification run

- `.claude/hooks/tests/test_heredoc_write_then_exec.py` (new, 23 tests) — all pass, through the real `check()` entry point (not a private helper), matching how the issue measured the base ALLOW.
- `.claude/hooks/tests/test_heredoc_target_scope.py` (main#1152's own suite) — 101 passed / 7 subtests, unchanged.
- `.claude/hooks/tests/` full suite — 2456 passed, 628 subtests.
- `.claude/lib/tests/` full suite — 1087 passed, 19 subtests.
- `ruff format --check`, `ruff check`, `mypy .claude/hooks/ .claude/lib/ --ignore-missing-imports` — all clean.
- Both `pre-commit` stages (commit + `--hook-stage pre-push`) green on the changed files, and the push itself ran the full pre-push gate set (mypy, pytest, memory-budget, headcount-budget, doc-freshness, office-drift, mermaid-render) green.

## Follow-up

Filing a separate tech-debt issue (labels `tech-debt`/`process`/`phase-10`, no wave label) for the `source`/`.` builtin-invocation gap named above.

## Test plan

- [x] New regression suite passes through the real `check()` entry point
- [x] Full hooks + lib suites green
- [x] Mutation table above, real output
- [x] False-positive direction verified (existing #1152 suite + new dedicated tests)
- [x] Both pre-commit stages green, no `--no-verify`
