### PR TITLE
fix(hooks/#1195): resolve simple literal assignments before commit-identity matching

### DIFF
--- a/.claude/hooks/_shell_parse.py
+++ b/.claude/hooks/_shell_parse.py
@@ -54,6 +54,20 @@ Public API
         inside quotes), strips leading `KEY=value` env-var assignments from
         each segment, and yields the surviving tokens.
 
+    resolve_simple_assignments(command) -> str
+        Bounded assignment-aware pre-pass (main#1195): resolves a leading
+        `NAME=value` assignment (bare literal value only — no `$`,
+        backticks, parens, or whitespace) and substitutes later `$NAME` /
+        `${NAME}` references elsewhere in `command` with that value, so
+        `g=git; $g commit` normalizes to `git commit` before either the
+        indirect-exec detector or the direct commit-segment finder sees it.
+        Returns `command` unchanged when tokenize() fails or no qualifying
+        assignment is found — can only ADD a detection, never remove one.
+        Deliberately does not resolve command substitution (`d=$(date)`),
+        positional/special parameters (`$1`, `$?`, ...), or multi-word/prose
+        values — see the module comment above the implementation for the
+        false-positive this excludes.
+
     iter_command_segments_ast(command) -> list[list[str]] | None
         Structural (bashlex) alternative to tokenize + iter_command_segments:
         parses `command` into a real Bash AST and returns every
@@ -1112,6 +1126,130 @@ def _strip_leading_env_assignments(segment: list[str]) -> list[str]:
     while i < len(segment) and _ENV_ASSIGN_RE.match(segment[i]):
         i += 1
     return segment[i:]
+
+
+# ---------------------------------------------------------------------------
+# Assignment-aware pre-pass (main#1195)
+# ---------------------------------------------------------------------------
+#
+# `_payload_looks_like_commit` (validate_commit_identity) and the direct
+# `git ... commit` finder (`find_git_subcommand`) both require the literal
+# token `git` in command position. Holding the command word in a shell
+# variable defeats BOTH with no interpreter wrapper at all:
+#
+#     g=git; $g commit -m x
+#
+# `$g` sits in command position exactly like a literal `git` would, and the
+# shell resolves it at runtime; neither matcher can see through the
+# indirection (measured on main#1193's head: `_payload_looks_like_commit`
+# returns False on this exact string, and the direct-typed form with no
+# wrapper at all is likewise allowed).
+#
+# This is a BOUNDED pre-pass, not general shell evaluation. It resolves only
+# a LEADING run of `NAME=value` tokens at a segment's start (the same shape
+# `_strip_leading_env_assignments` already recognises — one segment, one
+# leading run) whose value is a bare literal, and substitutes later `$NAME`
+# / `${NAME}` references anywhere in the command with that literal value.
+# Deliberately does NOT resolve:
+#   - command substitution (`d=$(date)`) — the value fails the
+#     literal-charset check below, so `d` is never added to the map and a
+#     later `$d` is left untouched. This is the guard against exactly the
+#     false-positive shape the issue calls out: `d=$(date); echo $d` is an
+#     ordinary shape and must not block.
+#   - positional/special parameters (`$1`, `$?`, `$@`, `$$`, ...) — the
+#     capture regex requires a name starting with a letter or underscore, so
+#     these never match as an assignment NAME in the first place.
+#   - multi-word / prose values (`msg="please git commit this later"`) — a
+#     quoted value survives shlex de-quoting as ONE token, so a value
+#     containing a space is caught and rejected by the literal-charset check
+#     (values in this module's charset never contain whitespace). Without
+#     this exclusion, resolving `$msg` inside an unrelated `echo $msg` would
+#     manufacture a `git ... commit` bridge out of prose that was never
+#     going to run a commit — a false positive of exactly the class the
+#     issue warns a false positive here is an outage.
+#   - `$1`-style arrays, `eval`-of-a-variable, and command substitution of
+#     the COMMAND WORD itself (`$(printf git) commit`) — out of scope per
+#     the issue; same family, strictly harder.
+#
+# Applied ONCE, on the raw command, before either the indirect-exec detector
+# or the direct commit-segment finder run — a single pre-pass point rather
+# than teaching two independent matchers the same resolution. main#1152's
+# repeated lesson is exactly this: two places answering the same question
+# independently drift. `resolve_simple_assignments` returns the command
+# UNCHANGED whenever no qualifying assignment is found (the overwhelming
+# majority of commands), so it can only ever ADD a detection, never remove
+# one, and is a no-op for every pre-existing passing shape.
+_SIMPLE_LITERAL_VALUE_RE = re.compile(r"^[A-Za-z0-9_./:@%+-]+$")
+
+# `$NAME` or `${NAME}` — a name starting with a letter/underscore, same
+# identifier shape `_ENV_ASSIGN_RE` requires on the assignment side. Digits-
+# leading references (`$1`, `$2`, ...) and single-punctuation specials
+# (`$?`, `$@`, `$$`, `$*`, `$#`) never match this pattern, by construction.
+_VAR_REF_RE = re.compile(r"\$\{(?P<name_braced>[A-Za-z_]\w*)\}|\$(?P<name_bare>[A-Za-z_]\w*)\b")
+
+
+def resolve_simple_assignments(command: str) -> str:
+    """Resolve simple literal `NAME=value` assignments before matching (main#1195).
+
+    Scans every pipeline segment (split on `;`, `&&`, `||`, `|` — the same
+    `_SEGMENT_OPS` set `iter_command_segments` splits on) for a LEADING run
+    of `NAME=value` tokens whose value is a bare literal (see the module
+    comment above for the exact exclusions), then substitutes later `$NAME`
+    / `${NAME}` references anywhere in `command` with the resolved value.
+
+    Returns `command` unchanged when `tokenize()` fails (this pre-pass never
+    manufactures a NEW parse failure — the existing `_PARSE_FAILURE`
+    fail-closed path in the caller already handles unparseable input) or
+    when no qualifying assignment is found.
+
+    Tokenizes `normalize_command_separators(command)`, NOT `command` itself
+    (measured defect, fixed before this function's first release): shlex
+    only recognises `;`/`|`/`&&`/`||` as standalone tokens when they are
+    ALREADY surrounded by whitespace, so the issue's own primary shape,
+    `g=git; $g commit -m x` (no space before `;`), tokenizes `g=git;` as ONE
+    token. The trailing `;` then lands inside the captured value ("git;"),
+    fails the literal-charset check below, and `g` is silently never
+    resolved — reintroducing the exact bug this function exists to close.
+    `normalize_command_separators` is quote-aware and pads every unquoted
+    separator with spaces first, so segmentation is correct regardless of
+    the operator's original spacing. Substitution is still applied to the
+    ORIGINAL `command` text — normalization only adds whitespace around
+    operators, never changes a token's value, so the assignment map built
+    from the normalized tokens is valid for substitution into either string.
+    """
+    tokens = tokenize(normalize_command_separators(command))
+    if tokens is None:
+        return command
+
+    segments: list[list[str]] = []
+    cur: list[str] = []
+    for tok in tokens:
+        if tok in _SEGMENT_OPS:
+            if cur:
+                segments.append(cur)
+            cur = []
+            continue
+        cur.append(tok)
+    if cur:
+        segments.append(cur)
+
+    assignments: dict[str, str] = {}
+    for segment in segments:
+        i = 0
+        while i < len(segment) and _ENV_ASSIGN_RE.match(segment[i]):
+            name, _eq, value = segment[i].partition("=")
+            if _SIMPLE_LITERAL_VALUE_RE.match(value):
+                assignments[name] = value
+            i += 1
+
+    if not assignments:
+        return command
+
+    def _substitute(m: re.Match[str]) -> str:
+        name = m.group("name_braced") or m.group("name_bare")
+        return assignments.get(name, m.group(0))
+
+    return _VAR_REF_RE.sub(_substitute, command)
 
 
 def bashlex_available() -> bool:

--- a/.claude/hooks/_shell_parse.py
+++ b/.claude/hooks/_shell_parse.py
@@ -1290,8 +1290,35 @@ def _leading_literal_assignments(tokens: list[str]) -> dict[str, str]:
     """Literal `NAME=value` pairs from the LEADING run of assignment tokens
     in `tokens`, tolerating one optional `export`/`declare` prefix (#1305).
 
+    `tokens` is first run through `strip_command_prefixes()` (main#1311) —
+    the SAME helper `find_git_subcommand` / `find_gh_subcommand` already use
+    to skip a compound-statement leader (`do`, `then`, `else`, `if`, `elif`,
+    `while`, `until`, `{`, `(`) or a transparent wrapper (`timeout`, `env`,
+    `nice`, ...) before looking for the command word. Without this, `for f
+    in a; do g=git; $g commit -m x; done` tokenizes its `do`-segment to
+    `["do", "g=git"]`; the leading-position check saw `"do"` (not an
+    assignment, not `export`/`declare`) and stopped immediately, so the
+    assignment one token to the right — at index 1, not 0 — was never
+    captured, and the hook ALLOWed a command a real shell genuinely runs
+    (confirmed with a marker proxy; same gap defeats `while`/`if` bodies and
+    a wrapped `bash -c '...'` indirect-exec payload the same way). This is
+    the module's own documented hazard
+    (`extract_dash_c_pairs` vs `find_git_subcommand` holding different views
+    of one segment) recurring one level up — `_leading_literal_assignments`
+    had its own, narrower notion of "leading" than the rest of the module.
+    Routing through `strip_command_prefixes()` here (default
+    `compound_leaders=True`, the gate-matcher setting: over-matching can at
+    worst capture an assignment from a body that may not run, which per this
+    pre-pass's own invariant can only ADD a detection, never remove one) is
+    the fix, rather than adding `do`/`then` to `_ASSIGNMENT_KEYWORDS` (a
+    THIRD independent view of the same segment, reproducing the hazard
+    again).
+
     Returns `{}` when `tokens` carries no qualifying leading assignment.
     """
+    if not tokens:
+        return {}
+    tokens = strip_command_prefixes(tokens)
     if not tokens:
         return {}
     i = 1 if tokens[0] in _ASSIGNMENT_KEYWORDS else 0
@@ -1379,6 +1406,89 @@ def _substitute_var_refs(text: str, assignments: dict[str, str]) -> str:
     return _VAR_REF_RE.sub(_sub, text)
 
 
+def _single_quoted_spans(text: str) -> list[tuple[int, int]]:
+    """(start, end) spans of every single-quoted region's INSIDE text.
+
+    Main#1195 finding 1 (round 4): a SAME-segment prefix assignment (`g=git
+    bash -c '$g commit -m x'`) genuinely resolves inside a SINGLE-quoted
+    argument, because that argument is opaque text handed to a CHILD
+    interpreter (`bash -c '...'`) which does its OWN expansion, in its OWN
+    environment — and a prefix assignment is placed into the invoked
+    command's environment regardless of `export` (real-shell-verified with a
+    marker proxy: this genuinely runs `git commit -m x`). That is a DIFFERENT
+    evaluator, and a different visibility rule, than the bare/double-quoted
+    reference `resolve_simple_assignments`'s docstring already covers (`A=1
+    B=git $B commit -m z` — the OUTER shell expands `$B` itself, before its
+    own prefix takes effect, so it stays unresolved; `bash -c "$g commit"`
+    is the identical case one level down — the OUTER shell expands the
+    double-quoted argument at that SAME expansion point, so `$g` is unset
+    there too and must NOT resolve). Quotes are the only signal available
+    post-tokenization for which evaluator will see a given `$NAME` — hence
+    scanning for single-quoted spans specifically, rather than teaching
+    `_substitute_var_refs` about "this is a child payload" some other way.
+
+    Escape-aware the same way `_iter_original_segment_spans` is: a backslash
+    escapes the next character when inside DOUBLE quotes or unquoted (POSIX:
+    single quotes take no backslash-escaping at all, so none is honoured
+    while scanning for the close of a `'...'` span — an escaped quote is not
+    a thing single quotes support). Returned spans exclude the delimiting
+    quote characters themselves, so callers can substitute inside them
+    without disturbing the quoting.
+    """
+    spans: list[tuple[int, int]] = []
+    quote: str | None = None
+    inner_start = 0
+    i = 0
+    n = len(text)
+    while i < n:
+        c = text[i]
+        if quote is not None:
+            if quote == '"' and c == "\\" and i + 1 < n:
+                i += 2
+                continue
+            if c == quote:
+                if quote == "'":
+                    spans.append((inner_start, i))
+                quote = None
+            i += 1
+            continue
+        if c == "\\" and i + 1 < n:
+            i += 2
+            continue
+        if c in ("'", '"'):
+            quote = c
+            inner_start = i + 1
+            i += 1
+            continue
+        i += 1
+    return spans
+
+
+def _substitute_within_single_quotes(text: str, assignments: dict[str, str]) -> str:
+    """Apply `_substitute_var_refs` to `text`, restricted to single-quoted spans.
+
+    Returns `text` unchanged (same object) when nothing inside any
+    single-quoted span actually changes, matching the no-op contract the
+    rest of `resolve_simple_assignments` relies on.
+    """
+    spans = _single_quoted_spans(text)
+    if not spans:
+        return text
+    parts: list[str] = []
+    prev_end = 0
+    changed = False
+    for start, end in spans:
+        parts.append(text[prev_end:start])
+        quoted = text[start:end]
+        substituted = _substitute_var_refs(quoted, assignments)
+        if substituted != quoted:
+            changed = True
+        parts.append(substituted)
+        prev_end = end
+    parts.append(text[prev_end:])
+    return "".join(parts) if changed else text
+
+
 def resolve_simple_assignments(command: str) -> str:
     """Resolve simple literal `NAME=value` assignments before matching (main#1195).
 
@@ -1407,6 +1517,16 @@ def resolve_simple_assignments(command: str) -> str:
     assignments are folded into the running map for segments that follow
     (so they become visible starting with the NEXT segment, never the
     current one).
+
+    Round 4 exception (main#1195 finding 1): a segment's own leading
+    assignments DO apply within a single-quoted span of that SAME segment —
+    `g=git bash -c '$g commit -m x'` genuinely runs `git commit -m x`,
+    real-shell-verified, because the quoted text is a CHILD interpreter's
+    payload (expanded later, in an environment the prefix assignment already
+    populated), not a reference the outer shell expands itself. See
+    `_single_quoted_spans` for the full reasoning; `bash -c "$g commit"`
+    (double-quoted) is unaffected and stays unresolved, same as a bare
+    same-segment reference.
 
     Returns `command` unchanged when `tokenize()` fails (this pre-pass never
     manufactures a NEW parse failure — the existing `_PARSE_FAILURE`
@@ -1471,6 +1591,22 @@ def resolve_simple_assignments(command: str) -> str:
             segment_text = _substitute_var_refs(orig_segment_text, active)
             if segment_text != orig_segment_text:
                 changed = True
+
+        # Round 4 (main#1195 finding 1): a segment's OWN leading assignments
+        # — unlike the running `active` map above — apply ONLY inside a
+        # single-quoted span of THIS SAME segment (see
+        # `_single_quoted_spans`'s docstring for the real-shell reasoning:
+        # that text is opaque to the outer shell and is expanded later by a
+        # CHILD interpreter that inherits the prefix-assigned environment).
+        # A bare or double-quoted reference in the same segment is expanded
+        # by the OUTER shell instead, at the same point `active` (never
+        # `own_assignments`) already governs — untouched by this pass.
+        if own_assignments:
+            quoted_text = _substitute_within_single_quotes(segment_text, own_assignments)
+            if quoted_text != segment_text:
+                segment_text = quoted_text
+                changed = True
+
         out_parts.append(segment_text)
         prev_end = end
 

--- a/.claude/hooks/_shell_parse.py
+++ b/.claude/hooks/_shell_parse.py
@@ -57,10 +57,21 @@ Public API
     resolve_simple_assignments(command) -> str
         Bounded assignment-aware pre-pass (main#1195): resolves a leading
         `NAME=value` assignment (bare literal value only — no `$`,
-        backticks, parens, or whitespace) and substitutes later `$NAME` /
-        `${NAME}` references elsewhere in `command` with that value, so
+        backticks, parens, or whitespace; an optional single leading
+        `export`/`declare` keyword is tolerated, #1305) and substitutes
+        later `$NAME` / `${NAME}` references with that value, so
         `g=git; $g commit` normalizes to `git commit` before either the
         indirect-exec detector or the direct commit-segment finder sees it.
+        Resolution is POSITIONAL, not a single flat last-wins map: each
+        pipeline segment is substituted using only the assignment state
+        accumulated from segments STRICTLY BEFORE it, in source order — the
+        same rule a real shell applies. This closes the order-blind hole a
+        flat map opens (main#1195 review round 2): `g=git; $g commit -m x;
+        g=echo` must still resolve `$g` to `git` at the commit site even
+        though `g` is reassigned afterward, and — the mirror image a naive
+        "first assignment wins" flip would introduce — `g=echo; $g commit;
+        g=git` must NOT resolve `$g` to `git`, because that reassignment
+        hasn't happened yet at the point `$g` is used.
         Returns `command` unchanged when tokenize() fails or no qualifying
         assignment is found — can only ADD a detection, never remove one.
         Deliberately does not resolve command substitution (`d=$(date)`),
@@ -1179,77 +1190,258 @@ def _strip_leading_env_assignments(segment: list[str]) -> list[str]:
 # UNCHANGED whenever no qualifying assignment is found (the overwhelming
 # majority of commands), so it can only ever ADD a detection, never remove
 # one, and is a no-op for every pre-existing passing shape.
+#
+# ---------------------------------------------------------------------------
+# Positional resolution, not a flat last-wins map (main#1195 review round 2)
+# ---------------------------------------------------------------------------
+#
+# The first cut of this pre-pass built ONE flat `{name: value}` map across
+# EVERY segment of the command (last assignment to a given name wins,
+# regardless of where in the command it appears) and then substituted every
+# `$NAME` reference in the whole command against that single map. That is
+# order-blind, and a trailing reassignment reopens the exact bypass this
+# pre-pass exists to close:
+#
+#     g=git; $g commit -m x; g=echo
+#
+# A real shell resolves `$g` at the point it is used — `git`, because that
+# is the value `g` holds when the second segment runs; the later `g=echo`
+# hasn't happened yet. The flat map instead sees `g`'s LAST assignment
+# anywhere in the command (`echo`) and substitutes it everywhere, including
+# at the earlier reference — turning `$g commit -m x` into `echo commit -m
+# x`, which is not a `git` invocation at all. Neither the indirect-exec
+# detector nor the direct commit-segment finder can then see the commit,
+# and it sails through unvalidated. Confirmed against real shell behaviour
+# (a printf/marker proxy shows the indirected command genuinely runs): this
+# is a live bypass, not a cosmetic mismatch, and it reproduces the same way
+# for `; g=true`, `|| g=x`, and `; false && g=nope` — any trailing
+# reassignment, on any of the operators this module treats as a segment
+# separator, erases the earlier resolution.
+#
+# The fix is POSITIONAL resolution: walk segments in the ORDER they appear
+# in `command`, keep a running map of assignments seen so far, and resolve
+# each segment's `$NAME` references against that running map BEFORE folding
+# in that segment's own leading assignments (a segment's own assignment
+# takes effect for segments that follow it, never for references inside
+# itself — matching how a real shell evaluates one line before the next).
+#
+# A "first assignment wins, globally" flip was considered and rejected: it
+# fixes the above shape but breaks its mirror image,
+#
+#     g=echo; $g commit; g=git
+#
+# where the FIRST assignment (`echo`) is genuinely what `$g` holds at the
+# point of use, and the LATER `g=git` must NOT retroactively "resolve" the
+# reference — that would manufacture a `git commit` detection out of a
+# command that never runs one. Position-aware resolution (this
+# implementation) gets both directions right, because it always asks "what
+# does `g` hold at THIS point in the command", not "what is `g`'s first or
+# last value anywhere in the command".
+#
+# Still not covered (measured, not a gap in the mechanism above — a
+# different limitation entirely): `export g=git` / `declare g=git` are
+# folded IN here (main#1195's own reviewer: same bare-literal shape one
+# token to the right, arguably the most idiomatic spelling of the issue).
+# `local`/`typeset`/`readonly`, any wrapper (`env g=git ...`), command
+# substitution of the assigned value or the command word itself, and
+# multi-word/prose values remain OUT of scope — same non-goal boundary as
+# the rest of this module's exclusions, documented in the function
+# docstring below.
 _SIMPLE_LITERAL_VALUE_RE = re.compile(r"^[A-Za-z0-9_./:@%+-]+$")
 
 # `$NAME` or `${NAME}` — a name starting with a letter/underscore, same
 # identifier shape `_ENV_ASSIGN_RE` requires on the assignment side. Digits-
 # leading references (`$1`, `$2`, ...) and single-punctuation specials
 # (`$?`, `$@`, `$$`, `$*`, `$#`) never match this pattern, by construction.
+# The trailing `\b` on the bare form is load-bearing, not decorative: it is
+# what stops a shorter assigned name from being treated as a PREFIX of a
+# longer, unrelated reference (`$gone`, `$g_2`, `$gx` must never be read as
+# `$g` followed by literal `one`/`_2`/`x` — see the name-prefix-conflation
+# tests in `ResolveSimpleAssignmentsTests`, test_shell_parse.py, which
+# assert the resolver's OUTPUT STRING directly rather than a downstream
+# verdict, precisely so that weakening this anchor is caught here rather
+# than staying invisible behind a matcher that would reject the corrupted
+# name anyway).
 _VAR_REF_RE = re.compile(r"\$\{(?P<name_braced>[A-Za-z_]\w*)\}|\$(?P<name_bare>[A-Za-z_]\w*)\b")
+
+# Shell keywords that may prefix a literal `NAME=value` assignment at a
+# segment's leading position (#1305): `export FOO=bar` and `declare
+# FOO=bar` are the same bare-literal shape one token to the right of a bare
+# `FOO=bar`, not a harder family — folded in here rather than deferred.
+# Recognised only as a SINGLE leading token (one keyword, not stacked or
+# wrapped); `local`/`typeset`/`readonly` and any other wrapper stay out of
+# scope, same as everything else this pre-pass declines to resolve.
+_ASSIGNMENT_KEYWORDS = frozenset({"export", "declare"})
+
+
+def _leading_literal_assignments(tokens: list[str]) -> dict[str, str]:
+    """Literal `NAME=value` pairs from the LEADING run of assignment tokens
+    in `tokens`, tolerating one optional `export`/`declare` prefix (#1305).
+
+    Returns `{}` when `tokens` carries no qualifying leading assignment.
+    """
+    if not tokens:
+        return {}
+    i = 1 if tokens[0] in _ASSIGNMENT_KEYWORDS else 0
+    found: dict[str, str] = {}
+    while i < len(tokens) and _ENV_ASSIGN_RE.match(tokens[i]):
+        name, _eq, value = tokens[i].partition("=")
+        if _SIMPLE_LITERAL_VALUE_RE.match(value):
+            found[name] = value
+        i += 1
+    return found
+
+
+def _iter_original_segment_spans(command: str) -> list[tuple[int, int]]:
+    """Quote/escape-aware (start, end) span of each pipeline segment in
+    `command`, as ORIGINAL-text character offsets (main#1195 review round 2).
+
+    Mirrors `normalize_command_separators`'s operator/quote/escape rules
+    exactly — the same `;` / `|` / `&&` / `||` operator set, plus a bare
+    unescaped newline counting as a statement terminator — so segmentation
+    can never drift from the rest of this module's notion of "one command".
+    Unlike `normalize_command_separators`, this records spans into the
+    ORIGINAL text rather than rewriting it: `resolve_simple_assignments`
+    needs to substitute EACH segment using only the assignment state visible
+    strictly BEFORE it (positional resolution), while every other byte of
+    `command` — separators, whitespace, a backslash-newline continuation —
+    must survive untouched in the final output (downstream heredoc handling
+    depends on real newlines staying real newlines).
+
+    A backslash-newline continuation is not special-cased separately: it
+    falls out of the generic "backslash escapes the next character outside
+    quotes" rule below, which consumes the backslash AND the following
+    newline as one unit before the newline-terminator check ever sees it —
+    the same outcome `normalize_command_separators` reaches via an explicit
+    pre-pass, without needing one here.
+    """
+    spans: list[tuple[int, int]] = []
+    quote: str | None = None
+    seg_start = 0
+    i = 0
+    n = len(command)
+    while i < n:
+        c = command[i]
+        if quote is not None:
+            if c == "\\" and quote == '"' and i + 1 < n:
+                i += 2
+                continue
+            if c == quote:
+                quote = None
+            i += 1
+            continue
+        if c in ("'", '"'):
+            quote = c
+            i += 1
+            continue
+        if c == "\\" and i + 1 < n:
+            i += 2
+            continue
+        if c == "\n":
+            spans.append((seg_start, i))
+            i += 1
+            seg_start = i
+            continue
+        if command[i : i + 2] in ("&&", "||"):
+            spans.append((seg_start, i))
+            i += 2
+            seg_start = i
+            continue
+        if c in (";", "|"):
+            spans.append((seg_start, i))
+            i += 1
+            seg_start = i
+            continue
+        i += 1
+    spans.append((seg_start, n))
+    return spans
+
+
+def _substitute_var_refs(text: str, assignments: dict[str, str]) -> str:
+    """Replace every `$NAME` / `${NAME}` in `text` found in `assignments`."""
+
+    def _sub(m: re.Match[str]) -> str:
+        name = m.group("name_braced") or m.group("name_bare")
+        return assignments.get(name, m.group(0))
+
+    return _VAR_REF_RE.sub(_sub, text)
 
 
 def resolve_simple_assignments(command: str) -> str:
     """Resolve simple literal `NAME=value` assignments before matching (main#1195).
 
-    Scans every pipeline segment (split on `;`, `&&`, `||`, `|` — the same
-    `_SEGMENT_OPS` set `iter_command_segments` splits on) for a LEADING run
-    of `NAME=value` tokens whose value is a bare literal (see the module
-    comment above for the exact exclusions), then substitutes later `$NAME`
-    / `${NAME}` references anywhere in `command` with the resolved value.
+    Walks `command`'s pipeline segments (split on `;`, `&&`, `||`, `|` — the
+    same `_SEGMENT_OPS` set `iter_command_segments` splits on, plus a bare
+    newline as a statement terminator) IN SOURCE ORDER, maintaining a running
+    map of literal `NAME=value` assignments seen in EARLIER segments. Each
+    segment's `$NAME` / `${NAME}` references are substituted against that
+    running map COMBINED WITH the segment's own leading assignments (see
+    `_leading_literal_assignments`; a bare literal value, optionally
+    prefixed by `export`/`declare`, #1305) — a same-line prefix like `A=1
+    B=git $B commit -m z` still resolves `$B`, matching the one-shot
+    env-assignment shape `_strip_leading_env_assignments` already treats as
+    a single unit, while a reassignment in a LATER segment (`g=git; $g
+    commit -m x; g=echo`) does NOT retroactively change what an EARLIER
+    segment's reference resolved to, and a reassignment that hasn't
+    happened YET (`g=echo; $g commit; g=git`) does not resolve early either.
+    This is what makes resolution POSITIONAL rather than "last write
+    anywhere wins" or "first write anywhere wins" — see the module comment
+    above this section for the two concrete cross-segment shapes that make
+    the distinction observable, not just theoretical. After a segment is
+    substituted, its own leading assignments are folded into the running
+    map for segments that follow.
 
     Returns `command` unchanged when `tokenize()` fails (this pre-pass never
     manufactures a NEW parse failure — the existing `_PARSE_FAILURE`
     fail-closed path in the caller already handles unparseable input) or
-    when no qualifying assignment is found.
-
-    Tokenizes `normalize_command_separators(command)`, NOT `command` itself
-    (measured defect, fixed before this function's first release): shlex
-    only recognises `;`/`|`/`&&`/`||` as standalone tokens when they are
-    ALREADY surrounded by whitespace, so the issue's own primary shape,
-    `g=git; $g commit -m x` (no space before `;`), tokenizes `g=git;` as ONE
-    token. The trailing `;` then lands inside the captured value ("git;"),
-    fails the literal-charset check below, and `g` is silently never
-    resolved — reintroducing the exact bug this function exists to close.
-    `normalize_command_separators` is quote-aware and pads every unquoted
-    separator with spaces first, so segmentation is correct regardless of
-    the operator's original spacing. Substitution is still applied to the
-    ORIGINAL `command` text — normalization only adds whitespace around
-    operators, never changes a token's value, so the assignment map built
-    from the normalized tokens is valid for substitution into either string.
+    when no substitution actually changes the text (the overwhelming
+    majority of commands) — so it can only ever ADD a detection, never
+    remove one, and is a no-op for every pre-existing passing shape.
     """
-    tokens = tokenize(normalize_command_separators(command))
-    if tokens is None:
+    if tokenize(normalize_command_separators(command)) is None:
         return command
 
-    segments: list[list[str]] = []
-    cur: list[str] = []
-    for tok in tokens:
-        if tok in _SEGMENT_OPS:
-            if cur:
-                segments.append(cur)
-            cur = []
-            continue
-        cur.append(tok)
-    if cur:
-        segments.append(cur)
+    spans = _iter_original_segment_spans(command)
+    if not spans:
+        return command
 
     assignments: dict[str, str] = {}
-    for segment in segments:
-        i = 0
-        while i < len(segment) and _ENV_ASSIGN_RE.match(segment[i]):
-            name, _eq, value = segment[i].partition("=")
-            if _SIMPLE_LITERAL_VALUE_RE.match(value):
-                assignments[name] = value
-            i += 1
+    out_parts: list[str] = []
+    prev_end = 0
+    changed = False
+    for start, end in spans:
+        out_parts.append(command[prev_end:start])
+        orig_segment_text = command[start:end]
 
-    if not assignments:
-        return command
+        # Assignments are extracted from the segment's ORIGINAL (pre-
+        # substitution) text, never the substituted text: a value that is
+        # itself a variable reference (`g=$a`) fails the literal-charset
+        # check regardless, but resolving `$a` first and THEN re-checking
+        # the substituted text would let a chained reference become newly
+        # "literal" — reopening the `a=git; g=$a` non-goal this module
+        # already, correctly, declines to resolve.
+        seg_tokens = tokenize(orig_segment_text)
+        own_assignments = _leading_literal_assignments(seg_tokens) if seg_tokens else {}
 
-    def _substitute(m: re.Match[str]) -> str:
-        name = m.group("name_braced") or m.group("name_bare")
-        return assignments.get(name, m.group(0))
+        # This segment's own leading assignments apply to ITS OWN reference
+        # substitution too (the same-line shape above), so the map used
+        # HERE is the running (strictly-earlier) state extended with this
+        # segment's own assignments — never the running state alone, and
+        # never this segment's assignments alone.
+        active = {**assignments, **own_assignments} if own_assignments else assignments
+        segment_text = orig_segment_text
+        if active:
+            segment_text = _substitute_var_refs(orig_segment_text, active)
+            if segment_text != orig_segment_text:
+                changed = True
+        out_parts.append(segment_text)
+        prev_end = end
 
-    return _VAR_REF_RE.sub(_substitute, command)
+        if own_assignments:
+            assignments.update(own_assignments)
+
+    out_parts.append(command[prev_end:])
+    return "".join(out_parts) if changed else command
 
 
 def bashlex_available() -> bool:

--- a/.claude/hooks/_shell_parse.py
+++ b/.claude/hooks/_shell_parse.py
@@ -1247,6 +1247,18 @@ def _strip_leading_env_assignments(segment: list[str]) -> list[str]:
 # multi-word/prose values remain OUT of scope — same non-goal boundary as
 # the rest of this module's exclusions, documented in the function
 # docstring below.
+#
+# Round 3 correction (main#1195 review round 3): the paragraph above already
+# stated the correct rule ("never for references inside itself"), but the
+# implementation contradicted it — a segment's own leading assignments were
+# ALSO folded into the map used to substitute that same segment's own
+# references, which is not how a real shell resolves a prefix assignment
+# (word expansion happens before the prefix takes effect). See
+# `resolve_simple_assignments`'s docstring and the code comment at its
+# `active = assignments` line for the corrected behaviour and the real-shell
+# verification. `local`/`typeset`/`readonly` remain a documented non-goal
+# here regardless of this correction; #1308 tracks that `typeset`/`readonly`
+# (unlike `local`) are live at top level and may warrant a future widening.
 _SIMPLE_LITERAL_VALUE_RE = re.compile(r"^[A-Za-z0-9_./:@%+-]+$")
 
 # `$NAME` or `${NAME}` — a name starting with a letter/underscore, same
@@ -1374,22 +1386,27 @@ def resolve_simple_assignments(command: str) -> str:
     same `_SEGMENT_OPS` set `iter_command_segments` splits on, plus a bare
     newline as a statement terminator) IN SOURCE ORDER, maintaining a running
     map of literal `NAME=value` assignments seen in EARLIER segments. Each
-    segment's `$NAME` / `${NAME}` references are substituted against that
-    running map COMBINED WITH the segment's own leading assignments (see
-    `_leading_literal_assignments`; a bare literal value, optionally
-    prefixed by `export`/`declare`, #1305) — a same-line prefix like `A=1
-    B=git $B commit -m z` still resolves `$B`, matching the one-shot
-    env-assignment shape `_strip_leading_env_assignments` already treats as
-    a single unit, while a reassignment in a LATER segment (`g=git; $g
-    commit -m x; g=echo`) does NOT retroactively change what an EARLIER
-    segment's reference resolved to, and a reassignment that hasn't
-    happened YET (`g=echo; $g commit; g=git`) does not resolve early either.
-    This is what makes resolution POSITIONAL rather than "last write
-    anywhere wins" or "first write anywhere wins" — see the module comment
-    above this section for the two concrete cross-segment shapes that make
-    the distinction observable, not just theoretical. After a segment is
-    substituted, its own leading assignments are folded into the running
-    map for segments that follow.
+    segment's `$NAME` / `${NAME}` references are substituted ONLY against
+    that running (strictly-earlier) map — NEVER against the segment's own
+    leading assignments (see `_leading_literal_assignments`; a bare literal
+    value, optionally prefixed by `export`/`declare`, #1305). This mirrors
+    real POSIX shell semantics: a command's words are expanded BEFORE its
+    own prefix assignments take effect, so a same-line prefix like `A=1
+    B=git $B commit -m z` must NOT resolve `$B` (real-shell-verified with a
+    printf/marker proxy, main#1195 review round 3) — `$B` is unset at
+    expansion time, and the prefix assignment only scopes the invoked
+    command's environment, not the expansion of its own argument list. A
+    reassignment in a LATER segment (`g=git; $g commit -m x; g=echo`) does
+    NOT retroactively change what an EARLIER segment's reference resolved
+    to, and a reassignment that hasn't happened YET (`g=echo; $g commit;
+    g=git`) does not resolve early either. This is what makes resolution
+    POSITIONAL rather than "last write anywhere wins" or "first write
+    anywhere wins" — see the module comment above this section for the
+    concrete cross-segment shapes that make the distinction observable, not
+    just theoretical. After a segment is substituted, its own leading
+    assignments are folded into the running map for segments that follow
+    (so they become visible starting with the NEXT segment, never the
+    current one).
 
     Returns `command` unchanged when `tokenize()` fails (this pre-pass never
     manufactures a NEW parse failure — the existing `_PARSE_FAILURE`
@@ -1423,12 +1440,32 @@ def resolve_simple_assignments(command: str) -> str:
         seg_tokens = tokenize(orig_segment_text)
         own_assignments = _leading_literal_assignments(seg_tokens) if seg_tokens else {}
 
-        # This segment's own leading assignments apply to ITS OWN reference
-        # substitution too (the same-line shape above), so the map used
-        # HERE is the running (strictly-earlier) state extended with this
-        # segment's own assignments — never the running state alone, and
-        # never this segment's assignments alone.
-        active = {**assignments, **own_assignments} if own_assignments else assignments
+        # POSIX shells expand a command's words BEFORE applying that same
+        # command's own prefix assignments (main#1195 review round 3, real-
+        # shell verified with a printf/marker proxy). So a segment's OWN
+        # leading assignments must NOT be visible to references inside that
+        # SAME segment — only the running state accumulated from segments
+        # STRICTLY BEFORE it (this already matches the module's own top-of-
+        # file contract; merging `own_assignments` into `active` was the bug,
+        # not a documented design choice). Concretely:
+        #   - `A=1 B=git $B commit -m z` — `$B` is unset at expansion time
+        #     (its own segment's `B=git` prefix hasn't taken effect yet); a
+        #     real shell never runs git here, so `$B` must stay unresolved.
+        #   - `g=git; g=echo $g commit -m x` — `$g` in the second segment
+        #     must resolve against the RUNNING state (`git`, from segment 1),
+        #     NOT `echo` (this segment's own prefix): a real shell expands
+        #     `$g` to the OUTER shell's current value of `g` before the
+        #     prefix assignment takes effect, so the invoked command is
+        #     `git commit -m x` (with `g=echo` scoped only to that child's
+        #     environment).
+        #   - `g=git; g=echo $g commit -m x` reread the other way is the
+        #     LIVE-BYPASS direction: the OLD code (merging `own_assignments`
+        #     in) resolved `$g` to `echo` — this segment's own prefix — and
+        #     so allowed the command outright, hiding a real `git commit`
+        #     that the shell genuinely runs via the prior segment's `g=git`.
+        # `active = assignments` (no merge) makes all four rows in the
+        # main#1195 review-round-3 table shell-correct with one deletion.
+        active = assignments
         segment_text = orig_segment_text
         if active:
             segment_text = _substitute_var_refs(orig_segment_text, active)

--- a/.claude/hooks/tests/test_shell_parse.py
+++ b/.claude/hooks/tests/test_shell_parse.py
@@ -1580,5 +1580,171 @@ class CdRoutingWhenBashlexCannotParse(unittest.TestCase):
             self.assertEqual(resolved, self._shell_truth(template, shell))
 
 
+class ResolveSimpleAssignmentsTests(unittest.TestCase):
+    """Direct output-string tests for `resolve_simple_assignments` (main#1195
+    review round 2).
+
+    Every OTHER test that touches this pre-pass — in `test_validate_commit_
+    identity.py` — only observes `check()`'s downstream block/allow verdict.
+    That is the wrong level to catch a resolver that silently produces the
+    WRONG substituted text but happens to still be rejected (or still
+    happens to still be blocked) by whatever consumes it: main#1195's own
+    review found that mutating `_VAR_REF_RE`'s bare-name capture to drop its
+    trailing `\\b` boundary AND weaken its quantifier corrupts `$gone` into
+    `gitone` — a downstream matcher rejects "gitone" as not `git` either, so
+    a verdict-only test suite of 16 cases passed unchanged under that
+    mutation. Asserting the resolver's RETURNED STRING directly, as this
+    class does, is the only level at which that corruption is observable.
+    `resolve_simple_assignments` had no direct unit test before this class.
+    """
+
+    def test_basic_bare_assignment_resolves(self) -> None:
+        self.assertEqual(
+            sp.resolve_simple_assignments("g=git; $g commit -m x"),
+            "g=git; git commit -m x",
+        )
+
+    def test_braced_form_resolves(self) -> None:
+        self.assertEqual(
+            sp.resolve_simple_assignments("g=git; ${g} commit -m x"),
+            "g=git; git commit -m x",
+        )
+
+    def test_no_qualifying_assignment_returns_input_unchanged(self) -> None:
+        cmd = "echo hello world"
+        self.assertEqual(sp.resolve_simple_assignments(cmd), cmd)
+
+    def test_unassigned_reference_left_literal(self) -> None:
+        cmd = "echo $NEVERASSIGNED"
+        self.assertEqual(sp.resolve_simple_assignments(cmd), cmd)
+
+    def test_unparseable_command_returned_unchanged(self) -> None:
+        cmd = 'git commit -m "unterminated'
+        self.assertEqual(sp.resolve_simple_assignments(cmd), cmd)
+
+    # --- positional resolution (main#1195 review round 2: the resolver was
+    # order-blind — one flat last-wins map across the whole command) --------
+
+    def test_trailing_reassignment_via_semicolon_does_not_corrupt_earlier_use(self) -> None:
+        """`g=git; $g commit -m x; g=echo` — the primary repro. A flat
+        last-wins map resolves `$g` to `echo` (the LAST assignment anywhere
+        in the command), turning this into `echo commit -m x` and hiding
+        the git invocation entirely. Positional resolution must still read
+        `$g` as `git` at the point it is actually used.
+        """
+        self.assertEqual(
+            sp.resolve_simple_assignments("g=git; $g commit -m x; g=echo"),
+            "g=git; git commit -m x; g=echo",
+        )
+
+    def test_trailing_reassignment_to_true_does_not_corrupt_earlier_use(self) -> None:
+        self.assertEqual(
+            sp.resolve_simple_assignments("g=git; $g commit -m x; g=true"),
+            "g=git; git commit -m x; g=true",
+        )
+
+    def test_trailing_reassignment_via_or_operator_does_not_corrupt_earlier_use(self) -> None:
+        self.assertEqual(
+            sp.resolve_simple_assignments("g=git; $g commit -m x || g=x"),
+            "g=git; git commit -m x || g=x",
+        )
+
+    def test_trailing_reassignment_via_and_operator_does_not_corrupt_earlier_use(self) -> None:
+        self.assertEqual(
+            sp.resolve_simple_assignments("g=git; $g commit -m x; false && g=nope"),
+            "g=git; git commit -m x; false && g=nope",
+        )
+
+    def test_reassignment_that_has_not_happened_yet_is_not_used_early(self) -> None:
+        """Mirror image of the trailing-reassignment shapes above — a naive
+        "first assignment wins, globally" fix (rejected; see the module
+        comment above `resolve_simple_assignments` in `_shell_parse.py`)
+        would get THIS shape wrong. `$g` is used while `g` still holds
+        `echo`; the LATER `g=git` must not retroactively resolve it.
+        """
+        self.assertEqual(
+            sp.resolve_simple_assignments("g=echo; $g commit; g=git"),
+            "g=echo; echo commit; g=git",
+        )
+
+    def test_same_segment_multiple_leading_assignments_resolve_within_segment(self) -> None:
+        """`A=1 B=git $B commit -m z` — a same-line assignment prefix DOES
+        apply to that same line's own command word (the one-shot
+        env-assignment shape `_strip_leading_env_assignments` already
+        treats as a single unit), unlike a reassignment across a `;` /
+        `&&` / `||` segment boundary.
+        """
+        self.assertEqual(
+            sp.resolve_simple_assignments("A=1 B=git $B commit -m z"),
+            "A=1 B=git git commit -m z",
+        )
+
+    # --- name-prefix conflation guard (main#1195 review round 2, finding 2) -
+
+    def test_shorter_assignment_not_conflated_with_longer_bare_name(self) -> None:
+        """`$gone` is a DIFFERENT variable from `$g`. The greedy identifier
+        match plus the trailing `\\b` boundary in `_VAR_REF_RE` must capture
+        the FULL name "gone" (never assigned) and leave it untouched. A
+        weakened boundary/quantifier would instead read this as `$g` +
+        literal "one", corrupting the output to "gitone" — invisible to any
+        test that only checks a downstream block/allow verdict.
+        """
+        cmd = "g=git; echo $gone"
+        self.assertEqual(sp.resolve_simple_assignments(cmd), cmd)
+
+    def test_shorter_assignment_not_conflated_with_underscore_suffixed_name(self) -> None:
+        cmd = "g=git; echo $g_2"
+        self.assertEqual(sp.resolve_simple_assignments(cmd), cmd)
+
+    def test_shorter_assignment_not_conflated_with_bare_suffix(self) -> None:
+        cmd = "g=git; echo $gx"
+        self.assertEqual(sp.resolve_simple_assignments(cmd), cmd)
+
+    # --- documented non-goals: must remain unresolved ------------------------
+
+    def test_command_substitution_value_not_resolved(self) -> None:
+        cmd = "d=$(date); echo $d"
+        self.assertEqual(sp.resolve_simple_assignments(cmd), cmd)
+
+    def test_multiword_value_not_resolved(self) -> None:
+        cmd = 'msg="please git commit this later"; echo $msg'
+        self.assertEqual(sp.resolve_simple_assignments(cmd), cmd)
+
+    def test_value_containing_variable_reference_does_not_chain(self) -> None:
+        """`g=$a` fails the literal-value check (contains `$`), so `g` is
+        never added to the assignment map — a later `$g` stays literal even
+        though `a` itself resolved earlier in the command. (The `a=git; g=$a`
+        segment's own displayed text still shows `a`'s value substituted in
+        — a pre-existing textual side effect of substituting every segment,
+        not a resolution of `g`; the load-bearing assertion here is that the
+        trailing `$g` is untouched.)
+        """
+        self.assertEqual(
+            sp.resolve_simple_assignments("a=git; g=$a; $g commit -m x"),
+            "a=git; g=git; $g commit -m x",
+        )
+
+    def test_local_keyword_prefix_is_out_of_scope(self) -> None:
+        """Only `export`/`declare` are folded in (#1305); `local` and any
+        other prefix keyword remain a non-goal.
+        """
+        cmd = "local g=git; $g commit -m x"
+        self.assertEqual(sp.resolve_simple_assignments(cmd), cmd)
+
+    # --- #1305: export/declare fold-in ---------------------------------------
+
+    def test_export_prefixed_assignment_resolves(self) -> None:
+        self.assertEqual(
+            sp.resolve_simple_assignments("export g=git; $g commit -m x"),
+            "export g=git; git commit -m x",
+        )
+
+    def test_declare_prefixed_assignment_resolves(self) -> None:
+        self.assertEqual(
+            sp.resolve_simple_assignments("declare g=git; $g commit -m x"),
+            "declare g=git; git commit -m x",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.claude/hooks/tests/test_shell_parse.py
+++ b/.claude/hooks/tests/test_shell_parse.py
@@ -1761,6 +1761,92 @@ class ResolveSimpleAssignmentsTests(unittest.TestCase):
             "declare g=git; git commit -m x",
         )
 
+    # --- main#1195 round 4, finding 1: same-segment prefix DOES resolve
+    # inside a single-quoted CHILD payload, real-shell-verified with a
+    # marker proxy (`g=git bash -c '$g commit -m x'` genuinely runs
+    # `git commit -m x`) -------------------------------------------------
+
+    def test_same_segment_prefix_resolves_inside_single_quoted_child_payload(
+        self,
+    ) -> None:
+        self.assertEqual(
+            sp.resolve_simple_assignments("g=git bash -c '$g commit -m x'"),
+            "g=git bash -c 'git commit -m x'",
+        )
+
+    def test_same_segment_prefix_resolves_inside_single_quoted_sh_dash_c(self) -> None:
+        """Same shape, `sh -c` instead of `bash -c` — the fix lives in the
+        assignment/quote resolver, not in anything interpreter-specific.
+        """
+        self.assertEqual(
+            sp.resolve_simple_assignments("g=git sh -c '$g commit -m x'"),
+            "g=git sh -c 'git commit -m x'",
+        )
+
+    def test_same_segment_prefix_resolves_inside_single_quoted_braced_payload(
+        self,
+    ) -> None:
+        self.assertEqual(
+            sp.resolve_simple_assignments("g=git bash -c '${g} commit -m x'"),
+            "g=git bash -c 'git commit -m x'",
+        )
+
+    def test_same_segment_prefix_not_resolved_inside_double_quoted_payload(
+        self,
+    ) -> None:
+        """Control for the above: `bash -c "$g commit -m x"` (double-quoted)
+        is expanded by the OUTER shell at the same expansion point a bare
+        same-segment reference is (`A=1 B=git $B commit -m z`) — BEFORE its
+        own prefix assignment takes effect — so `$g` must stay unresolved,
+        real-shell-verified with a marker proxy (no git run).
+        """
+        cmd = 'g=git bash -c "$g commit -m x"'
+        self.assertEqual(sp.resolve_simple_assignments(cmd), cmd)
+
+    # --- main#1195 round 4, finding 3: a compound-statement leader (`do`,
+    # `then`, ...) at a segment's leading position must not hide the
+    # assignment one token to the right, real-shell-verified with a marker
+    # proxy (each row genuinely runs `git commit -m x`) -------------------
+
+    def test_do_prefixed_segment_assignment_resolves_in_later_segment(self) -> None:
+        self.assertEqual(
+            sp.resolve_simple_assignments("for f in a; do g=git; $g commit -m x; done"),
+            "for f in a; do g=git; git commit -m x; done",
+        )
+
+    def test_then_prefixed_segment_assignment_resolves_in_later_segment(self) -> None:
+        self.assertEqual(
+            sp.resolve_simple_assignments("if true; then g=git; $g commit -m x; fi"),
+            "if true; then g=git; git commit -m x; fi",
+        )
+
+    def test_do_prefixed_segment_assignment_multichar_name_resolves(self) -> None:
+        """Vary the incidental dimension a single-character-name fixture
+        would hide (main#1195 finding 2's lesson, applied here too): `gg`,
+        not `g`.
+        """
+        self.assertEqual(
+            sp.resolve_simple_assignments("for f in a; do gg=git; $gg commit -m x; done"),
+            "for f in a; do gg=git; git commit -m x; done",
+        )
+
+    def test_do_prefixed_segment_assignment_braced_reference_resolves(self) -> None:
+        self.assertEqual(
+            sp.resolve_simple_assignments("for f in a; do g=git; ${g} commit -m x; done"),
+            "for f in a; do g=git; git commit -m x; done",
+        )
+
+    def test_do_prefixed_single_quoted_child_payload_resolves(self) -> None:
+        """Finding 1 and finding 3 compose: a `do`-prefixed segment's own
+        leading assignment feeding a single-quoted `bash -c` payload in the
+        SAME segment must resolve, real-shell-verified (genuinely runs
+        `git commit -m x`).
+        """
+        self.assertEqual(
+            sp.resolve_simple_assignments("for f in a; do g=git bash -c '$g commit -m x'; done"),
+            "for f in a; do g=git bash -c 'git commit -m x'; done",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.claude/hooks/tests/test_shell_parse.py
+++ b/.claude/hooks/tests/test_shell_parse.py
@@ -1667,16 +1667,32 @@ class ResolveSimpleAssignmentsTests(unittest.TestCase):
             "g=echo; echo commit; g=git",
         )
 
-    def test_same_segment_multiple_leading_assignments_resolve_within_segment(self) -> None:
-        """`A=1 B=git $B commit -m z` — a same-line assignment prefix DOES
-        apply to that same line's own command word (the one-shot
-        env-assignment shape `_strip_leading_env_assignments` already
-        treats as a single unit), unlike a reassignment across a `;` /
-        `&&` / `||` segment boundary.
+    def test_same_segment_leading_assignment_not_visible_to_own_expansion(self) -> None:
+        """`A=1 B=git $B commit -m z` — main#1195 review round 3,
+        real-shell-verified with a printf/marker proxy: POSIX expands a
+        command's words BEFORE applying that SAME command's own prefix
+        assignments, so `$B` is NOT visible to a reference inside its own
+        segment. A real shell never runs git here (`$B` is unset at
+        expansion time; `B=git` only scopes the invoked command's
+        environment). Supersedes the previous (wrong)
+        `test_same_segment_multiple_leading_assignments_resolve_within_segment`,
+        which encoded exactly this misreading of POSIX prefix-assignment
+        scope as the expected behaviour.
+        """
+        cmd = "A=1 B=git $B commit -m z"
+        self.assertEqual(sp.resolve_simple_assignments(cmd), cmd)
+
+    def test_same_segment_leading_assignment_becomes_visible_in_later_segment(self) -> None:
+        """The peeling loop must still consume BOTH leading assignment
+        tokens (`A=1` then `B=git`) in one segment — the multi-assignment
+        coverage the superseded test above was meant to pin, checked here
+        where a real shell agrees: once `;` moves the reference into a
+        LATER segment, `B`'s value from a two-assignment leading run is
+        visible.
         """
         self.assertEqual(
-            sp.resolve_simple_assignments("A=1 B=git $B commit -m z"),
-            "A=1 B=git git commit -m z",
+            sp.resolve_simple_assignments("A=1 B=git; $B commit -m z"),
+            "A=1 B=git; git commit -m z",
         )
 
     # --- name-prefix conflation guard (main#1195 review round 2, finding 2) -

--- a/.claude/hooks/tests/test_validate_commit_identity.py
+++ b/.claude/hooks/tests/test_validate_commit_identity.py
@@ -1675,6 +1675,185 @@ class AssignmentAwarePrePassTests(unittest.TestCase):
         cmd = "h=other; gi${x}t commit -m z"
         self.assertIsNone(hook.check(self._input(cmd)))
 
+    # --- main#1195 round 4, finding 2: row1/row3 must be pinned across
+    # braced AND multi-char-name variants, not just the bare single-char
+    # spelling — a mutant that composes the fix only for `${NAME}` refs, or
+    # only for names longer than one character, survived mutation testing
+    # against the original four rows (290 passed unchanged). Varying the
+    # incidental dimensions here is what makes those mutants die. --------
+
+    def test_row1_braced_variant_never_reaches_git_allows(self) -> None:
+        """`A=1 B=git ${B} commit -m z` — braced-reference sibling of row 1.
+        Real shell: `${B}` is unset at expansion time for the same reason
+        the bare form is (own-segment prefix not yet in effect). Must ALLOW.
+        """
+        self.assertIsNone(hook.check(self._input("A=1 B=git ${B} commit -m z")))
+
+    def test_row1_multichar_name_variant_never_reaches_git_allows(self) -> None:
+        """`A=1 BB=git $BB commit -m z` — multi-char-name sibling of row 1.
+        Must ALLOW for the identical real-shell reason (own-segment prefix
+        not yet in effect at expansion time), regardless of name length.
+        """
+        self.assertIsNone(hook.check(self._input("A=1 BB=git $BB commit -m z")))
+
+    def test_row3_braced_variant_cannot_hide_prior_running_value_blocks(self) -> None:
+        """`g=git; g=echo ${g} commit -m x` — braced-reference sibling of
+        row 3. Real shell: `${g}` resolves against the RUNNING state from
+        the prior segment (`git`), not this segment's own `g=echo` prefix.
+        Must BLOCK.
+        """
+        result = hook.check(self._input("g=git; g=echo ${g} commit -m x"))
+        self.assertIsNotNone(result, "prior-segment g=git must still resolve via ${g}")
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+        self.assertIn("missing `-c user.name=` flag", result["reason"])
+
+    def test_row3_multichar_name_variant_cannot_hide_prior_running_value_blocks(
+        self,
+    ) -> None:
+        """`gg=git; gg=echo $gg commit -m x` — multi-char-name sibling of
+        row 3. Must BLOCK for the identical real-shell reason, regardless of
+        name length.
+        """
+        result = hook.check(self._input("gg=git; gg=echo $gg commit -m x"))
+        self.assertIsNotNone(result, "prior-segment gg=git must still resolve at the commit site")
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+        self.assertIn("missing `-c user.name=` flag", result["reason"])
+
+    # --- main#1195 round 4, finding 1: same-segment prefix assignment DOES
+    # resolve inside a SINGLE-quoted child payload (`bash -c '...'`), because
+    # that text is expanded by the CHILD interpreter in an environment the
+    # prefix assignment already populated — real-shell-verified with a
+    # marker proxy. All six rows below were measured against a real shell
+    # (fake `git` on PATH, printing a marker iff it actually runs) before
+    # being pinned here. -------------------------------------------------
+
+    def test_prefix_in_single_quoted_bash_dash_c_payload_blocks(self) -> None:
+        """Row 1: `g=git bash -c '$g commit -m x'` — marker proxy: real
+        shell RUNS the fake `git`. Must BLOCK; ALLOWed at 632b99d (the
+        round-3 fix's own regression, against this PR's previous head).
+        """
+        result = hook.check(self._input("g=git bash -c '$g commit -m x'"))
+        self.assertIsNotNone(
+            result, "same-segment prefix feeding a quoted child payload must block"
+        )
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+        self.assertTrue(
+            result["reason"].startswith(
+                "BLOCKED: indirect-exec wrapper detected (shell -c) carrying a hidden `git commit`."
+            ),
+            result["reason"],
+        )
+
+    def test_prefix_in_double_quoted_bash_dash_c_payload_allows(self) -> None:
+        """Row 2 (control): `g=git bash -c "$g commit -m x"` — marker proxy:
+        real shell does NOT run `git` (the OUTER shell expands the
+        double-quoted argument itself, before the prefix takes effect, same
+        expansion point as a bare same-segment reference). Must ALLOW.
+        """
+        self.assertIsNone(hook.check(self._input('g=git bash -c "$g commit -m x"')))
+
+    def test_prefix_in_single_quoted_sh_dash_c_payload_blocks(self) -> None:
+        """Row 3: `g=git sh -c '$g commit -m x'` — marker proxy: real shell
+        RUNS the fake `git`. Must BLOCK, same as the `bash -c` spelling.
+        """
+        result = hook.check(self._input("g=git sh -c '$g commit -m x'"))
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+
+    def test_prefix_in_single_quoted_braced_payload_blocks(self) -> None:
+        """Row 4: `g=git bash -c '${g} commit -m x'` — braced form inside
+        the single-quoted payload. Marker proxy: real shell RUNS the fake
+        `git`. Must BLOCK.
+        """
+        result = hook.check(self._input("g=git bash -c '${g} commit -m x'"))
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+
+    def test_no_prefix_unset_reference_in_single_quoted_payload_allows(self) -> None:
+        """Row 5 (control): `bash -c '$g commit -m x'` with no `g=git`
+        prefix anywhere. Marker proxy: real shell does NOT run `git` (`$g`
+        is genuinely unset). Must ALLOW.
+        """
+        self.assertIsNone(hook.check(self._input("bash -c '$g commit -m x'")))
+
+    def test_cross_segment_semicolon_single_quoted_payload_still_blocks(self) -> None:
+        """Row 6: `g=git; bash -c '$g commit -m x'` — the assignment is in
+        an EARLIER segment (`;`, not a same-segment prefix), so it reaches
+        the quoted payload via the pre-existing RUNNING map, unchanged by
+        this round's fix (the running map already applies everywhere,
+        quote-blind). Pinned so a future change to the running map's
+        quote-awareness is caught here.
+        """
+        result = hook.check(self._input("g=git; bash -c '$g commit -m x'"))
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+
+    # --- main#1195 round 4, finding 3 (#1311): a compound-statement leader
+    # (`do`, `then`, ...) at a segment's leading position must not hide an
+    # assignment one token to the right — real-shell-verified with a marker
+    # proxy (each row genuinely runs `git commit -m x`), the same defect
+    # class as the wrapped `bash -c` choke point above. ------------------
+
+    def test_for_loop_do_body_assignment_blocks(self) -> None:
+        """`for f in a; do g=git; $g commit -m x; done` — marker proxy: real
+        shell RUNS the fake `git`. Must BLOCK; ALLOWed before the
+        `strip_command_prefixes()` fix (`_leading_literal_assignments` saw
+        `"do"` at the leading position and stopped before ever looking at
+        `g=git` one token to the right).
+        """
+        result = hook.check(self._input("for f in a; do g=git; $g commit -m x; done"))
+        self.assertIsNotNone(result, "do-prefixed segment assignment must still resolve")
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+        self.assertIn("missing `-c user.name=` flag", result["reason"])
+
+    def test_while_loop_do_body_assignment_blocks(self) -> None:
+        result = hook.check(
+            self._input('n=0; while [ "$n" -lt 1 ]; do g=git; $g commit -m x; n=1; done')
+        )
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+
+    def test_if_then_body_assignment_blocks(self) -> None:
+        result = hook.check(self._input("if true; then g=git; $g commit -m x; fi"))
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+
+    def test_for_loop_do_body_multichar_name_blocks(self) -> None:
+        """Vary the incidental dimension: a multi-char name (`gg`), not `g`
+        — the exact fixture-narrowness finding 2 (above) is about."""
+        result = hook.check(self._input("for f in a; do gg=git; $gg commit -m x; done"))
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+
+    def test_for_loop_do_body_braced_reference_blocks(self) -> None:
+        result = hook.check(self._input("for f in a; do g=git; ${g} commit -m x; done"))
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+
+    def test_for_loop_do_body_single_quoted_child_payload_blocks(self) -> None:
+        """Finding 1 and finding 3 compose: a `do`-prefixed segment's own
+        leading assignment feeding a single-quoted `bash -c` payload in the
+        SAME segment. Marker proxy: real shell RUNS the fake `git`. Must
+        BLOCK.
+        """
+        result = hook.check(self._input("for f in a; do g=git bash -c '$g commit -m x'; done"))
+        self.assertIsNotNone(
+            result, "do-prefixed same-segment prefix must resolve in the quoted payload"
+        )
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.claude/hooks/tests/test_validate_commit_identity.py
+++ b/.claude/hooks/tests/test_validate_commit_identity.py
@@ -1370,5 +1370,215 @@ class WrappedCommitIdentityRegression(unittest.TestCase):
         self.assertIsNotNone(hook.check(self._input(self._commit("", identity=False))))
 
 
+class AssignmentAwarePrePassTests(unittest.TestCase):
+    """main#1195 — a payload/command-word held in a shell variable defeats
+    both the phrase matcher (`_payload_looks_like_commit`) and the direct
+    commit-segment finder (`find_git_subcommand`, via `_find_commit_segment`)
+    with NO interpreter wrapper at all:
+
+        g=git; $g commit -m x
+
+    `resolve_simple_assignments` (`_shell_parse.py`) is a bounded pre-pass
+    applied at two choke points: once on the outer command in `check()`
+    (fixes the direct-typed shape), and once on each extracted wrapper
+    payload inside `_payload_looks_like_commit` (fixes the same shape one
+    level down, e.g. inside a `bash -c '...'` argument).
+
+    All assertions drive through the real `check()` — never a private
+    helper — per the issue's own measurement method. Every BLOCK assertion
+    checks the SPECIFIC reason string (not a bare substring that survives if
+    the wrong row fires), and every ALLOW assertion checks the value is
+    `None`, not merely "not exceptional".
+    """
+
+    @staticmethod
+    def _input(command: str) -> dict:
+        return {"tool_name": "Bash", "tool_input": {"command": command}}
+
+    def _valid_identity(self) -> tuple[str, str]:
+        name = next(iter(hook.ROSTER), None)
+        if not name:
+            self.skipTest("local roster is empty")
+        return name, hook.ROSTER[name]
+
+    # --- the issue's own measured shapes -----------------------------------
+
+    def test_direct_typed_variable_command_word_glued_semicolon_missing_identity_blocks(
+        self,
+    ) -> None:
+        """POS: the issue's PRIMARY repro, typed directly, no wrapper at all.
+
+        `bash -lc 'g=git; $g commit -m x'` reproduced the shell truth; this
+        pins the identical shape as the literal outer Bash `command` (no
+        `bash -c` wrapper), with `;` glued directly to `git` (no space) —
+        the exact spelling that defeated shlex's separator detection before
+        the `normalize_command_separators` fix.
+        """
+        result = hook.check(self._input("g=git; $g commit -m x"))
+        self.assertIsNotNone(result, "variable-held command word must be seen as git commit")
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+        self.assertEqual(
+            result["reason"],
+            "BLOCKED: git commit missing `-c user.name=` flag. "
+            "Charter § Commit Identity requires per-commit identity via -c flags. "
+            'Example: git -c user.name="Kwame Asante" '
+            '-c user.email="parametrization+Kwame.Asante@gmail.com" commit -m "..."',
+        )
+
+    def test_direct_typed_variable_command_word_glued_semicolon_valid_identity_allows(
+        self,
+    ) -> None:
+        """POS mirror: same shape, but with a VALID identity — must ALLOW.
+
+        Proves the fix resolves the command word without breaking identity
+        validation itself (a compliant commit behind the variable must still
+        pass, not be blocked as if it were still hidden).
+        """
+        name, email = self._valid_identity()
+        cmd = f'g=git; $g -c user.name="{name}" -c user.email="{email}" commit -m x'
+        result = hook.check(self._input(cmd))
+        self.assertIsNone(result, f"compliant commit behind $g must be ALLOWED, got: {result}")
+
+    def test_direct_typed_variable_command_word_spaced_semicolon_blocks(self) -> None:
+        """POS: same shape with a space before `;` (`g=git ; $g commit -m x`).
+
+        This spelling was ALREADY reaching the right segment split before
+        this fix (space-separated `;` was already its own token) — it still
+        allowed, because the real gap was `find_git_subcommand` requiring
+        the literal token `git`, not the segment split. Pinned separately
+        from the glued-semicolon case so a regression in either spelling is
+        caught independently.
+        """
+        result = hook.check(self._input("g=git ; $g commit -m x"))
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+        self.assertIn("missing `-c user.name=` flag", result["reason"])
+
+    def test_wrapped_bash_dash_c_variable_command_word_blocks(self) -> None:
+        """POS: the issue's wrapped shape, `bash -c 'g=git; $g commit -m x'`.
+
+        Exercises the SECOND choke point: the resolver applied inside
+        `_payload_looks_like_commit` to the extracted `-c` payload, which the
+        outer-command resolver alone cannot reach (the quoted payload is one
+        opaque token at the outer level).
+        """
+        cmd = "bash -c 'g=git; $g commit -m x'"
+        result = hook.check(self._input(cmd))
+        self.assertIsNotNone(result, "indirect wrapper hiding a variable command word must block")
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+        self.assertTrue(
+            result["reason"].startswith(
+                "BLOCKED: indirect-exec wrapper detected (shell -c) carrying a hidden `git commit`."
+            ),
+            result["reason"],
+        )
+
+    def test_heredoc_body_variable_command_word_blocks(self) -> None:
+        """POS: same indirection inside a heredoc fed to a real interpreter.
+
+        Confirms the payload-level resolver fix is not special-cased to the
+        `-c` shape — every wrapper shape funnels through the same
+        `_payload_looks_like_commit` choke point.
+        """
+        cmd = "bash <<'EOF'\ng=git\n$g commit -m x\nEOF"
+        result = hook.check(self._input(cmd))
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+        self.assertIn("indirect-exec", result["reason"])
+
+    # --- false-positive corpus: ordinary shapes must NOT block -------------
+
+    def test_command_substitution_value_not_resolved_allows(self) -> None:
+        """NEG (the issue's own required sweep item): `d=$(date); echo $d`.
+
+        Command substitution is explicitly out of scope: the value fails the
+        literal-charset check, so `d` is never captured and `$d` is left
+        untouched. An ordinary shape; must not block.
+        """
+        self.assertIsNone(hook.check(self._input("d=$(date); echo $d")))
+
+    def test_prose_value_with_git_commit_words_not_resolved_allows(self) -> None:
+        """NEG: a quoted, multi-word value merely mentioning "git commit".
+
+        `msg="please git commit this later"; echo $msg` is prose, not an
+        invocation. A quoted value survives shlex de-quoting as ONE token
+        containing whitespace, so the literal-charset check (which never
+        allows whitespace) rejects it — `msg` is never captured, so
+        resolving `$msg` cannot manufacture a `git ... commit` bridge out of
+        this prose. This is the false-positive class the assignment-aware
+        pre-pass could otherwise introduce; it must not fire.
+        """
+        cmd = 'msg="please git commit this later"; echo $msg'
+        self.assertIsNone(hook.check(self._input(cmd)))
+
+    def test_unrelated_assignment_and_reuse_allows(self) -> None:
+        """NEG: ordinary env-var reuse with no relation to git at all."""
+        self.assertIsNone(hook.check(self._input("FOO=bar; echo $FOO")))
+
+    def test_double_indirection_via_command_substitution_of_command_word_allows(
+        self,
+    ) -> None:
+        """NEG: `g=$(echo git); $g commit -m x` — command substitution OF the
+        command word itself. Explicitly out of scope per the issue (same
+        family as `$(printf git) commit`, strictly harder) — `g`'s value
+        contains `$` and parens, so it fails the literal check and is never
+        captured; `$g` stays literal and unresolved.
+        """
+        self.assertIsNone(hook.check(self._input("g=$(echo git); $g commit -m x")))
+
+    def test_similarly_named_variable_not_conflated_allows(self) -> None:
+        """NEG: `g=git; $gone commit -m x` — `$gone` is a DIFFERENT variable
+        from `$g`; the greedy identifier match in the reference regex
+        captures the name "gone" in full, which was never assigned, so it is
+        left untouched. Guards against a name-prefix conflation bug.
+        """
+        self.assertIsNone(hook.check(self._input("g=git; $gone commit -m x")))
+
+    def test_positional_parameter_not_treated_as_assignment_target_allows(self) -> None:
+        """NEG: `set -- git commit; echo $1` — positional parameters (`$1`)
+        are explicitly out of scope; the capture regex requires a name
+        starting with a letter or underscore, so `$1` can never be an
+        assignment target in the first place. `git commit` here is a DATA
+        argument to `set --`, not an invocation — must not block.
+        """
+        self.assertIsNone(hook.check(self._input("set -- git commit; echo $1")))
+
+    # --- multi-assignment / `${NAME}` form coverage -------------------------
+
+    def test_multiple_leading_assignments_in_one_segment_resolves_second(self) -> None:
+        """POS: `A=1 B=git $B commit -m z` — TWO leading env-style
+        assignments share one segment before the real command starts. Pins
+        the peeling loop consuming BOTH leading tokens (not just the first)
+        before it reaches `$B`.
+        """
+        result = hook.check(self._input("A=1 B=git $B commit -m z"))
+        self.assertIsNotNone(result, "second leading assignment (B=git) must still resolve")
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+        self.assertIn("missing `-c user.name=` flag", result["reason"])
+
+    def test_braced_variable_reference_form_resolves(self) -> None:
+        """POS: `${g}` (braced form) must resolve the same as bare `$g`."""
+        result = hook.check(self._input("g=git; ${g} commit -m x"))
+        self.assertIsNotNone(result, "braced ${g} reference must resolve to git")
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+        self.assertIn("missing `-c user.name=` flag", result["reason"])
+
+    def test_unassigned_variable_reference_left_literal_allows(self) -> None:
+        """NEG: `$NEVERASSIGNED commit -m x` — no assignment anywhere in the
+        command, so `assignments.get(name, m.group(0))` must return the
+        ORIGINAL text unchanged, not an empty string or a KeyError. An
+        unresolved variable used as a command word is not a `git` command
+        (whatever it resolves to at runtime, the hook cannot know, and does
+        not need to for THIS shape — nothing here spells `git`).
+        """
+        self.assertIsNone(hook.check(self._input("$NEVERASSIGNED commit -m x")))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.claude/hooks/tests/test_validate_commit_identity.py
+++ b/.claude/hooks/tests/test_validate_commit_identity.py
@@ -1565,17 +1565,78 @@ class AssignmentAwarePrePassTests(unittest.TestCase):
 
     # --- multi-assignment / `${NAME}` form coverage -------------------------
 
-    def test_multiple_leading_assignments_in_one_segment_resolves_second(self) -> None:
-        """POS: `A=1 B=git $B commit -m z` — TWO leading env-style
-        assignments share one segment before the real command starts. Pins
-        the peeling loop consuming BOTH leading tokens (not just the first)
-        before it reaches `$B`.
+    def test_same_segment_leading_assignment_not_resolved_allows(self) -> None:
+        """NEG (main#1195 review round 3, real-shell-verified via
+        printf/marker proxy): `A=1 B=git $B commit -m z` — a same-segment
+        prefix assignment is NOT visible to that segment's OWN expansion.
+        `$B` stays unresolved, so this is not a detected git invocation and
+        must ALLOW. Supersedes the previous (wrong)
+        `test_multiple_leading_assignments_in_one_segment_resolves_second`,
+        which asserted a BLOCK verdict for a misreading of POSIX
+        prefix-assignment scope — a real shell never runs git for this
+        input; the PR body's own bypass-closed table row for this exact
+        string was likewise corrected (see the PR follow-up comment).
         """
-        result = hook.check(self._input("A=1 B=git $B commit -m z"))
-        self.assertIsNotNone(result, "second leading assignment (B=git) must still resolve")
+        self.assertIsNone(hook.check(self._input("A=1 B=git $B commit -m z")))
+
+    def test_two_leading_assignments_resolve_in_later_segment_blocks(self) -> None:
+        """POS: the peeling loop must still consume BOTH leading assignment
+        tokens (`A=1` then `B=git`) in one segment — pinned here where a
+        real shell agrees with the block verdict: once `;` moves the
+        reference into a LATER segment, `B`'s value resolves and the
+        hidden `git commit` is caught.
+        """
+        result = hook.check(self._input("A=1 B=git; $B commit -m z"))
+        self.assertIsNotNone(
+            result, "second leading assignment (B=git) must resolve once used in a later segment"
+        )
         assert result is not None
         self.assertEqual(result["decision"], "block")
         self.assertIn("missing `-c user.name=` flag", result["reason"])
+
+    # --- main#1195 review round 3: the four adversarial rows, marker-proxy
+    # verified against a real shell (printf/marker proxy: a fake `git`
+    # executable on PATH plus real `echo`), pinned exactly as measured -----
+
+    def test_row1_same_segment_prefix_never_reaches_git_allows(self) -> None:
+        """`A=1 B=git $B commit -m z` — marker proxy: real shell reports
+        `MARKERARG: command not found` (`$B` unset at expansion time). Must
+        ALLOW; the OLD code blocked this (false positive).
+        """
+        self.assertIsNone(hook.check(self._input("A=1 B=git $B commit -m z")))
+
+    def test_row2_own_prefix_reassignment_does_not_shadow_running_value_allows(
+        self,
+    ) -> None:
+        """`g=echo; g=git $g commit -m x` — marker proxy: real shell runs
+        `echo commit -m x` (`$g` resolves against the RUNNING state from the
+        prior segment, `echo`, not this segment's own `g=git` prefix). Must
+        ALLOW; the OLD code blocked this (false positive).
+        """
+        self.assertIsNone(hook.check(self._input("g=echo; g=git $g commit -m x")))
+
+    def test_row3_own_prefix_reassignment_cannot_hide_prior_running_value_blocks(
+        self,
+    ) -> None:
+        """`g=git; g=echo $g commit -m x` — marker proxy: real shell runs
+        the fake `git` executable (`$g` resolves against the RUNNING state
+        from the prior segment, `git`, not this segment's own `g=echo`
+        prefix). Must BLOCK; the OLD code ALLOWED this outright — a LIVE
+        BYPASS with no interpreter wrapper at all, not merely a cosmetic
+        false positive.
+        """
+        result = hook.check(self._input("g=git; g=echo $g commit -m x"))
+        self.assertIsNotNone(result, "prior-segment g=git must still resolve at the commit site")
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+        self.assertIn("missing `-c user.name=` flag", result["reason"])
+
+    def test_row4_background_assignment_never_reaches_foreground_allows(self) -> None:
+        """`g=git & $g commit -m x` — marker proxy: real shell reports
+        `MARKERARG: command not found` (`g=git` runs as a backgrounded job
+        in its own subshell; the foreground `$g` is unset). Must ALLOW.
+        """
+        self.assertIsNone(hook.check(self._input("g=git & $g commit -m x")))
 
     def test_braced_variable_reference_form_resolves(self) -> None:
         """POS: `${g}` (braced form) must resolve the same as bare `$g`."""

--- a/.claude/hooks/tests/test_validate_commit_identity.py
+++ b/.claude/hooks/tests/test_validate_commit_identity.py
@@ -1502,17 +1502,33 @@ class AssignmentAwarePrePassTests(unittest.TestCase):
         self.assertIsNone(hook.check(self._input("d=$(date); echo $d")))
 
     def test_prose_value_with_git_commit_words_not_resolved_allows(self) -> None:
-        """NEG: a quoted, multi-word value merely mentioning "git commit".
+        """NEG: a quoted, multi-word value merely mentioning "git commit" as
+        an ARGUMENT (`echo $msg`), not in command position.
 
         `msg="please git commit this later"; echo $msg` is prose, not an
-        invocation. A quoted value survives shlex de-quoting as ONE token
-        containing whitespace, so the literal-charset check (which never
-        allows whitespace) rejects it — `msg` is never captured, so
-        resolving `$msg` cannot manufacture a `git ... commit` bridge out of
-        this prose. This is the false-positive class the assignment-aware
-        pre-pass could otherwise introduce; it must not fire.
+        invocation: even resolved, `$msg` lands as an argument to `echo`,
+        never as the first token of a segment, so `find_git_subcommand`
+        (which requires `git` to be that first token) does not fire either
+        way. Pinned as a regression guard that the pre-pass does not change
+        this outcome for an ordinary "argument merely mentions git" shape.
         """
         cmd = 'msg="please git commit this later"; echo $msg'
+        self.assertIsNone(hook.check(self._input(cmd)))
+
+    def test_multiword_command_string_value_not_resolved_allows(self) -> None:
+        """NEG: `cmd="git commit -m z"; $cmd` — a full command line assigned
+        to a variable, then invoked BARE (real shell word-splitting would
+        actually run it). This is the test that pins the literal-charset
+        guard itself: the value contains whitespace, so `cmd` is never
+        captured and `$cmd` is left as one unresolved literal token (not
+        equal to `git`), so `find_git_subcommand` does not see a `git`
+        command in command position. Deliberately out of scope (multi-word
+        values are not resolved) — this is a documented boundary, not an
+        oversight: resolving it would reopen the prose-argument
+        false-positive class one level lower (through direct segment
+        matching instead of `_INNER_COMMIT_RE`).
+        """
+        cmd = 'cmd="git commit -m z"; $cmd'
         self.assertIsNone(hook.check(self._input(cmd)))
 
     def test_unrelated_assignment_and_reuse_allows(self) -> None:
@@ -1578,6 +1594,25 @@ class AssignmentAwarePrePassTests(unittest.TestCase):
         not need to for THIS shape — nothing here spells `git`).
         """
         self.assertIsNone(hook.check(self._input("$NEVERASSIGNED commit -m x")))
+
+    def test_unresolved_reference_leaves_exact_literal_not_merely_nonempty(self) -> None:
+        """NEG (truncating-mutant guard): an UNASSIGNED reference sitting
+        between two literal fragments must be left EXACTLY as typed, not
+        collapsed to an empty string, when substitution runs at all (i.e.
+        when at least one OTHER name in the command WAS assigned, so the
+        `assignments` map is non-empty and the substitution pass executes).
+
+        `h=other; gi${x}t commit -m z` — `x` is never assigned. If the
+        "leave unresolved" fallback ever degraded from returning the
+        original matched text to returning `""`, `${x}` would vanish and the
+        surrounding literal fragments would collapse into `git` by
+        coincidence (`"gi" + "" + "t"` == `"git"`), manufacturing a command
+        word that was never there. Asserting merely `assertIsNotNone` on the
+        wrong branch would pass under exactly this truncating mutant; this
+        asserts the correct (allowed) OUTCOME instead.
+        """
+        cmd = "h=other; gi${x}t commit -m z"
+        self.assertIsNone(hook.check(self._input(cmd)))
 
 
 if __name__ == "__main__":

--- a/.claude/hooks/validate_commit_identity.py
+++ b/.claude/hooks/validate_commit_identity.py
@@ -118,6 +118,7 @@ from _shell_parse import (  # noqa: E402
     iter_command_segments,
     iter_command_segments_ast,
     iter_interpreter_invocations,
+    resolve_simple_assignments,
     resolve_tool_cwd,
     strip_data_heredocs,
     strip_heredocs,
@@ -404,10 +405,25 @@ _INNER_COMMIT_RE = re.compile(
 
 
 def _payload_looks_like_commit(payload: str) -> bool:
-    """Return True if the (already-extracted) inner payload contains git commit."""
+    """Return True if the (already-extracted) inner payload contains git commit.
+
+    main#1195: the payload itself may be a compound mini-script (a `bash -c`
+    argument, a heredoc body, an `eval` argument, ...) carrying its OWN
+    `NAME=value; $NAME commit` indirection — the top-level
+    `resolve_simple_assignments` pass in `check()` only sees the OUTER
+    command, and an outer-quoted payload is one opaque token there (it fails
+    the literal-value check because it contains whitespace, so it is never
+    treated as an outer assignment). Applying the same bounded resolution
+    HERE, on the extracted payload text itself, is what makes
+    `bash -c 'g=git; $g commit -m x'` resolve the same way the unwrapped
+    `g=git; $g commit -m x` does — one shared resolver, applied at both the
+    outer-command choke point and this inner-payload choke point, rather
+    than two independent copies of the same logic (main#1152's drift
+    lesson).
+    """
     if not payload:
         return False
-    return bool(_INNER_COMMIT_RE.search(strip_heredocs(payload)))
+    return bool(_INNER_COMMIT_RE.search(resolve_simple_assignments(strip_heredocs(payload))))
 
 
 def _strip_outer_quotes(s: str) -> str:
@@ -654,12 +670,22 @@ def check(input_data: dict) -> dict | None:
     command = input_data.get("tool_input", {}).get("command", "")
     cwd = resolve_tool_cwd(input_data)
 
+    # main#1195: assignment-aware pre-pass. `g=git; $g commit -m x` needs no
+    # interpreter wrapper at all — `$g` sits in command position exactly
+    # like a literal `git` would, and both the indirect-exec detector below
+    # and `_find_commit_segment` require the literal token `git`. Resolving
+    # simple literal assignments FIRST, once, means both matchers see
+    # `git commit -m x` and neither needs its own copy of this logic. Only
+    # this resolved copy is used for detection; `command` (the original,
+    # as typed) is still what gets logged in a block reason.
+    resolved_command = resolve_simple_assignments(command)
+
     # #475 fix 2: indirect-exec bypass detection. Runs BEFORE the segment
     # tokenizer because wrappers like `printf '…git commit…' | bash` and
     # `bash <script>` hide the actual git invocation from the outer-command
     # parser — if we let `_find_commit_segment` decide first it would return
     # None and the command would slip through unvalidated.
-    indirect_shape = _detect_indirect_commit(command, cwd=cwd)
+    indirect_shape = _detect_indirect_commit(resolved_command, cwd=cwd)
     if indirect_shape is not None:
         result = {
             "decision": "block",
@@ -683,7 +709,7 @@ def check(input_data: dict) -> dict | None:
         log_pretooluse_block("validate_commit_identity", command, result["reason"])
         return result
 
-    commit_segment = _find_commit_segment(command)
+    commit_segment = _find_commit_segment(resolved_command)
     if commit_segment is _PARSE_FAILURE:
         # tokenize() returned None — shlex could not parse the command. Use
         # the regex fallback: if it looks like a git commit, block (fail-closed);


### PR DESCRIPTION
Closes #1195
Closes #1305

## Shape

`_payload_looks_like_commit`'s `_INNER_COMMIT_RE` requires a literal `git ... commit` bridge inside one scanned token, and the direct commit finder (`find_git_subcommand`, via `_find_commit_segment`) requires the literal token `git` in command position. Holding the command word in a shell variable defeats **both**, with no interpreter wrapper needed at all:

```
g=git; $g commit -m x
```

## Decision: option 1 (assignment-aware pre-pass), not option 2

Option 2 ("flag the shape, fail closed") was rejected: "a payload that assigns a variable and later uses it in command position" is not a rare or unusual shape — `d=$(date); echo $d`, `out=$(mktemp); cat > "$out"`, and any ordinary use of a shell variable as an argument all have this exact structure. Failing closed on the *shape* rather than the *resolved value* would false-block the majority of ordinary scripting idioms this org's own hooks and workflows use. The issue itself flagged this needs "a false-positive sweep first" — the sweep (below) confirms the risk is real and option 2 is not viable without an intractable amount of shape-vs-intent discrimination that option 1 sidesteps by only ever resolving what it can prove is a bare literal.

Option 1 is bounded and testable: resolve a **leading** `NAME=value` assignment whose value is a **bare literal** (no `$`, backticks, parens, or whitespace — checked via `_SIMPLE_LITERAL_VALUE_RE = re.compile(r"^[A-Za-z0-9_./:@%+-]+$")`), then substitute later `$NAME`/`${NAME}` references with that value, before either matcher runs. Implemented once as `resolve_simple_assignments()` in `_shell_parse.py`, applied at **two choke points**:
- once on the outer command in `validate_commit_identity.check()` (fixes the direct-typed shape)
- once on each extracted wrapper payload inside `_payload_looks_like_commit` (fixes the same shape one layer down, e.g. inside a `bash -c '...'` argument, where the outer-command resolver alone can't reach it — the quoted payload is one opaque token at the outer level)

One shared implementation at both points, rather than two independent copies — this repo's own `_shell_parse.py` docstring (main#1152) is explicit that two places answering the same question independently is how this class of bug recurs.

`export`/`declare` are folded into the same-shape leading assignment (#1305, scope of this PR — verified including braced (`${g}`) and `bash -c`-wrapped forms, composed with positional ordering); `local`/`typeset`/`readonly` remain out of scope and are carried by #1308 (see the round-3 section below).

## Review round 3 (this update): a live bypass in the positional-resolution fix itself

Round 2 made resolution positional (a running map accumulated from strictly-earlier segments, not one flat last-wins map) to close an order-blind hole. But the round-2 code also merged a segment's **own** leading assignments into the map used to substitute that **same** segment's own `$NAME` references. That is not how a real shell resolves a prefix assignment: **POSIX expands a command's words BEFORE applying that command's own prefix assignments.** Verified against a real shell with a printf/marker proxy (a fake `git` executable on `PATH`, real `echo` as the control):

| input | round-2 code | real shell | verdict |
|---|---|---|---|
| `A=1 B=git $B commit -m z` | blocks | never runs git (`$B` unset at expansion time) | **false positive** |
| `g=echo; g=git $g commit -m x` | blocks | runs `echo commit -m x` (`$g` resolves against the prior segment's running value, `echo`) | **false positive** |
| `g=git; g=echo $g commit -m x` | **allows** | **runs the real `git commit -m x`** (`$g` resolves against the prior segment's running value, `git`; the same-segment `g=echo` prefix never applies to its own expansion) | **LIVE BYPASS, no wrapper** |
| `g=git & $g commit -m x` | blocks | `g` is set only in a backgrounded subshell; the foreground `$g` stays unset | **false positive** |

The fix is a one-line deletion in `resolve_simple_assignments`: substitute each segment's references against the running (strictly-earlier) state alone, never merged with that segment's own leading assignments (`active = assignments`, not `active = {**assignments, **own_assignments}`). All four rows are now shell-correct with the marker proxy; the module's own top-of-file API doc and the "positional resolution" section comment already stated this rule correctly — only the code contradicted it.

**Cost:** two pre-existing tests asserted the now-refuted round-2 same-segment behavior and were replaced (not weakened) with shell-correct assertions, plus explicit regression coverage for all four rows above:
- `test_shell_parse.py::ResolveSimpleAssignmentsTests::test_same_segment_multiple_leading_assignments_resolve_within_segment` → `test_same_segment_leading_assignment_not_visible_to_own_expansion` (+ a new `test_same_segment_leading_assignment_becomes_visible_in_later_segment` preserving the original multi-assignment-peeling coverage, now checked where a real shell agrees — once `;` moves the reference into a later segment)
- `test_validate_commit_identity.py::AssignmentAwarePrePassTests::test_multiple_leading_assignments_in_one_segment_resolves_second` → `test_same_segment_leading_assignment_not_resolved_allows` (+ `test_two_leading_assignments_resolve_in_later_segment_blocks` for the same cross-segment coverage), plus four new `test_row{1,2,3,4}_*` tests pinning the marker-proxy table above directly.

Full suite after the fix: `.claude/hooks/tests` 2574 passed / 672 subtests (was 2548/672 before round 3's two new test files' worth of additions), `.claude/lib/tests` 1178 passed / 78 subtests, ruff clean, mypy clean.

**#1308** (filed, not blocking this PR): `local` is correctly excluded from `_ASSIGNMENT_KEYWORDS`, but for a better reason than previously documented — it's a function builtin, errors at top level, and never sets the variable at all (now pinned by `test_local_keyword_prefix_is_out_of_scope`, unchanged). `typeset` and `readonly`, however, are **not** in that category: both are valid at top level and both ran the indirected command under the marker proxy in round-3 testing — they are a live gap of the same shape, tracked separately by #1308 rather than folded into this PR's already-reviewed diff.

## What it covers (measured)

| shape | before | after |
|---|---|---|
| `g=git; $g commit -m x` (typed directly, no wrapper, `;` glued to `git`) | allow | **block** (missing `-c user.name=`) |
| same, with valid `-c user.name=`/`-c user.email=` | allow | **allow** (correctly — fix doesn't break compliant commits) |
| `g=git ; $g commit -m x` (space before `;`) | allow | **block** |
| `bash -c 'g=git; $g commit -m x'` (the issue's wrapped repro) | allow | **block** (`indirect-exec wrapper detected (shell -c)`) |
| `bash <<'EOF'\ng=git\n$g commit -m x\nEOF` (heredoc payload, same choke point) | allow | **block** |
| `A=1 B=git $B commit -m z` (same-segment prefix assignment) | allow | **allow** (correctly — corrected in review round 3: a real shell never runs git here, `$B` is unset at expansion time; see the round-3 section above. **This row previously read "block" — that was factually wrong, the real shell never runs git for this input.**) |
| `A=1 B=git; $B commit -m z` (same two-assignment leading run, but `$B` used in a LATER segment) | allow | **block** |
| `g=git; ${g} commit -m x` (braced form) | allow | **block** |

## False-positive corpus (must stay ALLOW — all verified via real `check()`)

| payload | result |
|---|---|
| `d=$(date); echo $d` (issue's own required sweep item — command substitution) | **allow** (value contains `$(`, fails literal-charset check, never captured) |
| `msg="please git commit this later"; echo $msg` (prose argument, not command position) | **allow** |
| `FOO=bar; echo $FOO` (ordinary unrelated env-var reuse) | **allow** |
| `g=$(echo git); $g commit -m x` (command-substitution of the command word itself — explicitly out of scope, same family as `$(printf git) commit`) | **allow** |
| `g=git; $gone commit -m x` (name-prefix conflation guard — `$gone` ≠ `$g`) | **allow** |
| `set -- git commit; echo $1` (positional parameter, explicitly out of scope) | **allow** |
| `cmd="git commit -m z"; $cmd` (multi-word/full-command-string value, used bare — a REAL shell would word-split and run it; deliberately not resolved, documented boundary) | **allow** |
| `$NEVERASSIGNED commit -m x` (no assignment anywhere; fallback must be the literal, not empty/KeyError) | **allow** |
| `h=other; gi${x}t commit -m z` (truncating-mutant guard: an unresolved reference must not collapse to `""` and coincidentally spell `git` out of adjacent literal text) | **allow** |

## Mutation table

7 real mutations applied to the shipped diff (each applied with `Edit`, run against the `AssignmentAwarePrePassTests` suite, then reverted with `git checkout HEAD --` since the fix commit was already checkpointed):

| # | mutation | tests that catch it |
|---|---|---|
| M1 | `tokenize(command)` instead of `tokenize(normalize_command_separators(command))` | 3 fail: glued-semicolon direct-typed, wrapped `-c`, braced-form |
| M2 | dropped the literal-charset guard (`if True: assignments[name] = value`) | `test_multiword_command_string_value_not_resolved_allows` fails |
| M3 | `while` → `if` in the leading-assignment peel loop | `test_two_leading_assignments_resolve_in_later_segment_blocks` fails |
| M4 | dropped the `name_braced` capture group (bare `$NAME` only) | `test_braced_variable_reference_form_resolves` fails |
| M5 | unresolved-reference fallback `""` instead of the original matched text | `test_unresolved_reference_leaves_exact_literal_not_merely_nonempty` fails |
| M6 | removed `resolve_simple_assignments()` call from `_payload_looks_like_commit` | `test_wrapped_bash_dash_c_variable_command_word_blocks` fails |
| M7 | reverted `_find_commit_segment(resolved_command)` to `_find_commit_segment(command)` | 4 fail: both direct-typed cases, multi-assignment, braced-form |

Every mutation is caught by at least one test; every test passes on the real (unmutated) code. `AssignmentAwarePrePassTests`: 16/16 pre-round-3 (now superseded/expanded, see the round-3 section). Full `.claude/hooks/tests` suite: 2574/2574 passed, 672 subtests, on this branch after round 3.

Two real bugs were found and fixed *during* mutation testing, not before it:
- the first draft of the assignment-capture pass tokenized the raw `command` directly; the issue's own primary repro (`g=git; $g commit`, `;` glued to `git` with no space) tokenizes `g=git;` as ONE token, so the trailing `;` landed inside the captured value and failed the literal-charset check, silently un-fixing the headline shape. Fixed by tokenizing `normalize_command_separators(command)` instead (a quote-aware helper this module already provides for exactly this class of bug).
- the first draft of the "prose value" false-positive test used the *unwrapped* form, which allows for an unrelated reason (git isn't first-in-segment) regardless of the charset guard — it wasn't actually testing what its docstring claimed. Replaced with a test that targets the guard directly (a bare multi-word command-string value).

A third bug — the live bypass documented in the "Review round 3" section above — was found and fixed in this update, after merge-gate review flagged the `active = {**assignments, **own_assignments}` seam as a risk.

## What's deliberately left uncovered (explicit non-goals, matching the issue's own scope)

- Command substitution of the command word itself (`$(printf git) commit`) and `eval`-of-a-variable — same family, strictly harder; `eval` is partially covered by shape 6 of `_detect_indirect_commit` already.
- Positional/special parameters (`$1`, `$?`, `$@`, ...) — the capture regex requires a name starting with a letter/underscore, so these can never be an assignment target.
- Multi-word / full-command-string values used bare (`cmd="git commit -m z"; $cmd`) — a real shell would word-split and actually run this, but resolving it would reopen the prose-false-positive class one level lower (through direct segment matching instead of `_INNER_COMMIT_RE`). Filing this as its own follow-up tech-debt issue rather than silently widening this PR's scope.
- The `[^;&|]` bridge bound in `_INNER_COMMIT_RE` generally, and the parsing-layer #1150 umbrella this issue sits one layer below — unchanged, out of scope here.
- `local`/`typeset`/`readonly` prefix keywords — see #1308 above.

## Files

- `.claude/hooks/_shell_parse.py` — new `resolve_simple_assignments()` + `_SIMPLE_LITERAL_VALUE_RE` / `_VAR_REF_RE`, docstring entry; round-3 update: `active = assignments` (dropped the same-segment merge) plus corrected comments/docstrings
- `.claude/hooks/validate_commit_identity.py` — wired at both choke points (`check()` and `_payload_looks_like_commit`)
- `.claude/hooks/tests/test_validate_commit_identity.py` — `AssignmentAwarePrePassTests`, expanded in round 3 (see above)
- `.claude/hooks/tests/test_shell_parse.py` — `ResolveSimpleAssignmentsTests`, expanded in round 3 (see above)

Not merging per instructions — requesting review.
