### PR TITLE
fix(hook4/#1220): scan mode must not claim an exclusion it did not apply

### DIFF
--- a/.claude/hooks/tests/test_validate_pr_review.py
+++ b/.claude/hooks/tests/test_validate_pr_review.py
@@ -39,7 +39,16 @@ from unittest import mock
 _HERE = Path(__file__).resolve().parent
 _HOOKS_DIR = _HERE.parent
 sys.path.insert(0, str(_HOOKS_DIR))
+sys.path.insert(0, str(_HOOKS_DIR.parent / "lib"))
 
+# The oracle driver (`.claude/lib/`) is the THIRD surface that renders the
+# comment-scan enum, alongside `check()`'s block message and its allow-path
+# advisory (#1273). `CommentScanModeTotalityTests` below asserts all three agree
+# on the same mode set, which is only possible from a module that can see both;
+# this import exists for that class and for nothing else. The dependency runs
+# test -> lib -> hook (pr_review_state already imports the gate), so it adds no
+# cycle to the shipped code.
+import pr_review_state as prs  # noqa: E402
 import validate_pr_review as hook  # noqa: E402
 
 
@@ -4506,25 +4515,97 @@ class IsSelfReviewTests(unittest.TestCase):
 
 
 class RefineCommentScanScopeTests(unittest.TestCase):
-    """#1210: the ONE allowed scope transition, and the three forbidden ones."""
+    """#1210's allowed transitions, re-keyed by #1220 on roster membership."""
 
+    ROSTER = {"aino virtanen", "santiago ferreira", "nino kavtaradze"}
     IDENT = (hook.CommitAuthorIdentity(lastname="Virtanen", initial="a", display="Aino Virtanen"),)
+    BOT = (
+        hook.CommitAuthorIdentity(
+            lastname="dependabot[bot]", initial="d", display="dependabot[bot]"
+        ),
+    )
 
-    def test_no_branch_author_upgrades_when_commits_named_someone(self):
+    def test_no_branch_author_upgrades_when_commits_named_a_roster_persona(self):
         self.assertEqual(
-            hook.refine_comment_scan_scope(hook.COMMENT_SCAN_NO_BRANCH_AUTHOR, self.IDENT),
+            hook.refine_comment_scan_scope(
+                hook.COMMENT_SCAN_NO_BRANCH_AUTHOR, self.IDENT, self.ROSTER
+            ),
+            hook.COMMENT_SCAN_COMMIT_AUTHOR_EXCLUDED,
+        )
+
+    def test_derived_identity_matching_no_roster_persona_is_reported_inert(self):
+        """THE #1220 unit-level kill-shot.
+
+        Pre-fix this returned COMMIT_AUTHOR_EXCLUDED — "an identity was derived"
+        reported as "an exclusion was applied". `dependabot[bot]` can never be a
+        Requestor that survives roster filtering, so nothing was subtracted and
+        the mode must not claim one was.
+        """
+        self.assertEqual(
+            hook.refine_comment_scan_scope(
+                hook.COMMENT_SCAN_NO_BRANCH_AUTHOR, self.BOT, self.ROSTER
+            ),
+            hook.COMMENT_SCAN_COMMIT_AUTHOR_NON_ROSTER,
+        )
+
+    def test_one_roster_persona_among_several_derivations_is_still_live(self):
+        """A human fixup on a bot branch. Exclusion IS live for that human, so
+        the inert reading must not win just because a bot is also in the tuple —
+        the predicate is ANY, not ALL."""
+        self.assertEqual(
+            hook.refine_comment_scan_scope(
+                hook.COMMENT_SCAN_NO_BRANCH_AUTHOR, self.BOT + self.IDENT, self.ROSTER
+            ),
+            hook.COMMENT_SCAN_COMMIT_AUTHOR_EXCLUDED,
+        )
+
+    def test_same_surname_different_person_is_not_live(self):
+        """#1172 must hold in the new predicate too: Lucas is not Santiago.
+
+        The roster here contains `santiago ferreira` and NOT Lucas. A liveness
+        check written as a surname `in` test would call this live and re-open the
+        Ferreira/Ferreira collision inside the reporting layer.
+        """
+        lucas = (
+            hook.CommitAuthorIdentity(lastname="Ferreira", initial="l", display="Lucas Ferreira"),
+        )
+        self.assertEqual(
+            hook.refine_comment_scan_scope(hook.COMMENT_SCAN_NO_BRANCH_AUTHOR, lucas, self.ROSTER),
+            hook.COMMENT_SCAN_COMMIT_AUTHOR_NON_ROSTER,
+        )
+
+    def test_unreadable_roster_keeps_the_pre_1220_answer(self):
+        """An empty roster means the roster could not be READ, not that the org
+        is empty — so "matches no roster persona" would be a finding derived
+        from a failed read. The undecidable case keeps the modal EXCLUDED
+        wording rather than asserting inertness it cannot establish."""
+        self.assertEqual(
+            hook.refine_comment_scan_scope(hook.COMMENT_SCAN_NO_BRANCH_AUTHOR, self.IDENT, set()),
             hook.COMMENT_SCAN_COMMIT_AUTHOR_EXCLUDED,
         )
 
     def test_no_branch_author_stays_when_commits_named_nobody(self):
         self.assertEqual(
-            hook.refine_comment_scan_scope(hook.COMMENT_SCAN_NO_BRANCH_AUTHOR, ()),
+            hook.refine_comment_scan_scope(hook.COMMENT_SCAN_NO_BRANCH_AUTHOR, (), self.ROSTER),
             hook.COMMENT_SCAN_NO_BRANCH_AUTHOR,
         )
 
     def test_ref_derived_author_is_never_downgraded(self):
         self.assertEqual(
-            hook.refine_comment_scan_scope(hook.COMMENT_SCAN_AUTHOR_EXCLUDED, self.IDENT),
+            hook.refine_comment_scan_scope(
+                hook.COMMENT_SCAN_AUTHOR_EXCLUDED, self.IDENT, self.ROSTER
+            ),
+            hook.COMMENT_SCAN_AUTHOR_EXCLUDED,
+        )
+
+    def test_ref_derived_author_is_not_downgraded_by_a_non_roster_derivation(self):
+        """The #1220 arm must not leak onto the ref path either: a declared
+        `{Initial}.{Lastname}` author keeps its exclusion whatever the commits
+        say, including when they say `dependabot[bot]`."""
+        self.assertEqual(
+            hook.refine_comment_scan_scope(
+                hook.COMMENT_SCAN_AUTHOR_EXCLUDED, self.BOT, self.ROSTER
+            ),
             hook.COMMENT_SCAN_AUTHOR_EXCLUDED,
         )
 
@@ -4535,9 +4616,28 @@ class RefineCommentScanScopeTests(unittest.TestCase):
         defense-in-depth hard-block one layer up.
         """
         self.assertEqual(
-            hook.refine_comment_scan_scope(hook.COMMENT_SCAN_NOT_RUN, self.IDENT),
+            hook.refine_comment_scan_scope(hook.COMMENT_SCAN_NOT_RUN, self.IDENT, self.ROSTER),
             hook.COMMENT_SCAN_NOT_RUN,
         )
+
+    def test_not_run_is_not_relabelled_as_inert_either(self):
+        """#1220 added a second reachable answer, so NOT_RUN now has two ways to
+        be laundered. Both must be closed."""
+        self.assertEqual(
+            hook.refine_comment_scan_scope(hook.COMMENT_SCAN_NOT_RUN, self.BOT, self.ROSTER),
+            hook.COMMENT_SCAN_NOT_RUN,
+        )
+
+    def test_roster_names_is_required_not_defaulted(self):
+        """A caller that forgets the roster must fail loudly.
+
+        A `set()` default would read as "roster unreadable" and hand them a
+        plausible EXCLUDED answer for every input — the silent-wrong direction.
+        """
+        with self.assertRaises(TypeError):
+            hook.refine_comment_scan_scope(  # type: ignore[call-arg]
+                hook.COMMENT_SCAN_NO_BRANCH_AUTHOR, self.BOT
+            )
 
 
 class CommitIdentitySelfReviewExclusionTests(_ResolveOverFakeCommentsHarness):
@@ -4658,6 +4758,69 @@ class CommitIdentitySelfReviewExclusionTests(_ResolveOverFakeCommentsHarness):
         self.assertEqual(
             [i.display for i in verdicts.commit_author_identities], ["dependabot[bot]"]
         )
+        # #1220: THE assertion this test was missing, and the reason it stayed
+        # green through the defect. It pinned the count and the derived
+        # identities — the safe half of the claim — while the mode said
+        # `commit-author-excluded`, i.e. announced a subtraction of a verdict
+        # that was never subtracted. Both approvals are still counted above; the
+        # mode must now describe that honestly.
+        self.assertEqual(verdicts.comment_scan, hook.COMMENT_SCAN_COMMIT_AUTHOR_NON_ROSTER)
+
+    def test_bot_branch_with_a_human_fixup_commit_still_reports_live_exclusion(self):
+        """Anti-vacuity control for the test above (#1220).
+
+        Same dependabot ref, same two roster approvals — except one commit is
+        authored by one of the approvers. Without this, the assertion above would
+        be satisfied by a change that simply stopped ever reporting
+        COMMIT_AUTHOR_EXCLUDED on a non-charter ref, which would re-open #1210:
+        Nino's own verdict must still be subtracted AND still be described as
+        subtracted.
+        """
+        verdicts = self._resolve(
+            self.DEPENDABOT_REF,
+            [self._verdict("Lucas Ferreira"), self._verdict("Nino Kavtaradze")],
+            commits=[
+                _api_commit(
+                    "c0",
+                    "2026-07-15T19:13:59Z",
+                    author_name="dependabot[bot]",
+                    author_email="49699333+dependabot[bot]@users.noreply.github.com",
+                ),
+                _api_commit(
+                    "c1",
+                    "2026-07-15T19:13:59Z",
+                    author_name="Nino Kavtaradze",
+                    author_email="parametrization+Nino.Kavtaradze@gmail.com",
+                ),
+            ],
+        )
+        self.assertEqual(verdicts.distinct_reviewers, {"lucas ferreira"})
+        self.assertEqual(verdicts.total_distinct, 1)
+        self.assertEqual(verdicts.comment_scan, hook.COMMENT_SCAN_COMMIT_AUTHOR_EXCLUDED)
+
+    def test_an_unreadable_roster_does_not_report_the_bot_as_inert(self):
+        """The degraded read must not masquerade as an inertness measurement.
+
+        With an unreadable roster (`_load_roster_names` returns the empty set)
+        EVERY identity trivially matches nothing, so a naive predicate would
+        report `commit-author-non-roster` — a confident claim about roster
+        membership derived from a failed roster read. The mode falls back to the
+        pre-#1220 answer instead.
+        """
+        verdicts = self._resolve(
+            self.DEPENDABOT_REF,
+            [self._verdict("Lucas Ferreira"), self._verdict("Nino Kavtaradze")],
+            roster=set(),
+            commits=[
+                _api_commit(
+                    "c0",
+                    "2026-07-15T19:13:59Z",
+                    author_name="dependabot[bot]",
+                    author_email="49699333+dependabot[bot]@users.noreply.github.com",
+                )
+            ],
+        )
+        self.assertEqual(verdicts.comment_scan, hook.COMMENT_SCAN_COMMIT_AUTHOR_EXCLUDED)
 
     def test_squash_flattened_identity_excludes_nobody(self):
         """The bare principal must not resolve to the persona roster.json maps it to.
@@ -5069,6 +5232,67 @@ class CommitAuthorBlockDiagnosticTests(_ResolveOverFakeCommentsHarness):
         self.assertIn("WITHOUT self-review exclusion", unavailable)
         self.assertNotIn("WITHOUT self-review exclusion", excluded)
 
+    BOT = hook.CommitAuthorIdentity(
+        lastname="dependabot[bot]", initial="d", display="dependabot[bot]"
+    )
+
+    def test_non_roster_derivation_does_not_claim_a_subtraction(self):
+        """#1220 at the block surface.
+
+        Pre-fix this input produced the COMMIT_AUTHOR_EXCLUDED text, which told
+        the operator "Verdicts from those personas were excluded as self-reviews"
+        on a PR where nothing had been excluded — sending them to look for a
+        dropped verdict that never existed.
+        """
+        reason = self._block_reason(
+            self._verdicts(hook.COMMENT_SCAN_COMMIT_AUTHOR_NON_ROSTER, (self.BOT,))
+        )
+        # Still NAMES the derivation — it is what an operator would audit if
+        # they suspected the wrong person had been picked.
+        self.assertIn("COMMIT IDENTITY", reason)
+        self.assertIn("dependabot[bot]", reason)
+        # And states the fact the old message got wrong.
+        self.assertIn("matches no roster persona", reason)
+        self.assertIn("NO verdict was excluded as a self-review", reason)
+        # The false claim must be gone, not merely joined by a true one.
+        self.assertNotIn("is excluded as a self-review;", reason)
+        # The count itself is untouched by the mode (this is a description fix).
+        self.assertIn("1/2 required peer reviews", reason)
+
+    def test_inert_and_live_commit_derivations_read_differently(self):
+        """The two commit-derived modes make OPPOSITE claims about whether a
+        verdict was subtracted, so sharing wording would restore exactly the
+        ambiguity #1220 removed. Both name the derivation; only one asserts an
+        exclusion."""
+        live = self._block_reason(
+            self._verdicts(
+                hook.COMMENT_SCAN_COMMIT_AUTHOR_EXCLUDED,
+                (
+                    hook.CommitAuthorIdentity(
+                        lastname="Kavtaradze", initial="n", display="Nino Kavtaradze"
+                    ),
+                ),
+            )
+        )
+        inert = self._block_reason(
+            self._verdicts(hook.COMMENT_SCAN_COMMIT_AUTHOR_NON_ROSTER, (self.BOT,))
+        )
+        self.assertNotEqual(live, inert)
+        self.assertIn("is excluded as a self-review", live)
+        self.assertNotIn("matches no roster persona", live)
+        self.assertIn("matches no roster persona", inert)
+
+    def test_inert_mode_is_not_collapsed_into_the_no_author_wording(self):
+        """It must not borrow NO_BRANCH_AUTHOR's text either: that mode's claim
+        is "the PR's commits named no persona", and here they named one."""
+        inert = self._block_reason(
+            self._verdicts(hook.COMMENT_SCAN_COMMIT_AUTHOR_NON_ROSTER, (self.BOT,))
+        )
+        no_author = self._block_reason(self._verdicts(hook.COMMENT_SCAN_NO_BRANCH_AUTHOR))
+        self.assertNotEqual(inert, no_author)
+        self.assertIn("commits named no persona either", no_author)
+        self.assertNotIn("commits named no persona either", inert)
+
 
 class AllowPathScanDisclosureTests(_ResolveOverFakeCommentsHarness):
     """#1211: the ALLOW path must say when self-review exclusion was unavailable.
@@ -5278,6 +5502,273 @@ class AllowPathScanDisclosureTests(_ResolveOverFakeCommentsHarness):
         allowed = self._allow_result(self._verdicts(hook.COMMENT_SCAN_NO_BRANCH_AUTHOR))
         assert allowed is not None
         self.assertEqual(allowed["decision"], "allow")
+
+    BOT_IDENTITY = (
+        hook.CommitAuthorIdentity(
+            lastname="dependabot[bot]", initial="d", display="dependabot[bot]"
+        ),
+    )
+
+    def test_inert_commit_derivation_also_discloses_on_the_allow_path(self):
+        """#1220 extends #1211's disclosure to the mode it split off.
+
+        COMMIT_AUTHOR_NON_ROSTER produces a reviewer set byte-identical to
+        NO_BRANCH_AUTHOR's — no verdict was excluded in either — so the #1211
+        exposure is identical and the disclosure must fire. Pre-#1220 this input
+        was labelled COMMIT_AUTHOR_EXCLUDED and the advisory stayed SILENT on it,
+        i.e. the gate skipped the disclosure on the strength of a subtraction it
+        had not performed.
+        """
+        result = self._allow_result(
+            self._verdicts(hook.COMMENT_SCAN_COMMIT_AUTHOR_NON_ROSTER, identities=self.BOT_IDENTITY)
+        )
+        assert result is not None, "an inert derivation excluded nothing — that must be disclosed"
+        self.assertEqual(result["decision"], "allow")
+        message = result["systemMessage"]
+        self.assertIn("WITHOUT self-review exclusion", message)
+        self.assertIn("dependabot[bot]", message)
+        self.assertIn("matches no roster persona", message)
+        self.assertIn(self.HEAD_REF, message)
+        self.assertIn("2/2", message)
+        self.assertNotIn("BLOCKED", message)
+
+    def test_the_two_no_exclusion_advisories_are_not_the_same_text(self):
+        """Both disclose "nothing was excluded" and they do so for different
+        reasons — one because nobody was derivable, one because the person
+        derived is not a roster persona. A reader has to be able to tell which,
+        because only the second one names an identity worth auditing."""
+        derived = self._allow_result(
+            self._verdicts(hook.COMMENT_SCAN_COMMIT_AUTHOR_NON_ROSTER, identities=self.BOT_IDENTITY)
+        )
+        none_derived = self._allow_result(self._verdicts(hook.COMMENT_SCAN_NO_BRANCH_AUTHOR))
+        assert derived is not None and none_derived is not None
+        self.assertNotEqual(derived["systemMessage"], none_derived["systemMessage"])
+        self.assertIn("COMMIT IDENTITY", derived["systemMessage"])
+        self.assertNotIn("COMMIT IDENTITY", none_derived["systemMessage"])
+        # Exactly one advisory each — the new branch must not double-emit.
+        self.assertEqual(derived["systemMessage"].count("NOTE: PR"), 1)
+        self.assertEqual(none_derived["systemMessage"].count("NOTE: PR"), 1)
+
+    def test_advisory_reports_the_real_count_on_a_wave_bootstrap_single_reviewer(self):
+        """The allow tail is reachable at 1/2, and the count must not be a literal.
+
+        `check()` allows a 1/2 PR through the wave-bootstrap single-reviewer
+        exception, so this advisory can fire on a PR with ONE reviewer. Every
+        pre-existing test here supplies a 2/2 fixture, which is why hardcoding
+        the count to `2/2` survived the whole suite — found by Nadia Khoury
+        reviewing #1270. Both no-exclusion modes are checked, so neither branch
+        can regress to a literal.
+        """
+        for mode, identities in (
+            (hook.COMMENT_SCAN_NO_BRANCH_AUTHOR, ()),
+            (hook.COMMENT_SCAN_COMMIT_AUTHOR_NON_ROSTER, self.BOT_IDENTITY),
+        ):
+            with self.subTest(mode=mode):
+                verdicts = self._verdicts(mode, identities=identities)
+                verdicts.distinct_reviewers = {"aino virtanen"}
+                verdicts.wave_bootstrap_exception = True
+                result = self._allow_result(verdicts)
+                assert result is not None, "the disclosure must ride the bootstrap allow too"
+                self.assertEqual(result["decision"], "allow")
+                message = result["systemMessage"]
+                self.assertIn("reached 1/2 WITHOUT self-review exclusion", message)
+                self.assertNotIn("2/2", message)
+
+
+class CommentScanModeTotalityTests(unittest.TestCase):
+    """Every COMMENT_SCAN_* mode must be WIRED on every surface that renders it.
+
+    #1273: the enum is rendered by three independent hand-written surfaces —
+    `check()`'s block `scan_diagnostic`, `check()`'s allow-path advisory, and
+    `pr_review_state._describe_comment_scan` — and nothing pinned that a new
+    mode reached all three. #1220 added a fifth mode, which is exactly the event
+    that would have exercised the gap, so the pin lands with it.
+
+    The coverage table below is DELIBERATE, not derived: a mode's absence from a
+    surface is a decision (AUTHOR_EXCLUDED needs no block diagnostic — the ref
+    names the author, nothing is surprising), and the `_TABLE` equality guard
+    makes adding a sixth mode fail here until someone records that decision.
+    """
+
+    # mode -> (block diagnostic expected?, allow advisory expected?)
+    _TABLE = {
+        # The scan never ran: the block path must SHOUT, and the allow path is
+        # unreachable (`resolve_review_verdicts` hard-blocks upstream).
+        hook.COMMENT_SCAN_NOT_RUN: (True, False),
+        # Nothing excluded, nobody derived: both surfaces disclose (#1206/#1211).
+        hook.COMMENT_SCAN_NO_BRANCH_AUTHOR: (True, True),
+        # Nothing excluded, someone derived: both surfaces disclose (#1220).
+        hook.COMMENT_SCAN_COMMIT_AUTHOR_NON_ROSTER: (True, True),
+        # Exclusion applied on commit evidence: block names the subtraction; the
+        # allow path stays silent because exclusion can only remove verdicts and
+        # so can never manufacture a pass (#1210/#1211).
+        hook.COMMENT_SCAN_COMMIT_AUTHOR_EXCLUDED: (True, False),
+        # Exclusion applied on the ref the human declared: nothing surprising to
+        # report on either surface.
+        hook.COMMENT_SCAN_AUTHOR_EXCLUDED: (False, False),
+    }
+
+    UNRECOGNIZED = "UNRECOGNIZED SCAN MODE"
+
+    def test_table_covers_exactly_the_declared_mode_set(self):
+        """The guard that makes every other test in this class total.
+
+        Without it, adding a sixth constant would leave the loops below iterating
+        five modes and passing — the vacuity #1215 is about.
+        """
+        self.assertEqual(set(self._TABLE), set(hook.ALL_COMMENT_SCAN_MODES))
+        self.assertEqual(
+            len(hook.ALL_COMMENT_SCAN_MODES),
+            len(set(hook.ALL_COMMENT_SCAN_MODES)),
+            "ALL_COMMENT_SCAN_MODES must not contain duplicates",
+        )
+
+    @staticmethod
+    def _verdicts(comment_scan, *, reviewers):
+        return hook.ReviewVerdicts(
+            number=691,
+            head_ref="dependabot/docker/x-1.2.3",
+            labels=[],
+            branch_author_lastname=None,
+            content_sha="837c272a",
+            content_ts=None,
+            formal_reviewers=set(),
+            comment_reviewers=set(reviewers),
+            non_roster_requestors=set(),
+            roster_comment_reviewers=set(reviewers),
+            roster_names={"aino virtanen", "nino kavtaradze"},
+            distinct_reviewers=set(reviewers),
+            stale_verdicts_comment=[],
+            stale_verdicts_formal=[],
+            reviews_missing_tech_debt=[],
+            tech_debt_issue_numbers=[],
+            tech_debt_unparseable=[],
+            wave_bootstrap_exception=False,
+            comment_scan=comment_scan,
+            commit_author_identities=(
+                hook.CommitAuthorIdentity(
+                    lastname="dependabot[bot]", initial="d", display="dependabot[bot]"
+                ),
+            ),
+        )
+
+    def _check(self, comment_scan, *, reviewers):
+        input_data = {
+            "tool_name": "Bash",
+            "tool_input": {"command": "gh pr merge 691 --repo noorinalabs/noorinalabs-main"},
+        }
+        with (
+            mock.patch.object(
+                hook,
+                "get_pr_data",
+                return_value={
+                    "author": "parametrization",
+                    "number": 691,
+                    "reviews": [],
+                    "headRefName": "dependabot/docker/x-1.2.3",
+                    "labels": [],
+                },
+            ),
+            mock.patch.object(
+                hook,
+                "resolve_review_verdicts",
+                return_value=self._verdicts(comment_scan, reviewers=reviewers),
+            ),
+            mock.patch.object(hook, "log_pretooluse_block"),
+        ):
+            return hook.check(input_data)
+
+    def test_every_mode_gets_its_declared_block_diagnostic(self):
+        """A mode with no block branch renders a bare count — the pre-#1206
+        state, where a number with no provenance read as a measurement."""
+        for mode, (wants_block, _) in self._TABLE.items():
+            with self.subTest(mode=mode):
+                result = self._check(mode, reviewers={"aino virtanen"})
+                assert result is not None
+                reason = str(result["reason"])
+                # The generic 2-reviewer body is always present; the scan
+                # diagnostic is the prefix that precedes it.
+                prefix = reason.split("BLOCKED: PR #691 has 1/2 required peer reviews")[0]
+                if wants_block:
+                    self.assertTrue(
+                        prefix.strip(), f"{mode} renders no block scan diagnostic at all"
+                    )
+                    self.assertIn(
+                        "scan",
+                        prefix.lower(),
+                        f"{mode}'s block diagnostic never mentions the scan",
+                    )
+                else:
+                    self.assertEqual(prefix, "", f"{mode} unexpectedly renders a block diagnostic")
+
+    def test_every_mode_matches_its_declared_allow_advisory_coverage(self):
+        for mode, (_, wants_advisory) in self._TABLE.items():
+            with self.subTest(mode=mode):
+                result = self._check(mode, reviewers={"aino virtanen", "nino kavtaradze"})
+                if wants_advisory:
+                    assert result is not None, f"{mode} must disclose on the allow path"
+                    self.assertEqual(result["decision"], "allow")
+                    self.assertIn("self-review exclusion", result["systemMessage"])
+                else:
+                    self.assertIsNone(result, f"{mode} must stay silent on the allow path")
+
+    def test_every_mode_renders_a_recognized_report_line(self):
+        """`pr_review_state._describe_comment_scan` used to end in a bare
+        `return` on NO_BRANCH_AUTHOR's text, so an unwired mode was described as
+        "the PR's commits named no persona" — confident, specific, wrong. The
+        fallback now says UNRECOGNIZED; no declared mode may reach it."""
+        for mode in hook.ALL_COMMENT_SCAN_MODES:
+            with self.subTest(mode=mode):
+                line = prs._describe_comment_scan(
+                    _review_state_for_mode(mode, commit_authors=["dependabot[bot]"])
+                )
+                self.assertTrue(line.strip(), f"{mode} renders an empty report line")
+                self.assertNotIn(self.UNRECOGNIZED, line, f"{mode} is unwired in the oracle report")
+
+    def test_report_lines_are_pairwise_distinct(self):
+        """Two modes that render identically cannot be told apart by the reader,
+        which is the whole reason the enum exists."""
+        rendered = {
+            mode: prs._describe_comment_scan(
+                _review_state_for_mode(mode, commit_authors=["dependabot[bot]"])
+            )
+            for mode in hook.ALL_COMMENT_SCAN_MODES
+        }
+        self.assertEqual(
+            len(set(rendered.values())),
+            len(rendered),
+            f"collapsed report lines: {rendered}",
+        )
+
+    def test_the_unrecognized_marker_is_actually_reachable(self):
+        """Positive control for the two tests above.
+
+        If the fallback were unreachable — or the marker string a typo — the
+        `assertNotIn` assertions would pass for every input forever, including
+        for a mode nobody wired. An undeclared mode must hit it.
+        """
+        line = prs._describe_comment_scan(_review_state_for_mode("some-future-mode"))
+        self.assertIn(self.UNRECOGNIZED, line)
+        self.assertIn("some-future-mode", line)
+
+
+def _review_state_for_mode(comment_scan, *, commit_authors=()):
+    """A minimal `pr_review_state.ReviewState` carrying just the scan mode."""
+    return prs.ReviewState(
+        pr_number="691",
+        repo="noorinalabs/noorinalabs-main",
+        head_ref="dependabot/docker/x-1.2.3",
+        branch_author_lastname="Ferreira",
+        formal_reviewers=[],
+        comment_reviewers=[],
+        non_roster_requestors=[],
+        distinct_reviewer_count=0,
+        wave_bootstrap_exception=False,
+        reviews_missing_tech_debt=[],
+        tech_debt_issue_numbers=[],
+        comment_scan=comment_scan,
+        commit_authors=list(commit_authors),
+    )
 
 
 if __name__ == "__main__":

--- a/.claude/hooks/validate_pr_review.py
+++ b/.claude/hooks/validate_pr_review.py
@@ -1025,7 +1025,59 @@ COMMENT_SCAN_NO_BRANCH_AUTHOR = "no-branch-author"
 # different evidence and an operator reading a block message needs to know
 # which: the ref prefix is a human declaration, the commit author is a
 # measurement, and only the latter can be defeated by a squash (#1177).
+#
+# As of #1220 this mode requires the derived identity to name a ROSTER persona.
+# See COMMENT_SCAN_COMMIT_AUTHOR_NON_ROSTER below for why.
 COMMENT_SCAN_COMMIT_AUTHOR_EXCLUDED = "commit-author-excluded"
+# The ref named no persona, the COMMITS named someone, and that someone matches
+# NO roster persona — a `dependabot[bot]`, a `GitHub` web-UI commit, an outside
+# contributor (#1220).
+#
+# WHY THIS IS ITS OWN STATE AND NOT A REUSE OF EITHER NEIGHBOUR. "An identity
+# was derived" and "an exclusion was applied" are two different facts, and
+# pre-#1220 `refine_comment_scan_scope` reported the first as if it were the
+# second: on a dependabot head ref carrying two genuine roster approvals the
+# gate correctly counted both (deploy#691 stays fixed) and then described itself
+# as having subtracted a self-review that never existed. The COUNT was right and
+# the DESCRIPTION was false — the same defect class #1206/#1207 fixed, one layer
+# up.
+#
+# It is not NO_BRANCH_AUTHOR either: that mode's whole claim is "the PR's commits
+# named no persona", and here they named `dependabot[bot]`. Collapsing the two
+# would throw away the derived identity an operator needs in order to check the
+# classification — the derivation is exactly what they would want to audit if
+# they suspected it had picked the wrong person.
+#
+# The inertness is provable, not incidental, and it is the same argument
+# `commit_author_identities` already makes for not roster-filtering the
+# derivation itself: only roster-valid Requestors can enter `distinct_reviewers`
+# (`resolve_review_verdicts` filters them), so an exclusion keyed on a non-roster
+# identity can only ever remove a verdict that roster filtering would have
+# removed anyway. The count under this mode is identical to the count under
+# NO_BRANCH_AUTHOR — which is why this is a reporting distinction and touches no
+# threshold.
+COMMENT_SCAN_COMMIT_AUTHOR_NON_ROSTER = "commit-author-non-roster"
+
+# Every comment-scan mode, in one place (#1220, narrowing #1273).
+#
+# Exists so a totality test can iterate the mode set rather than a hand-copied
+# list: the enum is rendered by THREE independent hand-written surfaces
+# (`check()`'s block `scan_diagnostic`, `check()`'s allow-path advisory, and
+# `pr_review_state._describe_comment_scan`), and before this tuple existed a
+# sixth mode could be added with none of them noticing — the reader would get a
+# blank or a wrong description, silently. `test_validate_pr_review.py::
+# CommentScanModeTotalityTests` iterates this tuple and fails if any mode is
+# unwired on any surface.
+#
+# Order is narrative (least to most evidence about the branch author), not
+# semantic; nothing may branch on position.
+ALL_COMMENT_SCAN_MODES = (
+    COMMENT_SCAN_NOT_RUN,
+    COMMENT_SCAN_NO_BRANCH_AUTHOR,
+    COMMENT_SCAN_COMMIT_AUTHOR_NON_ROSTER,
+    COMMENT_SCAN_COMMIT_AUTHOR_EXCLUDED,
+    COMMENT_SCAN_AUTHOR_EXCLUDED,
+)
 
 
 def comment_scan_scope(head_ref: str) -> str:
@@ -1071,15 +1123,54 @@ def comment_scan_scope(head_ref: str) -> str:
     )
 
 
+def commit_author_exclusion_is_live(
+    commit_authors: tuple[CommitAuthorIdentity, ...],
+    roster_names: set[str],
+) -> bool:
+    """True when a commit-derived identity could actually remove a verdict (#1220).
+
+    An exclusion keyed on an identity that matches no roster persona is INERT by
+    construction: `resolve_review_verdicts` filters `comment_reviewers` against
+    the roster, so a Requestor that `is_self_review` would drop for matching
+    `dependabot[bot]` could never have reached `distinct_reviewers` anyway. This
+    is the same argument `commit_author_identities` makes for NOT roster-filtering
+    the derivation itself — stated here as a predicate so the reporting layer can
+    tell an operator which of the two situations they are in.
+
+    Comparison is `charter_trailer.is_branch_author`, the ONE person-comparison
+    in the org (#1172). There is deliberately no surname `in` test written here:
+    a roster containing `santiago ferreira` must NOT make a commit authored by
+    `Lucas Ferreira` look live, and the initial discriminator is what prevents
+    that.
+
+    `roster_names` are lowercase canonical persona names as `_load_roster_names`
+    returns them; `is_branch_author` lowercases both sides, so the case does not
+    matter here.
+
+    NOTE the empty-roster case is NOT decided here — an empty `roster_names`
+    means the roster could not be READ (`_load_roster_names`'s documented
+    degraded return), not that the org has no members, and this function would
+    answer False for every identity on that input. `refine_comment_scan_scope`
+    handles it explicitly rather than letting the degraded read masquerade as a
+    finding.
+    """
+    return any(
+        is_branch_author(name, identity.lastname, identity.initial)
+        for identity in commit_authors
+        for name in roster_names
+    )
+
+
 def refine_comment_scan_scope(
     ref_scope: str,
     commit_authors: tuple[CommitAuthorIdentity, ...],
+    roster_names: set[str],
 ) -> str:
-    """Upgrade a ref-derived scan scope with what the PR's COMMITS said (#1210).
+    """Refine a ref-derived scan scope with what the PR's COMMITS said (#1210/#1220).
 
-    Exactly ONE transition: `NO_BRANCH_AUTHOR` → `COMMIT_AUTHOR_EXCLUDED`, and
-    only when at least one identity was derived. Everything else is returned
-    untouched, which is the whole safety argument for this function:
+    Only `NO_BRANCH_AUTHOR` is ever refined, into one of three answers. Every
+    other input is returned untouched, which is the whole safety argument for
+    this function:
 
       - `AUTHOR_EXCLUDED` is never downgraded — a ref that names a persona keeps
         its exclusion no matter what the commits say.
@@ -1087,16 +1178,45 @@ def refine_comment_scan_scope(
         a mode. `resolve_review_verdicts` hard-blocks on it upstream, and
         silently relabelling it here would launder that block into a result.
       - `NO_BRANCH_AUTHOR` with no derived identity stays as it was, so the
-        honest "exclusion was not available" reporting survives for genuine bot
-        branches and for commit data that named nobody.
+        honest "exclusion was not available" reporting survives for a
+        merge-only branch and for commit data that named nobody.
+
+    #1220 SPLIT THE UPGRADE IN TWO. It used to be keyed on `commit_authors`
+    being non-empty alone, i.e. on "an identity was derived" — which is not the
+    same fact as "an exclusion was applied". On a `dependabot/**` ref the first
+    is true and the second is false, so the mode announced a subtraction that
+    never happened while the count (correctly) included both roster approvals.
+    Keying the EXCLUDED answer on `commit_author_exclusion_is_live` and giving
+    the inert case its own `COMMIT_AUTHOR_NON_ROSTER` mode makes the description
+    match the arithmetic. The count is untouched either way — both modes produce
+    exactly the reviewer set `NO_BRANCH_AUTHOR` would have produced, because the
+    exclusion itself still runs off the same unfiltered `commit_authors` tuple.
+
+    AN UNREADABLE ROSTER IS NOT AN INERTNESS FINDING. `_load_roster_names`
+    returns the empty set when the roster dirs could not be read, and on that
+    input every identity trivially "matches no roster persona" — reporting
+    NON_ROSTER there would state a measurement derived from a failed read, the
+    `feedback_silent_zero_is_not_a_measurement` shape this enum exists to
+    prevent. So an empty roster keeps the pre-#1220 answer: an identity WAS
+    derived, `is_self_review` IS keyed on it, and whether it bit is unknown —
+    which is what `COMMIT_AUTHOR_EXCLUDED`'s (modal, post-#1220) wording says.
 
     The mode is a REPORT, not a decision: the exclusion itself is applied by
-    `is_self_review` from the same `commit_authors` tuple. They cannot drift
-    because both read that one value.
+    `is_self_review` from the same `commit_authors` tuple, unfiltered. They
+    cannot drift because both read that one value.
+
+    `roster_names` is REQUIRED, not defaulted. A default of `set()` would read
+    as "roster unreadable" to the branch above and quietly hand a caller who
+    forgot the argument a plausible answer; a missing argument must be a
+    TypeError at the call site instead.
     """
-    if ref_scope == COMMENT_SCAN_NO_BRANCH_AUTHOR and commit_authors:
+    if ref_scope != COMMENT_SCAN_NO_BRANCH_AUTHOR or not commit_authors:
+        return ref_scope
+    if not roster_names:
         return COMMENT_SCAN_COMMIT_AUTHOR_EXCLUDED
-    return ref_scope
+    if commit_author_exclusion_is_live(commit_authors, roster_names):
+        return COMMENT_SCAN_COMMIT_AUTHOR_EXCLUDED
+    return COMMENT_SCAN_COMMIT_AUTHOR_NON_ROSTER
 
 
 PROJECT_NUMBER = 2
@@ -2019,7 +2139,6 @@ def resolve_review_verdicts(pr_data: dict, repo: str | None = None) -> ReviewVer
     commit_authors: tuple[CommitAuthorIdentity, ...] = (
         () if branch_author_lastname else commit_author_identities(commits)
     )
-    scan_scope = refine_comment_scan_scope(scan_scope, commit_authors)
 
     comment_result = check_comment_reviews(
         number,
@@ -2040,6 +2159,21 @@ def resolve_review_verdicts(pr_data: dict, repo: str | None = None) -> ReviewVer
         raise CommentScanUndeterminedError(comment_result.undetermined)
 
     roster_names = _load_roster_names(repo=repo)
+
+    # Refined AFTER the roster load, not before, because #1220's discriminator
+    # is "does a derived identity name a roster persona" and that needs the
+    # roster. Deliberately placed here rather than hoisting `_load_roster_names`
+    # above `check_comment_reviews`: hoisting it would move `RosterResolutionError`
+    # ahead of `CommentScanUndeterminedError` in the raise order, so a PR with
+    # BOTH an unreadable comment thread and an unresolvable child roster would
+    # start reporting a different one of its two determinate failures. Both
+    # hard-block, so nothing counts differently — but the diagnosis an operator
+    # is handed would silently change, and this issue is about descriptions.
+    #
+    # `scan_scope` is not read between `comment_scan_scope` above and here;
+    # `check_comment_reviews` takes the branch author and the identities, never
+    # the mode.
+    scan_scope = refine_comment_scan_scope(scan_scope, commit_authors, roster_names)
 
     non_roster_requestors = {r for r in comment_result.reviewers if r not in roster_names}
     roster_comment_reviewers = comment_result.reviewers - non_roster_requestors
@@ -2410,10 +2544,26 @@ def check(input_data: dict) -> dict | None:
             scan_diagnostic = (
                 f"NOTE: head ref `{verdicts.head_ref or '(unknown)'}` carries no "
                 "`{Initial}.{Lastname}` branch-author prefix, so the branch author was "
-                f"derived from COMMIT IDENTITY instead: {derived}. Verdicts from those "
-                "personas were excluded as self-reviews; every other roster-valid Approved "
+                f"derived from COMMIT IDENTITY instead: {derived}. Any verdict from those "
+                "personas is excluded as a self-review; every other roster-valid Approved "
                 "Requestor counts. The scan DID run; the count below is a real measurement "
                 "(#1210).\n\n"
+            )
+        elif verdicts.comment_scan == COMMENT_SCAN_COMMIT_AUTHOR_NON_ROSTER:
+            # #1220: an identity WAS derived, and it excluded nothing. Saying so
+            # is the point — the pre-#1220 message claimed a subtraction here,
+            # which sent an operator looking for a verdict that was never
+            # dropped. Naming the identity still matters: it is what they would
+            # audit if they thought the derivation had picked the wrong person.
+            derived = ", ".join(i.display for i in verdicts.commit_author_identities) or "(none)"
+            scan_diagnostic = (
+                f"NOTE: head ref `{verdicts.head_ref or '(unknown)'}` carries no "
+                "`{Initial}.{Lastname}` branch-author prefix, so the branch author was "
+                f"derived from COMMIT IDENTITY instead: {derived} — which matches no roster "
+                "persona, so NO verdict was excluded as a self-review (a bot, a web-UI "
+                "commit, or an outside contributor). Every roster-valid Approved Requestor "
+                "counts. The scan DID run; the count below is a real measurement "
+                "(#1206/#1220).\n\n"
             )
         elif verdicts.comment_scan == COMMENT_SCAN_NO_BRANCH_AUTHOR:
             scan_diagnostic = (
@@ -2577,7 +2727,16 @@ def check(input_data: dict) -> dict | None:
     # on a ref that names nobody, and the operator would see no trace of it.
     # Disclosing only on block told them the one thing they did not need.
     #
-    # Scoped deliberately to NO_BRANCH_AUTHOR:
+    # Scoped deliberately to the two modes under which NOTHING was excluded:
+    #   - NO_BRANCH_AUTHOR — neither the ref nor the commits named anyone.
+    #   - COMMIT_AUTHOR_NON_ROSTER (#1220) — the commits named someone who is
+    #     not a roster persona, so the exclusion was armed on an identity that
+    #     could not appear in the reviewer set and removed nothing. The reviewer
+    #     set here is byte-identical to the one NO_BRANCH_AUTHOR would produce,
+    #     so the #1211 exposure is byte-identical too: staying silent because an
+    #     identity happened to be derivable would disclose on the arithmetic's
+    #     twin and not on the arithmetic itself.
+    # and deliberately NOT to:
     #   - AUTHOR_EXCLUDED / COMMIT_AUTHOR_EXCLUDED — exclusion WAS applied.
     #     Applying it can only REMOVE verdicts, so it can never manufacture a
     #     pass; the block path already names those subtractions, which is where
@@ -2585,6 +2744,11 @@ def check(input_data: dict) -> dict | None:
     #   - NOT_RUN — `resolve_review_verdicts` hard-blocks upstream, so it is
     #     unreachable here; it is left alone rather than given wording that
     #     could only ever fire on a regression already caught elsewhere.
+    #
+    # `total_distinct` is interpolated, never a literal `2`: this tail is also
+    # reachable at 1/2 through the wave-bootstrap single-reviewer exception, and
+    # a hardcoded count would misreport exactly the PR that had the fewest
+    # reviewers to lose.
     #
     # Wording is proportionate on purpose: an allowed merge is a correct
     # outcome under the charter threshold, and this states which discriminator
@@ -2600,6 +2764,17 @@ def check(input_data: dict) -> dict | None:
             "counted, including any posted by whoever wrote this branch. The scan DID "
             "run and the charter threshold is unchanged — this states which "
             "discriminator was unavailable, not a defect (#1206/#1211)."
+        )
+    elif verdicts.comment_scan == COMMENT_SCAN_COMMIT_AUTHOR_NON_ROSTER:
+        derived = ", ".join(i.display for i in verdicts.commit_author_identities) or "(none)"
+        advisories.append(
+            f"NOTE: PR {pr_display} reached {total_distinct}/2 WITHOUT self-review "
+            f"exclusion. Head ref `{verdicts.head_ref or '(unknown)'}` carries no "
+            "`{Initial}.{Lastname}` branch-author prefix, and the branch author derived "
+            f"from COMMIT IDENTITY — {derived} — matches no roster persona, so no verdict "
+            "was excluded as a self-review: every roster-valid Approved Requestor was "
+            "counted. The scan DID run and the charter threshold is unchanged — this "
+            "states which discriminator was unavailable, not a defect (#1211/#1220)."
         )
 
     if advisories:

--- a/.claude/lib/pr_review_state.py
+++ b/.claude/lib/pr_review_state.py
@@ -312,14 +312,43 @@ def _describe_comment_scan(state: ReviewState) -> str:
         derived = ", ".join(state.commit_authors) or "(none)"
         return (
             "RAN — head ref names no branch author, so the branch author was derived "
-            f"from COMMIT IDENTITY: {derived}. Their own verdicts are excluded from the "
+            f"from COMMIT IDENTITY: {derived}. Any verdict of theirs is excluded from the "
             "reviewer set (self-review exclusion active, #1210)."
         )
+    if state.comment_scan == gate.COMMENT_SCAN_COMMIT_AUTHOR_NON_ROSTER:
+        # #1220: derived an identity, excluded nothing. Pre-#1220 this state was
+        # reported as COMMIT_AUTHOR_EXCLUDED above, and this report line told a
+        # dependabot PR's reader that a self-review had been subtracted when the
+        # count had subtracted nothing at all.
+        derived = ", ".join(state.commit_authors) or "(none)"
+        return (
+            "RAN — head ref names no branch author, so the branch author was derived "
+            f"from COMMIT IDENTITY: {derived} — which matches NO roster persona (a bot, a "
+            "web-UI commit, or an outside contributor), so no self-review exclusion was "
+            "applied and no verdict was subtracted (#1220)."
+        )
+    if state.comment_scan == gate.COMMENT_SCAN_NO_BRANCH_AUTHOR:
+        return (
+            "RAN — head ref names no branch author (bot / wave-merge / non-charter branch) "
+            "and the PR's commits named no persona either (bot author, merge-only branch, or "
+            "a squash-flattened identity — #1177/#1210), so no self-review exclusion was "
+            "applied. Roster filtering and the 2-reviewer threshold are unchanged."
+        )
+    # Explicit fallback, added with #1220's fifth mode (narrowing #1273).
+    #
+    # This used to be a bare `return` on the NO_BRANCH_AUTHOR text, i.e. a silent
+    # catch-all: any mode the gate grew that nobody wired here would have been
+    # rendered as "the PR's commits named no persona" — a confident, specific,
+    # WRONG claim, which is the exact failure this whole enum exists to prevent.
+    # An unrecognized mode is now reported as unrecognized. The marker string is
+    # asserted-absent for every `gate.ALL_COMMENT_SCAN_MODES` entry by
+    # `test_validate_pr_review.py::CommentScanModeTotalityTests`, so reaching
+    # this line in production means a mode was added without wiring this surface.
     return (
-        "RAN — head ref names no branch author (bot / wave-merge / non-charter branch) "
-        "and the PR's commits named no persona either (bot author, merge-only branch, or "
-        "a squash-flattened identity — #1177/#1210), so no self-review exclusion was "
-        "applied. Roster filtering and the 2-reviewer threshold are unchanged."
+        f"RAN — but this report does not recognize scan mode {state.comment_scan!r} "
+        "(UNRECOGNIZED SCAN MODE), so it cannot say whether self-review exclusion was "
+        "applied. Treat the exclusion state as unknown and report this — it is a tooling "
+        "defect, not a finding about the PR (#1220/#1273)."
     )
 
 

--- a/.claude/lib/tests/test_pr_review_state.py
+++ b/.claude/lib/tests/test_pr_review_state.py
@@ -978,5 +978,127 @@ class CommitAuthorScanModeReportTests(unittest.TestCase):
         self.assertFalse(state.passes())
 
 
+class InertCommitDerivationReportTests(unittest.TestCase):
+    """#1220 at the report layer: derived an identity, subtracted nothing.
+
+    This is the surface the issue was filed FROM — an operator running the
+    oracle on a dependabot PR was told "Their own verdicts are excluded from the
+    reviewer set (self-review exclusion active)" about `dependabot[bot]`, on a
+    PR where both roster approvals had been counted in full.
+    """
+
+    BOT_REF = "dependabot/docker/integration-tests/fake_oauth/python-d3400aa"
+
+    @staticmethod
+    def _state(comment_scan, **overrides):
+        kwargs = dict(
+            pr_number="1220",
+            repo="noorinalabs/noorinalabs-deploy",
+            head_ref="dependabot/docker/integration-tests/fake_oauth/python-d3400aa",
+            branch_author_lastname=None,
+            formal_reviewers=[],
+            comment_reviewers=["lucas ferreira", "nino kavtaradze"],
+            non_roster_requestors=[],
+            distinct_reviewer_count=2,
+            wave_bootstrap_exception=False,
+            reviews_missing_tech_debt=[],
+            tech_debt_issue_numbers=[],
+            content_sha="837c272a",
+            comment_scan=comment_scan,
+        )
+        kwargs.update(overrides)
+        return prs.ReviewState(**kwargs)
+
+    def test_inert_mode_names_the_derivation_and_denies_the_subtraction(self):
+        text = prs._render_text(
+            self._state(
+                prs.gate.COMMENT_SCAN_COMMIT_AUTHOR_NON_ROSTER,
+                commit_authors=["dependabot[bot]"],
+            )
+        )
+        self.assertIn("comment verdict scan: RAN", text)
+        # Still names WHO was derived — the auditable part.
+        self.assertIn("COMMIT IDENTITY", text)
+        self.assertIn("dependabot[bot]", text)
+        # And denies the subtraction the old line asserted.
+        self.assertIn("matches NO roster persona", text)
+        self.assertIn("no verdict was subtracted", text)
+        self.assertNotIn("self-review exclusion active", text)
+
+    def test_inert_and_live_lines_read_differently(self):
+        """Opposite claims about the same count must not share wording."""
+        inert = prs._render_text(
+            self._state(
+                prs.gate.COMMENT_SCAN_COMMIT_AUTHOR_NON_ROSTER,
+                commit_authors=["dependabot[bot]"],
+            )
+        )
+        live = prs._render_text(
+            self._state(
+                prs.gate.COMMENT_SCAN_COMMIT_AUTHOR_EXCLUDED,
+                commit_authors=["Nino Kavtaradze"],
+            )
+        )
+        self.assertNotEqual(inert, live)
+        self.assertIn("self-review exclusion active", live)
+        self.assertNotIn("matches NO roster persona", live)
+
+    def test_unrecognized_mode_says_so_instead_of_borrowing_a_neighbour(self):
+        """The catch-all used to be NO_BRANCH_AUTHOR's text, so an unwired mode
+        was described as "the PR's commits named no persona" — a specific claim
+        about evidence nobody had looked at."""
+        text = prs._render_text(self._state("some-future-mode"))
+        self.assertIn("UNRECOGNIZED SCAN MODE", text)
+        self.assertIn("some-future-mode", text)
+        self.assertNotIn("commits named no persona either", text)
+
+    def test_compute_review_state_reports_the_inert_mode_end_to_end(self):
+        """Wiring, through the REAL `resolve_review_verdicts` — the issue's own
+        reproduction shape: a dependabot head ref, one bot-authored commit, two
+        genuine roster approvals. Both must still count (deploy#691) and the
+        mode must no longer claim an exclusion."""
+        pr_data = {
+            "author": "app/dependabot",
+            "number": 691,
+            "reviews": [],
+            "headRefName": self.BOT_REF,
+            "labels": [],
+        }
+        comments = [
+            _charter_comment("Lucas Ferreira", "Approved", _AFTER),
+            _charter_comment("Nino Kavtaradze", "Approved", _AFTER),
+        ]
+
+        def fake_run(args, capture_output, text, timeout):  # noqa: ARG001
+            result = mock.MagicMock()
+            result.returncode = 0
+            result.stdout = json.dumps(comments)
+            return result
+
+        with (
+            mock.patch.object(prs.gate, "get_pr_data", return_value=pr_data),
+            mock.patch.object(prs.gate.subprocess, "run", side_effect=fake_run),
+            mock.patch.object(
+                prs.gate,
+                "fetch_pr_commits",
+                return_value=[_api_commit("c0", _NOW, name="dependabot[bot]")],
+            ),
+            mock.patch.object(
+                prs.gate,
+                "_load_roster_names",
+                return_value={"lucas ferreira", "nino kavtaradze"},
+            ),
+        ):
+            state = prs.compute_review_state("691", repo="noorinalabs/noorinalabs-deploy")
+
+        self.assertEqual(state.comment_scan, prs.gate.COMMENT_SCAN_COMMIT_AUTHOR_NON_ROSTER)
+        self.assertEqual(state.commit_authors, ["dependabot[bot]"])
+        # deploy#691 stays fixed: the count is untouched by the description fix.
+        self.assertEqual(state.comment_reviewers, ["lucas ferreira", "nino kavtaradze"])
+        self.assertEqual(state.distinct_reviewer_count, 2)
+        self.assertTrue(state.passes())
+        self.assertNotIn("self-review exclusion active", prs._render_text(state))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #1220

## The defect

`refine_comment_scan_scope` upgraded `NO_BRANCH_AUTHOR` → `COMMIT_AUTHOR_EXCLUDED` on **any** derived identity:

```python
if ref_scope == COMMENT_SCAN_NO_BRANCH_AUTHOR and commit_authors:
    return COMMENT_SCAN_COMMIT_AUTHOR_EXCLUDED
```

"An identity was derived" is not the same fact as "an exclusion was applied." On a `dependabot/**` head ref the first is true and the second is false, so the gate counted both roster approvals correctly (deploy#691 stays fixed) and then described itself as having subtracted a self-review that never existed. Same defect class as #1206/#1207 — the mode is meant to be an honest description of what the scan actually did.

## The fix: a fifth mode, not a reword

`COMMENT_SCAN_COMMIT_AUTHOR_NON_ROSTER` — an identity **was** derived and it matches **no roster persona**.

I chose the new state over the issue's option 3 (reword only) because the two facts an operator needs here are genuinely different, and collapsing either way throws one away:

- It is not `COMMIT_AUTHOR_EXCLUDED`: that mode's claim is that a subtraction is in force, and here none is.
- It is not `NO_BRANCH_AUTHOR`: that mode's claim is "the PR's commits named no persona", and here they named `dependabot[bot]`. Collapsing into it would discard the derived identity — which is exactly what an operator would audit if they suspected the derivation had picked the wrong person.

The inertness is **provable, not incidental**, and it is the same argument `commit_author_identities` already makes for not roster-filtering the derivation itself: only roster-valid Requestors reach `distinct_reviewers`, so an exclusion keyed on a non-roster identity can only ever remove a verdict roster filtering would have removed anyway. **The new mode and `NO_BRANCH_AUTHOR` produce byte-identical reviewer sets.**

Liveness is decided by `commit_author_exclusion_is_live`, which delegates to `charter_trailer.is_branch_author` — the one person-comparison in the org (#1172). No surname `in` test: a roster holding `santiago ferreira` must not make a `Lucas Ferreira` commit look live (mutation M3).

### Two deliberate degradations

- **Unreadable roster.** `_load_roster_names` returns `set()` when the roster dirs cannot be read. On that input *every* identity trivially "matches no roster persona", so reporting `NON_ROSTER` would be a measurement derived from a failed read — the `feedback_silent_zero_is_not_a_measurement` shape this enum exists to prevent. The undecidable case keeps the pre-#1220 answer (mutations M4, M13).
- **`roster_names` is a required positional arg**, not defaulted. A `set()` default would read as "roster unreadable" and hand a forgetful caller a plausible answer for every input.

## Scope: nothing the gate counts changed

Structurally guaranteed, not just asserted: `refine_comment_scan_scope` now runs **after** `check_comment_reviews`, so the scan has already completed by the time the mode is chosen. The exclusion itself still runs off the same **unfiltered** `commit_authors` tuple.

The refine call was placed after `_load_roster_names` rather than hoisting the roster load above `check_comment_reviews` **on purpose**: hoisting would move `RosterResolutionError` ahead of `CommentScanUndeterminedError` in the raise order, so a PR with both an unreadable comment thread and an unresolvable child roster would start reporting a different one of its two determinate failures. Both hard-block, so nothing counts differently — but the diagnosis handed to an operator would silently change, and this PR is about descriptions.

## Rendering surfaces touched — all three (#1273)

| # | Surface | Change |
|---|---|---|
| 1 | `validate_pr_review.check()` — block `scan_diagnostic` | New `NON_ROSTER` branch. `COMMIT_AUTHOR_EXCLUDED`'s wording made modal: "Verdicts from those personas **were excluded**" → "Any verdict from those personas **is excluded**" (true whether or not one existed). |
| 2 | `validate_pr_review.check()` — allow-path advisory (#1211/#1270) | Now fires for `NON_ROSTER` too, with its own wording. Its reviewer set is byte-identical to `NO_BRANCH_AUTHOR`'s, so staying silent would disclose on the arithmetic's twin and not on the arithmetic itself. |
| 3 | `pr_review_state._describe_comment_scan()` | New `NON_ROSTER` branch, and — separately — its **silent catch-all is gone**. It used to end in a bare `return` on `NO_BRANCH_AUTHOR`'s text, so any unwired mode was described as "the PR's commits named no persona": confident, specific, wrong. Unrecognized modes now say `UNRECOGNIZED SCAN MODE`. |

## #1273: narrowed, not closed

**Done here** — the part that makes a sixth mode fail loudly:

- `ALL_COMMENT_SCAN_MODES` (the constant tuple #1273 notes does not exist).
- `CommentScanModeTotalityTests` — iterates it against all three surfaces with a **declared coverage table**. Absence from a surface is a decision (`AUTHOR_EXCLUDED` needs no block diagnostic — the ref names the author, nothing is surprising), and `test_table_covers_exactly_the_declared_mode_set` fails until a new mode's decision is recorded. `test_the_unrecognized_marker_is_actually_reachable` is the positive control that keeps the `assertNotIn` assertions from passing vacuously forever.

**Still open on #1273** — the shared `describe_comment_scan_mode(...)` helper. The three surfaces still repeat the same substantive claims in three hand-written prose blocks; they now agree and are pinned to agree *structurally* (every mode wired, distinctly, everywhere), but not *textually*. I have commented on #1273 (comment 5167853575) to re-scope it to the dedup and record what this PR removed from it.

## Testing

Assertion-only tests are not the bar. Every new branch was mutation-tested; all runs drive the real `resolve_review_verdicts` / `check()` / `compute_review_state` entry points as the issue's reproduction does. Restores were `git checkout HEAD -- <file>`.

| # | Mutation | Killed by | Real output |
|---|---|---|---|
| M1 | Revert `refine_comment_scan_scope` to the pre-#1220 body (**the original defect**) | `RefineCommentScanScopeTests::test_derived_identity_matching_no_roster_persona_is_reported_inert`, `::test_same_surname_different_person_is_not_live`, `CommitIdentitySelfReviewExclusionTests::test_bot_branch_with_two_roster_approvals_still_passes`, `InertCommitDerivationReportTests::test_compute_review_state_reports_the_inert_mode_end_to_end` | `4 failed, 379 passed, 78 subtests passed` |
| M2 | Drop the liveness check — every derivation called inert (breaks #1210) | `::test_no_branch_author_upgrades_when_commits_named_a_roster_persona`, `::test_one_roster_persona_among_several_derivations_is_still_live`, `::test_bot_branch_with_a_human_fixup_commit_still_reports_live_exclusion`, `::test_self_approval_on_a_non_charter_ref_no_longer_reaches_two_of_two`, `CommitAuthorScanModeReportTests::test_compute_review_state_propagates_the_commit_derived_author` | `5 failed, 378 passed, 78 subtests passed` |
| M3 | Liveness by surname `in` — drops the #1172 initial discriminator | `RefineCommentScanScopeTests::test_same_surname_different_person_is_not_live` | `1 failed, 382 passed, 78 subtests passed` |
| M4 | Unreadable roster reported as an inertness finding | `::test_unreadable_roster_keeps_the_pre_1220_answer`, `CommitIdentitySelfReviewExclusionTests::test_an_unreadable_roster_does_not_report_the_bot_as_inert` | `2 failed, 381 passed, 78 subtests passed` |
| M5 | Block path: new mode gets no diagnostic at all | `CommitAuthorBlockDiagnosticTests::test_non_roster_derivation_does_not_claim_a_subtraction`, `::test_inert_and_live_commit_derivations_read_differently`, + subtest | `3 failed, 381 passed, 77 subtests` — `AssertionError: '' is not true : commit-author-non-roster renders no block scan diagnostic at all` (`SUBFAILED(mode='commit-author-non-roster') CommentScanModeTotalityTests::test_every_mode_gets_its_declared_block_diagnostic`) |
| M6 | Block path: new mode's body collapsed onto `NO_BRANCH_AUTHOR`'s prose (**the #1273 drift shape**) | `::test_non_roster_derivation_does_not_claim_a_subtraction`, `::test_inert_and_live_commit_derivations_read_differently`, `::test_inert_mode_is_not_collapsed_into_the_no_author_wording` | `3 failed, 380 passed, 78 subtests passed` |
| M7 | Allow path: new mode does not disclose | `AllowPathScanDisclosureTests::test_inert_commit_derivation_also_discloses_on_the_allow_path`, `::test_the_two_no_exclusion_advisories_are_not_the_same_text`, + subtest | `4 failed, 381 passed, 76 subtests` — `AssertionError: commit-author-non-roster must disclose on the allow path / assert None is not None` |
| M8 | Allow path: hardcode `2/2` on the `NO_BRANCH_AUTHOR` advisory (**Nadia's #1270 finding — this survived all 318 tests before**) | `AllowPathScanDisclosureTests::test_advisory_reports_the_real_count_on_a_wave_bootstrap_single_reviewer` | `SUBFAILED(mode='no-branch-author')` — `AssertionError: 'reached 1/2 WITHOUT self-review exclusion' not found in "NOTE: PR #691 reached 2/2 WITHOUT self-review exclusion. …"` |
| M8b | Same hardcode on the **new** advisory branch | same test, `mode='commit-author-non-roster'` | `AssertionError: 'reached 1/2 WITHOUT self-review exclusion' not found in 'NOTE: PR #691 reached 2/2 … derived from COMMIT IDENTITY — dependabot[bot] — matches no roster persona …'` |
| M9 | Oracle report: new mode unwired (falls to the fallback) | `InertCommitDerivationReportTests::test_inert_mode_names_the_derivation_and_denies_the_subtraction`, + subtest | `2 failed, 382 passed, 77 subtests` — `AssertionError: 'UNRECOGNIZED SCAN MODE' unexpectedly found … : commit-author-non-roster is unwired in the oracle report` |
| M10 | Oracle report: restore the silent `NO_BRANCH_AUTHOR` catch-all | `CommentScanModeTotalityTests::test_the_unrecognized_marker_is_actually_reachable`, `InertCommitDerivationReportTests::test_unrecognized_mode_says_so_instead_of_borrowing_a_neighbour` | `2 failed, 381 passed, 78 subtests passed` |
| M11 | **A sixth mode declared but wired nowhere** — the #1273 scenario | `CommentScanModeTotalityTests::test_table_covers_exactly_the_declared_mode_set` + `SUBFAILED(mode='some-future-mode') ::test_every_mode_renders_a_recognized_report_line` | `2 failed, 382 passed, 78 subtests passed` — `AssertionError: Items in the second set but not the first: 'some-future-mode'` |
| M12 | Call site forgets the roster (passes the degraded `set()`) | `::test_bot_branch_with_two_roster_approvals_still_passes`, `InertCommitDerivationReportTests::test_compute_review_state_reports_the_inert_mode_end_to_end` | `2 failed, 381 passed, 78 subtests passed` |
| M13 | **The description fix leaks into the COUNT** — roster-filter the derivation itself | `::test_bot_branch_with_two_roster_approvals_still_passes`, `::test_an_unreadable_roster_does_not_report_the_bot_as_inert`, `InertCommitDerivationReportTests::test_compute_review_state_reports_the_inert_mode_end_to_end` | `3 failed, 380 passed, 78 subtests passed` |

Baseline for every row: `383 passed, 78 subtests passed` across the two suites.

Honest note on M13: it is caught by the **mode** assertions (roster-filtering the derivation turns a bot branch into `NO_BRANCH_AUTHOR`), not by a count assertion — because on this input the count is genuinely unchanged. The count guarantee rests on the structural argument above plus the pre-existing `StrictlyNonRelaxingTests`, not on M13.

### The specific traps

- **#1203** (five bare `assertIn("1/2", reason)`): no new loose substring assertions. Every new assertion names either a specific mode constant or a specific rendered phrase (`"matches no roster persona"`, `"NO verdict was excluded as a self-review"`, `"reached 1/2 WITHOUT self-review exclusion"`). I have **not** touched the five pre-existing ones — that stays #1203's.
- **Nadia's #1270 finding**: covered by M8/M8b. `test_advisory_reports_the_real_count_on_a_wave_bootstrap_single_reviewer` drives the tail at `total_distinct == 1` via the wave-bootstrap exception — the combination that had no test — and subtests both no-exclusion modes so neither branch can regress to a literal.
- **The anti-vacuity lesson in situ**: `test_bot_branch_with_two_roster_approvals_still_passes` now asserts the **mode**, which is the assertion it was missing and the reason it stayed green through the defect. `test_bot_branch_with_a_human_fixup_commit_still_reports_live_exclusion` is its positive control — without it, the new mode assertion would be satisfied by a change that simply stopped ever reporting `COMMIT_AUTHOR_EXCLUDED` on a non-charter ref, re-opening #1210.

## Gates

`3666 passed, 668 subtests passed` (full `.claude/hooks/tests/` + `.claude/lib/tests/`). Both pre-commit stages clean over `--all-files`: ruff-format, ruff-lint, actionlint, cspell, checksums-ascii, fixture-realism, skill-graphql-pagination, mypy, mypy-skills, pytest, pytest-skills, memory-budget, headcount-budget, doc-freshness, office-drift, mermaid-render. `pre_commit_ci_sync.py` → `OK`. Hook exits 0 on empty stdin. No `--no-verify`.

Semantic overlay was current (288 tracked, 0 dirty) and needs no update: `ontology/conventions.md`'s only reference to this hook is the unchanged one-line role row, and no charter or doc file mentions the scan-mode vocabulary (`rg` over `.claude/team/charter/` and `docs/` returns nothing).

## Follow-up debt filed

- #1273 re-scoped (commented, not closed) — the shared renderer helper.
- **#1294** (new, `tech-debt`/`process`/`phase-10`, no wave label) — `check()`'s block-path `scan_diagnostic` still has no unrecognized-mode fallback, while `_describe_comment_scan` now does. Empty is a *legitimate* state there (`AUTHOR_EXCLUDED` renders nothing on purpose), so the `else` needs a design call rather than a reflex; pinned by test in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
