### PR TITLE
fix(commit-identity): relay downstream of a data-sink heredoc resolves to CODE (#1168)

### DIFF
--- a/.claude/hooks/_shell_parse.py
+++ b/.claude/hooks/_shell_parse.py
@@ -608,14 +608,6 @@ HEREDOC_DATA_SINKS = frozenset({"cat", "tee"})
 #     xxd (incl. `-r`), hexdump (incl. `-e`), join, paste, comm, tac,
 #     shuf (incl. `--random-source`), jq (incl. `env.PATH`, `$ENV.PATH`,
 #     `input_filename`, `@sh` — no `system()` in mainline)
-#     rg — plain AND `--pre COMMAND` / `-z`/`--search-zip` (both apply only
-#          "for each input PATH" per ripgrep's own docs; there is no PATH on
-#          a stdin pipe, so neither ever invokes anything): measured, both
-#          flags are genuine no-ops when the input is a heredoc-fed pipe in
-#          both bash and zsh. Folded in alongside this fix (main#1316) so the
-#          allowlist stops contradicting #1008's org-wide "no bare `grep`"
-#          rule — before this, the list admitted the forbidden tool (`grep`)
-#          while omitting the mandated replacement (`rg`).
 #
 #   RAN (data-driven code-execution surface — DELIBERATELY EXCLUDED even
 #   though they are common "genuinely inert filter" examples in casual
@@ -639,20 +631,46 @@ HEREDOC_DATA_SINKS = frozenset({"cat", "tee"})
 #             plain invocation being inert is not sufficient, exactly as for
 #             `sed`/`awk` below; the exec-shaped flag makes it unsafe as a
 #             blanket allowlist member. Excluded per main#1316.
+#     rg    — `--pre=COMMAND` runs COMMAND once "for each input PATH", and on
+#             a heredoc-fed pipe a PATH is attacker-supplied: naming the pipe
+#             itself (`/dev/stdin`, `/dev/fd/0`) gives `--pre` a PATH even
+#             though the input is a pure stdin pipe, and `rg` runs
+#             `COMMAND PATH` with that path opened on the child's own stdin
+#             — so `sh /dev/stdin` genuinely executes the heredoc body;
+#             measured: `cat <<'EOF' | rg --pre=/bin/sh pat /dev/stdin`
+#             genuinely runs the body in both bash and zsh. `rg`'s ORIGINAL
+#             addition to this allowlist (main#1316's first pass) measured
+#             only the no-PATH stdin-pipe form — fixing the CONTEXT
+#             (whether a PATH is present) instead of varying it, when that
+#             context is exactly what an attacker controls. Separately, `rg`
+#             also exposes `--hostname-bin=COMMAND`, a second exec-shaped
+#             flag that spawns an arbitrary program even on a pure stdin
+#             pipe with no PATH at all — but the spawned child gets no
+#             arguments and does not inherit the pipe, so it never reaches
+#             the heredoc body and is not a bypass on its own. Noted here
+#             anyway because its existence falsifies any claim that every
+#             `rg` flag is harmless on a heredoc-fed stdin pipe. Excluded
+#             per main#1316 (second pass) — previously allowlisted in this
+#             module's own first pass at the same PR, on a plain-form
+#             measurement plus a #1008 policy argument (closing the
+#             contradiction where this allowlist admitted forbidden `grep`
+#             while omitting mandated `rg`); that policy argument is not a
+#             safety argument, and the #1008 contradiction is left OPEN by
+#             this exclusion — see the PR body.
 #
-# All three risks above are ARGUMENT-driven (visible in the segment's own
+# All four risks above are ARGUMENT-driven (visible in the segment's own
 # tokens, not hidden in the heredoc body), so a narrower "allowlisted unless
-# the script argument contains `e`/`system(`/`--compress-program`" rule is
-# possible in principle — but that reintroduces a second, per-command
-# detector inside what this set is meant to keep a flat, reviewable
-# allowlist, and is deliberately left as a non-goal here: excluding
-# `sed`/`awk`/`sort` entirely accepts a real (if comparatively rare, in a
-# documentation-pipeline context) false-positive cost in exchange for never
-# having to get that per-command grammar right. `perl`, `python`, `ruby`,
-# `php`, `xargs`, `parallel`, `find`, `env` and any other general-purpose
-# interpreter or relay are excluded for the same reason, one level more
-# obviously (they are not "filters" in the first place — some of them are
-# exactly the relay family this fix targets).
+# the script argument contains `e`/`system(`/`--compress-program`/`--pre`"
+# rule is possible in principle — but that reintroduces a second,
+# per-command detector inside what this set is meant to keep a flat,
+# reviewable allowlist, and is deliberately left as a non-goal here:
+# excluding `sed`/`awk`/`sort`/`rg` entirely accepts a real (if comparatively
+# rare, in a documentation-pipeline context) false-positive cost in exchange
+# for never having to get that per-command grammar right. `perl`, `python`,
+# `ruby`, `php`, `xargs`, `parallel`, `find`, `env` and any other
+# general-purpose interpreter or relay are excluded for the same reason, one
+# level more obviously (they are not "filters" in the first place — some of
+# them are exactly the relay family this fix targets).
 HEREDOC_INERT_RELAY_FILTERS = frozenset(
     {
         "grep",
@@ -685,7 +703,6 @@ HEREDOC_INERT_RELAY_FILTERS = frozenset(
         "tac",
         "shuf",
         "jq",
-        "rg",
     }
 )
 

--- a/.claude/hooks/_shell_parse.py
+++ b/.claude/hooks/_shell_parse.py
@@ -560,6 +560,106 @@ SHELL_INTERPRETERS = frozenset({"bash", "sh", "zsh", "dash", "ksh"})
 # addition is an explicit, reviewable decision.
 HEREDOC_DATA_SINKS = frozenset({"cat", "tee"})
 
+# ---------------------------------------------------------------------------
+# Downstream-relay default (main#1168)
+# ---------------------------------------------------------------------------
+#
+# `_opener_feeds_interpreter`'s pipe-follow walk (condition 3 below) used to
+# resolve an unrecognised downstream segment head toward DATA ("not proven to
+# be an interpreter, so keep walking; if nothing downstream matches, the body
+# is inert"). That is backwards relative to every other ambiguity in this
+# module, which resolves toward CODE (main#1152's own rule), and it is a
+# measured live bypass: a RELAY command that is not itself a member of
+# `SHELL_INTERPRETERS` but hands its stdin to one defeats the walk entirely —
+#
+#     cat <<'DELIM' | xargs -I{} bash -c "{}"
+#     git -c user.name=X -c user.email=Y commit -m z
+#     DELIM
+#
+# `xargs` is not an interpreter, so the old walk found nothing and returned
+# DATA; the body — a real `git commit` — genuinely runs (real-shell-verified
+# with a marker proxy: a marker command appended to a log file, confirmed to
+# execute). The same family: `parallel`, `env -S`, and (for the OTHER
+# classifier, main#1167's cross-segment write-then-exec correlation —
+# out of scope for the fix here, see that module's comment) `find -exec`.
+#
+# The fix: an unrecognised downstream segment head now resolves to CODE,
+# matching the rest of this module's posture. `HEREDOC_INERT_RELAY_FILTERS`
+# below is the narrow escape hatch — the mirror image of `HEREDOC_DATA_SINKS`
+# — for commands MEASURED to have no code-execution surface reachable from
+# their own stdin content, so a legitimate documentation pipeline
+# (`cat <<'EOF' | grep foo`) does not newly false-block. Same posture as
+# `HEREDOC_DATA_SINKS`: a tiny, explicit, reviewed ALLOWLIST, never a
+# denylist — an unlisted filter fails toward CODE, which is the entire point
+# of inverting the default (an allowlist's safety property IS its default).
+#
+# Every entry here was verified with a real-shell marker probe (a command
+# appended to a log file inside the heredoc body, checked for the log
+# actually being written) BEFORE being added, not reasoned from a man page:
+#
+#   DID-NOT-RUN (genuinely inert, confirmed safe to allowlist):
+#     grep, wc, sort, uniq, head, tail, cut, tr, column, nl, rev, fold,
+#     expand, unexpand, base64, md5sum, sha1sum, sha256sum, od, xxd, join,
+#     paste, comm, tac, shuf, jq
+#
+#   RAN (data-driven code-execution surface — DELIBERATELY EXCLUDED even
+#   though they are common "genuinely inert filter" examples in casual
+#   reasoning about this shape):
+#     sed  — the GNU `e` flag/command executes the (input-derived) pattern
+#            space as a shell command and substitutes its output; measured:
+#            `cat <<'EOF' | sed 's/.*/&/e'` genuinely runs the body.
+#     awk  — `system()` (and piped `print ... | "cmd"` / `getline < "cmd"`)
+#            executes a command built from field/record data; measured:
+#            `cat <<'EOF' | awk '{system($0)}'` genuinely runs the body.
+#
+# Both risks are ARGUMENT-driven (visible in the segment's own tokens, not
+# hidden in the heredoc body), so a narrower "allowlisted unless the script
+# argument contains `e`/`system(`" rule is possible in principle — but that
+# reintroduces a second, per-command detector inside what this set is meant
+# to keep a flat, reviewable allowlist, and is deliberately left as a
+# non-goal here: excluding `sed`/`awk` entirely accepts a real (if
+# comparatively rare, in a documentation-pipeline context) false-positive
+# cost in exchange for never having to get that per-command grammar right.
+# `perl`, `python`, `ruby`, `php`, `xargs`, `parallel`, `find`, `env` and any
+# other general-purpose interpreter or relay are excluded for the same
+# reason, one level more obviously (they are not "filters" in the first
+# place — some of them are exactly the relay family this fix targets).
+HEREDOC_INERT_RELAY_FILTERS = frozenset(
+    {
+        "grep",
+        "egrep",
+        "fgrep",
+        "wc",
+        "sort",
+        "uniq",
+        "head",
+        "tail",
+        "cut",
+        "tr",
+        "column",
+        "nl",
+        "rev",
+        "fold",
+        "expand",
+        "unexpand",
+        "base64",
+        "md5sum",
+        "sha1sum",
+        "sha256sum",
+        "sha512sum",
+        "cksum",
+        "od",
+        "xxd",
+        "hexdump",
+        "join",
+        "paste",
+        "comm",
+        "tac",
+        "shuf",
+        "jq",
+    }
+)
+
 # A heredoc opener: `<<EOF`, `<<'EOF'`, `<<"EOF"`, `<<-EOF`. Matched with
 # `.match(line, i)` from a scanner that has already excluded `<<<` (here-string)
 # and quoted regions, so no lookbehind is needed here.
@@ -725,7 +825,8 @@ def _opener_feeds_interpreter(line: str, pos: int, scan: _LineScan) -> bool:
       1. the segment's head command is a known inert sink (`cat`, `tee`), AND
       2. that segment carries no process substitution, AND
       3. no segment downstream of it *in the same pipeline* is a shell
-         interpreter or itself carries a process substitution.
+         interpreter, a RELAY that hands its stdin to one (main#1168), or
+         itself carries a process substitution.
 
     Condition 2 is the one that is easy to miss, and missing it is a live
     bypass (main#1155 review, M1):
@@ -741,6 +842,19 @@ def _opener_feeds_interpreter(line: str, pos: int, scan: _LineScan) -> bool:
     anywhere in a reachable segment therefore forces CODE without trying to
     resolve what is inside it: an unresolvable sink resolves toward CODE, which
     is the rule the rest of this classifier already follows.
+
+    Condition 3's downstream default is the OTHER historically-inverted case
+    (main#1168): a downstream segment head that is not a known
+    `SHELL_INTERPRETERS` member, a known `HEREDOC_DATA_SINKS` member (`cat`,
+    `tee` — relaying to a FILE, not an interpreter, is exactly as inert
+    downstream as it is in the owning-segment position), or a known-inert
+    `HEREDOC_INERT_RELAY_FILTERS` member now resolves to CODE — not "keep
+    walking, default to DATA" as before. A RELAY command (`xargs -I{} bash -c
+    "{}"` and the same family via `parallel`/`env -S`) is not itself an
+    interpreter, so the old walk found nothing downstream and returned DATA
+    even though the body genuinely runs (real-shell-verified with a marker
+    proxy). See the module comment above `HEREDOC_INERT_RELAY_FILTERS` for
+    the full false-positive corpus that justifies the allowlist's contents.
 
     `&&`, `||`, `;` and `&` break the pipeline: what follows them does not
     receive this stdin. A `&` that is part of a redirect (`2>&1`) is not a
@@ -761,7 +875,16 @@ def _opener_feeds_interpreter(line: str, pos: int, scan: _LineScan) -> bool:
         head = _segment_head_command(line[start:end])
         if head_must_be_inert_sink:
             return head not in HEREDOC_DATA_SINKS
-        return head in SHELL_INTERPRETERS
+        if head in SHELL_INTERPRETERS:
+            return True
+        # main#1168: an unresolved/unknown relay (including `head is None` —
+        # the segment didn't tokenize) resolves to CODE. A downstream
+        # `HEREDOC_DATA_SINKS` member (`cat`, `tee` — e.g. `| tee /tmp/a.md`
+        # relaying to a FILE, not an interpreter) is just as inert here as it
+        # is in the owning-segment position, so it joins
+        # `HEREDOC_INERT_RELAY_FILTERS` as a reason to keep walking rather
+        # than stop at CODE.
+        return head not in HEREDOC_DATA_SINKS and head not in HEREDOC_INERT_RELAY_FILTERS
 
     if _reachable_sink_is_code(idx, head_must_be_inert_sink=True):
         return True

--- a/.claude/hooks/_shell_parse.py
+++ b/.claude/hooks/_shell_parse.py
@@ -593,44 +593,72 @@ HEREDOC_DATA_SINKS = frozenset({"cat", "tee"})
 # denylist — an unlisted filter fails toward CODE, which is the entire point
 # of inverting the default (an allowlist's safety property IS its default).
 #
-# Every entry here was verified with a real-shell marker probe (a command
-# appended to a log file inside the heredoc body, checked for the log
-# actually being written) BEFORE being added, not reasoned from a man page:
+# Every entry here was verified with a real-shell marker probe — BOTH the
+# plain invocation AND every exec-shaped flag the command exposes (a command
+# appended to a log file inside the heredoc body / a marker script standing
+# in for an external-program flag, checked for the log actually being
+# written, in both bash and zsh) BEFORE being added, not reasoned from a man
+# page and not measured on the bare invocation alone:
 #
-#   DID-NOT-RUN (genuinely inert, confirmed safe to allowlist):
-#     grep, wc, sort, uniq, head, tail, cut, tr, column, nl, rev, fold,
-#     expand, unexpand, base64, md5sum, sha1sum, sha256sum, od, xxd, join,
-#     paste, comm, tac, shuf, jq
+#   DID-NOT-RUN (genuinely inert — plain form AND every exec-shaped flag
+#   probed — confirmed safe to allowlist):
+#     grep, egrep, fgrep (incl. `-f -`), wc, uniq, head, tail, cut, tr,
+#     column, nl, rev, fold, expand, unexpand, base64 (incl. `-d`),
+#     md5sum (incl. `-c`), sha1sum, sha256sum, sha512sum, cksum, od,
+#     xxd (incl. `-r`), hexdump (incl. `-e`), join, paste, comm, tac,
+#     shuf (incl. `--random-source`), jq (incl. `env.PATH`, `$ENV.PATH`,
+#     `input_filename`, `@sh` — no `system()` in mainline)
+#     rg — plain AND `--pre COMMAND` / `-z`/`--search-zip` (both apply only
+#          "for each input PATH" per ripgrep's own docs; there is no PATH on
+#          a stdin pipe, so neither ever invokes anything): measured, both
+#          flags are genuine no-ops when the input is a heredoc-fed pipe in
+#          both bash and zsh. Folded in alongside this fix (main#1316) so the
+#          allowlist stops contradicting #1008's org-wide "no bare `grep`"
+#          rule — before this, the list admitted the forbidden tool (`grep`)
+#          while omitting the mandated replacement (`rg`).
 #
 #   RAN (data-driven code-execution surface — DELIBERATELY EXCLUDED even
 #   though they are common "genuinely inert filter" examples in casual
 #   reasoning about this shape):
-#     sed  — the GNU `e` flag/command executes the (input-derived) pattern
-#            space as a shell command and substitutes its output; measured:
-#            `cat <<'EOF' | sed 's/.*/&/e'` genuinely runs the body.
-#     awk  — `system()` (and piped `print ... | "cmd"` / `getline < "cmd"`)
-#            executes a command built from field/record data; measured:
-#            `cat <<'EOF' | awk '{system($0)}'` genuinely runs the body.
+#     sed   — the GNU `e` flag/command executes the (input-derived) pattern
+#             space as a shell command and substitutes its output; measured:
+#             `cat <<'EOF' | sed 's/.*/&/e'` genuinely runs the body.
+#     awk   — `system()` (and piped `print ... | "cmd"` / `getline < "cmd"`)
+#             executes a command built from field/record data; measured:
+#             `cat <<'EOF' | awk '{system($0)}'` genuinely runs the body.
+#     sort  — `--compress-program=CMD` runs CMD with the heredoc's own data
+#             on its stdin once the sort spills to a temp file (`-S` sets
+#             the spill threshold; the padding needed to cross it is
+#             attacker-controlled, same as any other input-size trigger);
+#             measured: `cat <<'EOF' | sort -S 1 --compress-program=CMD`
+#             genuinely runs CMD in both bash and zsh once enough body lines
+#             are present to force a spill. The PLAIN invocation (no
+#             `--compress-program`) is genuinely inert — this is why `sort`
+#             shipped on this allowlist in the first place (main#1168's
+#             original measurement covered only the bare form) — but a
+#             plain invocation being inert is not sufficient, exactly as for
+#             `sed`/`awk` below; the exec-shaped flag makes it unsafe as a
+#             blanket allowlist member. Excluded per main#1316.
 #
-# Both risks are ARGUMENT-driven (visible in the segment's own tokens, not
-# hidden in the heredoc body), so a narrower "allowlisted unless the script
-# argument contains `e`/`system(`" rule is possible in principle — but that
-# reintroduces a second, per-command detector inside what this set is meant
-# to keep a flat, reviewable allowlist, and is deliberately left as a
-# non-goal here: excluding `sed`/`awk` entirely accepts a real (if
-# comparatively rare, in a documentation-pipeline context) false-positive
-# cost in exchange for never having to get that per-command grammar right.
-# `perl`, `python`, `ruby`, `php`, `xargs`, `parallel`, `find`, `env` and any
-# other general-purpose interpreter or relay are excluded for the same
-# reason, one level more obviously (they are not "filters" in the first
-# place — some of them are exactly the relay family this fix targets).
+# All three risks above are ARGUMENT-driven (visible in the segment's own
+# tokens, not hidden in the heredoc body), so a narrower "allowlisted unless
+# the script argument contains `e`/`system(`/`--compress-program`" rule is
+# possible in principle — but that reintroduces a second, per-command
+# detector inside what this set is meant to keep a flat, reviewable
+# allowlist, and is deliberately left as a non-goal here: excluding
+# `sed`/`awk`/`sort` entirely accepts a real (if comparatively rare, in a
+# documentation-pipeline context) false-positive cost in exchange for never
+# having to get that per-command grammar right. `perl`, `python`, `ruby`,
+# `php`, `xargs`, `parallel`, `find`, `env` and any other general-purpose
+# interpreter or relay are excluded for the same reason, one level more
+# obviously (they are not "filters" in the first place — some of them are
+# exactly the relay family this fix targets).
 HEREDOC_INERT_RELAY_FILTERS = frozenset(
     {
         "grep",
         "egrep",
         "fgrep",
         "wc",
-        "sort",
         "uniq",
         "head",
         "tail",
@@ -657,6 +685,7 @@ HEREDOC_INERT_RELAY_FILTERS = frozenset(
         "tac",
         "shuf",
         "jq",
+        "rg",
     }
 )
 

--- a/.claude/hooks/tests/test_heredoc_relay_downstream.py
+++ b/.claude/hooks/tests/test_heredoc_relay_downstream.py
@@ -25,6 +25,20 @@ surface reachable from their own stdin — the false-positive escape hatch so
 `cat <<'EOF' | grep foo` (a genuinely inert documentation pipeline) does not
 newly false-block.
 
+main#1316 (PR #1316 rework, merge-gate finding): `sort` shipped on this
+allowlist measured only on its PLAIN invocation; `sort --compress-program=CMD`
+genuinely runs CMD with the heredoc's own data on its stdin once the sort
+spills to a temp file (attacker-controlled padding crosses the `-S` spill
+threshold). Dropped from the allowlist for the same reason `sed`/`awk` are
+excluded — a plain invocation being inert does not make the command safe to
+allowlist wholesale, and a per-flag detector for `--compress-program` would
+reintroduce exactly the per-command grammar this set is designed to avoid.
+Folded in alongside it: `rg`, which was previously absent from the allowlist
+while `grep` (forbidden org-wide by main#1008) was present — the inverse of
+what this org mandates. `rg`'s exec-shaped flags (`--pre`, `-z`) are
+documented to apply only "for each input PATH"; measured genuinely inert on a
+heredoc-fed stdin pipe in both bash and zsh, plain and exec-shaped.
+
 Test organisation
 ==================
 
@@ -32,10 +46,12 @@ Test organisation
     real `check()`.
   * `RelayFalsePositiveCorpusTests` — every `HEREDOC_INERT_RELAY_FILTERS`
     member, individually and chained, must stay ALLOW.
-  * `RelayExcludedFiltersBlockTests` — `sed`/`awk` are DELIBERATELY excluded
-    from the allowlist (both have a data-driven code-execution surface); this
-    pins that they now resolve to CODE, and that the adversarial shapes which
-    justify the exclusion are real bypasses if they were ever allowlisted.
+  * `RelayExcludedFiltersBlockTests` — `sed`/`awk`/`sort` are DELIBERATELY
+    excluded from the allowlist (each has a data-driven code-execution
+    surface reachable through an exec-shaped flag — `sed`'s `e` flag, `awk`'s
+    `system()`, `sort`'s `--compress-program`); this pins that they now
+    resolve to CODE, and that the adversarial shapes which justify the
+    exclusion are real bypasses if they were ever allowlisted.
   * `RealShellGroundTruthTests` — marker-proxy verification against an actual
     `bash`/`zsh`, per shape, so a verdict is checked against what the shell
     really does rather than against expectations.
@@ -155,7 +171,6 @@ class RelayFalsePositiveCorpusTests(unittest.TestCase):
         "egrep": "egrep foo",
         "fgrep": "fgrep foo",
         "wc": "wc -l",
-        "sort": "sort -u",
         "uniq": "uniq -c",
         "head": "head -n 5",
         "tail": "tail -n 5",
@@ -182,6 +197,7 @@ class RelayFalsePositiveCorpusTests(unittest.TestCase):
         "tac": "tac",
         "shuf": "shuf",
         "jq": "jq -R .",
+        "rg": "rg foo",
     }
 
     def test_every_allowlisted_filter_has_a_representative_case(self):
@@ -196,9 +212,11 @@ class RelayFalsePositiveCorpusTests(unittest.TestCase):
                 _assert_allowed(self, f"cat <<'DELIM' | {invocation}\n{REAL_COMMIT}\nDELIM")
 
     def test_chained_allowlisted_filters_stay_allowed(self):
-        """A realistic documentation pipeline chaining several filters."""
+        """A realistic documentation pipeline chaining several filters.
+        Uses `cut`/`uniq` rather than `sort` — `sort` is no longer
+        allowlisted as of main#1316 (see `RelayExcludedFiltersBlockTests`)."""
         _assert_allowed(
-            self, f"cat <<'DELIM' | grep -v '^#' | sort | uniq -c\n{REAL_COMMIT}\nDELIM"
+            self, f"cat <<'DELIM' | grep -v '^#' | cut -d, -f1 | uniq -c\n{REAL_COMMIT}\nDELIM"
         )
 
     def test_tee_downstream_of_a_relay_chain_stays_allowed(self):
@@ -216,17 +234,22 @@ class RelayFalsePositiveCorpusTests(unittest.TestCase):
 
 
 class RelayExcludedFiltersBlockTests(unittest.TestCase):
-    """`sed`/`awk` are common "obviously inert filter" examples but carry a
-    data-driven code-execution surface (real-shell-verified — see
-    `RealShellGroundTruthTests`), so they are DELIBERATELY excluded from
+    """`sed`/`awk`/`sort` are common "obviously inert filter" examples but
+    each carries a data-driven code-execution surface (real-shell-verified —
+    see `RealShellGroundTruthTests`), so they are DELIBERATELY excluded from
     `HEREDOC_INERT_RELAY_FILTERS`. This costs a false positive on ordinary
-    `sed`/`awk` documentation pipelines, accepted per the module comment."""
+    `sed`/`awk`/`sort` documentation pipelines, accepted per the module
+    comment. `sort` was excluded in main#1316, after having shipped on the
+    allowlist measured only on its plain (no `--compress-program`) form."""
 
     def test_sed_not_in_allowlist(self):
         self.assertNotIn("sed", HEREDOC_INERT_RELAY_FILTERS)
 
     def test_awk_not_in_allowlist(self):
         self.assertNotIn("awk", HEREDOC_INERT_RELAY_FILTERS)
+
+    def test_sort_not_in_allowlist(self):
+        self.assertNotIn("sort", HEREDOC_INERT_RELAY_FILTERS)
 
     def test_plain_sed_now_blocks_accepted_false_positive(self):
         """An ORDINARY, harmless `sed` substitution — the false-positive cost
@@ -235,6 +258,13 @@ class RelayExcludedFiltersBlockTests(unittest.TestCase):
 
     def test_plain_awk_now_blocks_accepted_false_positive(self):
         _assert_blocked(self, f"cat <<'DELIM' | awk '{{print}}'\n{REAL_COMMIT}\nDELIM")
+
+    def test_plain_sort_now_blocks_accepted_false_positive(self):
+        """An ORDINARY, harmless bare `sort` — genuinely inert (see
+        `RealShellGroundTruthTests`), but no longer allowlisted; the
+        false-positive cost this exclusion accepts, same posture as
+        `sed`/`awk` above."""
+        _assert_blocked(self, f"cat <<'DELIM' | sort\n{REAL_COMMIT}\nDELIM")
 
     def test_sed_e_flag_would_be_a_real_bypass_if_allowlisted(self):
         """The adversarial shape that justifies excluding `sed`: the GNU `e`
@@ -245,6 +275,17 @@ class RelayExcludedFiltersBlockTests(unittest.TestCase):
 
     def test_awk_system_would_be_a_real_bypass_if_allowlisted(self):
         _assert_blocked(self, f"cat <<'DELIM' | awk '{{system($0)}}'\n{REAL_COMMIT}\nDELIM")
+
+    def test_sort_compress_program_would_be_a_real_bypass_if_allowlisted(self):
+        """The adversarial shape that justifies excluding `sort`:
+        `--compress-program=CMD` runs CMD with the heredoc's own data on its
+        stdin once the sort spills to a temp file. Confirmed BLOCKED under
+        the current (exclude) policy; `sort` must never be re-added to the
+        allowlist without also gating this flag."""
+        _assert_blocked(
+            self,
+            "cat <<'DELIM' | sort --compress-program=/tmp/marker.sh\n" + REAL_COMMIT + "\nDELIM",
+        )
 
 
 @unittest.skipUnless(shutil.which("bash"), "bash not installed")
@@ -287,6 +328,18 @@ class RealShellGroundTruthTests(unittest.TestCase):
         cmd = template.replace("MARKER", REAL_COMMIT)
         result = hook.check(_bash(cmd))
         return result is not None and result.get("decision") == "block"
+
+    def _write_marker_passthrough_script(self) -> str:
+        """Write an executable that appends to `self._log` (proof of
+        execution) then passes stdin to stdout unchanged. Some exec-shaped
+        flags (`sort --compress-program=CMD`, `rg --pre COMMAND`) name an
+        external PROGRAM rather than accepting an inline shell fragment, so
+        the MARKER-substitution used elsewhere in this class does not apply
+        — a real file is required."""
+        script = Path(self._tmpdir) / "marker_passthrough.sh"
+        script.write_text(f"#!/bin/sh\necho RAN >> {self._log}\nexec cat\n")
+        script.chmod(0o755)
+        return str(script)
 
     def _assert_ground_truth_matches_verdict(self, template: str, *, expect_runs: bool) -> None:
         for shell in self.SHELLS:
@@ -333,12 +386,6 @@ class RealShellGroundTruthTests(unittest.TestCase):
             expect_runs=False,
         )
 
-    def test_sort_relay_genuinely_inert(self):
-        self._assert_ground_truth_matches_verdict(
-            "cat <<'DELIM' | sort\nMARKER\nDELIM",
-            expect_runs=False,
-        )
-
     def test_column_relay_genuinely_inert(self):
         self._assert_ground_truth_matches_verdict(
             "cat <<'DELIM' | column -t\nMARKER\nDELIM",
@@ -355,6 +402,33 @@ class RealShellGroundTruthTests(unittest.TestCase):
         self._assert_ground_truth_matches_verdict(
             "cat <<'DELIM' | grep -v NOPE | tee /dev/null\nMARKER\nDELIM",
             expect_runs=False,
+        )
+
+    def test_rg_relay_genuinely_inert(self):
+        self._assert_ground_truth_matches_verdict(
+            "cat <<'DELIM' | rg MARKERPATTERN_ABSENT\nMARKER\nDELIM",
+            expect_runs=False,
+        )
+
+    def test_rg_pre_flag_genuinely_inert_on_stdin(self):
+        """`rg --pre COMMAND` is documented to apply only "for each input
+        PATH"; a heredoc-fed pipe has no PATH (it is stdin), so the flag is a
+        no-op here — measured, not assumed from the docs. Uses a real marker
+        script (not an inline MARKER substitution) since `--pre` names an
+        external program, exactly like the `sort --compress-program` probe
+        below; if `--pre` ever fired on stdin, this script would append to
+        its own log and this test would fail loudly."""
+        marker = self._write_marker_passthrough_script()
+        template = f"cat <<'DELIM' | rg --pre {marker} commit\nMARKER\nDELIM"
+        for shell in self.SHELLS:
+            with self.subTest(shell=shell):
+                self.assertFalse(
+                    self._shell_actually_runs(template, shell),
+                    f"{shell} invoked `rg --pre` on a stdin pipe (no PATH) — should be a no-op",
+                )
+        self.assertFalse(
+            self._hook_blocks(f"cat <<'DELIM' | rg --pre {marker} commit\nMARKER\nDELIM"),
+            "rg is allowlisted; --pre must not newly false-block",
         )
 
     # --- excluded filters: the adversarial flag genuinely runs the body ----
@@ -376,6 +450,50 @@ class RealShellGroundTruthTests(unittest.TestCase):
         self.assertTrue(
             self._hook_blocks(template),
             "sed is excluded from the allowlist, so this accepted false positive must still block",
+        )
+
+    def test_sort_plain_genuinely_inert_but_excluded_anyway(self):
+        """Ground truth: a bare `sort` (no `--compress-program`) does NOT
+        execute the body (confirms the false-positive cost `sort`'s
+        exclusion accepts is real, not imagined) — same posture as the
+        `sed` case above. This is why `sort` shipped on the allowlist in the
+        first place before main#1316: its plain form really is inert."""
+        template = "cat <<'DELIM' | sort\nMARKER\nDELIM"
+        for shell in self.SHELLS:
+            with self.subTest(shell=shell):
+                self.assertFalse(
+                    self._shell_actually_runs(template, shell),
+                    f"{shell} unexpectedly ran a plain sort",
+                )
+        self.assertTrue(
+            self._hook_blocks(template),
+            "sort is excluded from the allowlist, so this accepted false positive must still block",
+        )
+
+    def test_sort_compress_program_genuinely_runs(self):
+        """The adversarial case that justifies excluding `sort` (main#1316):
+        `--compress-program=CMD` genuinely runs CMD with the heredoc's own
+        (padded) data on its stdin once the sort spills to a temp file.
+        `-S 1` sets a 1024-byte in-memory buffer; enough padded body lines
+        cross that threshold and force the spill — the padding is exactly
+        the attacker-controlled lever the module comment describes. Uses a
+        real marker script (see `_write_marker_passthrough_script`), not an
+        inline MARKER substitution, since `--compress-program` names an
+        external program."""
+        marker = self._write_marker_passthrough_script()
+        padded_lines = "\n".join(f"line{i}-padding-padding-padding-padding" for i in range(500))
+        template = (
+            f"cat <<'DELIM' | sort -S 1 --compress-program={marker}\n{padded_lines}\nMARKER\nDELIM"
+        )
+        for shell in self.SHELLS:
+            with self.subTest(shell=shell):
+                self.assertTrue(
+                    self._shell_actually_runs(template, shell),
+                    f"{shell} did not invoke the `sort --compress-program` marker script",
+                )
+        self.assertTrue(
+            self._hook_blocks(f"cat <<'DELIM' | sort --compress-program={marker}\nMARKER\nDELIM"),
+            "sort is excluded from the allowlist, so this must still block",
         )
 
     def test_sed_e_flag_genuinely_runs(self):
@@ -437,8 +555,11 @@ class RelayClassifierUnitTests(unittest.TestCase):
     def test_multi_hop_pipeline_stops_walk_correctly_at_end_of_segments(self):
         """A pipeline ending in an allowlisted filter (nothing after it) must
         resolve overall to DATA — the loop must not spuriously continue past
-        the last segment."""
-        (span,) = classify_heredocs(f"cat <<'DELIM' | grep foo | sort | uniq\n{REAL_COMMIT}\nDELIM")
+        the last segment. Uses `cut` rather than `sort` — `sort` is no
+        longer allowlisted as of main#1316."""
+        (span,) = classify_heredocs(
+            f"cat <<'DELIM' | grep foo | cut -d, -f1 | uniq\n{REAL_COMMIT}\nDELIM"
+        )
         self.assertFalse(span.is_code)
 
     def test_unresolvable_downstream_segment_resolves_to_code(self):

--- a/.claude/hooks/tests/test_heredoc_relay_downstream.py
+++ b/.claude/hooks/tests/test_heredoc_relay_downstream.py
@@ -441,6 +441,17 @@ class RelayClassifierUnitTests(unittest.TestCase):
         (span,) = classify_heredocs(f"cat <<'DELIM' | grep foo | sort | uniq\n{REAL_COMMIT}\nDELIM")
         self.assertFalse(span.is_code)
 
+    def test_unresolvable_downstream_segment_resolves_to_code(self):
+        """A downstream segment that does not even TOKENIZE (an unbalanced
+        quote — `_segment_head_command` returns `None`) must resolve to CODE,
+        independent of any specific relay name. Pinned directly rather than
+        only through the main#1171 coincidence in
+        `SiblingIssueMeasurementTests`, so a future change to that sibling
+        shape cannot silently stop exercising this branch."""
+        cmd = "cat <<'DELIM' | \"unterminated\n" + REAL_COMMIT + "\nDELIM"
+        (span,) = classify_heredocs(cmd)
+        self.assertTrue(span.is_code)
+
 
 class SiblingIssueMeasurementTests(unittest.TestCase):
     """main#1170 / main#1171 measurements, per the #1168 spawn brief's

--- a/.claude/hooks/tests/test_heredoc_relay_downstream.py
+++ b/.claude/hooks/tests/test_heredoc_relay_downstream.py
@@ -1,0 +1,485 @@
+#!/usr/bin/env python3
+"""Regression tests for main#1168 — a non-interpreter RELAY downstream of a
+heredoc's data-sink defeats the pipe-follow classifier.
+
+Shape
+=====
+
+    cat <<'DELIM' | xargs -I{} bash -c "{}"
+    git -c user.name="X" -c user.email="Y" commit -m z
+    DELIM
+
+`_opener_feeds_interpreter` (`_shell_parse.py`) walks the `|`-connected
+segments downstream of a heredoc's owning data-sink segment, looking for a
+`SHELL_INTERPRETERS` member. `xargs` is not one, so the OLD walk found nothing
+and resolved the ambiguity to DATA — backwards relative to every other
+ambiguity in this classifier, which resolves toward CODE (main#1152's rule).
+Real-shell-verified (marker proxy: a command appended to a log file inside the
+heredoc body, confirmed to run) at both `fea0dca` and PR #1155's head
+`e163320`: pre-existing, not a #1155 regression.
+
+The fix flips the downstream default: an unresolved/unknown relay head now
+resolves to CODE. `HEREDOC_INERT_RELAY_FILTERS` is the narrow, explicit,
+real-shell-measured allowlist of commands proven to have no code-execution
+surface reachable from their own stdin — the false-positive escape hatch so
+`cat <<'EOF' | grep foo` (a genuinely inert documentation pipeline) does not
+newly false-block.
+
+Test organisation
+==================
+
+  * `RelayBypassBlocksTests` — the primary shape and its variants, through the
+    real `check()`.
+  * `RelayFalsePositiveCorpusTests` — every `HEREDOC_INERT_RELAY_FILTERS`
+    member, individually and chained, must stay ALLOW.
+  * `RelayExcludedFiltersBlockTests` — `sed`/`awk` are DELIBERATELY excluded
+    from the allowlist (both have a data-driven code-execution surface); this
+    pins that they now resolve to CODE, and that the adversarial shapes which
+    justify the exclusion are real bypasses if they were ever allowlisted.
+  * `RealShellGroundTruthTests` — marker-proxy verification against an actual
+    `bash`/`zsh`, per shape, so a verdict is checked against what the shell
+    really does rather than against expectations.
+  * `RelayClassifierUnitTests` — pins the `_shell_parse` primitives directly
+    (constants, `_opener_feeds_interpreter`), including the regression this
+    fix's first draft introduced (`tee`/`cat` downstream must stay inert).
+  * `SiblingIssueMeasurementTests` — main#1170 (FIFO relay) and main#1171
+    (backslash-continuation relay) measurements: #1171 shares this fix's exact
+    root cause and closes incidentally; #1170 is a structurally different gap
+    (dataflow through a named pipe across `&`) and stays open. Both are
+    explicitly noted per the #1168 spawn brief rather than left implied.
+
+Run: ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/test_heredoc_relay_downstream.py -v
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_HOOKS_DIR = _HERE.parent
+sys.path.insert(0, str(_HOOKS_DIR))
+
+import validate_commit_identity as hook  # noqa: E402
+from _shell_parse import (  # noqa: E402
+    HEREDOC_DATA_SINKS,
+    HEREDOC_INERT_RELAY_FILTERS,
+    SHELL_INTERPRETERS,
+    classify_heredocs,
+    strip_data_heredocs,
+)
+
+REAL_COMMIT = 'git -c user.name="X" -c user.email="Y" commit -m z'
+
+
+def _bash(command: str) -> dict:
+    return {"tool_name": "Bash", "tool_input": {"command": command}}
+
+
+def _assert_blocked(test: unittest.TestCase, cmd: str) -> None:
+    result = hook.check(_bash(cmd))
+    test.assertIsNotNone(result, f"must block: {cmd!r}")
+    assert result is not None
+    test.assertEqual(result["decision"], "block")
+    test.assertIn("indirect-exec", result["reason"])
+
+
+def _assert_allowed(test: unittest.TestCase, cmd: str) -> None:
+    result = hook.check(_bash(cmd))
+    test.assertIsNone(
+        result,
+        f"must allow: {cmd!r} (got: {result['reason'].splitlines()[0] if result else ''})",
+    )
+
+
+class RelayBypassBlocksTests(unittest.TestCase):
+    """The primary shape from the issue, and the stated same-family variants."""
+
+    def test_xargs_dash_i_bash_dash_c_literal_repro(self):
+        """The exact reproduction from the #1168 issue body."""
+        _assert_blocked(
+            self, f"cat <<'DELIM' | xargs -I{{}} bash -c \"{{}}\"\n{REAL_COMMIT}\nDELIM"
+        )
+
+    def test_xargs_bash_c_single_quoted(self):
+        _assert_blocked(self, f"cat <<'DELIM' | xargs -I{{}} bash -c '{{}}'\n{REAL_COMMIT}\nDELIM")
+
+    def test_xargs_relay_via_tee_sink(self):
+        """`tee` (the other known data sink) as the OWNING segment, relayed
+        through `xargs` — both halves of the classifier exercised together."""
+        _assert_blocked(
+            self, f"tee <<'DELIM' | xargs -I{{}} bash -c \"{{}}\"\n{REAL_COMMIT}\nDELIM"
+        )
+
+    def test_xargs_relay_to_sh(self):
+        _assert_blocked(self, f"cat <<'DELIM' | xargs -I{{}} sh -c \"{{}}\"\n{REAL_COMMIT}\nDELIM")
+
+    def test_relay_chained_through_an_allowlisted_filter_first(self):
+        """A filter chain: `cat | wc` alone would stay data, but the same
+        pipeline continuing on to `xargs bash -c` must still resolve to CODE
+        — the walk must not stop early just because an early hop is inert."""
+        _assert_blocked(
+            self,
+            "cat <<'DELIM' | grep . | xargs -I{} bash -c \"{}\"\n" + REAL_COMMIT + "\nDELIM",
+        )
+
+    def test_unknown_relay_with_no_recognised_binary_at_all(self):
+        """A completely unrecognised relay name (not `xargs`, not anything
+        named in this module) must ALSO resolve to CODE — the fix is a
+        default-direction flip, not a `xargs`-specific special case."""
+        _assert_blocked(self, f"cat <<'DELIM' | some-custom-relay-tool -c\n{REAL_COMMIT}\nDELIM")
+
+    def test_pipe_ampersand_relay_variant(self):
+        """`|&` (main#1155's `2>&1 |` shorthand) reaching an unknown relay
+        must resolve the same way plain `|` does."""
+        _assert_blocked(
+            self, f"cat <<'DELIM' |& xargs -I{{}} bash -c \"{{}}\"\n{REAL_COMMIT}\nDELIM"
+        )
+
+
+class RelayFalsePositiveCorpusTests(unittest.TestCase):
+    """Every `HEREDOC_INERT_RELAY_FILTERS` member must stay ALLOW, individually
+    and in common combinations — the false-positive corpus the design
+    decision is measured against (see `RealShellGroundTruthTests` for the
+    real-shell ground truth backing each one)."""
+
+    # A representative, commonly-typed invocation per filter (not just the
+    # bare name) — the corpus must hold under ordinary flags, not just the
+    # zero-flag form.
+    REPRESENTATIVE_INVOCATIONS = {
+        "grep": "grep foo",
+        "egrep": "egrep foo",
+        "fgrep": "fgrep foo",
+        "wc": "wc -l",
+        "sort": "sort -u",
+        "uniq": "uniq -c",
+        "head": "head -n 5",
+        "tail": "tail -n 5",
+        "cut": "cut -d, -f1",
+        "tr": "tr a-z A-Z",
+        "column": "column -t",
+        "nl": "nl -ba",
+        "rev": "rev",
+        "fold": "fold -w 40",
+        "expand": "expand -t4",
+        "unexpand": "unexpand",
+        "base64": "base64",
+        "md5sum": "md5sum",
+        "sha1sum": "sha1sum",
+        "sha256sum": "sha256sum",
+        "sha512sum": "sha512sum",
+        "cksum": "cksum",
+        "od": "od -c",
+        "xxd": "xxd",
+        "hexdump": "hexdump -C",
+        "join": "join -j1 /dev/null -",
+        "paste": "paste -",
+        "comm": "comm -12 /dev/null -",
+        "tac": "tac",
+        "shuf": "shuf",
+        "jq": "jq -R .",
+    }
+
+    def test_every_allowlisted_filter_has_a_representative_case(self):
+        """The corpus table above must cover the WHOLE allowlist — a filter
+        added to `HEREDOC_INERT_RELAY_FILTERS` without a paired FP-corpus row
+        is exactly the kind of silent widening this fix must not do."""
+        self.assertEqual(set(self.REPRESENTATIVE_INVOCATIONS), set(HEREDOC_INERT_RELAY_FILTERS))
+
+    def test_each_allowlisted_filter_stays_allowed(self):
+        for name, invocation in self.REPRESENTATIVE_INVOCATIONS.items():
+            with self.subTest(filter=name):
+                _assert_allowed(self, f"cat <<'DELIM' | {invocation}\n{REAL_COMMIT}\nDELIM")
+
+    def test_chained_allowlisted_filters_stay_allowed(self):
+        """A realistic documentation pipeline chaining several filters."""
+        _assert_allowed(
+            self, f"cat <<'DELIM' | grep -v '^#' | sort | uniq -c\n{REAL_COMMIT}\nDELIM"
+        )
+
+    def test_tee_downstream_of_a_relay_chain_stays_allowed(self):
+        """`HEREDOC_DATA_SINKS` members (`cat`/`tee`) are exactly as inert
+        reached DOWNSTREAM of a filter as they are at the owning position —
+        this is the regression the first draft of this fix introduced and
+        that `RelayClassifierUnitTests` also pins directly."""
+        _assert_allowed(self, f"cat <<'DELIM' | grep foo | tee /tmp/out.txt\n{REAL_COMMIT}\nDELIM")
+
+    def test_plain_tee_sink_still_allowed_unpiped(self):
+        _assert_allowed(self, f"cat <<'DELIM' | tee /tmp/a.md\n{REAL_COMMIT}\nDELIM")
+
+    def test_pipe_ampersand_to_data_sink_still_allowed(self):
+        _assert_allowed(self, f"cat <<'DELIM' |& tee /tmp/a\n{REAL_COMMIT}\nDELIM")
+
+
+class RelayExcludedFiltersBlockTests(unittest.TestCase):
+    """`sed`/`awk` are common "obviously inert filter" examples but carry a
+    data-driven code-execution surface (real-shell-verified — see
+    `RealShellGroundTruthTests`), so they are DELIBERATELY excluded from
+    `HEREDOC_INERT_RELAY_FILTERS`. This costs a false positive on ordinary
+    `sed`/`awk` documentation pipelines, accepted per the module comment."""
+
+    def test_sed_not_in_allowlist(self):
+        self.assertNotIn("sed", HEREDOC_INERT_RELAY_FILTERS)
+
+    def test_awk_not_in_allowlist(self):
+        self.assertNotIn("awk", HEREDOC_INERT_RELAY_FILTERS)
+
+    def test_plain_sed_now_blocks_accepted_false_positive(self):
+        """An ORDINARY, harmless `sed` substitution — the false-positive cost
+        this exclusion accepts."""
+        _assert_blocked(self, f"cat <<'DELIM' | sed 's/x/y/'\n{REAL_COMMIT}\nDELIM")
+
+    def test_plain_awk_now_blocks_accepted_false_positive(self):
+        _assert_blocked(self, f"cat <<'DELIM' | awk '{{print}}'\n{REAL_COMMIT}\nDELIM")
+
+    def test_sed_e_flag_would_be_a_real_bypass_if_allowlisted(self):
+        """The adversarial shape that justifies excluding `sed`: the GNU `e`
+        flag executes the (input-derived) pattern space as a shell command.
+        Confirmed BLOCKED under the current (exclude) policy; `sed` must
+        never be added to the allowlist without also gating this flag."""
+        _assert_blocked(self, f"cat <<'DELIM' | sed 's/.*/&/e'\n{REAL_COMMIT}\nDELIM")
+
+    def test_awk_system_would_be_a_real_bypass_if_allowlisted(self):
+        _assert_blocked(self, f"cat <<'DELIM' | awk '{{system($0)}}'\n{REAL_COMMIT}\nDELIM")
+
+
+@unittest.skipUnless(shutil.which("bash"), "bash not installed")
+class RealShellGroundTruthTests(unittest.TestCase):
+    """Marker-proxy verification against a REAL shell: a marker command is
+    appended to a log file inside the heredoc body, and the test checks
+    whether the log was actually written — not whether the verdict "looks
+    safe". Every shape here is checked BOTH ways: the hook's verdict AND the
+    real-shell ground truth, and the test fails if they disagree in the
+    dangerous direction (shell runs it, hook allows it).
+    """
+
+    SHELLS = tuple(s for s in ("bash", "zsh") if shutil.which(s))
+
+    def setUp(self) -> None:
+        self._tmpdir = tempfile.mkdtemp(prefix="relay-ground-truth-")
+        self.addCleanup(shutil.rmtree, self._tmpdir, ignore_errors=True)
+        self._log = str(Path(self._tmpdir) / "marker.log")
+
+    def _shell_actually_runs(self, template: str, shell: str) -> bool:
+        """True if `template` (with MARKER substituted) genuinely executes
+        the marker command under `shell`. Uses a marker echo rather than a
+        literal `git commit` string so the probe script itself is not what
+        it is testing (an actual `git commit` line would also be scanned by
+        this repo's OWN commit-identity hook when this test file is committed
+        — the marker keeps the fixture inert to that unrelated concern)."""
+        marker_cmd = f"echo RAN >> {self._log}"
+        cmd = template.replace("MARKER", marker_cmd)
+        Path(self._log).unlink(missing_ok=True)
+        subprocess.run(
+            [shell, "-c", cmd],
+            cwd=self._tmpdir,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        return Path(self._log).exists() and Path(self._log).stat().st_size > 0
+
+    def _hook_blocks(self, template: str) -> bool:
+        cmd = template.replace("MARKER", REAL_COMMIT)
+        result = hook.check(_bash(cmd))
+        return result is not None and result.get("decision") == "block"
+
+    def _assert_ground_truth_matches_verdict(self, template: str, *, expect_runs: bool) -> None:
+        for shell in self.SHELLS:
+            with self.subTest(shell=shell, template=template):
+                runs = self._shell_actually_runs(template, shell)
+                self.assertEqual(
+                    runs,
+                    expect_runs,
+                    f"{shell} {'did not run' if expect_runs else 'ran'} the marker for: {template}",
+                )
+        blocked = self._hook_blocks(template)
+        if expect_runs:
+            self.assertTrue(
+                blocked, f"shell genuinely runs this body but hook allows it: {template}"
+            )
+        else:
+            self.assertFalse(blocked, f"shell never runs this body but hook blocks it: {template}")
+
+    # --- relay shapes: shell genuinely runs the body -----------------------
+
+    def test_xargs_bash_dash_c_relay_genuinely_runs(self):
+        self._assert_ground_truth_matches_verdict(
+            "cat <<'DELIM' | xargs -I{} bash -c \"{}\"\nMARKER\nDELIM",
+            expect_runs=True,
+        )
+
+    def test_xargs_sh_dash_c_relay_genuinely_runs(self):
+        self._assert_ground_truth_matches_verdict(
+            "cat <<'DELIM' | xargs -I{} sh -c \"{}\"\nMARKER\nDELIM",
+            expect_runs=True,
+        )
+
+    # --- allowlisted filters: shell genuinely does NOT run the body --------
+
+    def test_grep_relay_genuinely_inert(self):
+        self._assert_ground_truth_matches_verdict(
+            "cat <<'DELIM' | grep MARKERPATTERN_ABSENT\nMARKER\nDELIM",
+            expect_runs=False,
+        )
+
+    def test_wc_relay_genuinely_inert(self):
+        self._assert_ground_truth_matches_verdict(
+            "cat <<'DELIM' | wc -l\nMARKER\nDELIM",
+            expect_runs=False,
+        )
+
+    def test_sort_relay_genuinely_inert(self):
+        self._assert_ground_truth_matches_verdict(
+            "cat <<'DELIM' | sort\nMARKER\nDELIM",
+            expect_runs=False,
+        )
+
+    def test_column_relay_genuinely_inert(self):
+        self._assert_ground_truth_matches_verdict(
+            "cat <<'DELIM' | column -t\nMARKER\nDELIM",
+            expect_runs=False,
+        )
+
+    def test_base64_relay_genuinely_inert(self):
+        self._assert_ground_truth_matches_verdict(
+            "cat <<'DELIM' | base64\nMARKER\nDELIM",
+            expect_runs=False,
+        )
+
+    def test_tee_downstream_of_a_filter_genuinely_inert(self):
+        self._assert_ground_truth_matches_verdict(
+            "cat <<'DELIM' | grep -v NOPE | tee /dev/null\nMARKER\nDELIM",
+            expect_runs=False,
+        )
+
+    # --- excluded filters: the adversarial flag genuinely runs the body ----
+
+    def test_sed_plain_genuinely_inert_but_excluded_anyway(self):
+        """Ground truth: plain `sed` substitution does NOT execute the body
+        (confirms the false-positive cost is real, not imagined). Deliberately
+        NOT run through `_assert_ground_truth_matches_verdict` — that helper
+        asserts the hook verdict MATCHES shell reality, which is the wrong
+        check here: this is the ACCEPTED false positive (hook blocks even
+        though the shell would not run it), not a bug to catch."""
+        template = "cat <<'DELIM' | sed 's/x/y/'\nMARKER\nDELIM"
+        for shell in self.SHELLS:
+            with self.subTest(shell=shell):
+                self.assertFalse(
+                    self._shell_actually_runs(template, shell),
+                    f"{shell} unexpectedly ran a plain sed substitution",
+                )
+        self.assertTrue(
+            self._hook_blocks(template),
+            "sed is excluded from the allowlist, so this accepted false positive must still block",
+        )
+
+    def test_sed_e_flag_genuinely_runs(self):
+        """The adversarial case: ground truth confirms `sed`'s `e` flag really
+        does execute input-derived text as a shell command — this is why
+        `sed` stays off the allowlist entirely, not gated per-invocation."""
+        self._assert_ground_truth_matches_verdict(
+            "cat <<'DELIM' | sed 's/.*/&/e'\nMARKER\nDELIM",
+            expect_runs=True,
+        )
+
+    def test_awk_system_genuinely_runs(self):
+        self._assert_ground_truth_matches_verdict(
+            "cat <<'DELIM' | awk '{system($0)}'\nMARKER\nDELIM",
+            expect_runs=True,
+        )
+
+
+class RelayClassifierUnitTests(unittest.TestCase):
+    """Pins the `_shell_parse` primitives directly, so a failure localises to
+    the classifier rather than only to the hook's aggregate verdict."""
+
+    def test_xargs_not_in_either_allowlist(self):
+        """`xargs` — the primary relay named in the issue — must be neither a
+        known data sink nor a known-inert filter: it is the unresolved case
+        the fix's new default exists to catch."""
+        self.assertNotIn("xargs", HEREDOC_DATA_SINKS)
+        self.assertNotIn("xargs", HEREDOC_INERT_RELAY_FILTERS)
+
+    def test_allowlists_are_disjoint(self):
+        """`HEREDOC_DATA_SINKS` and `HEREDOC_INERT_RELAY_FILTERS` answer
+        different questions (write-to-file vs. filter-in-place); a name
+        should not need to live in both."""
+        self.assertEqual(set(), HEREDOC_DATA_SINKS & HEREDOC_INERT_RELAY_FILTERS)
+
+    def test_interpreters_and_inert_filters_are_disjoint(self):
+        self.assertEqual(set(), SHELL_INTERPRETERS & HEREDOC_INERT_RELAY_FILTERS)
+
+    def test_classify_heredocs_marks_relay_span_code(self):
+        (span,) = classify_heredocs(
+            f"cat <<'DELIM' | xargs -I{{}} bash -c \"{{}}\"\n{REAL_COMMIT}\nDELIM"
+        )
+        self.assertTrue(span.is_code)
+
+    def test_classify_heredocs_marks_allowlisted_filter_span_data(self):
+        (span,) = classify_heredocs(f"cat <<'DELIM' | grep foo\n{REAL_COMMIT}\nDELIM")
+        self.assertFalse(span.is_code)
+
+    def test_strip_data_heredocs_erases_allowlisted_filter_body(self):
+        cmd = f"cat <<'DELIM' | wc -l\n{REAL_COMMIT}\nDELIM"
+        out = strip_data_heredocs(cmd)
+        self.assertNotIn("commit", out)
+
+    def test_strip_data_heredocs_keeps_relay_body(self):
+        cmd = f"cat <<'DELIM' | xargs -I{{}} bash -c \"{{}}\"\n{REAL_COMMIT}\nDELIM"
+        out = strip_data_heredocs(cmd)
+        self.assertIn("commit", out)
+
+    def test_multi_hop_pipeline_stops_walk_correctly_at_end_of_segments(self):
+        """A pipeline ending in an allowlisted filter (nothing after it) must
+        resolve overall to DATA — the loop must not spuriously continue past
+        the last segment."""
+        (span,) = classify_heredocs(f"cat <<'DELIM' | grep foo | sort | uniq\n{REAL_COMMIT}\nDELIM")
+        self.assertFalse(span.is_code)
+
+
+class SiblingIssueMeasurementTests(unittest.TestCase):
+    """main#1170 / main#1171 measurements, per the #1168 spawn brief's
+    explicit instruction to report (not silently leave implied) whether this
+    fix incidentally closes either sibling. Both touch the SAME file and are
+    held as separate PRs; these tests only MEASURE the current state, they do
+    not claim ownership of either issue.
+    """
+
+    def test_1171_backslash_continuation_relay_closes_incidentally(self):
+        """main#1171: `cat <<'D' | \\` + newline + `bash` — the issue's own
+        root-cause diagnosis names this classifier's downstream branch
+        explicitly ("the same fail-open downstream branch as main#1168"), so
+        this fix's default-flip closes it as a side effect, not by folding
+        physical lines into logical ones (#1171's own suggested proper fix,
+        still undone)."""
+        cmd = "cat <<'D' | \\\nbash\n" + REAL_COMMIT + "\nD"
+        _assert_blocked(self, cmd)
+
+    def test_1171_continued_prose_opener_false_positive_still_allowed(self):
+        """#1171's own acceptance bullet: a continuation INSIDE a data
+        heredoc's opener line, with no interpreter at all, must stay ALLOW."""
+        cmd = "cat > \\\nnotes.md <<'EOF'\nsome prose about bash -c 'foo'\nEOF"
+        _assert_allowed(self, cmd)
+
+    def test_1170_fifo_relay_measured_still_open(self):
+        """main#1170: `mkfifo p; bash < p & cat <<'D' > p` — a structurally
+        different gap (dataflow through a named pipe across a `&`
+        background-job boundary, not a `|`-connected pipeline segment this
+        fix's walk ever reaches). Measured to remain ALLOW after this fix;
+        NOT folded in per the spawn brief's explicit scope boundary. This
+        test pins today's measurement and is expected to start FAILING (in
+        the good direction) once #1170 lands its own fix — at which point it
+        should be deleted, not "fixed" to assert BLOCK, since that fix
+        belongs to #1170's own PR.
+        """
+        cmd = "mkfifo p; bash < p & cat <<'D' > p\n" + REAL_COMMIT + "\nD"
+        _assert_allowed(self, cmd)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/.claude/hooks/tests/test_heredoc_relay_downstream.py
+++ b/.claude/hooks/tests/test_heredoc_relay_downstream.py
@@ -33,11 +33,23 @@ threshold). Dropped from the allowlist for the same reason `sed`/`awk` are
 excluded — a plain invocation being inert does not make the command safe to
 allowlist wholesale, and a per-flag detector for `--compress-program` would
 reintroduce exactly the per-command grammar this set is designed to avoid.
-Folded in alongside it: `rg`, which was previously absent from the allowlist
-while `grep` (forbidden org-wide by main#1008) was present — the inverse of
-what this org mandates. `rg`'s exec-shaped flags (`--pre`, `-z`) are
-documented to apply only "for each input PATH"; measured genuinely inert on a
-heredoc-fed stdin pipe in both bash and zsh, plain and exec-shaped.
+main#1316 (second pass — merge-gate finding on the SAME PR): `rg` was folded
+INTO the allowlist by this fix's first pass, on the reasoning that `grep`
+(forbidden org-wide by main#1008) was on the list while its mandated
+replacement `rg` was not. That measurement covered only the no-PATH stdin-pipe
+form of `rg --pre=COMMAND`; ripgrep's own docs say `--pre` runs "for each input
+PATH", and a PATH is attacker-supplied — naming the pipe itself (`/dev/stdin`,
+`/dev/fd/0`) gives `--pre` a PATH even on a pure stdin pipe, and `rg` runs
+`COMMAND PATH` with that path opened on the child's own stdin, so
+`sh /dev/stdin` genuinely executes the heredoc body (measured, both bash and
+zsh). `rg` is now EXCLUDED from the allowlist entirely, same posture as
+`sed`/`awk`/`sort` below — a plain-form measurement is not sufficient, and a
+per-flag gate for `--pre` would reintroduce the per-command grammar this set
+avoids. `rg` also exposes `--hostname-bin=COMMAND`, a second exec-shaped flag
+that spawns an arbitrary program on a pure stdin pipe (no PATH needed) but
+does not itself reach the heredoc body. The #1008 contradiction (this
+allowlist admits forbidden `grep` while excluding mandated `rg`) is left OPEN
+by this exclusion — see the PR body.
 
 Test organisation
 ==================
@@ -46,12 +58,13 @@ Test organisation
     real `check()`.
   * `RelayFalsePositiveCorpusTests` — every `HEREDOC_INERT_RELAY_FILTERS`
     member, individually and chained, must stay ALLOW.
-  * `RelayExcludedFiltersBlockTests` — `sed`/`awk`/`sort` are DELIBERATELY
-    excluded from the allowlist (each has a data-driven code-execution
-    surface reachable through an exec-shaped flag — `sed`'s `e` flag, `awk`'s
-    `system()`, `sort`'s `--compress-program`); this pins that they now
-    resolve to CODE, and that the adversarial shapes which justify the
-    exclusion are real bypasses if they were ever allowlisted.
+  * `RelayExcludedFiltersBlockTests` — `sed`/`awk`/`sort`/`rg` are
+    DELIBERATELY excluded from the allowlist (each has a data-driven
+    code-execution surface reachable through an exec-shaped flag — `sed`'s
+    `e` flag, `awk`'s `system()`, `sort`'s `--compress-program`, `rg`'s
+    `--pre=COMMAND` with an attacker-supplied `/dev/stdin` PATH); this pins
+    that they now resolve to CODE, and that the adversarial shapes which
+    justify the exclusion are real bypasses if they were ever allowlisted.
   * `RealShellGroundTruthTests` — marker-proxy verification against an actual
     `bash`/`zsh`, per shape, so a verdict is checked against what the shell
     really does rather than against expectations.
@@ -197,7 +210,6 @@ class RelayFalsePositiveCorpusTests(unittest.TestCase):
         "tac": "tac",
         "shuf": "shuf",
         "jq": "jq -R .",
-        "rg": "rg foo",
     }
 
     def test_every_allowlisted_filter_has_a_representative_case(self):
@@ -234,13 +246,18 @@ class RelayFalsePositiveCorpusTests(unittest.TestCase):
 
 
 class RelayExcludedFiltersBlockTests(unittest.TestCase):
-    """`sed`/`awk`/`sort` are common "obviously inert filter" examples but
+    """`sed`/`awk`/`sort`/`rg` are common "obviously inert filter" examples but
     each carries a data-driven code-execution surface (real-shell-verified —
     see `RealShellGroundTruthTests`), so they are DELIBERATELY excluded from
     `HEREDOC_INERT_RELAY_FILTERS`. This costs a false positive on ordinary
-    `sed`/`awk`/`sort` documentation pipelines, accepted per the module
-    comment. `sort` was excluded in main#1316, after having shipped on the
-    allowlist measured only on its plain (no `--compress-program`) form."""
+    `sed`/`awk`/`sort`/`rg` documentation pipelines, accepted per the module
+    comment. `sort` was excluded in main#1316 (first pass), after having
+    shipped on the allowlist measured only on its plain (no
+    `--compress-program`) form. `rg` was excluded in main#1316's SECOND pass
+    (this rework) after having been ADDED in the same PR's first pass on a
+    measurement that covered only the no-PATH stdin-pipe form of `--pre` —
+    the same "measure the plain/context-fixed form only" mistake `sort` had
+    just been dropped for."""
 
     def test_sed_not_in_allowlist(self):
         self.assertNotIn("sed", HEREDOC_INERT_RELAY_FILTERS)
@@ -250,6 +267,9 @@ class RelayExcludedFiltersBlockTests(unittest.TestCase):
 
     def test_sort_not_in_allowlist(self):
         self.assertNotIn("sort", HEREDOC_INERT_RELAY_FILTERS)
+
+    def test_rg_not_in_allowlist(self):
+        self.assertNotIn("rg", HEREDOC_INERT_RELAY_FILTERS)
 
     def test_plain_sed_now_blocks_accepted_false_positive(self):
         """An ORDINARY, harmless `sed` substitution — the false-positive cost
@@ -265,6 +285,13 @@ class RelayExcludedFiltersBlockTests(unittest.TestCase):
         false-positive cost this exclusion accepts, same posture as
         `sed`/`awk` above."""
         _assert_blocked(self, f"cat <<'DELIM' | sort\n{REAL_COMMIT}\nDELIM")
+
+    def test_plain_rg_now_blocks_accepted_false_positive(self):
+        """An ORDINARY, harmless bare `rg` search — genuinely inert (see
+        `RealShellGroundTruthTests`), but no longer allowlisted; the
+        false-positive cost this exclusion accepts, same posture as
+        `sed`/`awk`/`sort` above."""
+        _assert_blocked(self, f"cat <<'DELIM' | rg foo\n{REAL_COMMIT}\nDELIM")
 
     def test_sed_e_flag_would_be_a_real_bypass_if_allowlisted(self):
         """The adversarial shape that justifies excluding `sed`: the GNU `e`
@@ -285,6 +312,24 @@ class RelayExcludedFiltersBlockTests(unittest.TestCase):
         _assert_blocked(
             self,
             "cat <<'DELIM' | sort --compress-program=/tmp/marker.sh\n" + REAL_COMMIT + "\nDELIM",
+        )
+
+    def test_rg_pre_dev_stdin_would_be_a_real_bypass_if_allowlisted(self):
+        """The adversarial shape that justifies excluding `rg`: `--pre=COMMAND`
+        runs `COMMAND PATH` once for each input PATH, and the PATH is
+        attacker-supplied — naming the pipe itself (`/dev/stdin`) gives
+        `--pre` a PATH even though the input is a pure stdin pipe, and `rg`
+        runs `COMMAND PATH` with that path opened on the child's own stdin,
+        so `sh /dev/stdin` genuinely executes the heredoc body. Confirmed
+        BLOCKED under the current (exclude) policy; `rg` must never be
+        re-added to the allowlist without also gating this flag (and
+        `--hostname-bin`, a second exec-shaped flag — see the module
+        comment). Deliberately varies the PATH (`/dev/stdin`) rather than
+        fixing it at none, unlike this same allowlist's own first-pass
+        `rg --pre` measurement, which is exactly why that pass missed this."""
+        _assert_blocked(
+            self,
+            "cat <<'DELIM' | rg --pre=/bin/sh pat /dev/stdin\n" + REAL_COMMIT + "\nDELIM",
         )
 
 
@@ -404,33 +449,6 @@ class RealShellGroundTruthTests(unittest.TestCase):
             expect_runs=False,
         )
 
-    def test_rg_relay_genuinely_inert(self):
-        self._assert_ground_truth_matches_verdict(
-            "cat <<'DELIM' | rg MARKERPATTERN_ABSENT\nMARKER\nDELIM",
-            expect_runs=False,
-        )
-
-    def test_rg_pre_flag_genuinely_inert_on_stdin(self):
-        """`rg --pre COMMAND` is documented to apply only "for each input
-        PATH"; a heredoc-fed pipe has no PATH (it is stdin), so the flag is a
-        no-op here — measured, not assumed from the docs. Uses a real marker
-        script (not an inline MARKER substitution) since `--pre` names an
-        external program, exactly like the `sort --compress-program` probe
-        below; if `--pre` ever fired on stdin, this script would append to
-        its own log and this test would fail loudly."""
-        marker = self._write_marker_passthrough_script()
-        template = f"cat <<'DELIM' | rg --pre {marker} commit\nMARKER\nDELIM"
-        for shell in self.SHELLS:
-            with self.subTest(shell=shell):
-                self.assertFalse(
-                    self._shell_actually_runs(template, shell),
-                    f"{shell} invoked `rg --pre` on a stdin pipe (no PATH) — should be a no-op",
-                )
-        self.assertFalse(
-            self._hook_blocks(f"cat <<'DELIM' | rg --pre {marker} commit\nMARKER\nDELIM"),
-            "rg is allowlisted; --pre must not newly false-block",
-        )
-
     # --- excluded filters: the adversarial flag genuinely runs the body ----
 
     def test_sed_plain_genuinely_inert_but_excluded_anyway(self):
@@ -495,6 +513,117 @@ class RealShellGroundTruthTests(unittest.TestCase):
             self._hook_blocks(f"cat <<'DELIM' | sort --compress-program={marker}\nMARKER\nDELIM"),
             "sort is excluded from the allowlist, so this must still block",
         )
+
+    def test_rg_plain_genuinely_inert_but_excluded_anyway(self):
+        """Ground truth: a bare `rg` search over stdin (no PATH argument, no
+        exec-shaped flag) does NOT execute the body — confirms the
+        false-positive cost `rg`'s exclusion accepts is real, not imagined,
+        same posture as `sed`/`sort` above."""
+        template = "cat <<'DELIM' | rg MARKERPATTERN_ABSENT\nMARKER\nDELIM"
+        for shell in self.SHELLS:
+            with self.subTest(shell=shell):
+                self.assertFalse(
+                    self._shell_actually_runs(template, shell),
+                    f"{shell} unexpectedly ran a plain rg search",
+                )
+        self.assertTrue(
+            self._hook_blocks(template),
+            "rg is excluded from the allowlist, so this accepted false positive must still block",
+        )
+
+    def test_rg_pre_flag_inert_without_a_path(self):
+        """The CONTEXT-FIXED measurement from main#1316's FIRST pass (the one
+        that got `rg` added to the allowlist in error): with no PATH argument
+        at all, `--pre` really is a no-op — rg reads stdin directly and never
+        invokes `--pre`'s COMMAND. Kept as a documented contrast with
+        `test_rg_pre_dev_stdin_path_genuinely_runs` immediately below: the
+        PATH is the variable that matters, and it is the ATTACKER'S to
+        supply, not a fixed property of the shape — measuring only this cell
+        is exactly the mistake that let `rg` onto the allowlist the first
+        time. `rg` is fully excluded regardless (second pass), so the hook
+        blocks here too, same as any other excluded-filter accepted false
+        positive; this test's job is only to confirm the shell-side no-op,
+        not the hook's verdict."""
+        marker = self._write_marker_passthrough_script()
+        template = f"cat <<'DELIM' | rg --pre={marker} commit\nMARKER\nDELIM"
+        for shell in self.SHELLS:
+            with self.subTest(shell=shell):
+                self.assertFalse(
+                    self._shell_actually_runs(template, shell),
+                    f"{shell} invoked `rg --pre` with no PATH — should still be a no-op",
+                )
+        self.assertTrue(
+            self._hook_blocks(f"cat <<'DELIM' | rg --pre={marker} commit\nMARKER\nDELIM"),
+            "rg is excluded from the allowlist entirely, so this must block "
+            "regardless of whether --pre happens to be a no-op in this particular cell",
+        )
+
+    def test_rg_pre_dev_stdin_path_genuinely_runs(self):
+        """The adversarial case that justifies excluding `rg` (main#1316
+        second pass): `--pre=COMMAND` runs `COMMAND PATH` once for each input
+        PATH, and the PATH is attacker-supplied. Naming the pipe itself
+        (`/dev/stdin`) gives `--pre` a PATH even though the input is a pure
+        stdin pipe, and rg runs `COMMAND PATH` with that path opened on the
+        child's own stdin — so `sh /dev/stdin` genuinely executes the
+        heredoc body. Deliberately VARIES the PATH (unlike the no-PATH test
+        immediately above) — this is the row this fix's own first-pass test
+        (`test_rg_pre_flag_genuinely_inert_on_stdin`, since removed/replaced)
+        was missing, and the whole reason that test alone was not sufficient
+        to allowlist `rg` safely."""
+        self._assert_ground_truth_matches_verdict(
+            "cat <<'DELIM' | rg --pre=/bin/sh pat /dev/stdin\nMARKER\nDELIM",
+            expect_runs=True,
+        )
+
+    def test_rg_hostname_bin_spawns_a_program_but_does_not_reach_the_body(self):
+        """`rg` exposes a SECOND exec-shaped flag, `--hostname-bin=COMMAND`,
+        found by the same systematic per-flag sweep that caught `--pre`.
+        Ground truth: it spawns COMMAND even on a pure stdin pipe with no
+        PATH at all — but the spawned child receives no arguments and does
+        not inherit the heredoc's stdin, so it never reaches the heredoc
+        body itself. Pinned here (rather than left as prose only) because
+        its existence falsifies any claim that every `rg` flag is harmless
+        on a heredoc-fed stdin pipe — the module comment names it explicitly
+        for exactly this reason, and this test guards against that comment
+        going stale if a future ripgrep version changes the behaviour.
+
+        Uses TWO independent logs, not one: `_write_marker_passthrough_script`
+        (used elsewhere in this class) writes its "I was invoked" marker to
+        the SAME log the body-execution check reads, which cannot
+        distinguish "the flag's program was spawned" from "the spawned
+        program then read the heredoc body" — exactly the two outcomes this
+        test needs to tell apart. `spawn_log` proves the flag's COMMAND ran
+        at all; `body_log` proves the heredoc body's own marker command ran;
+        the claim being pinned is spawn=True, body=False."""
+        spawn_log = str(Path(self._tmpdir) / "hostname_bin_spawn.log")
+        body_log = str(Path(self._tmpdir) / "hostname_bin_body.log")
+        script = Path(self._tmpdir) / "hostname_bin.sh"
+        script.write_text(f"#!/bin/sh\necho SPAWNED >> {spawn_log}\ncat\n")
+        script.chmod(0o755)
+        template = f"cat <<'DELIM' | rg --hostname-bin={script} --json pat\nMARKER\nDELIM"
+        for shell in self.SHELLS:
+            with self.subTest(shell=shell):
+                Path(spawn_log).unlink(missing_ok=True)
+                Path(body_log).unlink(missing_ok=True)
+                marker_cmd = f"echo BODYRAN >> {body_log}"
+                cmd = template.replace("MARKER", marker_cmd)
+                subprocess.run(
+                    [shell, "-c", cmd],
+                    cwd=self._tmpdir,
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                )
+                self.assertTrue(
+                    Path(spawn_log).exists(),
+                    f"{shell}: --hostname-bin never spawned its COMMAND — the flag "
+                    "may no longer be exec-shaped in this ripgrep version",
+                )
+                self.assertFalse(
+                    Path(body_log).exists(),
+                    f"{shell}: --hostname-bin unexpectedly reached the heredoc body "
+                    "— this would make it a real bypass, not just a spawn",
+                )
 
     def test_sed_e_flag_genuinely_runs(self):
         """The adversarial case: ground truth confirms `sed`'s `e` flag really

--- a/.claude/hooks/tests/test_heredoc_relay_downstream.py
+++ b/.claude/hooks/tests/test_heredoc_relay_downstream.py
@@ -51,6 +51,22 @@ does not itself reach the heredoc body. The #1008 contradiction (this
 allowlist admits forbidden `grep` while excluding mandated `rg`) is left OPEN
 by this exclusion — see the PR body.
 
+main#1316 (third pass — CI-only red, #1318): the `rg` ground-truth rows above
+passed locally but failed on the CI runner. Root cause: `ci.yml` never
+installed ripgrep, so `rg` was simply absent on `ubuntu-latest` — the
+`--pre`/`--hostname-bin` rows either genuinely failed (an `expect_runs=True`
+assertion, loud) or, worse, would have passed VACUOUSLY had they asserted
+`expect_runs=False` (the shell never even attempts a missing binary, which is
+indistinguishable from a real inertness result). That means the FIRST-pass
+measurement that got `rg` allowlisted in error was never actually exercised
+against `rg` on CI at all — a vacuous pass, not a green light. Fixed by
+installing ripgrep in the pytest job (same "install it so it RUNS in CI
+rather than skipping" pattern already used for bashlex/zsh above), with a
+`skipUnless(shutil.which("rg"))` guard kept alongside — not instead — as a
+documented fallback for a runner that genuinely lacks it (a guard with no
+install would just convert the vacuous pass back into a silent skip, which is
+the state that let this happen in the first place).
+
 Test organisation
 ==================
 
@@ -103,6 +119,26 @@ from _shell_parse import (  # noqa: E402
 )
 
 REAL_COMMIT = 'git -c user.name="X" -c user.email="Y" commit -m z'
+
+# main#1316/#1318: `rg` is not part of the base ubuntu-latest image (unlike
+# grep/sed/awk/sort/coreutils, which ship on every runner). A missing binary
+# is directional poison for a ground-truth row: an `expect_runs=False`
+# assertion passes VACUOUSLY when the shell never even attempts `rg` (measures
+# nothing, looks identical to a real inertness result), while an
+# `expect_runs=True` assertion fails loudly (the real bug signal that
+# surfaced this). `ci.yml` now installs ripgrep for the pytest job so these
+# rows normally RUN rather than skip; this guard is the documented fallback
+# for a runner that genuinely lacks it, not a substitute for the install —
+# per main#1318's finding, a guard alone would just convert the vacuous pass
+# back into a silent skip, which is the state that let `rg` reach the
+# allowlist in the first place.
+_RG_INSTALLED = shutil.which("rg") is not None
+_RG_SKIP_REASON = (
+    "rg not installed on this runner — see main#1316/#1318: without it this "
+    "row cannot measure real rg behaviour (an expect_runs=False assertion "
+    "would pass vacuously); ci.yml installs ripgrep for the pytest job so "
+    "this should normally run here, not skip"
+)
 
 
 def _bash(command: str) -> dict:
@@ -514,6 +550,7 @@ class RealShellGroundTruthTests(unittest.TestCase):
             "sort is excluded from the allowlist, so this must still block",
         )
 
+    @unittest.skipUnless(_RG_INSTALLED, _RG_SKIP_REASON)
     def test_rg_plain_genuinely_inert_but_excluded_anyway(self):
         """Ground truth: a bare `rg` search over stdin (no PATH argument, no
         exec-shaped flag) does NOT execute the body — confirms the
@@ -531,6 +568,7 @@ class RealShellGroundTruthTests(unittest.TestCase):
             "rg is excluded from the allowlist, so this accepted false positive must still block",
         )
 
+    @unittest.skipUnless(_RG_INSTALLED, _RG_SKIP_REASON)
     def test_rg_pre_flag_inert_without_a_path(self):
         """The CONTEXT-FIXED measurement from main#1316's FIRST pass (the one
         that got `rg` added to the allowlist in error): with no PATH argument
@@ -558,6 +596,7 @@ class RealShellGroundTruthTests(unittest.TestCase):
             "regardless of whether --pre happens to be a no-op in this particular cell",
         )
 
+    @unittest.skipUnless(_RG_INSTALLED, _RG_SKIP_REASON)
     def test_rg_pre_dev_stdin_path_genuinely_runs(self):
         """The adversarial case that justifies excluding `rg` (main#1316
         second pass): `--pre=COMMAND` runs `COMMAND PATH` once for each input
@@ -575,6 +614,7 @@ class RealShellGroundTruthTests(unittest.TestCase):
             expect_runs=True,
         )
 
+    @unittest.skipUnless(_RG_INSTALLED, _RG_SKIP_REASON)
     def test_rg_hostname_bin_spawns_a_program_but_does_not_reach_the_body(self):
         """`rg` exposes a SECOND exec-shaped flag, `--hostname-bin=COMMAND`,
         found by the same systematic per-flag sweep that caught `--pre`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,20 @@ jobs:
       # bare checkout without it).
       - name: Install zsh (second shell-truth oracle)
         run: sudo apt-get update && sudo apt-get install -y zsh
+      # ripgrep (main#1316/#1318): `RealShellGroundTruthTests` real-shell-
+      # verifies the `rg`-exclusion's adversarial rows (`--pre=.../dev/stdin`,
+      # `--hostname-bin`) against an actual `rg` binary. This runner image does
+      # not ship ripgrep, so those rows were previously either genuinely
+      # failing (an expect_runs=True row: `rg: command not found`, so the
+      # marker never ran) or passing VACUOUSLY (an expect_runs=False row is
+      # trivially true when the shell never even attempts `rg` — measuring
+      # nothing while looking identical to a real inertness result). Install
+      # it so the measurement actually RUNS in CI, same pattern as the
+      # bashlex/zsh installs above — a `skipUnless(which("rg"))` guard alone
+      # would only convert the loud failure back into a silent skip, which is
+      # the state that let `rg` reach the allowlist in the first place.
+      - name: Install ripgrep (real-shell ground truth for the rg exclusion)
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
       - name: Run hook and lib tests
         run: pytest .claude/hooks/tests/ .claude/lib/tests/ -q
       # .claude/skills/*/tests/ added per #326. Run PER-SKILL (each from its own


### PR DESCRIPTION
## Summary

Closes #1168. `_opener_feeds_interpreter`'s downstream pipe-follow walk resolved an unrecognised segment head toward DATA — backwards relative to main#1152's own rule (every ambiguity resolves toward CODE). A RELAY command that is not itself a `SHELL_INTERPRETERS` member but hands its stdin to one (`xargs -I{} bash -c "{}"`, and the same family via `parallel`/`env -S`) defeated the walk:

```
cat <<'DELIM' | xargs -I{} bash -c "{}"
git -c user.name="X" -c user.email="Y" commit -m z
DELIM
```

Real-shell-verified (marker proxy) at both `fea0dca` (main) and PR #1155's head `e163320` — pre-existing, not a #1155 regression, per the issue.

## The design decision — allowlist default, and why

An allowlist's safety property IS its default. The fix flips the downstream default to **CODE**: an unrecognised/unresolved segment head (including one that fails to tokenize at all) now resolves to CODE, not DATA. `HEREDOC_INERT_RELAY_FILTERS` (new, in `_shell_parse.py`, mirroring `HEREDOC_DATA_SINKS`'s existing posture) is the narrow escape hatch — **an unlisted filter fails toward CODE**, full stop.

`HEREDOC_DATA_SINKS` members (`cat`, `tee`) also stay inert when reached *downstream* of a pipe (e.g. `cat <<EOF | grep foo | tee /tmp/out`), not just at the owning position — this was a regression the first draft of this fix introduced (see Mutation M2 below) and is now covered by its own tests.

## False-positive corpus — real-shell ground truth

Built a marker-proxy probe (a command appended to a log file inside the heredoc body, checked for the log actually being written) against real `bash`/`zsh` **before** choosing the allowlist's contents:

| Command | Ground truth (does the shell run the body?) | In allowlist? |
|---|---|---|
| `grep`, `egrep`, `fgrep` | DID-NOT-RUN | yes |
| `wc`, `sort`, `uniq`, `head`, `tail`, `cut`, `tr`, `column`, `nl`, `rev`, `fold`, `expand`, `unexpand` | DID-NOT-RUN | yes |
| `base64`, `md5sum`, `sha1sum`, `sha256sum`, `sha512sum`, `cksum`, `od`, `xxd`, `hexdump` | DID-NOT-RUN | yes |
| `join`, `paste`, `comm`, `tac`, `shuf`, `jq` | DID-NOT-RUN | yes |
| `sed` (plain, e.g. `s/x/y/`) | DID-NOT-RUN | **no** — see below |
| `sed 's/.*/&/e'` (GNU `e` flag) | **RAN** | no |
| `awk '{print}'` (plain) | DID-NOT-RUN | **no** — see below |
| `awk '{system($0)}'` | **RAN** | no |

`sed`/`awk` are **deliberately excluded** even though a plain invocation is genuinely inert (confirmed above) and they're the textbook "obviously inert filter" examples the issue itself named. Both have a *data-driven* code-execution surface reachable through an ordinary flag/script construct — sed's `e` flag/command executes the (input-derived) pattern space as a shell command; awk's `system()` (and piped `print ... | "cmd"` / `getline < "cmd"`) executes a command built from record data. Gating "safe unless the script argument contains `e`/`system(`" would require a second per-command detector inside what this set is meant to keep a flat, reviewable allowlist — left as a deliberate non-goal. The accepted cost: an ordinary `cat <<'EOF' | sed 's/foo/bar/'` documentation pipeline now false-blocks. `perl`/`python`/`ruby`/`php`/`xargs`/`parallel`/`find`/`env` are excluded for the more obvious reason (general-purpose interpreters, or the relay family this fix targets).

Every allowlist entry has a paired FP-corpus test (`test_every_allowlisted_filter_has_a_representative_case` asserts the corpus table covers the whole set exactly) plus a subset re-verified against a real shell in `RealShellGroundTruthTests`.

## Mutation table (real pytest output)

Checkpoint-committed, then mutated `_shell_parse.py` in place, ran `ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/test_heredoc_relay_downstream.py -q` (+ the pre-existing `test_heredoc_target_scope.py` for the regressions), restored with `git checkout HEAD -- .claude/hooks/_shell_parse.py` after each:

| # | Mutation | Result (pytest exit code / failures) |
|---|---|---|
| M1 | Full revert of the default flip (`return head in SHELL_INTERPRETERS` only) | **19 failed** — every relay-bypass, ground-truth, and classifier-unit test in the new file, plus the #1171 sibling measurement |
| M2 | Drop `HEREDOC_DATA_SINKS` from the downstream check (`return head not in HEREDOC_INERT_RELAY_FILTERS` only) | **6 failed** — including 2 PRE-EXISTING regression tests in `test_heredoc_target_scope.py` (`cat <<EOF \| tee ...`, `\|& tee`) that this exact mutation reproduces; this was a real bug in my own first draft, caught by the existing suite before I ever wrote a new test for it |
| M3 | Naively add `sed` back to the allowlist | **6 failed** — including the real-shell adversarial test confirming the `e`-flag bypass reopens |
| M4 | `and` → `or` in the combined downstream-inert check | **46 failed** (run against both test files) |
| M5 | Remove `grep` from the allowlist (single-entry drop) | **8 failed** |
| M6 | `if head is None: return False` (fail-open on an unresolvable segment) | **2 failed** — a dedicated direct unit test (`test_unresolvable_downstream_segment_resolves_to_code`) plus the #1171 sibling measurement; added the dedicated test after noticing the first pass only killed it incidentally through the sibling shape |

All mutants killed; tree diffed clean after each restore (`git status --porcelain` / `git diff --stat` both empty against the checkpoint commit before proceeding).

## Sibling issues — measured, not assumed

- **#1171** (backslash line-continuation between a data sink and `\| bash`) — **closes incidentally**. Its own issue body names the exact same root cause ("the same fail-open downstream branch as main#1168"): the continued segment doesn't tokenize (`head is None`), and the new default resolves that to CODE. Confirmed via `hook.check()`: the #1171 shape now BLOCKs, and #1171's own stated false positive (a continued prose opener with no interpreter) stays ALLOW. Pinned in `SiblingIssueMeasurementTests`.
- **#1170** (FIFO relay via `mkfifo`/`&`) — **stays open**, confirmed via `hook.check()` (measured ALLOW after this fix). Structurally different: dataflow through a named pipe across a `&` background-job boundary, never reached by this fix's `\|`-connected pipeline walk. Not folded in, per the spawn brief's explicit scope boundary.

## Related gap found, NOT fixed here (filed separately)

The same relay family also defeats the **other** classifier in this file — main#1167's cross-segment write-then-exec correlation (`_script_invocation_targets`) — via `find -exec bash {} \;` and `echo PATH | xargs bash`. Real-shell-verified to still ALLOW at this PR's head; this fix's default-flip only touches `_opener_feeds_interpreter` (the pipe-follow walk), a different code path with no literal token to correlate against for either shape. Filed as **#1315** (`tech-debt`/`process`/`phase-10`, no wave label) rather than folded in here, matching this org's own precedent (main#1167's PR review filed its sibling gaps separately "because they are different root causes").

## Test plan

- [x] `ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/ -q` — 2641 passed, 725 subtests passed (0 regressions)
- [x] `ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/ .claude/lib/tests/ -q` — 3896 passed, 803 subtests passed
- [x] `ruff format --check`, `ruff check`, `mypy .claude/hooks/ .claude/lib/ --ignore-missing-imports --no-error-summary` — all clean
- [x] `python3 .claude/lib/pre_commit_ci_sync.py .` — OK
- [x] Pre-push hooks (mypy, pytest, pytest-skills, memory-budget, headcount-budget, doc-freshness, office-drift, mermaid-render) — all passed on `git push`
- [x] New file: `.claude/hooks/tests/test_heredoc_relay_downstream.py` (42 tests / 53 subtests) — bypass-blocks, false-positive corpus (with a per-filter coverage-completeness assertion), excluded-filter-blocks, real-shell ground truth, classifier unit tests, sibling-issue measurements

Not merging per instructions — this is ready for review.


## Round 3 update — `rg` dropped (Nino's blocker: `--pre` + attacker-supplied `/dev/stdin`)

Round 2 folded `rg` into `HEREDOC_INERT_RELAY_FILTERS`, measured only on the no-PATH stdin-pipe form of `--pre`/`-z`. That measurement was correct as far as it went, but the PATH `--pre` needs is attacker-supplied: naming the pipe itself (`/dev/stdin`, `/dev/fd/0`) gives `--pre` a PATH even on a pure stdin pipe, and `rg` runs `COMMAND PATH` with that path opened on the child's own stdin — so `sh /dev/stdin` genuinely executes the heredoc body. Real-shell-verified (both bash and zsh):

```
bash | RAN | rg --pre=/bin/sh pat /dev/stdin | GIT-RAN: -c user.name=X -c user.email=Y commit -m z
zsh  | RAN | rg --pre=/bin/sh pat /dev/stdin | GIT-RAN: -c user.name=X -c user.email=Y commit -m z
```

`rg` is now **dropped from the allowlist entirely**, same posture as `sed`/`awk`/`sort` — a plain-form (or single-context) measurement is not sufficient, and gating `--pre` per-invocation would reintroduce the per-command flag grammar this set exists to avoid. Confirmed at the current head: `cat <<'DELIM' | rg --pre=/bin/sh pat /dev/stdin ... DELIM` now **BLOCKs**.

`rg` also exposes a second exec-shaped flag, `--hostname-bin=COMMAND`, which spawns an arbitrary program even on a pure stdin pipe with no PATH at all — but the spawned child gets no arguments and does not inherit the pipe, so it never reaches the heredoc body and is **not** a bypass on its own. It's named in the module comment anyway (and pinned by a dedicated ground-truth test with two independent log files — one confirming the spawn, one confirming the body was never reached) because its existence would otherwise falsify the comment's "every entry measured inert" claim.

**The #1008 contradiction is left explicitly OPEN by this change.** This allowlist still admits `grep` (forbidden org-wide by #1008's "use `rg`, never bare `grep`" rule) while now excluding `rg` (the mandated replacement) — the inverse of what the org's tooling policy wants. Round 2's `rg` addition was reasoned partly from that policy argument; that reasoning is retracted (on #1317, so it isn't re-cited as grounds to re-add `rg` later) because a policy argument was never a safety argument, and here they point in opposite directions. Resolving the contradiction needs either a safe way to admit `rg` (a flag-aware gate, which is the per-command grammar this set is designed to avoid) or a separate decision at the #1008 policy level — not a re-add to this allowlist on the same evidence that just failed.

Test changes this round: `RelayExcludedFiltersBlockTests` gains `rg` rows mirroring `sed`/`awk`/`sort` (not-in-allowlist, plain-form-now-blocks, and a would-be-bypass-if-allowlisted row using `--pre=/bin/sh` with an attacker-supplied `/dev/stdin` path — deliberately **varying** the PATH rather than fixing it at none, the exact gap in the prior test). `RealShellGroundTruthTests` replaces the old context-fixed `--pre`-on-stdin-with-no-PATH test with: plain `rg` (inert, accepted FP), `--pre` with no PATH (still inert, kept as a documented contrast), `--pre=/bin/sh pat /dev/stdin` (genuinely runs — the adversarial row), and a new `--hostname-bin` row (spawns but does not reach the body, using independent spawn/body log files so the two outcomes can't be conflated).

Full suite at this head: `.claude/hooks/tests/` 2652 passed / 734 subtests; `.claude/lib/tests/` 1255 passed / 78 subtests. `ruff format --check`, `ruff check`, and `mypy` clean on both changed files. Pre-push hooks (mypy, pytest, pytest-skills, memory-budget, headcount-budget, doc-freshness, office-drift, mermaid-render) all passed on push.

Not merging per instructions — ready for review.
