### PR TITLE
fix(hook4): a wave->main integration PR has no author on its branch — state the policy, then match it (#1216)

### DIFF
--- a/.claude/hooks/block_squash_wave_merge.py
+++ b/.claude/hooks/block_squash_wave_merge.py
@@ -51,11 +51,16 @@ from annunaki_log import log_pretooluse_block
 # The wave-branch shape is `charter_trailer.is_wave_branch` (main#1216) — do NOT
 # reimplement it here. This hook used to carry its own
 # `^deployments/phase-\d+/wave-\d+$`, which does not match the undashed
-# `deployments/phase15/wave-1` form that 4 of the org's repos used historically:
-# 32 of the 202 `deployments/**`-head PRs measured on 2026-08-03, all from
-# 2026-03-15..04-06. Nothing emits that spelling today, but wave branches are
-# RETAINED permanently as rollback anchors, so those 28 refs are still live and
-# still squashable — the guard was simply off for them. One definition, shared
+# `deployments/phase15/wave-1` form that 4 of the org's repos use: 32 of the 202
+# `deployments/**`-head PRs measured on 2026-08-03. That form is CURRENT, not
+# historical — an earlier draft of this comment claimed nothing emits it today
+# and that was wrong (retracted, #1310 review):
+# `noorinalabs-isnad-graph/scripts/create-wave.sh:38` constructs it live, and
+# `ontology/conventions.md:213` plus two child charters prescribe it as THE
+# convention. See `charter_trailer._WAVE_BRANCH_RE` for the full evidence and
+# #1313 for the spelling conflict. Wave branches are also RETAINED permanently
+# as rollback anchors, so those 28 refs stay live and squashable regardless —
+# the guard was simply off for all of them. One definition, shared
 # with the merge gate, is what keeps a second reader of the same charter shape
 # from disagreeing with the first — the `extract_branch_author_lastname` lesson
 # (main#1175).

--- a/.claude/hooks/block_squash_wave_merge.py
+++ b/.claude/hooks/block_squash_wave_merge.py
@@ -51,11 +51,14 @@ from annunaki_log import log_pretooluse_block
 # The wave-branch shape is `charter_trailer.is_wave_branch` (main#1216) — do NOT
 # reimplement it here. This hook used to carry its own
 # `^deployments/phase-\d+/wave-\d+$`, which does not match the undashed
-# `deployments/phase15/wave-1` form that 4 of the org's repos actually use: 32 of
-# the 202 `deployments/**`-head PRs measured on 2026-08-03. The guard was
-# therefore silently OFF on those branches. One definition, shared with the merge
-# gate, is what keeps a second reader of the same charter shape from disagreeing
-# with the first — the `extract_branch_author_lastname` lesson (main#1175).
+# `deployments/phase15/wave-1` form that 4 of the org's repos used historically:
+# 32 of the 202 `deployments/**`-head PRs measured on 2026-08-03, all from
+# 2026-03-15..04-06. Nothing emits that spelling today, but wave branches are
+# RETAINED permanently as rollback anchors, so those 28 refs are still live and
+# still squashable — the guard was simply off for them. One definition, shared
+# with the merge gate, is what keeps a second reader of the same charter shape
+# from disagreeing with the first — the `extract_branch_author_lastname` lesson
+# (main#1175).
 # `test_block_squash_wave_merge.py::SharedWaveBranchParsingTests` asserts this
 # module's binding IS `charter_trailer`'s, so a re-declared local copy fails a
 # named test rather than drifting silently.

--- a/.claude/hooks/block_squash_wave_merge.py
+++ b/.claude/hooks/block_squash_wave_merge.py
@@ -34,11 +34,11 @@ Exit codes:
 
 import json
 import os
-import re
 import subprocess
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "lib"))
 from _shell_parse import (
     find_gh_subcommand,
     iter_command_segments,
@@ -48,9 +48,18 @@ from _shell_parse import (
 )
 from annunaki_log import log_pretooluse_block
 
-# A wave branch is exactly `deployments/phase-<P>/wave-<M>` — anchored so a
-# feature branch that merely contains the substring does not match.
-WAVE_BRANCH_RE = re.compile(r"^deployments/phase-\d+/wave-\d+$")
+# The wave-branch shape is `charter_trailer.is_wave_branch` (main#1216) — do NOT
+# reimplement it here. This hook used to carry its own
+# `^deployments/phase-\d+/wave-\d+$`, which does not match the undashed
+# `deployments/phase15/wave-1` form that 4 of the org's repos actually use: 32 of
+# the 202 `deployments/**`-head PRs measured on 2026-08-03. The guard was
+# therefore silently OFF on those branches. One definition, shared with the merge
+# gate, is what keeps a second reader of the same charter shape from disagreeing
+# with the first — the `extract_branch_author_lastname` lesson (main#1175).
+# `test_block_squash_wave_merge.py::SharedWaveBranchParsingTests` asserts this
+# module's binding IS `charter_trailer`'s, so a re-declared local copy fails a
+# named test rather than drifting silently.
+from charter_trailer import is_wave_branch
 
 
 def _iter_squash_merges(command):
@@ -150,7 +159,7 @@ def check(input_data, *, base_runner=None):
         return None
     for pr, repo in _iter_squash_merges(command):
         base = _resolve_base_ref(pr, repo, runner=base_runner)
-        if base and WAVE_BRANCH_RE.match(base):
+        if is_wave_branch(base):
             reason = _reason(pr, repo)
             log_pretooluse_block("block_squash_wave_merge", command, reason)
             return {"decision": "block", "reason": reason}

--- a/.claude/hooks/tests/test_block_squash_wave_merge.py
+++ b/.claude/hooks/tests/test_block_squash_wave_merge.py
@@ -237,6 +237,12 @@ class UndashedPhaseWaveBranchTests(unittest.TestCase):
     `phase{N}` form — in isnad-graph, design-system, data-acquisition and
     landing-page — and the hook's own pattern did not match any of them, so a
     `--squash` into those wave branches was allowed straight through.
+
+    The form is HISTORICAL (all 32 from 2026-03-15..04-06; every wave-branch
+    name constructor in the repo emits the dashed form). It is still worth
+    guarding because wave branches are retained permanently as rollback anchors
+    — the 28 refs exist today and are squashable — but this is a historical-tail
+    fix, not a live outage, and the test says so rather than overstating it.
     """
 
     UNDASHED = "deployments/phase15/wave-1"

--- a/.claude/hooks/tests/test_block_squash_wave_merge.py
+++ b/.claude/hooks/tests/test_block_squash_wave_merge.py
@@ -238,11 +238,16 @@ class UndashedPhaseWaveBranchTests(unittest.TestCase):
     landing-page — and the hook's own pattern did not match any of them, so a
     `--squash` into those wave branches was allowed straight through.
 
-    The form is HISTORICAL (all 32 from 2026-03-15..04-06; every wave-branch
-    name constructor in the repo emits the dashed form). It is still worth
-    guarding because wave branches are retained permanently as rollback anchors
-    — the 28 refs exist today and are squashable — but this is a historical-tail
-    fix, not a live outage, and the test says so rather than overstating it.
+    The form is CURRENT, not historical. An earlier version of this docstring
+    called it a historical tail on the strength of the 2026-03-15..04-06 date
+    range; that inference was FALSE and is retracted (#1310 review).
+    `noorinalabs-isnad-graph/scripts/create-wave.sh:38` constructs the undashed
+    form live, and `ontology/conventions.md:213` — mirrored into the
+    data-acquisition and deploy child charters — prescribes it as THE convention
+    an implementer is told to target. The spelling conflict with the parent
+    charter's dashed form is tracked by #1313. Independently, wave branches are
+    retained permanently as rollback anchors, so the 28 refs stay squashable.
+    This guards a live gap; do not delete it as legacy coverage.
     """
 
     UNDASHED = "deployments/phase15/wave-1"

--- a/.claude/hooks/tests/test_block_squash_wave_merge.py
+++ b/.claude/hooks/tests/test_block_squash_wave_merge.py
@@ -206,5 +206,70 @@ class HeredocAndSegmentSafety(unittest.TestCase):
         self.assertEqual(result["decision"], "block")
 
 
+class SharedWaveBranchParsingTests(unittest.TestCase):
+    """This hook and the merge gate must agree on what a wave branch IS (#1216).
+
+    The hook used to carry its own `^deployments/phase-\\d+/wave-\\d+$`. The
+    merge gate now keys a review-policy carve-out on the same charter shape, and
+    two hand-maintained copies of one charter shape is exactly what cost the org
+    four months of divergence on `extract_branch_author_lastname` (main#1175) —
+    where #179 taught one copy the dash separator and the other never learned it.
+    """
+
+    def test_the_hook_binds_charter_trailers_predicate(self):
+        """Identity, not equivalence. A re-declared local copy fails HERE."""
+        sys.path.insert(0, str(_HOOKS_DIR.parent / "lib"))
+        import charter_trailer
+
+        self.assertIs(hook.is_wave_branch, charter_trailer.is_wave_branch)
+
+    def test_the_hook_no_longer_declares_its_own_pattern(self):
+        """A stale module-level `WAVE_BRANCH_RE` would be dead but readable, and
+        the next editor would reasonably believe it is the live definition."""
+        self.assertFalse(hasattr(hook, "WAVE_BRANCH_RE"))
+
+
+class UndashedPhaseWaveBranchTests(unittest.TestCase):
+    """The 32-PR blind spot the consolidation closes (#1216).
+
+    `deployments/phase15/wave-1` is a real production base ref. Across the 202
+    `deployments/**`-head PRs measured on 2026-08-03, 32 carry the undashed
+    `phase{N}` form — in isnad-graph, design-system, data-acquisition and
+    landing-page — and the hook's own pattern did not match any of them, so a
+    `--squash` into those wave branches was allowed straight through.
+    """
+
+    UNDASHED = "deployments/phase15/wave-1"
+
+    def test_squash_into_an_undashed_wave_branch_now_blocks(self):
+        result = hook.check(
+            _input("gh pr merge 890 --squash"),
+            base_runner=_runner({"890": self.UNDASHED}),
+        )
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+
+    def test_merge_into_an_undashed_wave_branch_still_allows(self):
+        """Anti-vacuity: the test above must not be satisfied by a hook that
+        blocks every merge onto that base."""
+        self.assertIsNone(
+            hook.check(
+                _input("gh pr merge 890 --merge"),
+                base_runner=_runner({"890": self.UNDASHED}),
+            )
+        )
+
+    def test_squash_into_a_non_wave_deployments_base_still_allows(self):
+        """The widening was `phase-?`, not `deployments/**`. Real ref
+        (isnad-graph#603/#612) — blocking here would be a new false positive."""
+        self.assertIsNone(
+            hook.check(
+                _input("gh pr merge 890 --squash"),
+                base_runner=_runner({"890": "deployments/phase12/cleanup"}),
+            )
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.claude/hooks/tests/test_validate_pr_review.py
+++ b/.claude/hooks/tests/test_validate_pr_review.py
@@ -5198,20 +5198,24 @@ class CommitIdentitySelfReviewExclusionTests(_ResolveOverFakeCommentsHarness):
 
 
 class OneDerivationDrivesModeAndExclusionTests(_ResolveOverFakeCommentsHarness):
-    """The #1297 shape, closed structurally rather than argued (#1216).
+    """One value decides both the reported mode and whether exclusion runs.
 
-    #1297 (open, from the #1292 merge gate) is the demonstration that narrowing
-    ONLY the tuple handed to `check_comment_reviews` — leaving the mode and every
-    diagnostic reading an unfiltered second tuple — keeps the whole suite green
-    while a self-approver reaches 2/2 on a non-charter ref. #1216 introduces
-    exactly the kind of edit that could do it: a slice where exclusion is turned
-    OFF.
+    `resolve_review_verdicts` derives `commit_authors` FROM `scan_scope`, so the
+    mode that is REPORTED and the tuple the exclusion is APPLIED from cannot
+    disagree about whether exclusion is live. #1216 adds a slice where exclusion
+    is turned OFF, which is exactly the kind of edit that could desynchronise
+    them; these tests pin the equivalence over every mode in both directions.
 
-    It is closed by construction instead: `resolve_review_verdicts` derives
-    `commit_authors` FROM `scan_scope`, so the mode that is reported and the
-    tuple the exclusion is applied from are one value. These tests pin that
-    equivalence directly, so an edit that reintroduces a second tuple fails here
-    rather than shipping green.
+    SCOPE — THIS DOES NOT CLOSE #1297, WHICH REMAINS OPEN. An earlier version of
+    this docstring said it did ("the #1297 shape, closed structurally"). That was
+    FALSE and is retracted (#1310 review): #1297's mutation applied verbatim to
+    this tree leaves the suite fully GREEN and lets a self-approver reach 2/2 on
+    3 of its 4 identity shapes, with the mode never moving. The coupling binds
+    whether the tuple is DERIVED; #1297 inserts a filtered COPY downstream of the
+    derivation, so derivation and mode still agree and nothing here notices. What
+    is caught is the mode-moving variant (M8/M9), which is a real and different
+    property. #1297 needs the two count assertions its own closing section
+    specifies — it must not be closed on the strength of this class.
     """
 
     # (head_ref, expected mode, expected reviewer set). The reviewer set is
@@ -5285,9 +5289,13 @@ class OneDerivationDrivesModeAndExclusionTests(_ResolveOverFakeCommentsHarness):
         """The invariant itself, over both groups: a NON-empty identity tuple
         must coincide exactly with a mode that claims exclusion is live.
 
-        This is the assertion #1297 says is missing on `main` — there, the
-        reported tuple and the excluded-from tuple are two expressions that
-        merely happen to be equal today.
+        On `main` the reported tuple and the excluded-from tuple are two separate
+        expressions that merely happen to be equal today; here they are one
+        value, and this asserts it over every mode.
+
+        NOT #1297's closing assertion — that one is a COUNT test on an
+        alias-only identity, and it is not written yet (#1297 stays open; see
+        the class docstring).
         """
         refs = [case[0] for case in self.MODES_WITHOUT_DERIVATION] + [
             case[0] for case in self.MODES_WITH_DERIVATION

--- a/.claude/hooks/tests/test_validate_pr_review.py
+++ b/.claude/hooks/tests/test_validate_pr_review.py
@@ -28,6 +28,7 @@ Or:  ENVIRONMENT=test python3 .claude/hooks/tests/test_validate_pr_review.py
 
 from __future__ import annotations
 
+import dataclasses
 import json
 import re
 import sys
@@ -743,8 +744,16 @@ class SharedBranchAuthorParsingTests(unittest.TestCase):
             hook.comment_scan_scope("A.Virtanen/1175-consolidation"),
             hook.COMMENT_SCAN_AUTHOR_EXCLUDED,
         )
+        # #1216: a wave branch now selects its own mode. Still the point of this
+        # assertion — the parser must not see an author in it — but the negative
+        # is now stated as "not AUTHOR_EXCLUDED" plus the specific mode, so the
+        # test keeps pinning the shared-parser wiring rather than the mode name.
         self.assertEqual(
             hook.comment_scan_scope("deployments/phase-3/wave-29"),
+            hook.COMMENT_SCAN_WAVE_INTEGRATION,
+        )
+        self.assertEqual(
+            hook.comment_scan_scope("deployments/phase12/cleanup"),
             hook.COMMENT_SCAN_NO_BRANCH_AUTHOR,
         )
 
@@ -3994,10 +4003,18 @@ class CommentScanScopeTotalityTests(unittest.TestCase):
 
     def test_non_persona_refs_select_the_no_branch_author_scan(self):
         """THE DEFECT, at the dispatch level. Every one of these returned "no
-        scan" before #1206; each must now name a real scanning mode."""
+        scan" before #1206; each must now name a real scanning mode.
+
+        `deployments/phase-10/wave-29` moved OUT of this list at #1216 — it
+        selects `WAVE_INTEGRATION` now, asserted in
+        `WaveBranchScanScopeTests` below. The remaining `deployments/**` entry is
+        a REAL production ref (isnad-graph#603/#612) that is NOT a wave branch,
+        and it is here to pin that the carve-out did not widen to the whole
+        `deployments/` namespace.
+        """
         for ref in (
             "dependabot/docker/integration-tests/fake_oauth/python-d3400aa",
-            "deployments/phase-10/wave-29",
+            "deployments/phase12/cleanup",
             "feature/some-hand-made-branch",
             "nohashinthisref",  # no `/` at all
             "",  # headRefName absent from the API response
@@ -4217,14 +4234,19 @@ class HeadRefScanRegressionTests(_ResolveOverFakeCommentsHarness):
     def test_wave_merge_branch_behaviour_is_unchanged(self):
         """`deployments/phase-N/wave-M` counted every roster reviewer before the
         fix (main#294's empty sentinel) and must still do so — same reviewers,
-        same count, and now under the generalised no-branch-author mode."""
+        same count.
+
+        The MODE changed at #1216 (`WAVE_INTEGRATION`, the policy answer) but the
+        counted set did not, which is this test's actual subject and the reason
+        it survives #1216 with one line touched.
+        """
         verdicts = self._resolve(
             "deployments/phase-10/wave-29",
             [self._verdict("Lucas Ferreira"), self._verdict("Nino Kavtaradze")],
         )
         self.assertEqual(verdicts.distinct_reviewers, {"lucas ferreira", "nino kavtaradze"})
         self.assertEqual(verdicts.total_distinct, 2)
-        self.assertEqual(verdicts.comment_scan, hook.COMMENT_SCAN_NO_BRANCH_AUTHOR)
+        self.assertEqual(verdicts.comment_scan, hook.COMMENT_SCAN_WAVE_INTEGRATION)
         self.assertIsNone(verdicts.branch_author_lastname)
 
     def test_two_reviewer_threshold_is_not_relaxed_anywhere(self):
@@ -4839,11 +4861,23 @@ class CommitIdentitySelfReviewExclusionTests(_ResolveOverFakeCommentsHarness):
         self.assertEqual(verdicts.distinct_reviewers, {"nino kavtaradze", "aino virtanen"})
         self.assertEqual(verdicts.total_distinct, 2)
 
-    def test_wave_merge_branch_now_excludes_its_author_too(self):
-        """The PRE-EXISTING main#294 hole, closed by the same derivation.
+    def test_wave_merge_branch_does_not_exclude_its_implementers(self):
+        """#1216 REVERSES #1210 on this ref, deliberately. Read the charter first.
 
-        `deployments/**` has carried this since main#294; #1210 closes it, not
-        just the increment #1207 added.
+        This test replaces `test_wave_merge_branch_now_excludes_its_author_too`,
+        which asserted the opposite. That is not a weakened assertion, it is a
+        different rule: `pull-requests/reviews.md` § Who Counts as "the PR
+        Author" states that a wave->main integration PR has no author on its
+        branch — its commits are the wave's implementers, each already
+        2x-reviewed on its own per-issue PR, and the integration PR authors
+        nothing of its own. #1210 subtracted a genuine Approved reviewer on 4
+        real PRs (main#711/#530/#293/#229) by treating them as authors.
+
+        The exclusion #1210 exists for is unaffected: it still fires on every
+        non-wave ref, pinned by `test_self_approval_on_a_non_charter_ref_no_
+        longer_reaches_two_of_two` and by
+        `test_a_non_wave_deployments_ref_keeps_the_commit_derived_exclusion`
+        below.
         """
         verdicts = self._resolve(
             self.WAVE_REF,
@@ -4851,8 +4885,72 @@ class CommitIdentitySelfReviewExclusionTests(_ResolveOverFakeCommentsHarness):
             roster=self.ROSTER | {"nadia khoury"},
             commits=self._authored_by("Nadia Khoury"),
         )
+        self.assertEqual(verdicts.distinct_reviewers, {"nadia khoury", "aino virtanen"})
+        self.assertEqual(verdicts.total_distinct, 2)
+        self.assertEqual(verdicts.comment_scan, hook.COMMENT_SCAN_WAVE_INTEGRATION)
+        # ONE tuple, not two (#1297). The carve-out is applied by NOT deriving,
+        # so there is no unfiltered second set for a diagnostic to disagree with.
+        self.assertEqual(verdicts.commit_author_identities, ())
+
+    def test_a_non_wave_deployments_ref_keeps_the_commit_derived_exclusion(self):
+        """The carve-out is the WAVE-BRANCH shape, not the `deployments/` prefix.
+
+        `deployments/phase12/cleanup` is a real production ref (isnad-graph#603
+        and #612). Widening `is_wave_branch` to `startswith("deployments/")`
+        turns this RED — which is the mutation that would silently re-open #1210
+        on a hand-made release branch.
+        """
+        verdicts = self._resolve(
+            "deployments/phase12/cleanup",
+            [self._verdict("Nadia Khoury"), self._verdict("Aino Virtanen")],
+            roster=self.ROSTER | {"nadia khoury"},
+            commits=self._authored_by("Nadia Khoury"),
+        )
         self.assertEqual(verdicts.distinct_reviewers, {"aino virtanen"})
         self.assertEqual(verdicts.total_distinct, 1)
+        self.assertEqual(verdicts.comment_scan, hook.COMMENT_SCAN_COMMIT_AUTHOR_EXCLUDED)
+
+    def test_the_undashed_phase_wave_ref_gets_the_same_carve_out(self):
+        """`deployments/phase15/wave-1` — 32 of 202 real PRs use this form.
+
+        Keying the carve-out on the charter's dashed spelling alone would leave
+        4 of the org's 7 repos on the #1210 behaviour while the other 3 moved,
+        i.e. two policies decided by a hyphen. RED if `_WAVE_BRANCH_RE` loses
+        its `-?`.
+        """
+        verdicts = self._resolve(
+            "deployments/phase15/wave-1",
+            [self._verdict("Nadia Khoury"), self._verdict("Aino Virtanen")],
+            roster=self.ROSTER | {"nadia khoury"},
+            commits=self._authored_by("Nadia Khoury"),
+        )
+        self.assertEqual(verdicts.distinct_reviewers, {"nadia khoury", "aino virtanen"})
+        self.assertEqual(verdicts.comment_scan, hook.COMMENT_SCAN_WAVE_INTEGRATION)
+
+    def test_main_711_replayed_from_its_real_payload(self):
+        """The measured false block, reproduced offline (main#711).
+
+        Real ref, real derived identities from the real commit payload, real
+        Approved Requestors. Under #1210 this is 1/2 and blocked with Wanjiku
+        Mwangi subtracted; under #1216 it is the 2/2 the reviewers actually
+        earned. A count assertion, not a substring one (#1203).
+        """
+        commits = self._authored_by("Aino Virtanen", "Santiago Ferreira", "Wanjiku Mwangi")
+        roster = self.ROSTER | {"nadia khoury", "wanjiku mwangi"}
+        thread = [self._verdict("Nadia Khoury"), self._verdict("Wanjiku Mwangi")]
+
+        after = self._resolve("deployments/phase-5/wave-5", thread, roster=roster, commits=commits)
+        self.assertEqual(after.distinct_reviewers, {"nadia khoury", "wanjiku mwangi"})
+        self.assertEqual(after.total_distinct, 2)
+
+        # The pre-#1216 answer on the identical input, so the delta is measured
+        # here rather than asserted from memory of what #1210 did.
+        with mock.patch.object(hook, "is_wave_branch", return_value=False):
+            before = self._resolve(
+                "deployments/phase-5/wave-5", thread, roster=roster, commits=commits
+            )
+        self.assertEqual(before.distinct_reviewers, {"nadia khoury"})
+        self.assertEqual(before.total_distinct, 1)
 
     def test_both_authors_of_a_handed_over_branch_are_excluded(self):
         verdicts = self._resolve(
@@ -5008,9 +5106,17 @@ class CommitIdentitySelfReviewExclusionTests(_ResolveOverFakeCommentsHarness):
         self.assertEqual(verdicts.commit_author_identities, ())
 
     def test_merge_only_branch_derives_no_author(self):
-        """No authored commits ⇒ no identity ⇒ the pre-#1210 state, unchanged."""
+        """No authored commits ⇒ no identity ⇒ the pre-#1210 state, unchanged.
+
+        Re-targeted from `WAVE_REF` to a non-charter ref at #1216: on a wave ref
+        the carve-out now short-circuits the derivation, so a wave ref could no
+        longer distinguish "derived nothing" from "did not derive" and this
+        test's subject would have quietly become untested (the vacuity shape
+        `feedback_fixture_makes_guard_assertion_inert`). The merge-commit skip
+        is what is under test, so it is asserted where the derivation still runs.
+        """
         verdicts = self._resolve(
-            self.WAVE_REF,
+            self.NON_CHARTER_REF,
             [self._verdict("Lucas Ferreira"), self._verdict("Nino Kavtaradze")],
             commits=[
                 _api_commit("m0", "2026-07-15T19:13:59Z", parents=2, author_name="Lucas Ferreira")
@@ -5029,6 +5135,116 @@ class CommitIdentitySelfReviewExclusionTests(_ResolveOverFakeCommentsHarness):
         ):
             with self.assertRaises(hook.CommitFetchError):
                 hook.resolve_review_verdicts(self._pr_data(self.NON_CHARTER_REF), repo=self.REPO)
+
+
+class OneDerivationDrivesModeAndExclusionTests(_ResolveOverFakeCommentsHarness):
+    """The #1297 shape, closed structurally rather than argued (#1216).
+
+    #1297 (open, from the #1292 merge gate) is the demonstration that narrowing
+    ONLY the tuple handed to `check_comment_reviews` — leaving the mode and every
+    diagnostic reading an unfiltered second tuple — keeps the whole suite green
+    while a self-approver reaches 2/2 on a non-charter ref. #1216 introduces
+    exactly the kind of edit that could do it: a slice where exclusion is turned
+    OFF.
+
+    It is closed by construction instead: `resolve_review_verdicts` derives
+    `commit_authors` FROM `scan_scope`, so the mode that is reported and the
+    tuple the exclusion is applied from are one value. These tests pin that
+    equivalence directly, so an edit that reintroduces a second tuple fails here
+    rather than shipping green.
+    """
+
+    # (head_ref, expected mode, expected reviewer set). The reviewer set is
+    # MEASURED per case, not shared: on `A.Virtanen/…` Aino is excluded by the
+    # REF arm even though the commit tuple is empty, and folding that case in
+    # with the wave refs would either assert something false or weaken the
+    # arithmetic assertion for all of them. (Caught by this very test on its
+    # first run — the two exclusion arms are not interchangeable.)
+    MODES_WITHOUT_DERIVATION = (
+        ("A.Virtanen/1216-x", hook.COMMENT_SCAN_AUTHOR_EXCLUDED, {"nino kavtaradze"}),
+        (
+            "deployments/phase-10/wave-29",
+            hook.COMMENT_SCAN_WAVE_INTEGRATION,
+            {"aino virtanen", "nino kavtaradze"},
+        ),
+        (
+            "deployments/phase15/wave-1",
+            hook.COMMENT_SCAN_WAVE_INTEGRATION,
+            {"aino virtanen", "nino kavtaradze"},
+        ),
+    )
+
+    MODES_WITH_DERIVATION = (
+        ("feature/hand-made", hook.COMMENT_SCAN_COMMIT_AUTHOR_EXCLUDED),
+        ("deployments/phase12/cleanup", hook.COMMENT_SCAN_COMMIT_AUTHOR_EXCLUDED),
+        ("dependabot/npm_and_yarn/x-1.2.3", hook.COMMENT_SCAN_COMMIT_AUTHOR_EXCLUDED),
+        ("", hook.COMMENT_SCAN_COMMIT_AUTHOR_EXCLUDED),
+    )
+
+    def _resolve_ref(self, head_ref):
+        return self._resolve(
+            head_ref,
+            [self._verdict("Aino Virtanen"), self._verdict("Nino Kavtaradze")],
+            commits=[
+                _api_commit(
+                    "c0",
+                    "2026-07-15T19:13:59Z",
+                    author_name="Aino Virtanen",
+                    author_email="parametrization+Aino.Virtanen@gmail.com",
+                )
+            ],
+        )
+
+    def test_a_mode_that_applies_no_commit_exclusion_carries_no_identities(self):
+        """No second tuple can exist for a diagnostic to disagree with."""
+        for head_ref, expected_mode, expected_reviewers in self.MODES_WITHOUT_DERIVATION:
+            with self.subTest(head_ref=head_ref):
+                verdicts = self._resolve_ref(head_ref)
+                self.assertEqual(verdicts.comment_scan, expected_mode)
+                self.assertEqual(verdicts.commit_author_identities, ())
+                # The arithmetic the empty tuple implies, asserted rather than
+                # inferred: on the wave refs Aino's own verdict is COUNTED;
+                # on the persona ref the REF arm still drops it.
+                self.assertEqual(verdicts.distinct_reviewers, expected_reviewers)
+
+    def test_a_mode_that_applies_commit_exclusion_carries_the_identities(self):
+        """Anti-vacuity: without this, a mutant that always passes `()` would
+        satisfy the test above for every ref and silently kill #1210."""
+        for head_ref, expected_mode in self.MODES_WITH_DERIVATION:
+            with self.subTest(head_ref=head_ref):
+                verdicts = self._resolve_ref(head_ref)
+                self.assertEqual(verdicts.comment_scan, expected_mode)
+                self.assertEqual(
+                    [i.display for i in verdicts.commit_author_identities], ["Aino Virtanen"]
+                )
+                # Aino authored the branch, so her verdict is SUBTRACTED.
+                self.assertEqual(verdicts.distinct_reviewers, {"nino kavtaradze"})
+                self.assertEqual(verdicts.total_distinct, 1)
+
+    def test_the_reported_identities_are_the_ones_the_exclusion_used(self):
+        """The invariant itself, over both groups: a NON-empty identity tuple
+        must coincide exactly with a mode that claims exclusion is live.
+
+        This is the assertion #1297 says is missing on `main` — there, the
+        reported tuple and the excluded-from tuple are two expressions that
+        merely happen to be equal today.
+        """
+        refs = [case[0] for case in self.MODES_WITHOUT_DERIVATION] + [
+            case[0] for case in self.MODES_WITH_DERIVATION
+        ]
+        for head_ref in refs:
+            with self.subTest(head_ref=head_ref):
+                verdicts = self._resolve_ref(head_ref)
+                exclusion_claimed = verdicts.comment_scan in (
+                    hook.COMMENT_SCAN_COMMIT_AUTHOR_EXCLUDED,
+                    hook.COMMENT_SCAN_COMMIT_AUTHOR_NON_ROSTER,
+                )
+                self.assertEqual(
+                    bool(verdicts.commit_author_identities),
+                    exclusion_claimed,
+                    f"{head_ref!r}: mode {verdicts.comment_scan!r} disagrees with the "
+                    f"identity tuple {verdicts.commit_author_identities!r}",
+                )
 
 
 class StrictlyNonRelaxingTests(_ResolveOverFakeCommentsHarness):
@@ -5438,6 +5654,46 @@ class CommitAuthorBlockDiagnosticTests(_ResolveOverFakeCommentsHarness):
         self.assertIn("commits named no persona either", no_author)
         self.assertNotIn("commits named no persona either", inert)
 
+    def test_wave_integration_block_states_the_short_count_is_not_a_subtraction(self):
+        """#1216 at the block surface.
+
+        An operator reading `1/2` on a wave-merge PR must be able to tell,
+        without opening the hook, that the gate dropped nobody — and must be
+        pointed at the merge path the charter actually prescribes for this PR
+        class rather than sent to hunt for a missing approval.
+        """
+        reason = self._block_reason(self._verdicts(hook.COMMENT_SCAN_WAVE_INTEGRATION))
+        self.assertIn("wave->main INTEGRATION PR", reason)
+        self.assertIn("no self-review exclusion was applied", reason)
+        self.assertIn("nothing was subtracted", reason)
+        self.assertIn("wave-merge:<rationale>", reason)
+        self.assertIn("1/2 required peer reviews", reason)
+        # The claim that would be FALSE here, and that NO_BRANCH_AUTHOR makes.
+        self.assertNotIn("commits named no persona either", reason)
+        # And it must not announce a derivation it deliberately did not perform.
+        self.assertNotIn("COMMIT IDENTITY", reason)
+
+    def test_wave_integration_reads_differently_from_every_other_mode(self):
+        """Five modes, five block texts. Two that collapse cannot be told apart
+        by the reader, which is the entire reason the enum exists (#1273)."""
+        rendered = {
+            hook.COMMENT_SCAN_WAVE_INTEGRATION: self._block_reason(
+                self._verdicts(hook.COMMENT_SCAN_WAVE_INTEGRATION)
+            ),
+            hook.COMMENT_SCAN_NO_BRANCH_AUTHOR: self._block_reason(
+                self._verdicts(hook.COMMENT_SCAN_NO_BRANCH_AUTHOR)
+            ),
+            hook.COMMENT_SCAN_COMMIT_AUTHOR_NON_ROSTER: self._block_reason(
+                self._verdicts(hook.COMMENT_SCAN_COMMIT_AUTHOR_NON_ROSTER, (self.BOT,))
+            ),
+            hook.COMMENT_SCAN_COMMIT_AUTHOR_EXCLUDED: self._block_reason(
+                self._verdicts(hook.COMMENT_SCAN_COMMIT_AUTHOR_EXCLUDED, (self.BOT,))
+            ),
+        }
+        self.assertEqual(
+            len(set(rendered.values())), len(rendered), f"collapsed block texts: {rendered}"
+        )
+
 
 class AllowPathScanDisclosureTests(_ResolveOverFakeCommentsHarness):
     """#1211: the ALLOW path must say when self-review exclusion was unavailable.
@@ -5552,6 +5808,57 @@ class AllowPathScanDisclosureTests(_ResolveOverFakeCommentsHarness):
         )
         self.assertIsNone(by_ref, "ref-derived exclusion was applied — nothing to disclose")
         self.assertIsNone(by_commit, "commit-derived exclusion was applied — nothing to disclose")
+
+    def test_wave_integration_allow_discloses_that_an_implementer_may_have_counted(self):
+        """#1216 at the surface that matters most: the merge is ALLOWED.
+
+        The whole risk of the carve-out is that a counted approval came from
+        someone whose work is in the branch. That is permitted, so the gate does
+        not block — but a reader who cannot see it happened cannot audit it, and
+        an undisclosed relaxation is the shape this advisory path was built for
+        (#1211).
+        """
+        wave_ref = "deployments/phase-10/wave-29"
+        result = self._allow_result(
+            self._verdicts(hook.COMMENT_SCAN_WAVE_INTEGRATION, head_ref=wave_ref),
+            head_ref=wave_ref,
+        )
+        assert result is not None, "an allowed wave-integration merge must disclose the carve-out"
+        self.assertEqual(result["decision"], "allow")
+        message = result["systemMessage"]
+        self.assertIn(wave_ref, message)
+        self.assertIn("WITHOUT self-review exclusion", message)
+        self.assertIn("wave->main INTEGRATION PR", message)
+        self.assertIn("their integration verdict counts", message)
+        self.assertIn("No verdict was subtracted", message)
+        # The count is interpolated, never a literal — a hardcoded `2/2` here
+        # survived all 318 tests once (#1292), so it is asserted as a fact about
+        # THIS fixture's two reviewers rather than as a constant.
+        self.assertIn("2/2", message)
+        # The false claim NO_BRANCH_AUTHOR makes and this mode must not borrow.
+        self.assertNotIn("commits named no roster persona either", message)
+        self.assertNotIn("BLOCKED", message)
+
+    def test_wave_integration_advisory_reports_a_one_of_two_count_honestly(self):
+        """Anti-hardcode control for the `2/2` above.
+
+        The wave-bootstrap exception can allow at 1/2, and a literal count in
+        the advisory would misreport exactly the PR with the fewest reviewers to
+        lose. Same mode, one reviewer, exception on.
+        """
+        wave_ref = "deployments/phase-10/wave-29"
+        verdicts = dataclasses.replace(
+            self._verdicts(hook.COMMENT_SCAN_WAVE_INTEGRATION, head_ref=wave_ref),
+            comment_reviewers={"aino virtanen"},
+            roster_comment_reviewers={"aino virtanen"},
+            distinct_reviewers={"aino virtanen"},
+            wave_bootstrap_exception=True,
+        )
+        result = self._allow_result(verdicts, head_ref=wave_ref)
+        assert result is not None
+        self.assertEqual(result["decision"], "allow")
+        self.assertIn("1/2", result["systemMessage"])
+        self.assertNotIn("2/2", result["systemMessage"])
 
     def test_both_advisories_survive_when_both_conditions_hold(self):
         """THE composition test — the case a second early `return` breaks.
@@ -5742,6 +6049,13 @@ class CommentScanModeTotalityTests(unittest.TestCase):
         hook.COMMENT_SCAN_NOT_RUN: (True, False),
         # Nothing excluded, nobody derived: both surfaces disclose (#1206/#1211).
         hook.COMMENT_SCAN_NO_BRANCH_AUTHOR: (True, True),
+        # Nothing excluded BY POLICY on a wave->main integration PR: both
+        # surfaces disclose (#1216). The block path must say the short count is
+        # not a subtraction (and point at the `wave-merge` admin exception); the
+        # allow path must say a counted approval may be an implementer's. This
+        # is the one mode where the reader could otherwise reasonably assume the
+        # gate had dropped someone.
+        hook.COMMENT_SCAN_WAVE_INTEGRATION: (True, True),
         # Nothing excluded, someone derived: both surfaces disclose (#1220).
         hook.COMMENT_SCAN_COMMIT_AUTHOR_NON_ROSTER: (True, True),
         # Exclusion applied on commit evidence: block names the subtraction; the

--- a/.claude/hooks/tests/test_validate_pr_review.py
+++ b/.claude/hooks/tests/test_validate_pr_review.py
@@ -4024,6 +4024,38 @@ class CommentScanScopeTotalityTests(unittest.TestCase):
             with self.subTest(ref=ref):
                 self.assertEqual(hook.comment_scan_scope(ref), hook.COMMENT_SCAN_NO_BRANCH_AUTHOR)
 
+    def test_the_declared_author_arm_outranks_the_wave_arm(self):
+        """#1216 precedence, pinned where it is otherwise UNFALSIFIABLE.
+
+        No real ref can satisfy both shapes — `_BRANCH_AUTHOR_PREFIX_RE` anchors
+        at the start and needs `{letter}.`, which `deployments/…` cannot supply —
+        so swapping the two `if`s in `comment_scan_scope` is a no-op against
+        every input and SURVIVED mutation M7 with the whole suite green.
+
+        A docstring saying "order matters" that no test can falsify is the
+        #1215 shape (an anti-vacuity claim that is itself vacuous). So the
+        precedence is pinned against the predicate rather than against a ref:
+        with `is_wave_branch` forced True, a ref that names its author must
+        STILL keep its exclusion. This is not a hypothetical guard — it is the
+        exact property that starts mattering the moment anyone widens
+        `is_wave_branch`, which is the likeliest future edit to this code.
+        """
+        with mock.patch.object(hook, "is_wave_branch", return_value=True):
+            self.assertEqual(
+                hook.comment_scan_scope("A.Virtanen/1216-x"),
+                hook.COMMENT_SCAN_AUTHOR_EXCLUDED,
+            )
+            self.assertEqual(
+                hook.comment_scan_scope("A.Virtanen-1216-x"),
+                hook.COMMENT_SCAN_AUTHOR_EXCLUDED,
+            )
+            # Anti-vacuity: the patch must actually be reaching the function, or
+            # the assertions above would pass against an unpatched call.
+            self.assertEqual(
+                hook.comment_scan_scope("feature/hand-made"),
+                hook.COMMENT_SCAN_WAVE_INTEGRATION,
+            )
+
     def test_no_head_ref_shape_ever_yields_not_run(self):
         """The invariant itself, stated once: NOT_RUN is not a reachable scope.
 
@@ -4698,6 +4730,34 @@ class RefineCommentScanScopeTests(unittest.TestCase):
                 hook.COMMENT_SCAN_NO_BRANCH_AUTHOR, self.IDENT, self.ROSTER
             ),
             hook.COMMENT_SCAN_COMMIT_AUTHOR_EXCLUDED,
+        )
+
+    def test_wave_integration_is_never_refined_even_with_derived_identities(self):
+        """#1216: the POLICY answer cannot be argued out of by commit evidence.
+
+        `resolve_review_verdicts` passes `()` on a wave ref, so in production
+        the `not commit_authors` guard already returns this untouched — which is
+        exactly why it needs a unit test: the property would otherwise hold by
+        the caller's grace rather than by the function's contract, and the next
+        caller would not inherit it. Deliberately passes a ROSTER-MATCHING
+        identity, the input that would upgrade any other non-terminal mode.
+        """
+        self.assertEqual(
+            hook.refine_comment_scan_scope(
+                hook.COMMENT_SCAN_WAVE_INTEGRATION, self.IDENT, self.ROSTER
+            ),
+            hook.COMMENT_SCAN_WAVE_INTEGRATION,
+        )
+        self.assertEqual(
+            hook.refine_comment_scan_scope(
+                hook.COMMENT_SCAN_WAVE_INTEGRATION, self.BOT, self.ROSTER
+            ),
+            hook.COMMENT_SCAN_WAVE_INTEGRATION,
+        )
+        # An unreadable roster must not shake it loose either.
+        self.assertEqual(
+            hook.refine_comment_scan_scope(hook.COMMENT_SCAN_WAVE_INTEGRATION, self.IDENT, set()),
+            hook.COMMENT_SCAN_WAVE_INTEGRATION,
         )
 
     def test_derived_identity_matching_no_roster_persona_is_reported_inert(self):

--- a/.claude/hooks/validate_pr_review.py
+++ b/.claude/hooks/validate_pr_review.py
@@ -185,8 +185,48 @@ Branch author from COMMIT IDENTITY (#1210):
     - ambiguous / wrong match  → OVER-excludes, dropping a reviewer and
                                  blocking; the block message names every derived
                                  identity so the mistake is visible, not silent
-  Scope: consulted ONLY where the ref names nobody. Where the ref names a
-  persona the behaviour is byte-for-byte unchanged.
+  Scope: consulted ONLY where the ref names nobody AND the ref is not a wave
+  branch (#1216, below). Where the ref names a persona the behaviour is
+  byte-for-byte unchanged.
+
+Wave->main integration PRs are NOT self-reviewed by their implementers (#1216):
+  #1210's derivation answers "who wrote this branch's content". On a
+  `{Initial}.{Lastname}` ref that is one person. On a `deployments/phase-N/
+  wave-M` ref it is the wave's ENTIRE implementer roster, because a wave branch
+  accumulates every per-issue PR merged into it — and #1210 then treated all of
+  them as "the branch author" of the integration PR and subtracted their
+  verdicts.
+
+  That is the wrong question on that ref. Every commit on a wave branch arrived
+  through a per-issue PR that already carried two independent reviewers; the
+  integration PR authors nothing of its own; and the charter already says so —
+  `pull-requests/wave-merge.md` § Wave Merge PR Verification point 5 declares
+  fresh 2-reviewer approval on an integration PR not required, with the
+  `wave-merge` admin exception as the expected path. So an implementer whose
+  merged work the branch contains is not its author, and their INTEGRATION
+  verdict counts. The rule is written in `pull-requests/reviews.md` § Who
+  counts as "the PR author"; this hook enforces it, it does not define it.
+
+  Measured over EVERY `deployments/**`-head PR in all 7 repos, 2026-08-03 (202
+  PRs, driven through `resolve_review_verdicts` itself): 4 PRs lose a genuine
+  Approved roster reviewer to the #1210 derivation and 3 cross the bar —
+  main#711 2/2->1/2 (Wanjiku Mwangi), main#530 2/2->1/2 and main#293 2/2->1/2
+  (Aino Virtanen), main#229 1/2->0/2. 112 of the 202 derive two or more
+  "authors"; the largest derives 11.
+
+  DIRECTION, STATED PLAINLY: this is the one change in this file's history that
+  moves the gate toward passing. It restores the pre-main#294 state on the wave
+  slice ONLY — `StrictlyNonRelaxingTests`' `before` baseline is exactly that
+  state, so the non-relaxing property still holds against it — and it is
+  bounded by `charter_trailer.is_wave_branch`, an anchored match on the charter
+  ref shape. Every other ref keeps #1210 intact, including a `deployments/**`
+  ref that is not a wave branch (`deployments/phase12/cleanup`, 2 real PRs).
+
+  RESIDUAL, not closed here: nothing identifies the persona who OPENED the
+  integration PR. They contribute merge commits, which the derivation skips by
+  design, so they were never subtracted pre-#1216 either. That is the
+  pre-main#294 state and is within the charter's stated tolerance for a PR class
+  that requires no fresh approvals at all — tracked separately, not hidden.
 
 Single-Reviewer Exception (resolves #228):
   When the PR is labeled `wave-bootstrap` AND there is exactly ONE distinct
@@ -230,6 +270,7 @@ from charter_trailer import (
     extract_branch_author_lastname,
     extract_charter_field,
     is_branch_author,
+    is_wave_branch,
     name_first_initial,
     name_lastname,
     strip_code_regions,
@@ -1051,6 +1092,26 @@ COMMENT_SCAN_COMMIT_AUTHOR_EXCLUDED = "commit-author-excluded"
 # NO_BRANCH_AUTHOR — which is why this is a reporting distinction and touches no
 # threshold.
 COMMENT_SCAN_COMMIT_AUTHOR_NON_ROSTER = "commit-author-non-roster"
+# The head ref is a charter WAVE BRANCH, so this is a wave->main integration PR
+# and commit-derived self-review exclusion is DELIBERATELY not applied (#1216).
+#
+# This is a POLICY mode, and it is the only one that is. The other four describe
+# what evidence happened to be available; this one records a decision the charter
+# makes — `pull-requests/reviews.md` § Who counts as "the PR author", and
+# `pull-requests/wave-merge.md` § Wave Merge PR Verification point 5: the code on
+# a wave branch was already 2x-reviewed on its per-issue PRs, the integration PR
+# introduces no authored content of its own, and an implementer whose merged work
+# it contains is not its author. Read the charter section before changing this;
+# the hook is the enforcement of a written rule, not the rule.
+#
+# WHY IT IS NOT `NO_BRANCH_AUTHOR`. That mode's claim is "the PR's commits named
+# no persona." On a wave branch they named five (measured: main#1083 -> Nurul
+# Hakim, Lucas Ferreira, Aino Virtanen, Weronika Zielinska, Nino Kavtaradze; 112
+# of 202 `deployments/**` PRs derive two or more). Rendering the deliberate
+# non-exclusion as an evidentiary absence is the #1220 defect exactly — a true
+# count under a false description — so it gets its own value and its own wording
+# on all three surfaces.
+COMMENT_SCAN_WAVE_INTEGRATION = "wave-integration"
 
 # Every comment-scan mode, in one place (#1220, narrowing #1273).
 #
@@ -1068,6 +1129,7 @@ COMMENT_SCAN_COMMIT_AUTHOR_NON_ROSTER = "commit-author-non-roster"
 ALL_COMMENT_SCAN_MODES = (
     COMMENT_SCAN_NOT_RUN,
     COMMENT_SCAN_NO_BRANCH_AUTHOR,
+    COMMENT_SCAN_WAVE_INTEGRATION,
     COMMENT_SCAN_COMMIT_AUTHOR_NON_ROSTER,
     COMMENT_SCAN_COMMIT_AUTHOR_EXCLUDED,
     COMMENT_SCAN_AUTHOR_EXCLUDED,
@@ -1078,18 +1140,29 @@ def comment_scan_scope(head_ref: str) -> str:
     """Return which self-review-exclusion mode the HEAD REF alone selects.
 
     The head ref's ONLY role in the comment scan is naming the branch author for
-    the self-review exclusion, so there are exactly two ref-derived modes and
-    **no third "don't scan" mode**:
+    the self-review exclusion, so there are exactly three ref-derived modes and
+    **no fourth "don't scan" mode**:
 
       - `COMMENT_SCAN_AUTHOR_EXCLUDED` — the ref carries the charter
         `{Initial}.{Lastname}[-/]…` prefix, so the branch author is identifiable
         and is excluded from the reviewer set.
-      - `COMMENT_SCAN_NO_BRANCH_AUTHOR` — the ref names no persona (a
-        `deployments/phase-N/wave-M` wave-merge branch, a `dependabot/**` bot
-        branch, a hand-made `feature/x`, or an empty `headRefName`). The scan
-        still runs, under the `""` sentinel the wave-merge path has used since
-        main#294, which `charter_trailer.is_branch_author` reads as "nobody is
-        the branch author".
+      - `COMMENT_SCAN_WAVE_INTEGRATION` — the ref is a charter wave branch
+        (`charter_trailer.is_wave_branch`), so this is a wave->main integration
+        PR. The scan runs and NO self-review exclusion is applied, by policy
+        rather than for want of evidence (#1216 — see the constant, and
+        `pull-requests/reviews.md` § Who counts as "the PR author").
+      - `COMMENT_SCAN_NO_BRANCH_AUTHOR` — the ref names no persona and is not a
+        wave branch (a `dependabot/**` bot branch, a hand-made `feature/x`, a
+        `deployments/**` ref that is not a wave branch, or an empty
+        `headRefName`). The scan still runs, under the `""` sentinel the
+        wave-merge path has used since main#294, which
+        `charter_trailer.is_branch_author` reads as "nobody is the branch
+        author"; `refine_comment_scan_scope` then decides what the COMMITS said.
+
+    ORDER MATTERS AND IS TESTED. The author-prefix arm is checked FIRST, so a
+    (currently impossible) ref that satisfied both shapes would keep its declared
+    author rather than acquiring the wave carve-out. The wave arm never widens
+    who may review a PR whose ref names its author.
 
     This function stays a pure function OF THE REF. `refine_comment_scan_scope`
     applies the second, commit-derived discriminator (#1210) on top of its
@@ -1110,11 +1183,11 @@ def comment_scan_scope(head_ref: str) -> str:
     never a roster persona, so it could never have been in the reviewer set. On
     a ref that DOES name a persona, exclusion is unchanged.
     """
-    return (
-        COMMENT_SCAN_AUTHOR_EXCLUDED
-        if extract_branch_author_lastname(head_ref)
-        else COMMENT_SCAN_NO_BRANCH_AUTHOR
-    )
+    if extract_branch_author_lastname(head_ref):
+        return COMMENT_SCAN_AUTHOR_EXCLUDED
+    if is_wave_branch(head_ref):
+        return COMMENT_SCAN_WAVE_INTEGRATION
+    return COMMENT_SCAN_NO_BRANCH_AUTHOR
 
 
 def commit_author_exclusion_is_live(
@@ -1168,6 +1241,14 @@ def refine_comment_scan_scope(
 
       - `AUTHOR_EXCLUDED` is never downgraded — a ref that names a persona keeps
         its exclusion no matter what the commits say.
+      - `WAVE_INTEGRATION` is never refined (#1216). It is a POLICY answer about
+        a wave->main integration PR, not a claim about what evidence was
+        available, so no amount of commit data may turn it into an exclusion.
+        `resolve_review_verdicts` passes `()` on that ref anyway, so the
+        `not commit_authors` guard below would already return it untouched —
+        this arm is stated because relying on the caller to keep passing `()`
+        would make the policy a property of one call site instead of of the
+        mode.
       - `NOT_RUN` is never upgraded — a scan that did not happen cannot acquire
         a mode. `resolve_review_verdicts` hard-blocks on it upstream, and
         silently relabelling it here would launder that block into a result.
@@ -2121,7 +2202,8 @@ def resolve_review_verdicts(pr_data: dict, repo: str | None = None) -> ReviewVer
 
     branch_author_lastname = extract_branch_author_lastname(head_ref)
 
-    # Commit-derived authors are consulted ONLY where the ref is silent (#1210).
+    # Commit-derived authors are consulted ONLY where the ref is silent (#1210)
+    # AND the PR is not a wave->main integration merge (#1216).
     #
     # Scope, and why it is this narrow. On a `{Initial}.{Lastname}` ref the
     # prefix is the author the human DECLARED, exclusion already works, and
@@ -2132,8 +2214,29 @@ def resolve_review_verdicts(pr_data: dict, repo: str | None = None) -> ReviewVer
     # nobody, `commit_author_identities` is the ONLY discriminator available and
     # `()` was the standing answer: for `deployments/**` since main#294, and for
     # every other non-charter ref since #1207 widened the sentinel.
+    #
+    # THE WAVE-BRANCH CARVE-OUT (#1216). On a wave branch the derivation answers
+    # a question nobody asked: it returns every implementer who landed a per-issue
+    # PR into the wave (measured max 11 identities; 112 of 202 `deployments/**`
+    # PRs derive 2+), calls them all "the branch author" of an integration PR
+    # that authored nothing, and subtracts their integration verdicts. Measured
+    # over every `deployments/**`-head PR in all 7 repos on 2026-08-03: 4 PRs
+    # lose a genuine Approved roster reviewer and 3 of those cross the bar
+    # (2/2 -> 1/2) — main#711 (Wanjiku Mwangi), main#530 and main#293 (Aino
+    # Virtanen). The charter rule this implements is in
+    # `pull-requests/reviews.md` § Who counts as "the PR author"; the substantive
+    # reason is that every commit on the branch already carried two independent
+    # reviewers on its own per-issue PR.
+    #
+    # DERIVED FROM `scan_scope`, not from a second read of the head ref. The mode
+    # that will be REPORTED and the tuple the exclusion is APPLIED from now come
+    # out of one value, so they cannot disagree about whether exclusion is live —
+    # which is the #1297 shape (narrow the tuple, leave the mode, ship a green
+    # suite over a re-opened hole) made structurally impossible here rather than
+    # argued against. For the two pre-#1216 ref classes this is exactly
+    # equivalent to the old `() if branch_author_lastname else …`.
     commit_authors: tuple[CommitAuthorIdentity, ...] = (
-        () if branch_author_lastname else commit_author_identities(commits)
+        commit_author_identities(commits) if scan_scope == COMMENT_SCAN_NO_BRANCH_AUTHOR else ()
     )
 
     comment_result = check_comment_reviews(
@@ -2561,11 +2664,31 @@ def check(input_data: dict) -> dict | None:
                 "counts. The scan DID run; the count below is a real measurement "
                 "(#1206/#1220).\n\n"
             )
+        elif verdicts.comment_scan == COMMENT_SCAN_WAVE_INTEGRATION:
+            # #1216. An operator staring at a short count on a wave-merge PR must
+            # not be told the gate subtracted somebody — it did not — nor be left
+            # to infer that the wave's implementers were silently dropped, which
+            # is what the pre-#1216 message asserted in so many words.
+            scan_diagnostic = (
+                f"NOTE: head ref `{verdicts.head_ref or '(unknown)'}` is a wave branch, so "
+                "this is a wave->main INTEGRATION PR. Its commits are the wave's "
+                "implementers, each already 2x-reviewed on its own per-issue PR, and the "
+                "integration PR authors no content of its own — so no self-review "
+                "exclusion was applied and EVERY roster-valid Approved Requestor counts, "
+                "including an implementer's (charter `pull-requests/reviews.md` § Who "
+                'counts as "the PR author", #1216). The scan DID run and nothing was '
+                "subtracted; the count below is short on approvals, not on eligibility.\n"
+                "Per `pull-requests/wave-merge.md` § Wave Merge PR Verification point 5, "
+                "fresh 2-reviewer approval on an integration PR is NOT required — the "
+                'expected path is `ADMIN_MERGE_EXCEPTION="wave-merge:<rationale>" gh pr '
+                "merge <N> --merge --admin`.\n\n"
+            )
         elif verdicts.comment_scan == COMMENT_SCAN_NO_BRANCH_AUTHOR:
             scan_diagnostic = (
                 f"NOTE: head ref `{verdicts.head_ref or '(unknown)'}` carries no "
-                "`{Initial}.{Lastname}` branch-author prefix (a bot branch, a wave-merge "
-                "branch, or a branch off the charter naming convention), AND the PR's "
+                "`{Initial}.{Lastname}` branch-author prefix (a bot branch, a non-wave "
+                "`deployments/**` branch, or a branch off the charter naming convention), "
+                "AND the PR's "
                 "commits named no persona either (a bot author, a merge-only branch, or a "
                 "squashed commit re-authored to the bare principal — #1177/#1210), so the "
                 "comment verdict scan ran WITHOUT self-review exclusion — every "
@@ -2760,6 +2883,23 @@ def check(input_data: dict) -> dict | None:
             "counted, including any posted by whoever wrote this branch. The scan DID "
             "run and the charter threshold is unchanged — this states which "
             "discriminator was unavailable, not a defect (#1206/#1211)."
+        )
+    elif verdicts.comment_scan == COMMENT_SCAN_WAVE_INTEGRATION:
+        # #1216. This is the surface that matters most for the carve-out: the
+        # merge is ALLOWED and the reader must be able to see, without reading
+        # the hook, that one of the counted approvals may be an implementer's.
+        # `total_distinct` is interpolated for the same reason as every other
+        # advisory here — a hardcoded `2/2` survived all 318 tests once (#1292).
+        advisories.append(
+            f"NOTE: PR {pr_display} reached {total_distinct}/2 WITHOUT self-review "
+            f"exclusion. Head ref `{verdicts.head_ref or '(unknown)'}` is a wave branch, "
+            "so this is a wave->main INTEGRATION PR: its commits were already 2x-reviewed "
+            "on their own per-issue PRs and it authors no content of its own, so by "
+            "charter an implementer whose merged work it contains is NOT its author and "
+            "their integration verdict counts (`pull-requests/reviews.md` § Who counts as "
+            '"the PR author", #1216). No verdict was subtracted. The scan DID run and the '
+            "charter threshold is unchanged — this states which exclusion was deliberately "
+            "not applied, not a defect."
         )
     elif verdicts.comment_scan == COMMENT_SCAN_COMMIT_AUTHOR_NON_ROSTER:
         derived = ", ".join(i.display for i in verdicts.commit_author_identities) or "(none)"

--- a/.claude/hooks/validate_pr_review.py
+++ b/.claude/hooks/validate_pr_review.py
@@ -1159,10 +1159,16 @@ def comment_scan_scope(head_ref: str) -> str:
         `charter_trailer.is_branch_author` reads as "nobody is the branch
         author"; `refine_comment_scan_scope` then decides what the COMMITS said.
 
-    ORDER MATTERS AND IS TESTED. The author-prefix arm is checked FIRST, so a
-    (currently impossible) ref that satisfied both shapes would keep its declared
-    author rather than acquiring the wave carve-out. The wave arm never widens
-    who may review a PR whose ref names its author.
+    ORDER MATTERS, AND IS PINNED AGAINST THE PREDICATE — not against a ref. The
+    author-prefix arm is checked FIRST, so a ref satisfying both shapes keeps its
+    declared author rather than acquiring the wave carve-out. No ref can satisfy
+    both today (`_BRANCH_AUTHOR_PREFIX_RE` anchors at the start and needs
+    `{letter}.`, which `deployments/…` cannot supply), so swapping these two
+    `if`s is a no-op against every real input — it SURVIVED mutation M7 with the
+    suite green. `CommentScanScopeTotalityTests::test_the_declared_author_arm_
+    outranks_the_wave_arm` therefore forces `is_wave_branch` True and asserts a
+    persona ref still yields AUTHOR_EXCLUDED. Stating "order matters" without
+    that test would be a claim nothing could falsify (#1215).
 
     This function stays a pure function OF THE REF. `refine_comment_scan_scope`
     applies the second, commit-derived discriminator (#1210) on top of its

--- a/.claude/hooks/validate_pr_review.py
+++ b/.claude/hooks/validate_pr_review.py
@@ -2236,11 +2236,27 @@ def resolve_review_verdicts(pr_data: dict, repo: str | None = None) -> ReviewVer
     #
     # DERIVED FROM `scan_scope`, not from a second read of the head ref. The mode
     # that will be REPORTED and the tuple the exclusion is APPLIED from now come
-    # out of one value, so they cannot disagree about whether exclusion is live —
-    # which is the #1297 shape (narrow the tuple, leave the mode, ship a green
-    # suite over a re-opened hole) made structurally impossible here rather than
-    # argued against. For the two pre-#1216 ref classes this is exactly
-    # equivalent to the old `() if branch_author_lastname else …`.
+    # out of one value, so they cannot disagree about WHETHER exclusion is live.
+    # That is the whole of what this buys, and it is worth having: #1216 adds a
+    # slice where exclusion is turned OFF, and this makes it impossible to report
+    # such a slice under a mode that claims exclusion is on. Pinned by
+    # `OneDerivationDrivesModeAndExclusionTests`. For the two pre-#1216 ref
+    # classes this is exactly equivalent to the old
+    # `() if branch_author_lastname else …`.
+    #
+    # IT DOES **NOT** CLOSE #1297, WHICH REMAINS OPEN. An earlier draft of this
+    # comment claimed the coupling made #1297's shape "structurally impossible."
+    # That claim was FALSE and is retracted here (#1310 review). #1297's mutation
+    # was applied to this tree verbatim: the full suite stays GREEN (3733 passed,
+    # 793 subtests) and 3 of its 4 identity shapes go 1/2 -> 2/2 — a self-approver
+    # reaching the threshold — with the mode unchanged at `commit-author-excluded`
+    # in every row. The coupling misses it because it binds whether the tuple is
+    # DERIVED to the reported mode, whereas #1297 inserts a FILTERED COPY
+    # downstream, between this derivation and the `check_comment_reviews` call
+    # below. The derivation and the mode still agree, so nothing moves; only a
+    # mutation that also moves a mode (M8/M9, the wave-slice variants) is caught.
+    # #1297 needs the two count assertions its own closing section specifies —
+    # that is its own change, and it must not be closed on the strength of this.
     commit_authors: tuple[CommitAuthorIdentity, ...] = (
         commit_author_identities(commits) if scan_scope == COMMENT_SCAN_NO_BRANCH_AUTHOR else ()
     )

--- a/.claude/lib/charter_trailer.py
+++ b/.claude/lib/charter_trailer.py
@@ -57,6 +57,7 @@ __all__ = [
     "extract_branch_author_lastname",
     "extract_charter_field",
     "is_branch_author",
+    "is_wave_branch",
     "name_first_initial",
     "name_lastname",
     "strip_code_regions",
@@ -373,3 +374,53 @@ def is_branch_author(field_value: str, branch_lastname: str, branch_initial: str
         # Same surname, different people (main#1172 — Lucas vs Santiago Ferreira).
         return False
     return True
+
+
+# The charter's WAVE BRANCH ref shape, parsed in ONE place (main#1216).
+#
+# A wave branch is the integration branch a `wave-branch`-model wave accumulates
+# its per-issue merges on (`pull-requests/wave-merge.md` § One Merge Model Per
+# Wave). It is the second charter-defined ref shape, alongside the
+# `{Initial}.{Lastname}` author prefix above, and it lives here for the same
+# reason that one does: two hooks must agree on what it means.
+#
+#   validate_pr_review        — a wave->main integration PR applies no
+#                               commit-derived self-review exclusion (main#1216).
+#   block_squash_wave_merge   — `gh pr merge --squash` into a wave branch is
+#                               hard-blocked (Hook 22, main#898/#222).
+#
+# BOTH `phase-N` AND `phaseN` ARE ACCEPTED, because both are in production. The
+# form the charter writes is `deployments/phase-{P}/wave-{M}`; the form 4 of the
+# org's repos actually use is `deployments/phase{P}/wave-{M}`. Measured on
+# 2026-08-03 over every `deployments/**`-head PR in all 7 repos (202 PRs): 168
+# carry the dashed form and **32 carry the undashed one** — 28 distinct refs
+# across isnad-graph, design-system, data-acquisition and landing-page
+# (`deployments/phase15/wave-1`, `deployments/phase10/wave-4`, …).
+#
+# That measurement is also a finding about the hook this pattern is consolidated
+# FROM: `block_squash_wave_merge.WAVE_BRANCH_RE` was `^deployments/phase-\d+/
+# wave-\d+$`, so Hook 22's squash guard has been silently OFF for those 32 PRs'
+# branches — a gate that returns "not a wave branch" for a wave branch. Reusing
+# one pattern closes that as a byproduct, in the fail-CLOSED direction (more
+# squashes blocked, never fewer). Writing a second, wider pattern in
+# `validate_pr_review` instead would have left the two definitions to drift
+# exactly as `extract_branch_author_lastname`'s two copies did for four months
+# (main#1175) — one definition, no drifting copy.
+#
+# ANCHORED AT BOTH ENDS, deliberately. `deployments/phase-3/wave-6-hotfix` and
+# `deployments/phase12/cleanup` (2 real PRs in isnad-graph) are NOT wave
+# branches, and each consumer's fail direction on a non-match is the safe one:
+# the merge gate keeps its commit-derived exclusion, Hook 22 keeps allowing a
+# squash it was already allowing.
+_WAVE_BRANCH_RE = re.compile(r"^deployments/phase-?\d+/wave-\d+$")
+
+
+def is_wave_branch(ref: str) -> bool:
+    """True when `ref` is a charter wave branch — `deployments/phase{-}N/wave-M`.
+
+    See `_WAVE_BRANCH_RE` for why both the dashed and undashed `phase` forms are
+    accepted and why the pattern is anchored. A `None`/empty ref is False, so a
+    caller that could not read the head ref gets "not a wave branch" — the
+    answer that leaves every consumer's stricter path in force.
+    """
+    return bool(ref) and bool(_WAVE_BRANCH_RE.match(ref))

--- a/.claude/lib/charter_trailer.py
+++ b/.claude/lib/charter_trailer.py
@@ -392,8 +392,9 @@ def is_branch_author(field_value: str, branch_lastname: str, branch_initial: str
 # BOTH `phase-N` AND `phaseN` ARE ACCEPTED, because both are in production. The
 # form the charter writes is `deployments/phase-{P}/wave-{M}`; the form 4 of the
 # org's repos actually use is `deployments/phase{P}/wave-{M}`. Measured on
-# 2026-08-03 over every `deployments/**`-head PR in all 7 repos (202 PRs): 168
-# carry the dashed form and **32 carry the undashed one** — 28 distinct refs
+# 2026-08-03 over every `deployments/**`-head PR in all 8 repos (202 PRs) — the
+# 7 children AND this parent, which contributes 41 of the 202 — of which 168
+# carry the dashed form and **32 carry the undashed one**: 28 distinct refs
 # across isnad-graph, design-system, data-acquisition and landing-page
 # (`deployments/phase15/wave-1`, `deployments/phase10/wave-4`, …).
 #
@@ -403,14 +404,34 @@ def is_branch_author(field_value: str, branch_lastname: str, branch_initial: str
 # branch on all 32. Reusing one pattern closes that as a byproduct, in the
 # fail-CLOSED direction (more squashes blocked, never fewer).
 #
-# SCOPE OF THAT GAP, STATED HONESTLY: the undashed form is HISTORICAL. All 32
-# PRs date from 2026-03-15..2026-04-06 and every wave-branch NAME CONSTRUCTOR in
-# the repo emits the dashed form (`wave_merge_model`, `validate_wave_audit`,
+# SCOPE OF THAT GAP: THE UNDASHED FORM IS CURRENT, NOT HISTORICAL. An earlier
+# draft of this comment said the opposite — that all 32 PRs date from
+# 2026-03-15..2026-04-06 and therefore "nothing produces the undashed spelling
+# today." The date range is accurate; the inference from it was FALSE, and is
+# retracted here (#1310 review). Every wave-branch name constructor IN THIS REPO
+# does emit the dashed form (`wave_merge_model`, `validate_wave_audit`,
 # `validate_wave_label_evidence`, `post_wave_kickoff_comment`, `wave_unwrapped`,
-# `framework.config.json`), so nothing produces the undashed spelling today. It
-# still matters because wave branches are RETAINED permanently as rollback
-# anchors (memory `feedback_wave_branch_merge_retain`) — those 28 refs are live
-# and squashable — but this is a historical-tail fix, not a live outage.
+# `framework.config.json`) — but this repo is not the only producer, and two
+# sources emit or prescribe the undashed spelling on `main` RIGHT NOW:
+#
+#   1. `noorinalabs-isnad-graph/scripts/create-wave.sh:38` — a committed,
+#      runnable constructor: BRANCH="deployments/phase${PHASE}/wave-${WAVE}".
+#   2. `ontology/conventions.md:213` IN THIS REPO documents the convention as
+#      `deployments/phase{N}/wave-{M}` — undashed — and both
+#      `noorinalabs-data-acquisition/.claude/team/charter.md` and
+#      `noorinalabs-deploy/.claude/team/charter.md` mirror it as the literal base
+#      an implementer is instructed to branch from and target.
+#
+# So the parent charter writes the dashed form while the org's own convention
+# document and two child charters write the undashed one. That spelling conflict
+# is real, is NOT resolved here, and is tracked by #1313; this pattern accepts
+# BOTH rather than picking a winner a hook has no standing to pick.
+#
+# DO NOT NARROW THIS PATTERN BACK TO `phase-` ON THE GROUNDS THAT THE UNDASHED
+# FORM IS DEAD — it is not. It is emitted by a live script, prescribed by the
+# live convention doc, and carried by 28 refs that are RETAINED permanently as
+# rollback anchors (memory `feedback_wave_branch_merge_retain`) and so stay
+# squashable indefinitely. This is a live gap, not a historical tail.
 #
 # Writing a second, wider pattern in `validate_pr_review` instead would have left
 # the two definitions to drift exactly as `extract_branch_author_lastname`'s two

--- a/.claude/lib/charter_trailer.py
+++ b/.claude/lib/charter_trailer.py
@@ -399,13 +399,22 @@ def is_branch_author(field_value: str, branch_lastname: str, branch_initial: str
 #
 # That measurement is also a finding about the hook this pattern is consolidated
 # FROM: `block_squash_wave_merge.WAVE_BRANCH_RE` was `^deployments/phase-\d+/
-# wave-\d+$`, so Hook 22's squash guard has been silently OFF for those 32 PRs'
-# branches — a gate that returns "not a wave branch" for a wave branch. Reusing
-# one pattern closes that as a byproduct, in the fail-CLOSED direction (more
-# squashes blocked, never fewer). Writing a second, wider pattern in
-# `validate_pr_review` instead would have left the two definitions to drift
-# exactly as `extract_branch_author_lastname`'s two copies did for four months
-# (main#1175) — one definition, no drifting copy.
+# wave-\d+$`, so Hook 22's squash guard answered "not a wave branch" for a wave
+# branch on all 32. Reusing one pattern closes that as a byproduct, in the
+# fail-CLOSED direction (more squashes blocked, never fewer).
+#
+# SCOPE OF THAT GAP, STATED HONESTLY: the undashed form is HISTORICAL. All 32
+# PRs date from 2026-03-15..2026-04-06 and every wave-branch NAME CONSTRUCTOR in
+# the repo emits the dashed form (`wave_merge_model`, `validate_wave_audit`,
+# `validate_wave_label_evidence`, `post_wave_kickoff_comment`, `wave_unwrapped`,
+# `framework.config.json`), so nothing produces the undashed spelling today. It
+# still matters because wave branches are RETAINED permanently as rollback
+# anchors (memory `feedback_wave_branch_merge_retain`) — those 28 refs are live
+# and squashable — but this is a historical-tail fix, not a live outage.
+#
+# Writing a second, wider pattern in `validate_pr_review` instead would have left
+# the two definitions to drift exactly as `extract_branch_author_lastname`'s two
+# copies did for four months (main#1175) — one definition, no drifting copy.
 #
 # ANCHORED AT BOTH ENDS, deliberately. `deployments/phase-3/wave-6-hotfix` and
 # `deployments/phase12/cleanup` (2 real PRs in isnad-graph) are NOT wave

--- a/.claude/lib/pr_review_state.py
+++ b/.claude/lib/pr_review_state.py
@@ -327,12 +327,24 @@ def _describe_comment_scan(state: ReviewState) -> str:
             "web-UI commit, or an outside contributor), so no self-review exclusion was "
             "applied and no verdict was subtracted (#1220)."
         )
+    if state.comment_scan == gate.COMMENT_SCAN_WAVE_INTEGRATION:
+        # #1216: the ONLY mode whose non-exclusion is a decision rather than a
+        # missing measurement, so it must not borrow the "commits named no
+        # persona" wording below — on a wave branch they named up to 11.
+        return (
+            "RAN — head ref is a wave branch, so this is a wave->main INTEGRATION PR: its "
+            "commits were already 2x-reviewed on their per-issue PRs and it authors no "
+            "content of its own, so commit-derived self-review exclusion is deliberately "
+            "NOT applied and an implementer's integration verdict counts (#1216). Nothing "
+            "was subtracted; roster filtering and the 2-reviewer threshold are unchanged."
+        )
     if state.comment_scan == gate.COMMENT_SCAN_NO_BRANCH_AUTHOR:
         return (
-            "RAN — head ref names no branch author (bot / wave-merge / non-charter branch) "
-            "and the PR's commits named no persona either (bot author, merge-only branch, or "
-            "a squash-flattened identity — #1177/#1210), so no self-review exclusion was "
-            "applied. Roster filtering and the 2-reviewer threshold are unchanged."
+            "RAN — head ref names no branch author (bot / non-wave `deployments/**` / "
+            "non-charter branch) and the PR's commits named no persona either (bot author, "
+            "merge-only branch, or a squash-flattened identity — #1177/#1210), so no "
+            "self-review exclusion was applied. Roster filtering and the 2-reviewer "
+            "threshold are unchanged."
         )
     # Explicit fallback, added with #1220's fifth mode (narrowing #1273).
     #

--- a/.claude/lib/tests/test_charter_trailer_identity.py
+++ b/.claude/lib/tests/test_charter_trailer_identity.py
@@ -39,6 +39,7 @@ from charter_trailer import (  # noqa: E402
     branch_author_first_initial,
     extract_branch_author_lastname,
     is_branch_author,
+    is_wave_branch,
     name_first_initial,
     name_lastname,
 )
@@ -417,6 +418,106 @@ class IsBranchAuthorTests(unittest.TestCase):
     def test_branch_initial_defaults_to_unknown(self):
         """Omitting the initial degrades to surname-only, not to "no match"."""
         self.assertTrue(is_branch_author("Santiago Ferreira", "Ferreira"))
+
+
+class IsWaveBranchTests(unittest.TestCase):
+    """`is_wave_branch` — the charter wave-branch ref shape (main#1216).
+
+    Two hooks read this one predicate and their fail directions differ, so the
+    cases below are split by which consumer a wrong answer would hurt:
+
+      * a FALSE NEGATIVE costs `block_squash_wave_merge` its guard (a squash
+        into a wave branch is allowed through) and costs `validate_pr_review`
+        nothing (it keeps the stricter commit-derived exclusion);
+      * a FALSE POSITIVE costs `validate_pr_review` the exclusion on a ref where
+        #1210 must still fire, which is the direction that matters here.
+
+    Every `deployments/**` string below is a REAL production head ref taken from
+    the 2026-08-03 sweep of all 202 `deployments/**`-head PRs across the 7 repos,
+    not an invented shape.
+    """
+
+    def test_the_charter_dashed_form_is_a_wave_branch(self):
+        for ref in (
+            "deployments/phase-10/wave-29",
+            "deployments/phase-5/wave-5",
+            "deployments/phase-3/wave-11",
+            "deployments/phase-2/wave-10",
+        ):
+            with self.subTest(ref=ref):
+                self.assertTrue(is_wave_branch(ref))
+
+    def test_the_undashed_phase_form_is_also_a_wave_branch(self):
+        """32 of the 202 measured PRs; 4 of the 7 repos use only this form.
+
+        `block_squash_wave_merge` carried `^deployments/phase-\\d+/wave-\\d+$`
+        before main#1216, so its squash guard answered "not a wave branch" for
+        every one of these — a gate silently off. RED if `_WAVE_BRANCH_RE`
+        loses its `-?`.
+        """
+        for ref in (
+            "deployments/phase15/wave-1",
+            "deployments/phase10/wave-4",
+            "deployments/phase9/wave-3",
+            "deployments/phase1/wave-1",
+            "deployments/phase5/wave-0",
+        ):
+            with self.subTest(ref=ref):
+                self.assertTrue(is_wave_branch(ref))
+
+    def test_a_non_wave_deployments_ref_is_not_a_wave_branch(self):
+        """The carve-out is a SHAPE, not the `deployments/` namespace.
+
+        `deployments/phase12/cleanup` is real (isnad-graph#603, #612). Relaxing
+        the predicate to `startswith("deployments/")` turns these green and
+        re-opens main#1210 on a hand-made release branch.
+        """
+        for ref in (
+            "deployments/phase12/cleanup",
+            "deployments/phase-3/wave-6-hotfix",
+            "deployments/phase-3/wave",
+            "deployments/wave-3",
+            "deployments/phase-3/wave-x",
+            "deployments/phase-/wave-3",
+            "deployments/",
+        ):
+            with self.subTest(ref=ref):
+                self.assertFalse(is_wave_branch(ref))
+
+    def test_the_pattern_is_anchored_at_both_ends(self):
+        """An unanchored `search` would match any ref CONTAINING the shape."""
+        for ref in (
+            "refs/heads/deployments/phase-3/wave-6",
+            "A.Virtanen/1216-deployments/phase-3/wave-6",
+            "deployments/phase-3/wave-6/nested",
+            " deployments/phase-3/wave-6",
+            "deployments/phase-3/wave-6 ",
+        ):
+            with self.subTest(ref=ref):
+                self.assertFalse(is_wave_branch(ref))
+
+    def test_a_persona_branch_is_never_a_wave_branch(self):
+        """Positive control against a predicate that just returns True.
+
+        Without this, every `assertTrue` above is satisfied by `lambda r: True`,
+        which would strip commit-derived exclusion from EVERY non-persona ref —
+        main#1210 fully re-opened.
+        """
+        for ref in (
+            "A.Virtanen/1216-wave-branch-implementer-exclusion",
+            "A.Virtanen-0179-branch-regex-fix",
+            "dependabot/npm_and_yarn/x-1.2.3",
+            "feature/some-hand-made-branch",
+            "main",
+        ):
+            with self.subTest(ref=ref):
+                self.assertFalse(is_wave_branch(ref))
+
+    def test_an_absent_ref_is_not_a_wave_branch(self):
+        """A ref the API did not return must leave every consumer's stricter
+        path in force, never acquire the carve-out."""
+        self.assertFalse(is_wave_branch(""))
+        self.assertFalse(is_wave_branch(None))  # type: ignore[arg-type]
 
 
 if __name__ == "__main__":

--- a/.claude/team/charter/pull-requests/reviews.md
+++ b/.claude/team/charter/pull-requests/reviews.md
@@ -35,7 +35,57 @@ The role names always describe the **comment** (not the PR):
 - The `TechDebt:` line is **mandatory** on every `Approved` and `ChangesRequested` comment. If the reviewer found non-blocking observations, they MUST create `tech-debt`-labeled issues BEFORE posting the verdict, then list the issue numbers, e.g. `TechDebt: #1054, #1055`. If no tech-debt was found, write `TechDebt: none`. The `#` is accepted either way (`#1054` or a bare `1054` both capture), but a value that is neither `none` nor a number — free text like "filed later" — parses to ZERO issue references and is recorded as unparseable rather than silently dropped (main#1055). Enforced by `validate_pr_review.py` PreToolUse hook at merge time.
 - The 2-reviewer rule is satisfied when there are `Approved` comments from **two distinct `Requestor` values**, neither of which is the PR author. Single-reviewer waivers per § Single-Reviewer Exception (Wave-Bootstrap Only) are honored by the hook (resolves main#228) when the PR is labeled `wave-bootstrap` and the single reviewer is the Standards & Quality Lead.
 - Each `Requestor` value on an `Approved` comment must name a persona in the local `.claude/team/roster/` (full-name match against `**Name:**` lines). Non-roster Requestor strings do NOT count toward the 2-reviewer threshold — Hook 4 filters them out and reports them in the BLOCK diagnostic. Mirrors `validate_commit_identity.py`'s strict-roster discipline (resolves main#498).
+- **Who counts as "the PR author"** — see § Who Counts as "the PR Author" (and Who May Review a Wave→Main Integration PR) below. The exclusion above is of the **PR author**, singular; on a wave→main integration PR that is nobody on the branch, and an implementer whose already-reviewed work the branch contains MAY post a counting `Approved`.
 - Charter-format fields (`Requestor:` / `Requestee:` / `RequestOrReplied:` / `TechDebt:`) MUST appear ONLY in the trailer block — a contiguous structured-fields block at the end of the comment body, ideally after a bare-line `---` separator. Hook 4 extracts fields only from the trailer-block substring (post-last-`---`) and strips inline (`` `…` ``) and fenced (```` ```…``` ````) code regions before matching. Prose that quotes the field syntax above the trailer (or uses backticks to discuss it) will be ignored by the extractor, but reviewers should still avoid duplicating field patterns in prose for clarity. Pre-#511 the regex first-matched any `<Field>:` mention, which false-blocked 3 reviewer verdicts in P3W11 batch 11 (main#509, deploy#337, deploy#339) — each required orchestrator REST PATCH (resolves main#511).
+
+## Who Counts as "the PR Author" (and Who May Review a Wave→Main Integration PR) <!-- promotion-target: hook -->
+
+The 2-reviewer rule excludes **the PR author**, singular. Because every agent shares one GitHub account, "the PR author" is not readable from the PR's `author` field; the gate derives it from two independent sources and uses whichever is available:
+
+1. **The head ref's `{FirstInitial}.{LastName}` prefix** — the author the human *declared*. Authoritative whenever present, which is 86.7% of the org's PRs (568/655 measured across 7 repos).
+2. **The authors of the PR's own non-merge commits** (main#1210) — the only discriminator available on a ref carrying no prefix (`feature/x`, `dependabot/**`, an empty ref). Without it, a human on a hand-made branch could post their own `Approved`, add one genuine reviewer, and reach 2/2 where 1/2 is correct.
+
+### The rule
+
+**An implementer MAY post a counting `Approved` on the wave→main integration PR that contains their own merged work.** Their commits are on that branch; they are not its author.
+
+**An implementer MAY NOT review the per-issue PR that contains their own commits.** This is unchanged and is where the whole force of the self-review rule lives. A per-issue PR carries the `{FirstInitial}.{LastName}` prefix, so source 1 excludes its author; a per-issue PR on a hand-made ref is caught by source 2.
+
+### Why the wave→main integration PR is the exception
+
+A wave→main integration PR has head ref `deployments/phase-{P}/wave-{M}` and base `main`. Neither source names its author:
+
+- The ref names no persona — it names a wave.
+- Its non-merge commits are **the wave's entire implementer roster**, because a wave branch accumulates every per-issue PR merged into it. Those commits **already carried two independent reviewers each, on their own per-issue PR**, and reached the branch through those reviewed merges. The integration PR authors no content of its own.
+
+Treating all of them as "the PR author" applies a content-review rule to a PR that is not a content review — which [`wave-merge.md`](wave-merge.md) § Wave Merge PR Verification point 5 already says in as many words: *"the wave→main PR is an integration merge, not new code to re-review… Collecting fresh 2-reviewer approvals on the integration PR is not required and should not be requested."* This section states explicitly the corollary that was previously left implicit and that a hook had silently decided the other way.
+
+The verdict an implementer casts on an integration PR is an **integration** verdict — this branch merges cleanly into `main`, CI is green on the combined tree, the scope is what the wave declared — not a re-review of their own diff. Reviewers should write it that way (cf. main#711's verdicts: *"an integration verdict over work already 2-reviewed and CI-green on the wave branch, not a line re-review"*).
+
+### What this is NOT
+
+- It is **not** a relaxation of the 2-reviewer threshold. Two distinct roster-valid current `Approved` Requestors are still required, and roster filtering is untouched.
+- It is **not** a licence to self-approve anywhere else. On every non-wave ref — including a `deployments/**` ref that is not a wave branch, e.g. `deployments/phase12/cleanup` — commit-derived exclusion is fully in force.
+- It does **not** make the integration PR's reviews mandatory. Point 5 of `wave-merge.md` still governs: fresh approvals are not required there, and the `wave-merge` admin exception remains the expected merge path.
+
+### Stated residual
+
+Nothing identifies the persona who *opened* the integration PR. They contribute merge commits (from `gh pr merge <per-issue-PR>` into the wave branch), and merge commits are deliberately excluded from author derivation — running a merge does not make you an author of the merged content. So on this PR class, a persona who both sequenced the wave merges and posts an `Approved` is not subtracted. This is the pre-main#294 state, not a new gap, and it sits inside the tolerance point 5 already grants a PR class that requires no fresh approvals at all. It is recorded here rather than left to be rediscovered.
+
+### Evidence
+
+Measured on 2026-08-03 over **every** `deployments/**`-head PR in all 7 repos (**202** PRs), driven through the gate's own `resolve_review_verdicts`:
+
+| PR | ref | before → after | genuine reviewer subtracted |
+|---|---|---|---|
+| `noorinalabs-main#711` | `deployments/phase-5/wave-5` | 2/2 → 1/2 | Wanjiku Mwangi |
+| `noorinalabs-main#530` | `deployments/phase-3/wave-11` | 2/2 → 1/2 | Aino Virtanen |
+| `noorinalabs-main#293` | `deployments/phase-3/wave-6` | 2/2 → 1/2 | Aino Virtanen |
+| `noorinalabs-main#229` | `deployments/phase-2/wave-10` | 1/2 → 0/2 | Aino Virtanen |
+
+112 of the 202 derived **two or more** "branch authors"; the largest derived **11**. The eligible reviewer pool does **not** collapse below two — the roster gate unions all 7 repos' rosters (76 personas), so the remaining pool never dropped below 67 in the sweep. The cost is a **false subtraction of review work that was actually done**, plus a block message asserting that five people are "the branch author" of a PR none of them opened.
+
+<!-- Resolves main#1216. Enforced by `validate_pr_review.py` (`COMMENT_SCAN_WAVE_INTEGRATION`, keyed on `charter_trailer.is_wave_branch`). -->
 
 ## Review Prompt Template (Mandatory) <!-- promotion-target: none -->
 When the orchestrator assigns a review to any agent, the prompt **MUST** include a copy-paste-ready `gh pr comment` command with all fields pre-filled. Do not rely on agents writing the format from memory — this has a 100% error rate.

--- a/.claude/team/charter/pull-requests/reviews.md
+++ b/.claude/team/charter/pull-requests/reviews.md
@@ -68,13 +68,17 @@ The verdict an implementer casts on an integration PR is an **integration** verd
 - It is **not** a licence to self-approve anywhere else. On every non-wave ref — including a `deployments/**` ref that is not a wave branch, e.g. `deployments/phase12/cleanup` — commit-derived exclusion is fully in force.
 - It does **not** make the integration PR's reviews mandatory. Point 5 of `wave-merge.md` still governs: fresh approvals are not required there, and the `wave-merge` admin exception remains the expected merge path.
 
-### Stated residual
+### Stated residuals
 
-Nothing identifies the persona who *opened* the integration PR. They contribute merge commits (from `gh pr merge <per-issue-PR>` into the wave branch), and merge commits are deliberately excluded from author derivation — running a merge does not make you an author of the merged content. So on this PR class, a persona who both sequenced the wave merges and posts an `Approved` is not subtracted. This is the pre-main#294 state, not a new gap, and it sits inside the tolerance point 5 already grants a PR class that requires no fresh approvals at all. It is recorded here rather than left to be rediscovered.
+Two, both recorded here rather than left to be rediscovered. Neither is a regression — each is strictly narrower than the pre-main#294 state this section restores — and both sit inside the tolerance `wave-merge.md` point 5 already grants a PR class that requires no fresh approvals at all.
+
+1. **The opener is not identified.** Nothing identifies the persona who *opened* the integration PR. They contribute merge commits (from `gh pr merge <per-issue-PR>` into the wave branch), and merge commits are deliberately excluded from author derivation — running a merge does not make you an author of the merged content. So on this PR class, a persona who both sequenced the wave merges and posts an `Approved` is not subtracted.
+
+2. **The carve-out keys on head-ref *shape* alone** ([main#1312](https://github.com/noorinalabs/noorinalabs-main/issues/1312)). `comment_scan_scope` never consults the base ref, nor whether the branch actually accumulated reviewed per-issue merges — only whether the head ref matches `deployments/phase{-}N/wave-M`. So a hand-named branch of that shape carrying *original* content gets the carve-out, and its author's own `Approved` counts toward 2/2 (measured; a `feature/**` control gives 1/2). This is a residual of a **different kind** from the opener above: that one is about who is missed, this one is about a ref that was never a wave branch being treated as one. Options and their costs are in the issue.
 
 ### Evidence
 
-Measured on 2026-08-03 over **every** `deployments/**`-head PR in all 7 repos (**202** PRs), driven through the gate's own `resolve_review_verdicts`:
+Measured on 2026-08-03 over **every** `deployments/**`-head PR in all **8** repos — the 7 children **and** this parent, which contributes 41 of them (**202** PRs) — driven through the gate's own `resolve_review_verdicts`:
 
 | PR | ref | before → after | genuine reviewer subtracted |
 |---|---|---|---|
@@ -83,7 +87,11 @@ Measured on 2026-08-03 over **every** `deployments/**`-head PR in all 7 repos (*
 | `noorinalabs-main#293` | `deployments/phase-3/wave-6` | 2/2 → 1/2 | Aino Virtanen |
 | `noorinalabs-main#229` | `deployments/phase-2/wave-10` | 1/2 → 0/2 | Aino Virtanen |
 
-112 of the 202 derived **two or more** "branch authors"; the largest derived **11**. The eligible reviewer pool does **not** collapse below two — the roster gate unions all 7 repos' rosters (76 personas), so the remaining pool never dropped below 67 in the sweep. The cost is a **false subtraction of review work that was actually done**, plus a block message asserting that five people are "the branch author" of a PR none of them opened.
+112 of the 202 derived **two or more** "branch authors"; the largest derived **11**.
+
+The eligible reviewer pool does **not** collapse below two. `_load_roster_names` unions the **parent** roster (which already carries all 76 personas, via the #1162 org manifest) with the named child repo's own roster — it is not a union across all 7 children, and every repo resolves to the same 76. Counting only the **roster-valid** derived identities, the remaining eligible pool never dropped below **67** across the 202 PRs. *(The naive `76 − 11 = 65` is the wrong figure: 2 of the largest derivation's 11 identities are not roster personas and were always inert, so they were never subtracting anything.)*
+
+The real cost is a **false subtraction of review work that was actually done**, plus a block message asserting that up to **11** people are "the branch author" of a PR none of them opened.
 
 <!-- Resolves main#1216. Enforced by `validate_pr_review.py` (`COMMENT_SCAN_WAVE_INTEGRATION`, keyed on `charter_trailer.is_wave_branch`). -->
 

--- a/.claude/team/charter/pull-requests/wave-merge.md
+++ b/.claude/team/charter/pull-requests/wave-merge.md
@@ -76,6 +76,8 @@ At the **end of a wave or phase**, the Manager creates a PR from the deployments
 
 The **user approves the merge sequence**; the orchestrator executes the `wave-merge` merges per point 5. Do not proceed to the next phase until every wave→main PR is merged and the Step 11.5 reachability gate is clean.
 
+> **Who may review the integration PR (main#1216).** Point 5 says fresh 2-reviewer approval is not *required* here. When reviews are nonetheless posted — good practice, and what the team has actually done — **an implementer whose merged work the branch contains may post a counting `Approved`**: the integration PR authors no content of its own, and each of its commits already carried two independent reviewers on its per-issue PR. The full rule, the residual it leaves open, and the 202-PR measurement behind it are in [`reviews.md`](reviews.md) § Who Counts as "the PR Author". Between main#1210 and main#1216 the merge gate silently enforced the opposite, subtracting genuine reviewers on 4 measured PRs.
+
 ## Wave-Wrapup Staging-Promotion Gate (Mandatory) <!-- promotion-target: skill -->
 
 A wave is **not closeable** until its merged code has been promoted to **staging green**. This is Phase-3 end-state criterion #3 (`noorinalabs-main#325`): "/wave-wrapup requires successful stg promotion as a wave-completion criterion." The gate is the wrapup-time enforcement counterpart of the same liveness contract the deploy track exists to satisfy — code that merged to main but never reached a green staging deploy is the deploy-track analogue of the stranded-wave-branch pattern (§ the reachability gate in `/wave-wrapup` Step 11.5).


### PR DESCRIPTION
Closes #1216.

**This was a charter question before it was a code change, and it is answered in the charter first.** Reviewers: read the `reviews.md` section before the hook diff — the hook is the enforcement of a written rule, not the rule.

---

## Rework round 2 — three commits on top of `47c6dc5`, **text only, no behaviour change**

The merge-gate review blocked on **two shipped prose claims that outran their evidence**, in a PR whose subject is descriptions that outran their evidence. Both are retracted below, in place, rather than softened. Nothing in the diff's behaviour changed; the tree was diffed before every commit.

| commit | what |
|---|---|
| `eec8bdf` | **Retracts** the "#1297 is structurally impossible here" claim. I reproduced the falsification myself — mutation applied verbatim, suite green, 3 of 4 rows self-approving. **#1297 stays OPEN.** (§ 4) |
| `1b0c568` | **Corrects** "the undashed form is historical / nothing emits it today" in all four places. Two live sources cited. (§ Byproduct) |
| `693253d` | Names **#1312** as a second stated residual; fixes the 8-repo, roster-union and pool-figure phrasings. (§ Residuals, § 2) |

**Escalation question — settled, not escalated.** I asked to be blocked if a reviewer thought the policy text needed the owner. The ruling is narrower and stronger than my own reasoning, and I am adopting it: `wave-merge.md` point 5 does not merely say the integration PR is "not new code to re-review" — it makes the admin exception the **expected** merge path, says fresh 2-reviewer approval is "not required and should not be requested", and calls the 0/2 BLOCK "expected and audited"; `ci-gates.md` makes `wave-merge` a **pre-authorized** bypass. **The charter therefore already permits this PR class to merge with zero qualifying approvals**, so a rule letting one of two approvals come from an implementer **cannot expand what may merge** — it is strictly weaker than the position point 5 already holds. The durable form of the test: ***does this let something merge that could not merge before?*** No. Standards call.

---

## 1. The policy, stated explicitly

New section in [`pull-requests/reviews.md`](.claude/team/charter/pull-requests/reviews.md) — **§ Who Counts as "the PR Author" (and Who May Review a Wave→Main Integration PR)**, with a pointer from the 2-reviewer rule at its § Validation list and a cross-link from `wave-merge.md`:

> **An implementer MAY post a counting `Approved` on the wave→main integration PR that contains their own merged work.** Their commits are on that branch; they are not its author.
>
> **An implementer MAY NOT review the per-issue PR that contains their own commits.** Unchanged — that is where the whole force of the self-review rule lives.

**This is a clarification, not a new policy.** `wave-merge.md` § Wave Merge PR Verification point 5 already says the wave→main PR "is an *integration* merge, **not new code to re-review**" and that "collecting *fresh* 2-reviewer approvals on the integration PR is **not** required and should not be requested." #1210 silently decided the opposite via a hook. I judged writing down the corollary of an existing charter position to be a Standards call rather than an owner one, and **asked to be blocked if a reviewer disagreed**. The merge gate reviewed the premise independently and confirmed it — see § Rework above for the reasoning I have adopted, which is narrower and stronger than mine.

### The residuals, stated rather than left to be rediscovered

**Two**, both now named in the charter's § Stated residuals. Neither is a regression — each is strictly narrower than the pre-main#294 state this restores — and both sit inside the tolerance point 5 already grants a PR class that requires no fresh approvals at all.

1. **The opener is not identified.** Nothing identifies the persona who **opened** the integration PR — they contribute only merge commits, which the derivation skips by design (running a merge does not make you an author of the merged content). So a persona who both sequenced the wave merges and posts an `Approved` is not subtracted. Filed as [#1309](https://github.com/noorinalabs/noorinalabs-main/issues/1309).
2. **The carve-out keys on head-ref *shape* alone** — [#1312](https://github.com/noorinalabs/noorinalabs-main/issues/1312), found by the merge-gate review, **added in rework**. `comment_scan_scope` never consults the base ref, nor whether the branch actually accumulated reviewed per-issue merges — only the ref shape. So a hand-named `deployments/phase-99/wave-1` carrying *original* content gets the carve-out and its author self-approves to 2/2 (measured; a `feature/**` control gives 1/2). A residual of a **different kind** from the opener: that one is about who is missed, this one is about a ref that was never a wave branch being treated as one. My original § Stated residual named only the first, which is exactly the failure that section exists to prevent.

---

## 2. Re-measured sweep — the exposure GREW

Re-run against **current `main`**, not trusting the issue's numbers. Every `deployments/**`-head PR in **all 8 repos** — the 7 children **and** this parent, which contributes 41 of the 202 (corrected in rework; I had written "7") — driven through the shipped `resolve_review_verdicts` itself (nothing re-implemented — that re-derivation is the #1046 defect class this file warns about repeatedly).

| | issue (#1216, at filing) | this PR (2026-08-03, current `main`) |
|---|---|---|
| PRs swept | 172 | **202** |
| genuine Approved reviewer subtracted | 2 | **4** |
| false blocks (≥2 → <2) | 2 | **3** |

| PR | ref | before → after | subtracted |
|---|---|---|---|
| `noorinalabs-main#711` | `deployments/phase-5/wave-5` | **2/2 → 1/2** | Wanjiku Mwangi |
| `noorinalabs-main#530` | `deployments/phase-3/wave-11` | **2/2 → 1/2** | Aino Virtanen |
| `noorinalabs-main#293` | `deployments/phase-3/wave-6` | **2/2 → 1/2** | Aino Virtanen |
| `noorinalabs-main#229` | `deployments/phase-2/wave-10` | 1/2 → 0/2 | Aino Virtanen |

`main#293` is **new since the issue was filed**. 112 of 202 derive **two or more** "branch authors"; the largest derives **11**.

### Two corrections to the issue's framing

1. **"The pool can fall below two, making the wave merge unapprovable" is NOT supported.** The remaining eligible pool never dropped below **67** across the 202 PRs. I am not repeating a claim I could not measure. The real cost is a **false subtraction of review work that was actually done**, plus a block message asserting that up to 11 people are "the branch author" of a PR none of them opened.

   *Corrected in rework, twice.* **(a)** I had written that `_load_roster_names` "unions all 7 repos' rosters." It does not — it unions the **parent** roster with the **named child repo's** roster, and the parent alone already resolves to all **76** personas via the #1162 org manifest; every repo resolves to the same 76. Verified by calling it. **(b)** The **67** counts only **roster-valid** derived identities. The naive `76 − 11 = 65` is the wrong figure — 2 of the largest derivation's 11 identities are not personas and were always inert, so they never subtracted anything. Which measure the number is is now stated in the charter text rather than left for a reader to reconstruct.

2. **A methodology correction on my own first pass.** My initial sweep hand-rolled a `**Name:**` roster parser; the roster files carry the name in the H1, so it returned the empty set for every repo, filtered every real Approved Requestor out, and reported a confident **`0 subtracted`**. A silent zero, not a measurement. The sweep now calls the gate's own `_load_roster_names` and **hard-exits on an empty roster** rather than measuring off a failed read.

   **This measurement has now silently zeroed twice, for two people, for two unrelated reasons.** The independent merge-gate re-measurement *also* returned a confident `0 subtracted` across all 202 on its first attempt — from a different cause: an export carrying no child-repo roster dirs, so all 202 raised `RosterResolutionError` and the comparison loop skipped every one of them. Two different mistakes, identical output, and in both cases that output is **indistinguishable from the healthy answer**. So the shape is the hazard, not either mistake: a sweep whose failure mode is "measured nothing" and whose success mode is "found nothing" cannot be made safe by being more careful — it needs an independent liveness signal. Both of us caught it only by counting something *alongside* the result (roster size; error count). Recorded on [#1309](https://github.com/noorinalabs/noorinalabs-main/issues/1309), because the next person to sweep this data will find a third way to zero it.

---

## 3. Mutation table — real names, real output

15 mutations, one at a time, each restored with `git checkout HEAD -- <file>`. Baseline: `3733 passed, 793 subtests`.

| # | mutation | verdict | caught by |
|---|---|---|---|
| M1 | `is_wave_branch` always **True** — every non-persona ref gets the carve-out (**#1210 dead**) | CAUGHT | 25 tests |
| M2 | `is_wave_branch` always **False** — the carve-out is a no-op | CAUGHT | 16 tests |
| M3 | drop `-?` — the 32 undashed real PRs keep #1210, Hook 22 stays blind | CAUGHT | 4 (`test_the_undashed_phase_form_is_also_a_wave_branch`, `test_squash_into_an_undashed_wave_branch_now_blocks`, …) |
| M4 | unanchor the pattern — any ref *containing* the shape gets the carve-out | CAUGHT | 2 (`test_the_pattern_is_anchored_at_both_ends`, …) |
| M5 | widen to the `deployments/` **namespace** instead of the wave shape | CAUGHT | 7 (`test_a_non_wave_deployments_ref_keeps_the_commit_derived_exclusion`, …) |
| M6 | drop the empty/None guard — an absent head ref crashes instead of failing strict | CAUGHT | 2 (`test_an_absent_ref_is_not_a_wave_branch`, `test_unresolvable_base_fails_open`) |
| M7 | swap `comment_scan_scope` arms — the wave arm outranks the declared author | CAUGHT | 1 (`test_the_declared_author_arm_outranks_the_wave_arm`) — **survived run 1**, see below |
| M8 | **#1297 shape**: mode says `WAVE_INTEGRATION`, the exclusion still runs | CAUGHT | 5 (`test_the_reported_identities_are_the_ones_the_exclusion_used`, `test_main_711_replayed_from_its_real_payload`, …) |
| M9 | **#1220 shape inverted**: derive for the report, pass `()` to the exclusion | CAUGHT | 9 |
| M10 | `refine_comment_scan_scope` may downgrade `WAVE_INTEGRATION` | CAUGHT | 3 (`test_wave_integration_is_never_refined_even_with_derived_identities`, …) |
| M11 | delete the `WAVE_INTEGRATION` **block diagnostic** | CAUGHT | 2 (`test_wave_integration_block_states_the_short_count_is_not_a_subtraction`, `test_every_mode_gets_its_declared_block_diagnostic`) |
| M12 | delete the `WAVE_INTEGRATION` **allow advisory** (undisclosed relaxation) | CAUGHT | 4 |
| M13 | hardcode `2/2` in the allow advisory (**the #1292 shape**) | CAUGHT | 1 (`test_wave_integration_advisory_reports_a_one_of_two_count_honestly`) |
| M14 | collapse the `WAVE_INTEGRATION` report line into `NO_BRANCH_AUTHOR`'s text | CAUGHT | 1 (`test_every_mode_renders_a_recognized_report_line`) |
| M15 | Hook 22 re-declares its own strict local pattern (**the #1175 drift**) | CAUGHT | 14 |

**15 / 15 caught.**

### M7 is the one worth reading

M7 (swap the two arms of `comment_scan_scope`) **survived the first run** — no real ref can satisfy both shapes, so the swap is a no-op against every input. The problem was not the survivor: it was that I had written **"ORDER MATTERS AND IS TESTED"** in the docstring while nothing could falsify it. That is **#1215's shape exactly — an anti-vacuity claim that is itself vacuous.** Rather than soften the claim, I made it true: force `is_wave_branch` True and assert a persona ref *still* yields `AUTHOR_EXCLUDED`, plus a third assertion proving the patch is reaching the function so the first two are not passing against an unpatched call.

Same treatment for M10: it was caught only via the `NOT_RUN` assertions, i.e. the never-refined property held **by the caller's grace** (`resolve_review_verdicts` passes `()` on a wave ref) rather than by the function's contract. Now asserted directly on `refine_comment_scan_scope`.

### Also caught by the harness: a stray live mutation

I interrupted a mutation run to edit those same files, and the harness's per-mutation `git checkout HEAD --` had not yet restored M1 — `is_wave_branch` was left `return True` in the tree. Caught by diffing before committing. Flagging it because it is the failure mode a reviewer should assume of any mutation harness.

---

## 4. The code

- **`charter_trailer.is_wave_branch`** — ONE definition of the charter wave-branch shape, anchored, accepting **both** production spellings (`phase-N` and `phaseN`).
- **`COMMENT_SCAN_WAVE_INTEGRATION`** — a new mode, selected by `comment_scan_scope`. It is the only **policy** mode; the other four describe what evidence happened to be available. Rendering it as `NO_BRANCH_AUTHOR` ("the PR's commits named no persona") would be **false** — on a wave branch they named up to 11 — which is the **#1220 defect one layer up**: a true count under a false description.
- **`resolve_review_verdicts` now derives `commit_authors` FROM `scan_scope`**, not from a second read of the head ref. **The mode that is reported and the tuple the exclusion is applied from are one value**, so they cannot disagree about *whether* exclusion is live — which matters because #1216 adds the first slice where exclusion is turned OFF. Pinned by `OneDerivationDrivesModeAndExclusionTests`; M8/M9 (the mode-moving variants) are caught. Exactly equivalent to the old expression on both pre-#1216 ref classes.

  > **RETRACTED IN REWORK — this does NOT close [#1297](https://github.com/noorinalabs/noorinalabs-main/issues/1297), and #1297 stays open.** I had claimed the coupling made #1297's shape "structurally impossible here rather than argued against." **That was false, and I verified it myself rather than accepting it on report.** Applying #1297's mutation verbatim to this head tree: **`3733 passed, 793 subtests`, pytest exit 0 — the whole suite stays green.** Probing `resolve_review_verdicts` directly on a non-charter ref reproduces #1297's table exactly, so it is not an equivalent mutant either:
  >
  > | commit author fields | shipped head | mutated head |
  > |---|---|---|
  > | `name="Nino Kavtaradze"`, `+Nino.Kavtaradze@` | 1/2 | 1/2 |
  > | `name="nino-k"`, `+Nino.Kavtaradze@` | 1/2 | **2/2** |
  > | `name=""`, `+Nino.Kavtaradze@` | 1/2 | **2/2** |
  > | `name="Kavtaradze"`, bare principal | 1/2 | **2/2** |
  >
  > Mode stays `commit-author-excluded` in every mutated row. **Why the coupling misses it:** it binds whether the tuple is *derived* to the reported mode; #1297 inserts a **filtered copy downstream** of the derivation, so derivation and mode still agree and no mode moves. M8/M9 are wave-slice variants that *do* move a mode, which is why they are caught and this is not. The retraction is written into the source comment and both affected docstrings — narrowed to what the coupling actually establishes, not softened into ambiguity. **#1297 needs the two count assertions its own closing section specifies; do not close it on this PR.** A comment asserting a hole is structurally impossible, sitting above a hole a two-line edit walks through with a green suite, is precisely the defect class this file's history is about — and I shipped one.
- All **three** mode-rendering surfaces wired (the #1273 totality test forces it): block diagnostic, allow-path advisory, `pr_review_state._describe_comment_scan`.

### Direction, stated plainly

**This is the one change in this file's history that moves the gate toward passing.** It restores the pre-main#294 state on the **wave slice only**, bounded by an anchored match on the charter ref shape. `StrictlyNonRelaxingTests`' `before` baseline *is* that state, so its subset property still holds. Every other ref keeps #1210 fully intact — including a `deployments/**` ref that is **not** a wave branch (`deployments/phase12/cleanup`, 2 real PRs, pinned by a test and by M5).

No `assertIn("1/2", reason)`-style loose substring assertions were added ([#1203](https://github.com/noorinalabs/noorinalabs-main/issues/1203)); counts are asserted as sets and integers, and the advisory's count is pinned at both `2/2` **and** `1/2` so a hardcoded literal cannot survive (the #1292 shape).

### Byproduct, fail-closed

Consolidating the matcher revealed Hook 22's own `^deployments/phase-\d+/wave-\d+$` never matched the undashed `deployments/phase15/wave-1` form — **32 of the 202** PRs across 4 repos. Hook 22 now imports the shared predicate, with an **identity** test (`assertIs`) so a re-declared local copy fails a named test rather than drifting (the #1175 lesson).

> **CORRECTED IN REWORK — the undashed form is CURRENT, not historical.** I had scoped this as a historical tail in four places: "all 32 from 2026-03-15..04-06; every wave-branch name constructor emits the dashed form … nothing produces the undashed spelling today." The date range is accurate. **The inference from it was false.** Two live sources on `main`, both verified in this worktree:
>
> 1. **`noorinalabs-isnad-graph/scripts/create-wave.sh:38`** — a committed, runnable constructor emitting the undashed form: `BRANCH="deployments/phase${PHASE}/wave-${WAVE}"`.
> 2. **`ontology/conventions.md:213`, in this repo** — the org's own semantic overlay documents the convention as `deployments/phase{N}/wave-{M}`, **undashed**, and both `noorinalabs-data-acquisition/.claude/team/charter.md` and `noorinalabs-deploy/.claude/team/charter.md` mirror it (5 occurrences each) as the literal base an implementer is told to branch from and target.
>
> So the undashed spelling is what someone reading *"what is the convention"* is currently instructed to use. **The direction makes this fix more valuable than I claimed, not less** — the correction is entirely about the prose, which as written invited the next editor to narrow `_WAVE_BRANCH_RE` back to `phase-` on the grounds that the form is dead. All four sites now say explicitly not to, and cite the two sources. The `conventions.md` ⇄ parent-charter spelling conflict is **not** resolved here — the pattern accepts both rather than picking a winner a hook has no standing to pick — and is tracked by [#1313](https://github.com/noorinalabs/noorinalabs-main/issues/1313).
>
> Worth naming: "historical" was an *inference from the dates*, presented with the same confidence as the measured numbers around it. Retention was the reason I gave for fixing the gap anyway, and it turns out to have been the weaker of the two reasons actually available.

---

## 5. Gates

- `3733 passed, 793 subtests` — full `.claude/hooks/tests/` + `.claude/lib/tests/`
- `ruff format` + `ruff check` clean · `mypy` clean (196 files) · `pre_commit_ci_sync` clean · all pre-commit hooks passed on every commit (no `--no-verify`)

## 6. Follow-up debt

All three are `tech-debt` / `process` / `phase-10`, **no wave label**, on the board. **None is closed by this PR.**

- [**#1309**](https://github.com/noorinalabs/noorinalabs-main/issues/1309) — *the wave→main integration PR's OPENER is identifiable by no discriminator the gate has*. Carries the measurement (merge-commit author is the bare `parametrization` principal on 147/202), why option 2 ("derive from merge commits") is a **silent-zero shape** and should not be taken without solving the bare-principal problem first, and why this is inside stated tolerance today. Residual **1**.
- [**#1312**](https://github.com/noorinalabs/noorinalabs-main/issues/1312) — *the carve-out keys on head-ref **shape** alone*, so a hand-named `deployments/phase-99/wave-1` carrying original content self-approves to 2/2. Strictly narrower than the pre-main#294 baseline, so not a regression. Residual **2**, added to the charter in rework.
- [**#1313**](https://github.com/noorinalabs/noorinalabs-main/issues/1313) — the undashed-form scoping correction above, plus the `ontology/conventions.md` ⇄ parent-charter **spelling conflict** (undashed vs dashed) that this PR deliberately does not resolve.
- [**#1297**](https://github.com/noorinalabs/noorinalabs-main/issues/1297) — **stays open.** See the retraction in § 4; this PR does not close it and its claim to have done so is withdrawn.

---

**Do NOT merge** — 2 reviewers per charter, and the policy text is the part that needs the scrutiny.

