### PR TITLE
fix(#1182): source suggestions from the org manifest; distinct diagnostic for an uncloned target repo

### DIFF
--- a/.claude/skills/wave-scope/tests/test_validate_matrix_names.py
+++ b/.claude/skills/wave-scope/tests/test_validate_matrix_names.py
@@ -1348,22 +1348,33 @@ class ManifestSourcedSuggestionTests(unittest.TestCase):
             self.assertEqual(_report_stderr(report)[0], 1)
 
     def test_manifest_persona_on_a_CLONED_repo_still_gets_substitution_guidance(self):
-        """The `not membership_decidable` conjunct is load-bearing.
+        """The `membership_decidable` branch is load-bearing.
 
         Same name, same manifest — but the target roster IS readable, so this is
-        a genuine wrong-assignment and the substitution guidance is correct.
-        Drop the conjunct and this reds on the `--fetch-missing` assertion.
+        a genuine wrong-assignment: reassign / onboard / record a substitution,
+        NOT `--fetch-missing`. Collapse the branch and this reds.
+
+        The row must still not echo the declared name back as its own
+        suggestion, which is exactly what `_suggest` returns on an exact
+        manifest hit — measured against the real org roster on the first draft
+        of this change: `implementer: 'Nikolaos Papadopoulos'  ->  suggestions:
+        Nikolaos Papadopoulos`.
         """
         with tempfile.TemporaryDirectory() as tmpdir:
             org = self._build_org(Path(tmpdir))
             report = validate({self.CLONED_REPO: {"implementer": self.ORG_PERSONA}}, org)
             finding = report[self.CLONED_REPO][0]
             self.assertFalse(finding["resolved"])
-            self.assertEqual(finding["unresolved_reason"], "unknown-name")
+            self.assertEqual(finding["unresolved_reason"], "org-persona-not-a-member")
             code, err = _report_stderr(report)
             self.assertEqual(code, 1)
             self.assertIn("implementer_substitutions", err)
             self.assertNotIn("--fetch-missing", err)
+            row = _finding_row(err, "implementer")
+            self.assertIn("NOT on this repo's roster", row)
+            self.assertNotIn("suggestions:", row)
+            # The roster it COULD take is named, so the fix is one read away.
+            self.assertIn("Bereket Tadesse", err)
 
     def test_genuine_typo_on_an_uncloned_repo_still_reports_unknown_name(self):
         """A misspelling is NOT the environment gap — but it still gets a real suggestion.

--- a/.claude/skills/wave-scope/tests/test_validate_matrix_names.py
+++ b/.claude/skills/wave-scope/tests/test_validate_matrix_names.py
@@ -1411,6 +1411,38 @@ class ManifestSourcedSuggestionTests(unittest.TestCase):
             self.assertIn("implementer_substitutions", err)
             self.assertIn("2/2 names UNRESOLVED", err)
 
+    def test_all_three_unresolved_classes_print_their_own_remediation(self):
+        """All three trailers are independent `if`s, not one chained decision.
+
+        Two classes is not enough to catch chaining: with only one of the two
+        LATER counters non-zero, an `elif` still runs. Only a run carrying all
+        three distinguishes independent `if`s from a chain — measured, the
+        two-class test left the `elif org_persona_unreadable` mutant ALIVE.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = self._build_org(Path(tmpdir))
+            report = validate(
+                {
+                    self.UNCLONED_REPO: {"implementer": self.ORG_PERSONA},  # unreadable
+                    self.CLONED_REPO: {"implementer": self.ORG_PERSONA},  # not-a-member
+                    "noorinalabs-isnad-graph": {"implementer": "Totally Unknown"},
+                },
+                org,
+            )
+            reasons = sorted(
+                f["unresolved_reason"] for fs in report.values() for f in fs if not f["resolved"]
+            )
+            self.assertEqual(
+                reasons,
+                ["org-persona-not-a-member", "org-persona-unreadable-roster", "unknown-name"],
+            )
+            code, err = _report_stderr(report)
+            self.assertEqual(code, 1)
+            self.assertIn("Resolve each unknown name", err)
+            self.assertIn("resolve as KNOWN org personas but are NOT on", err)
+            self.assertIn("--fetch-missing", err)
+            self.assertIn("3/3 names UNRESOLVED", err)
+
     def test_scope_mode_carries_the_diagnostic_end_to_end(self):
         """The path /wave-scope § 12.5 and /wave-kickoff § 0b actually run."""
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/.claude/skills/wave-scope/tests/test_validate_matrix_names.py
+++ b/.claude/skills/wave-scope/tests/test_validate_matrix_names.py
@@ -81,6 +81,20 @@ def _report_stderr(report: dict) -> tuple[int, str]:
     return code, buf.getvalue()
 
 
+def _finding_row(err: str, role: str) -> str:
+    """Return the single per-finding line for `role` from captured stderr (#1182).
+
+    Whole-stream `assertIn` is not enough here: the remediation TRAILERS repeat
+    the same phrases the per-row line uses, so a stream-level assertion stays
+    green with the row line deleted. Tests that care about what the row says
+    must assert against the row.
+    """
+    rows = [ln for ln in err.splitlines() if ln.strip().startswith(f"- {role}:")]
+    if len(rows) != 1:
+        raise AssertionError(f"expected exactly 1 {role!r} finding row, got {len(rows)}:\n{err}")
+    return rows[0]
+
+
 def _write_slim_roster_card(roster_dir: Path, role_slug: str, name: str) -> None:
     """Mimic the NEW slim card shape (#1010): H1 `# <Name> — <Role>`, no
     `**Name:**` field. Verbatim to the shipped template so the fixture can't
@@ -1284,7 +1298,14 @@ class ManifestSourcedSuggestionTests(unittest.TestCase):
             code, err = _report_stderr(report)
             self.assertEqual(code, 1)
             self.assertNotIn("(no close matches)", err)
-            self.assertIn("KNOWN org persona", err)
+            # Assert on the ROW, not on the whole stream: the trailer paragraph
+            # also contains "KNOWN org persona", so a whole-stream assertion
+            # passes even with the per-row line deleted (measured — that
+            # mutation SURVIVED the first draft of this test).
+            row = _finding_row(err, "implementer")
+            self.assertIn("KNOWN org persona", row)
+            # And it must not echo the declared name back as its own suggestion.
+            self.assertNotIn("suggestions:", row)
 
     def test_uncloned_org_persona_is_steered_to_fetch_missing_not_substitution(self):
         """Bullet 2: the remediation must not point at changing a correct assignment."""

--- a/.claude/skills/wave-scope/tests/test_validate_matrix_names.py
+++ b/.claude/skills/wave-scope/tests/test_validate_matrix_names.py
@@ -1439,7 +1439,7 @@ class ManifestSourcedSuggestionTests(unittest.TestCase):
             code, err = _report_stderr(report)
             self.assertEqual(code, 1)
             self.assertIn("Resolve each unknown name", err)
-            self.assertIn("resolve as KNOWN org personas but are NOT on", err)
+            self.assertIn("a commit-capable slot cannot take them", err)
             self.assertIn("--fetch-missing", err)
             self.assertIn("3/3 names UNRESOLVED", err)
 

--- a/.claude/skills/wave-scope/tests/test_validate_matrix_names.py
+++ b/.claude/skills/wave-scope/tests/test_validate_matrix_names.py
@@ -11,6 +11,8 @@ org-dir state (which changes wave-to-wave).
 
 from __future__ import annotations
 
+import contextlib
+import io
 import json
 import sys
 import tempfile
@@ -64,6 +66,19 @@ def _build_fake_org_dir(tmp: Path) -> Path:
     _write_roster_card(graph_roster, "eng_idris", "Idris Yusuf")
     _write_roster_card(graph_roster, "eng_marisol", "Marisol Vega-Cruz")
     return tmp
+
+
+def _report_stderr(report: dict) -> tuple[int, str]:
+    """Run `_print_report_to_stderr` capturing its output (#1182).
+
+    Returns `(exit_code, captured_stderr)` so a test can assert on the exit
+    code AND on the operator-facing text in one call, instead of asserting on
+    report internals and merely hoping they reach the terminal.
+    """
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+        code = _print_report_to_stderr(report)
+    return code, buf.getvalue()
 
 
 def _write_slim_roster_card(roster_dir: Path, role_slug: str, name: str) -> None:
@@ -1195,6 +1210,207 @@ class ScopeModeSlotDiscoveryTests(unittest.TestCase):
             impl = next(f for f in findings if f["role"] == "implementer")
             self.assertEqual(impl["membership"], "overridden")
             self.assertEqual(_print_report_to_stderr(report), 0)
+
+
+class ManifestSourcedSuggestionTests(unittest.TestCase):
+    """#1182: never claim "(no close matches)" about a name held in the same frame.
+
+    Symptom, measured against the real org roster with
+    `noorinalabs-user-service` deliberately not cloned:
+
+        - implementer: 'Anya Kowalczyk'  ->  suggestions: (no close matches)
+          reviewer     resolved=True
+
+    `Anya Kowalczyk` is an exact key of the `org_manifest` set `validate()` had
+    already loaded, so the assertion was disprovable from a local; and the same
+    name resolved one slot away, leaving the operator unable to tell whether the
+    persona exists. The trailer then pointed at recording an
+    `implementer_substitution` — changing a CORRECT assignment — when the real
+    remedy is `--fetch-missing` or cloning the repo.
+
+    The fix is MESSAGE-ONLY. `test_1182_message_change_is_semantically_inert`
+    is the load-bearing guard: widening the RESOLUTION set instead of the
+    SUGGESTION set flips this exact row to `resolved=True membership=unverified`,
+    exit 0 — the silent pass #1134 exists to stop.
+    """
+
+    # In the manifest and on a THIRD child's roster; on neither the parent cards
+    # nor the target repo's, so unresolved for a commit-capable slot.
+    ORG_PERSONA = "Nikolaos Papadopoulos"
+    # `_build_fake_org_dir` creates no design-system dir at all → roster
+    # unreadable → membership undecidable. This is the "not cloned" case.
+    UNCLONED_REPO = "noorinalabs-design-system"
+    # Created WITH a roster by `_build_fake_org_dir` (Bereket Tadesse, Lucas
+    # Ferreira) → membership decidable. The discriminator for the second conjunct.
+    CLONED_REPO = "noorinalabs-deploy"
+
+    def _build_org(self, tmp: Path) -> Path:
+        org = _build_fake_org_dir(tmp)
+        _write_roster_card(
+            org / "noorinalabs-data-acquisition" / ".claude" / "team" / "roster",
+            "data_engineer_nikolaos",
+            self.ORG_PERSONA,
+        )
+        manifest = {
+            name: f"parametrization+{name.replace(' ', '.')}@gmail.com"
+            for name in ("Nadia Khoury", "Anya Kowalczyk", self.ORG_PERSONA)
+        }
+        (org / ".claude" / "team" / "roster.json").write_text(json.dumps(manifest, indent=2))
+        return org
+
+    def test_no_close_matches_is_not_claimed_about_a_manifest_name(self):
+        """Bullet 1: the report may not deny holding a name it holds.
+
+        Also pins problem 2 — the SAME name in the SAME run resolves in the
+        review-class slot, which is what made the old output unreadable.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = self._build_org(Path(tmpdir))
+            self.assertIn(self.ORG_PERSONA, _load_org_manifest_names(org), "fixture premise")
+            report = validate(
+                {
+                    self.UNCLONED_REPO: {
+                        "implementer": self.ORG_PERSONA,
+                        "reviewer": self.ORG_PERSONA,
+                    }
+                },
+                org,
+            )
+            by_role = {f["role"]: f for f in report[self.UNCLONED_REPO]}
+            self.assertFalse(by_role["implementer"]["resolved"])
+            self.assertTrue(by_role["reviewer"]["resolved"], "the asymmetry being explained")
+            # Sourced from `review_combined`: the manifest is now visible here.
+            self.assertIn(self.ORG_PERSONA, by_role["implementer"]["suggestions"])
+            code, err = _report_stderr(report)
+            self.assertEqual(code, 1)
+            self.assertNotIn("(no close matches)", err)
+            self.assertIn("KNOWN org persona", err)
+
+    def test_uncloned_org_persona_is_steered_to_fetch_missing_not_substitution(self):
+        """Bullet 2: the remediation must not point at changing a correct assignment."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = self._build_org(Path(tmpdir))
+            report = validate({self.UNCLONED_REPO: {"implementer": self.ORG_PERSONA}}, org)
+            finding = report[self.UNCLONED_REPO][0]
+            self.assertEqual(finding["unresolved_reason"], "org-persona-unreadable-roster")
+            code, err = _report_stderr(report)
+            self.assertEqual(code, 1)
+            self.assertIn("--fetch-missing", err)
+            self.assertIn("clone the repo", err)
+            self.assertNotIn("implementer_substitutions", err)
+
+    def test_1182_message_change_is_semantically_inert(self):
+        """THE guard: #1182 added advisory keys and nothing else.
+
+        Strips the two advisory keys and asserts the remaining entry is
+        byte-identical to the pre-#1182 shape, with exit 1. A future
+        "improvement" that widens the RESOLUTION set to fix the message reds
+        here on `resolved`, on `membership`, and on the exit code at once.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = self._build_org(Path(tmpdir))
+            report = validate({self.UNCLONED_REPO: {"implementer": self.ORG_PERSONA}}, org)
+            finding = dict(report[self.UNCLONED_REPO][0])
+            for advisory_key in ("suggestions", "unresolved_reason"):
+                self.assertIn(advisory_key, finding, "fixture premise: advisory key present")
+                finding.pop(advisory_key)
+            self.assertEqual(
+                finding,
+                {
+                    "role": "implementer",
+                    "declared": self.ORG_PERSONA,
+                    "resolved": False,
+                    "membership": "n/a",
+                    "slot_class": "known",
+                },
+            )
+            self.assertEqual(_report_stderr(report)[0], 1)
+
+    def test_manifest_persona_on_a_CLONED_repo_still_gets_substitution_guidance(self):
+        """The `not membership_decidable` conjunct is load-bearing.
+
+        Same name, same manifest — but the target roster IS readable, so this is
+        a genuine wrong-assignment and the substitution guidance is correct.
+        Drop the conjunct and this reds on the `--fetch-missing` assertion.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = self._build_org(Path(tmpdir))
+            report = validate({self.CLONED_REPO: {"implementer": self.ORG_PERSONA}}, org)
+            finding = report[self.CLONED_REPO][0]
+            self.assertFalse(finding["resolved"])
+            self.assertEqual(finding["unresolved_reason"], "unknown-name")
+            code, err = _report_stderr(report)
+            self.assertEqual(code, 1)
+            self.assertIn("implementer_substitutions", err)
+            self.assertNotIn("--fetch-missing", err)
+
+    def test_genuine_typo_on_an_uncloned_repo_still_reports_unknown_name(self):
+        """A misspelling is NOT the environment gap — but it still gets a real suggestion.
+
+        This is the case where widening the SUGGESTION source pays off without
+        the new diagnostic: `combined` had nothing close, so the operator was
+        told "(no close matches)" for a one-character typo of a real persona.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = self._build_org(Path(tmpdir))
+            report = validate({self.UNCLONED_REPO: {"implementer": "Nikolas Papadopolous"}}, org)
+            finding = report[self.UNCLONED_REPO][0]
+            self.assertEqual(finding["unresolved_reason"], "unknown-name")
+            self.assertIn(self.ORG_PERSONA, finding["suggestions"])
+            code, err = _report_stderr(report)
+            self.assertEqual(code, 1)
+            self.assertIn(f"suggestions: {self.ORG_PERSONA}", err)
+            self.assertIn("implementer_substitutions", err)
+
+    def test_both_remediations_print_when_both_classes_are_present(self):
+        """The two trailers are independent, not mutually exclusive."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = self._build_org(Path(tmpdir))
+            report = validate(
+                {
+                    self.UNCLONED_REPO: {"implementer": self.ORG_PERSONA},
+                    self.CLONED_REPO: {"implementer": "Totally Unknown"},
+                },
+                org,
+            )
+            code, err = _report_stderr(report)
+            self.assertEqual(code, 1)
+            self.assertIn("--fetch-missing", err)
+            self.assertIn("implementer_substitutions", err)
+            self.assertIn("2/2 names UNRESOLVED", err)
+
+    def test_scope_mode_carries_the_diagnostic_end_to_end(self):
+        """The path /wave-scope § 12.5 and /wave-kickoff § 0b actually run."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = self._build_org(Path(tmpdir))
+            scope = {
+                "tier_1_core": [
+                    {
+                        "id": f"{self.UNCLONED_REPO}#77",
+                        "ref": "design-system#77",
+                        "implementer": self.ORG_PERSONA,
+                        "reviewer": "Nadia Khoury",
+                    }
+                ]
+            }
+            report = validate_scope(scope, org)
+            findings = report[f"{self.UNCLONED_REPO} (design-system#77)"]
+            impl = next(f for f in findings if f["role"] == "implementer")
+            self.assertFalse(impl["resolved"])
+            self.assertEqual(impl["unresolved_reason"], "org-persona-unreadable-roster")
+            code, err = _report_stderr(report)
+            self.assertEqual(code, 1)
+            self.assertIn("--fetch-missing", err)
+
+    def test_resolved_rows_carry_no_unresolved_reason(self):
+        """The key exists only where it means something."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            org = self._build_org(Path(tmpdir))
+            report = validate({"noorinalabs-isnad-graph": {"implementer": "Anya Kowalczyk"}}, org)
+            finding = report["noorinalabs-isnad-graph"][0]
+            self.assertTrue(finding["resolved"])
+            self.assertNotIn("unresolved_reason", finding)
+            self.assertEqual(_report_stderr(report)[0], 0)
 
 
 if __name__ == "__main__":

--- a/.claude/skills/wave-scope/validate_matrix_names.py
+++ b/.claude/skills/wave-scope/validate_matrix_names.py
@@ -149,9 +149,14 @@ named on the `unverified` path this row never reaches.
 
 `suggestions` is advisory text: nothing reads it, and it never feeds `resolved`
 or the exit code. So it is sourced from `review_combined` for every slot, and an
-unresolved commit-capable name that IS a known org persona whose target roster
-could not be read gets its own diagnostic (`unresolved_reason`) pointing at
-`--fetch-missing` instead of at the substitution guidance.
+unresolved commit-capable name that IS a known org persona gets its own
+diagnostic (`unresolved_reason`) instead of a suggestion list — because
+`_suggest` returns the declared name ITSELF for an exact manifest hit, and
+"suggestions: Anya Kowalczyk" printed against `implementer: 'Anya Kowalczyk'`
+reads as a second bug. Two such rows, distinguished by whether membership is
+even decidable: roster unreadable (not cloned) points at `--fetch-missing`;
+roster readable and the name is not on it is a genuine assignment problem and
+keeps the reassign/onboard/substitution guidance.
 
 This is deliberately MESSAGE-ONLY. `resolved` stays False and the exit code
 stays 1 for exactly the rows they did before — the #1134 carve-out pinned by
@@ -340,6 +345,7 @@ OVERRIDE_KEY = "roster_union_override"
 # remediation paragraph is printed for an unresolved row and are read nowhere
 # else — never by the exit-code arithmetic, which keys off `resolved`.
 _REASON_ORG_PERSONA_UNREADABLE = "org-persona-unreadable-roster"
+_REASON_ORG_PERSONA_NOT_A_MEMBER = "org-persona-not-a-member"
 _REASON_UNKNOWN_NAME = "unknown-name"
 
 
@@ -560,7 +566,14 @@ def validate(
       - ``"org-persona-unreadable-roster"`` — the name is a known org-manifest
         persona and the target repo's roster could not be read (not cloned).
         Remedy: `--fetch-missing` or clone the repo — NOT a substitution.
+      - ``"org-persona-not-a-member"`` — known org-manifest persona, target
+        roster IS readable, and the name is not on it. A genuine assignment
+        problem (reassign / onboard), but still not a "no close matches" one.
       - ``"unknown-name"``  — every other unresolved name.
+
+    The two org-persona reasons exist so the row can STATE the finding instead
+    of echoing the declared name back as its own suggestion, which is what
+    `_suggest` returns for an exact manifest hit.
 
     `slot_class` (#1180) is ``"known"`` when the slot key is in
     `KNOWN_ROLE_SLOTS`, else ``"unclassified"`` — a hard failure in
@@ -629,11 +642,16 @@ def validate(
                 # construction: `review_combined` contains `org_manifest`, so a
                 # manifest name in a review slot has already resolved.
                 in_manifest = any(declared_clean.lower() == known.lower() for known in org_manifest)
-                entry["unresolved_reason"] = (
-                    _REASON_ORG_PERSONA_UNREADABLE
-                    if in_manifest and not membership_decidable
-                    else _REASON_UNKNOWN_NAME
-                )
+                if not in_manifest:
+                    entry["unresolved_reason"] = _REASON_UNKNOWN_NAME
+                elif membership_decidable:
+                    # Known org persona, target roster READABLE and he is not on
+                    # it. A genuine assignment problem — but the row must still
+                    # not "suggest" the declared name back at the operator.
+                    entry["unresolved_reason"] = _REASON_ORG_PERSONA_NOT_A_MEMBER
+                    entry["repo_roster"] = sorted(repo_roster)
+                else:
+                    entry["unresolved_reason"] = _REASON_ORG_PERSONA_UNREADABLE
                 repo_findings.append(entry)
                 continue
             # #1134: commit-capable slots on a child repo must be repo members.
@@ -736,6 +754,7 @@ def _print_report_to_stderr(report: dict[str, list[dict[str, object]]]) -> int:
     unresolved = 0
     unknown_name = 0
     org_persona_unreadable = 0
+    org_persona_not_member = 0
     cross_repo = 0
     overridden = 0
     unverified = 0
@@ -745,8 +764,11 @@ def _print_report_to_stderr(report: dict[str, list[dict[str, object]]]) -> int:
             total += 1
             if not f["resolved"]:
                 unresolved += 1
-                if f.get("unresolved_reason") == _REASON_ORG_PERSONA_UNREADABLE:
+                reason = f.get("unresolved_reason")
+                if reason == _REASON_ORG_PERSONA_UNREADABLE:
                     org_persona_unreadable += 1
+                elif reason == _REASON_ORG_PERSONA_NOT_A_MEMBER:
+                    org_persona_not_member += 1
                 else:
                     unknown_name += 1
             if f.get("slot_class") == "unclassified":
@@ -771,13 +793,26 @@ def _print_report_to_stderr(report: dict[str, list[dict[str, object]]]) -> int:
                 continue
             print(f"\n  {repo}:", file=sys.stderr)
             for f in bad:
-                if f.get("unresolved_reason") == _REASON_ORG_PERSONA_UNREADABLE:
-                    # #1182: printing "suggestions: <the declared name itself>"
-                    # here would read as a bug, so this row states the finding.
+                # #1182: for a name the manifest holds EXACTLY, printing
+                # "suggestions: <the declared name itself>" reads as a bug, so
+                # these two rows state the finding instead of suggesting.
+                reason = f.get("unresolved_reason")
+                if reason == _REASON_ORG_PERSONA_UNREADABLE:
                     print(
                         f"    - {f['role']}: {f['declared']!r}  →  KNOWN org persona "
                         "(present in .claude/team/roster.json); this repo's roster "
                         "could not be read — not cloned?",
+                        file=sys.stderr,
+                    )
+                    continue
+                if reason == _REASON_ORG_PERSONA_NOT_A_MEMBER:
+                    raw_roster = f.get("repo_roster")
+                    roster = raw_roster if isinstance(raw_roster, list) else []
+                    roster_str = ", ".join(roster) if roster else "(empty)"
+                    print(
+                        f"    - {f['role']}: {f['declared']!r}  →  KNOWN org persona "
+                        "(present in .claude/team/roster.json), but NOT on this "
+                        f"repo's roster.\n      repo roster: {roster_str}",
                         file=sys.stderr,
                     )
                     continue
@@ -794,6 +829,19 @@ def _print_report_to_stderr(report: dict[str, list[dict[str, object]]]) -> int:
                 "  Approved substitutions: record under"
                 " wave_{M}_decisions.implementer_substitutions"
                 " in cross-repo-status.json with rationale.",
+                file=sys.stderr,
+            )
+        if org_persona_not_member:
+            print(
+                f"\n  {org_persona_not_member} of the above resolve as KNOWN org personas but"
+                " are NOT on\n"
+                "  the target repo's roster, so a commit-capable slot cannot take them\n"
+                "  (#1134 — that slot must COMMIT there). This IS an assignment problem:\n"
+                "    (a) reassign to a member of the target repo's roster (preferred), or\n"
+                "    (b) onboard the persona into <repo>/.claude/team/roster/ + roster.json.\n"
+                "  If the assignment is genuinely intended, record it under"
+                " wave_{M}_decisions.implementer_substitutions\n"
+                "  in cross-repo-status.json with a rationale.",
                 file=sys.stderr,
             )
         if org_persona_unreadable:

--- a/.claude/skills/wave-scope/validate_matrix_names.py
+++ b/.claude/skills/wave-scope/validate_matrix_names.py
@@ -833,9 +833,9 @@ def _print_report_to_stderr(report: dict[str, list[dict[str, object]]]) -> int:
             )
         if org_persona_not_member:
             print(
-                f"\n  {org_persona_not_member} of the above resolve as KNOWN org personas but"
-                " are NOT on\n"
-                "  the target repo's roster, so a commit-capable slot cannot take them\n"
+                f"\n  {org_persona_not_member} unresolved row(s) above name a KNOWN org persona"
+                " who is NOT on the\n"
+                "  target repo's roster, so a commit-capable slot cannot take them\n"
                 "  (#1134 — that slot must COMMIT there). This IS an assignment problem:\n"
                 "    (a) reassign to a member of the target repo's roster (preferred), or\n"
                 "    (b) onboard the persona into <repo>/.claude/team/roster/ + roster.json.\n"
@@ -846,7 +846,8 @@ def _print_report_to_stderr(report: dict[str, list[dict[str, object]]]) -> int:
             )
         if org_persona_unreadable:
             print(
-                f"\n  {org_persona_unreadable} of the above is a KNOWN org persona on a repo\n"
+                f"\n  {org_persona_unreadable} unresolved row(s) above name a KNOWN org persona"
+                " on a repo\n"
                 "  whose roster could not be read. That is an ENVIRONMENT gap, not a bad\n"
                 "  assignment — do NOT record an implementer_substitution for it, and note\n"
                 "  that the same name DOES resolve in a review-class slot (the org-union\n"

--- a/.claude/skills/wave-scope/validate_matrix_names.py
+++ b/.claude/skills/wave-scope/validate_matrix_names.py
@@ -124,6 +124,43 @@ but unclassified key is reported `slot_class="unclassified"` and fails the run �
 NOT merely warned about, because a warning printed inside an otherwise-green job
 is exactly the advisory posture § Hard fail already records as insufficient.
 
+Suggestions are ADVISORY and are drawn from the WIDEST set (#1182)
+==================================================================
+The narrow-resolution rule above governs what RESOLVES. It must not also govern
+what the report is allowed to SAY. Sourcing `suggestions` from the same narrow
+`combined` set made the validator print a claim it could disprove from a local
+in the same call frame:
+
+    # noorinalabs-user-service deliberately not cloned; real org roster data
+    {"noorinalabs-user-service": {"implementer": "Anya Kowalczyk",
+                                  "reviewer":    "Anya Kowalczyk"}}
+
+        implementer: 'Anya Kowalczyk'  ->  suggestions: (no close matches)
+        reviewer     resolved=True
+
+`Anya Kowalczyk` is an exact key of the `org_manifest` set `validate()` had
+already loaded, and is a real member of the target repo's own roster. So the
+report asserted "(no close matches)" about a name it held, and the SAME name in
+the SAME run resolved one line above — leaving an operator unable to tell
+whether the persona exists at all. The printed remediation then steered toward
+recording an `implementer_substitution`, i.e. toward changing a CORRECT
+assignment, when the real remedy (`--fetch-missing` / clone the repo) was only
+named on the `unverified` path this row never reaches.
+
+`suggestions` is advisory text: nothing reads it, and it never feeds `resolved`
+or the exit code. So it is sourced from `review_combined` for every slot, and an
+unresolved commit-capable name that IS a known org persona whose target roster
+could not be read gets its own diagnostic (`unresolved_reason`) pointing at
+`--fetch-missing` instead of at the substitution guidance.
+
+This is deliberately MESSAGE-ONLY. `resolved` stays False and the exit code
+stays 1 for exactly the rows they did before — the #1134 carve-out pinned by
+`test_manifest_does_not_pass_implementer_on_uncloned_repo` is untouched, and
+`test_1182_message_change_is_semantically_inert` pins the inertness directly so
+a later "improvement" cannot quietly relax it. Widening the RESOLUTION set here
+is the over-broad variant that flips this case to `resolved=True
+membership=unverified`, exit 0 — the silent pass #1134 exists to stop.
+
 Why check 2 is implementer-only. The implementer is the only role that must
 produce a **commit in the target repo**, where `validate_commit_identity`
 (Hook 5) resolves the author against that repo's roster. Reviewers never
@@ -298,6 +335,12 @@ NON_ROLE_ROW_KEYS: frozenset[str] = frozenset({"pre_kickoff_blocker"})
 # Not a role slot and not metadata — the recorded #1134 escape hatch, consumed
 # by `_override_rationale` rather than validated as a name.
 OVERRIDE_KEY = "roster_union_override"
+
+# `unresolved_reason` values (#1182). PURELY diagnostic: they select which
+# remediation paragraph is printed for an unresolved row and are read nowhere
+# else — never by the exit-code arithmetic, which keys off `resolved`.
+_REASON_ORG_PERSONA_UNREADABLE = "org-persona-unreadable-roster"
+_REASON_UNKNOWN_NAME = "unknown-name"
 
 
 def is_role_slot_key(key: str) -> bool:
@@ -511,6 +554,14 @@ def validate(
                            cannot decide, so does not fail
       - ``"n/a"``        — review-class slot, parent-repo row, or unresolved name
 
+    `unresolved_reason` (#1182) is present on UNRESOLVED entries only and is
+    purely diagnostic — it selects which remediation `_print_report_to_stderr`
+    prints, and never changes `resolved` or the exit code:
+      - ``"org-persona-unreadable-roster"`` — the name is a known org-manifest
+        persona and the target repo's roster could not be read (not cloned).
+        Remedy: `--fetch-missing` or clone the repo — NOT a substitution.
+      - ``"unknown-name"``  — every other unresolved name.
+
     `slot_class` (#1180) is ``"known"`` when the slot key is in
     `KNOWN_ROLE_SLOTS`, else ``"unclassified"`` — a hard failure in
     `_print_report_to_stderr`. It is orthogonal to `resolved` / `membership`:
@@ -565,7 +616,24 @@ def validate(
                 "slot_class": "known" if role in KNOWN_ROLE_SLOTS else "unclassified",
             }
             if not resolved:
-                entry["suggestions"] = _suggest(declared_clean, candidates)
+                # #1182: advisory text is sourced from the WIDEST name set the
+                # call frame holds, NOT from the (deliberately narrow)
+                # resolution set — see module docstring § Suggestions are
+                # ADVISORY. Nothing downstream reads `suggestions`, so this
+                # cannot move `resolved` or the exit code.
+                entry["suggestions"] = _suggest(declared_clean, review_combined)
+                # An unresolved commit-capable name that IS a known org persona,
+                # on a repo whose roster could not be read, is an ENVIRONMENT
+                # gap (repo not cloned), not a bad assignment. It gets its own
+                # remediation. Unreachable for review-class slots by
+                # construction: `review_combined` contains `org_manifest`, so a
+                # manifest name in a review slot has already resolved.
+                in_manifest = any(declared_clean.lower() == known.lower() for known in org_manifest)
+                entry["unresolved_reason"] = (
+                    _REASON_ORG_PERSONA_UNREADABLE
+                    if in_manifest and not membership_decidable
+                    else _REASON_UNKNOWN_NAME
+                )
                 repo_findings.append(entry)
                 continue
             # #1134: commit-capable slots on a child repo must be repo members.
@@ -666,6 +734,8 @@ def _print_report_to_stderr(report: dict[str, list[dict[str, object]]]) -> int:
     """
     total = 0
     unresolved = 0
+    unknown_name = 0
+    org_persona_unreadable = 0
     cross_repo = 0
     overridden = 0
     unverified = 0
@@ -675,6 +745,10 @@ def _print_report_to_stderr(report: dict[str, list[dict[str, object]]]) -> int:
             total += 1
             if not f["resolved"]:
                 unresolved += 1
+                if f.get("unresolved_reason") == _REASON_ORG_PERSONA_UNREADABLE:
+                    org_persona_unreadable += 1
+                else:
+                    unknown_name += 1
             if f.get("slot_class") == "unclassified":
                 unclassified += 1
             membership = f.get("membership")
@@ -697,6 +771,16 @@ def _print_report_to_stderr(report: dict[str, list[dict[str, object]]]) -> int:
                 continue
             print(f"\n  {repo}:", file=sys.stderr)
             for f in bad:
+                if f.get("unresolved_reason") == _REASON_ORG_PERSONA_UNREADABLE:
+                    # #1182: printing "suggestions: <the declared name itself>"
+                    # here would read as a bug, so this row states the finding.
+                    print(
+                        f"    - {f['role']}: {f['declared']!r}  →  KNOWN org persona "
+                        "(present in .claude/team/roster.json); this repo's roster "
+                        "could not be read — not cloned?",
+                        file=sys.stderr,
+                    )
+                    continue
                 raw_suggestions = f.get("suggestions")
                 suggestions = raw_suggestions if isinstance(raw_suggestions, list) else []
                 sug_str = ", ".join(suggestions) if suggestions else "(no close matches)"
@@ -704,12 +788,29 @@ def _print_report_to_stderr(report: dict[str, list[dict[str, object]]]) -> int:
                     f"    - {f['role']}: {f['declared']!r}  →  suggestions: {sug_str}",
                     file=sys.stderr,
                 )
-        print(
-            "\n  Resolve each unknown name before /wave-kickoff fan-out.\n"
-            "  Approved substitutions: record under wave_{M}_decisions.implementer_substitutions"
-            " in cross-repo-status.json with rationale.",
-            file=sys.stderr,
-        )
+        if unknown_name:
+            print(
+                "\n  Resolve each unknown name before /wave-kickoff fan-out.\n"
+                "  Approved substitutions: record under"
+                " wave_{M}_decisions.implementer_substitutions"
+                " in cross-repo-status.json with rationale.",
+                file=sys.stderr,
+            )
+        if org_persona_unreadable:
+            print(
+                f"\n  {org_persona_unreadable} of the above is a KNOWN org persona on a repo\n"
+                "  whose roster could not be read. That is an ENVIRONMENT gap, not a bad\n"
+                "  assignment — do NOT record an implementer_substitution for it, and note\n"
+                "  that the same name DOES resolve in a review-class slot (the org-union\n"
+                "  manifest widens review-class resolution only, #1162).\n"
+                "\n  Pick one and re-run:\n"
+                "    (a) --fetch-missing — resolve the target roster over the network, or\n"
+                "    (b) clone the repo beside the parent.\n"
+                "\n  It stays a failure (exit 1) until then, deliberately: a commit-capable\n"
+                "  slot passes only on a name the TARGET repo can vouch for (#1134), and\n"
+                "  membership cannot be decided from an unreadable roster.",
+                file=sys.stderr,
+            )
 
     if cross_repo:
         print(


### PR DESCRIPTION
Closes #1182.

`validate_matrix_names.py` reported a genuine member of an uncloned repo's roster as UNRESOLVED with `(no close matches)` — an assertion it could disprove from a local in the same call frame. Suggestions for a commit-capable slot were drawn from `combined` (the deliberately narrow resolution set), so the `org_manifest` set `validate()` had already loaded was invisible to `_suggest`.

## The bug, measured

Real org roster data, `noorinalabs-user-service` deliberately absent from the org dir, `org_dir` passed explicitly so `_find_org_dir()`'s walk-up-from-cwd cannot produce a false negative. Reproducer run at `77dc9af` (= `origin/main` at branch point, i.e. **after** #1180/PR #1277):

```
real noorinalabs-user-service roster member: Anya Kowalczyk
in org manifest?  True   (manifest personas: 76)
noorinalabs-user-service cloned in scratch org? False
target repo roster read: []

validate_matrix_names: 1/2 names UNRESOLVED across 1 entries.

  noorinalabs-user-service:
    - implementer: 'Anya Kowalczyk'  →  suggestions: (no close matches)

  Resolve each unknown name before /wave-kickoff fan-out.
  Approved substitutions: record under wave_{M}_decisions.implementer_substitutions in cross-repo-status.json with rationale.

  implementer resolved=False  membership='n/a' suggestions=[]
  reviewer    resolved=True   membership='n/a' suggestions=None
  exit code: 1
```

## After

```
validate_matrix_names: 1/2 names UNRESOLVED across 1 entries.

  noorinalabs-user-service:
    - implementer: 'Anya Kowalczyk'  →  KNOWN org persona (present in .claude/team/roster.json); this repo's roster could not be read — not cloned?

  1 unresolved row(s) above name a KNOWN org persona on a repo
  whose roster could not be read. That is an ENVIRONMENT gap, not a bad
  assignment — do NOT record an implementer_substitution for it, and note
  that the same name DOES resolve in a review-class slot (the org-union
  manifest widens review-class resolution only, #1162).

  Pick one and re-run:
    (a) --fetch-missing — resolve the target roster over the network, or
    (b) clone the repo beside the parent.

  It stays a failure (exit 1) until then, deliberately: a commit-capable
  slot passes only on a name the TARGET repo can vouch for (#1134), and
  membership cannot be decided from an unreadable roster.

  implementer resolved=False  membership='n/a' suggestions=['Anya Kowalczyk'] unresolved_reason='org-persona-unreadable-roster'
  reviewer    resolved=True   membership='n/a' suggestions=None
  exit code: 1
```

## Proof the change is semantically inert

Same scenario, pre-change tree exported with `git archive origin/main` (never `git --work-tree` against the shared checkout), post-change tree at branch HEAD:

| | `resolved` | `membership` | exit |
|---|---|---|---|
| BEFORE (`origin/main` `77dc9af`) | `False` | `n/a` | **1** |
| AFTER (branch HEAD `6b1bef4`) | `False` | `n/a` | **1** |

The only report-shape deltas are the two advisory keys (`suggestions`, `unresolved_reason`) — nothing reads them, and neither feeds the exit-code arithmetic, which keys off `resolved`.

`test_1182_message_change_is_semantically_inert` pins this directly: it strips the advisory keys and asserts the remaining entry is byte-identical to the pre-#1182 shape, plus exit 1. The over-broad variant this guards against — widening the RESOLUTION set instead of the suggestion set — was measured on the same live data and flips this exact row to:

```
  implementer resolved=True   membership='unverified'
  exit code: 0
```

which is the silent pass #1134 exists to stop. `test_manifest_does_not_pass_implementer_on_uncloned_repo` and `test_third_child_reviewer_resolves_and_implementer_stays_gated` both go red under it (see M4 below), so the carve-out is pinned from three directions.

## A second, self-inflicted bug found and fixed mid-change

Widening the suggestion source fixed the lie but created a new one on the adjacent case. `difflib.get_close_matches` returns the declared name ITSELF on an exact manifest hit, so a known org persona scoped onto a repo that **is** cloned printed:

```
    - implementer: 'Nikolaos Papadopoulos'  →  suggestions: Nikolaos Papadopoulos
```

Measured on the real org dir while checking the #1289 interaction. That row now states the finding and names the roster the slot could actually take:

```
    - implementer: 'Nikolaos Papadopoulos'  →  KNOWN org persona (present in .claude/team/roster.json), but NOT on this repo's roster.
      repo roster: Anya Kowalczyk, Idris Yusuf, Mateo Salazar, Nadia Boukhari
```

Hence three `unresolved_reason` values, not two. Unlike the uncloned case this one **is** a genuine assignment problem, so it keeps the reassign / onboard / recorded-substitution guidance and deliberately does not mention `--fetch-missing`.

## Mutation table

15 mutants, each applied to the committed validator, `pytest tests/ -q` run from `.claude/skills/wave-scope` (the way `pytest-skills` runs it in CI), then restored with `git checkout HEAD -- <path>`. Baseline and post-restore both `71 passed, 38 subtests passed`.

| # | Mutation | Result | Killed by |
|---|---|---|---|
| M1 | suggestion source reverted to the narrow `combined` (the #1182 bug) | KILLED | `test_no_close_matches_is_not_claimed_about_a_manifest_name`, `test_genuine_typo_on_an_uncloned_repo_still_reports_unknown_name` |
| M2 | `elif membership_decidable` collapsed to always-true | KILLED | `test_1182_message_change_is_semantically_inert`, `test_uncloned_org_persona_is_steered_to_fetch_missing_not_substitution`, `test_scope_mode_carries_the_diagnostic_end_to_end`, +2 |
| M3 | `if not in_manifest` collapsed to never | KILLED | `test_genuine_typo_on_an_uncloned_repo_still_reports_unknown_name`, `test_all_three_unresolved_classes_print_their_own_remediation` |
| M4 | **the over-broad variant**: widen the RESOLUTION set instead of the suggestion set | KILLED | `test_1182_message_change_is_semantically_inert`, `OrgUnionManifestTests::test_manifest_does_not_pass_implementer_on_uncloned_repo`, `OrgUnionManifestTests::test_third_child_reviewer_resolves_and_implementer_stays_gated`, `UnclassifiedRoleSlotTests::test_unclassified_slot_resolves_against_the_narrow_set`, +5 |
| M5 | unknown-name trailer printed unconditionally | KILLED | `test_uncloned_org_persona_is_steered_to_fetch_missing_not_substitution` |
| M6 | `--fetch-missing` trailer printed unconditionally | KILLED | `test_manifest_persona_on_a_CLONED_repo_still_gets_substitution_guidance` |
| M7 | distinct uncloned per-row line removed | KILLED | `test_no_close_matches_is_not_claimed_about_a_manifest_name` |
| M8 | unknown-name and `--fetch-missing` trailers made mutually exclusive | KILLED | `test_all_three_unresolved_classes_print_their_own_remediation` |
| M9 | `unresolved_reason` stamped on RESOLVED rows too | KILLED | `test_resolved_rows_carry_no_unresolved_reason` |
| M10 | uncloned branch relabelled `unknown-name` | KILLED | `test_no_close_matches_is_not_claimed_about_a_manifest_name`, `test_scope_mode_carries_the_diagnostic_end_to_end`, +3 |
| M11 | `continue` after the uncloned row dropped (row printed twice) | KILLED | `test_no_close_matches_is_not_claimed_about_a_manifest_name` |
| M12 | not-a-member per-row line removed (falls through to the self-referential suggestion) | KILLED | `test_manifest_persona_on_a_CLONED_repo_still_gets_substitution_guidance` |
| M13 | not-a-member trailer suppressed | KILLED | `test_manifest_persona_on_a_CLONED_repo_still_gets_substitution_guidance`, `test_all_three_unresolved_classes_print_their_own_remediation` |
| M14 | not-a-member row no longer names the roster it could take | KILLED | `test_manifest_persona_on_a_CLONED_repo_still_gets_substitution_guidance` |
| M15 | not-a-member trailer chained after unknown-name | KILLED | `test_all_three_unresolved_classes_print_their_own_remediation` |

**Two mutants survived the first drafts and are the reason two of the tests exist:**

- **M7 survived draft 1.** The remediation trailer also contains the phrase `KNOWN org persona`, so a whole-stream `assertIn` stayed green with the per-row line deleted — the assertion was vacuous. Fixed by `_finding_row()`, which extracts the single per-finding line for a role and raises unless there is exactly one, so row-level claims are checked against the row. (That helper is also what kills M11 and M12.)
- **M8 survived draft 2.** With only ONE of the two later counters non-zero, an `elif` still executes, so a two-class run cannot distinguish three independent `if`s from a chain. `test_all_three_unresolved_classes_print_their_own_remediation` carries all three unresolved classes at once and kills M8 and M15.

## Interaction with #1289

**Measured, not asserted.** #1289's exact matrix (`implementer` / `reviewer` / `risk_owner: "Santiago Ferreira"`) run against the real org dir on both trees:

```
BEFORE EXIT=1
       validate_matrix_names: 1/3 names UNRESOLVED across 1 entries.
       validate_matrix_names: 1/3 CROSS-REPO IMPLEMENTER assignment(s) with no recorded override (#1134).
       validate_matrix_names: 1/3 UNCLASSIFIED role slot(s) (#1180).
AFTER  EXIT=1
       validate_matrix_names: 1/3 names UNRESOLVED across 1 entries.
       validate_matrix_names: 1/3 CROSS-REPO IMPLEMENTER assignment(s) with no recorded override (#1134).
       validate_matrix_names: 1/3 UNCLASSIFIED role slot(s) (#1180).
```

The compound `#1134` + `#1180` message #1289 objects to is **byte-identical** across the change; the only stderr delta in that scenario is the `implementer` row inside the UNRESOLVED block. That is structural, not luck: `risk_owner` **resolves** (Santiago is on the parent cards), so it goes down the membership path, while everything this PR touches lives on the `if not resolved:` path and in the UNRESOLVED print block. **This PR neither fixes nor worsens #1289**, and does not conflict with its candidate fix (skip the membership check when `slot_class == "unclassified"`), which is in the other branch.

## Gates

All run locally from the org root before pushing.

- `pytest` (wave-scope, CI-style from the skill dir): `71 passed, 38 subtests passed`
- `pytest .claude/hooks/tests/ .claude/lib/tests/`: `3641 passed, 651 subtests passed`
- every skill suite: promotion-audit 102, wave-kickoff 8, wave-scope 71, wave-wrapup 15 — `OVERALL=0`
- `ruff check .claude/skills/wave-scope/`: `All checks passed!` · `ruff format`: clean
- `mypy .claude/skills/wave-scope` and `mypy .claude/hooks/ .claude/lib/`: no errors
- `python3 .claude/lib/pre_commit_ci_sync.py .`: `OK: pre-commit config mirrors all CI-enforced checks.`
- full pre-push hook set passed on `git push` (mypy, mypy-skills, pytest, pytest-skills, memory-budget, headcount-budget, doc-freshness, office-drift, mermaid-render)

## Follow-up debt

- #1291 — the same membership failure is split across the UNRESOLVED block and the `#1134` CROSS-REPO block depending on whether the persona is parent-carded, and `roster_union_override` is consequently reachable only for parent-carded personas (`tech-debt` / `process` / `phase-10`, no wave label). Measured while implementing this PR.

## Reviewers

Two per charter. Not for merge by me — the orchestrator drives the review gate.
