### PR TITLE
refactor(lib): extract wave_state.py + gh.py shared helpers (#1119)

### DIFF
--- a/.claude/lib/gh.py
+++ b/.claude/lib/gh.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""The one `gh` subprocess shim for `.claude/lib/` (main#1119, epic main#1019).
+
+Six modules had grown a byte-for-byte identical `_run_gh` whose docstrings
+openly admitted the mirroring ("same contract as ``wave_status._run_gh``",
+"mirrors :mod:`wave_status`"). This is that function, once.
+
+The main#688 contract this preserves
+====================================
+Every `gh` invocation goes through :func:`run_gh`, which calls
+``subprocess.run(["gh", *args], ...)`` with an explicit ARG LIST — never a
+shell string, never ``shell=True``. That is the whole point: this org's shell
+is zsh, which does NOT word-split an unquoted ``$var`` the way bash does, so
+a newline-joined repo list passed through a shell collapsed into a single
+bogus ``--repo`` value (merged-PR count 0 -> division by zero). No shell means
+no word-splitting, under any shell, ever.
+
+Error behaviour is deliberately UNCHANGED from the six functions it replaces
+=============================================================================
+:func:`run_gh` uses ``check=True`` and lets ``subprocess.CalledProcessError``
+(and ``OSError``/``FileNotFoundError``) propagate RAW. It does **not** wrap
+them in :class:`GhError`.
+
+That is not an oversight, it is the consolidation's safety property. Callers
+already catch the raw exception types and degrade gracefully on them —
+`red_sweep.py` and `base_pin_drift_sweep.py` both define
+``_GH_ERRORS = (subprocess.CalledProcessError, OSError)`` and use it to turn a
+gh failure into "undetermined" rather than a crash. Had this shim started
+raising a new exception class, those ``except`` clauses would silently stop
+matching and a graceful degrade would become an unhandled traceback — a
+fail-open gate turning into a crash, from a change advertised as a pure
+DRY cleanup. If a future caller wants wrapped errors it should wrap at its
+own call site (see `verify_deployable_merge._run_gh`, which does exactly
+that and is the reason :class:`GhError` lives here).
+
+Not consolidated here, on purpose
+=================================
+* ``gh_rest.py::_run_gh`` — different contract entirely: a ``timeout=``, no
+  ``check=True``, and it raises ``GhRestError`` on non-zero exit precisely so
+  a REST fallback never masquerades as an empty result (#1224). Folding it in
+  would destroy that guarantee.
+* ``verify_deployable_merge.py::_run_gh`` — keeps its own thin wrapper because
+  wrapping failures into :class:`GhError` IS its distinct behaviour (readiness
+  "cannot be determined", exit 2). It now builds that wrapper on
+  :func:`run_gh` and imports :class:`GhError` from here, so the subprocess
+  call and the exception type are still single-source.
+
+Module name
+===========
+Deliberately the bare `gh`, joining the existing `gh_rest.py` / `gh_quota.py`
+family. `.claude/lib` is inserted at ``sys.path[0]`` by its own modules, so
+this name shadows any same-named third-party package for those importers;
+there is none today, and the sibling naming makes the family obvious.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+
+class GhError(RuntimeError):
+    """A gh/API call failed and the answer cannot be determined.
+
+    The canonical wrapped-failure type for this package. :func:`run_gh` never
+    raises it (see module docstring § Error behaviour); it exists for callers
+    that deliberately convert a raw ``CalledProcessError`` into an
+    "undetermined" verdict — `verify_deployable_merge` re-exports it so
+    ``verify_deployable_merge.GhError`` and ``gh.GhError`` are the same class
+    and an ``isinstance`` check works across both spellings.
+    """
+
+
+def run_gh(args: list[str]) -> str:
+    """Run ``gh <args>`` with an explicit arg list and return stdout.
+
+    Never a shell string and never ``shell=True`` — no shell means no
+    word-splitting, so a multi-word value can never collapse into one bogus
+    flag (main#688).
+
+    Raises ``subprocess.CalledProcessError`` on a non-zero exit and
+    ``FileNotFoundError`` when gh is not on PATH — both RAW and unwrapped, so
+    existing ``except (subprocess.CalledProcessError, OSError)`` handlers keep
+    matching. See module docstring § Error behaviour.
+    """
+    proc = subprocess.run(
+        ["gh", *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return proc.stdout

--- a/.claude/lib/kickoff_sweep.py
+++ b/.claude/lib/kickoff_sweep.py
@@ -74,9 +74,13 @@ import sys
 from pathlib import Path
 
 _LIB_DIR = Path(__file__).resolve().parent
-_REPO_ROOT = _LIB_DIR.parents[1]
+sys.path.insert(0, str(_LIB_DIR))
+import gh  # noqa: E402
+import wave_state  # noqa: E402
+
+_REPO_ROOT = wave_state.REPO_ROOT
 _HOOKS_DIR = _REPO_ROOT / ".claude" / "hooks"
-_DEFAULT_STATUS = _REPO_ROOT / "cross-repo-status.json"
+_DEFAULT_STATUS = wave_state.DEFAULT_STATUS_PATH
 
 # The kickoff hook is the single source of truth for the comment body, the
 # assignment-row lookup, the merge-model read and the idempotency check. The
@@ -116,15 +120,9 @@ SKIP_FETCH_UNKNOWN = "skip_fetch_unknown"
 _INCOMPLETE_ACTIONS = frozenset({POST_FAILED, SKIP_FETCH_UNKNOWN})
 
 
-def _run_gh(args: list[str]) -> str:
-    """Run ``gh <args>`` with an explicit arg list and return stdout.
-
-    Never a shell string and never ``shell=True`` — no shell means no
-    word-splitting, the main#688 contract shared with wave_status.py /
-    wave_merge_model.py.
-    """
-    proc = subprocess.run(["gh", *args], capture_output=True, text=True, check=True)
-    return proc.stdout
+# Shared gh shim (main#1119). Stays a module-level name because it is the
+# default for this module's injected `run_gh=` parameters.
+_run_gh = gh.run_gh
 
 
 def wave_labels(phase: str | int, wave: str | int) -> list[str]:
@@ -335,12 +333,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("phase", help="phase number (P)")
     parser.add_argument("wave", help="wave number (M)")
-    parser.add_argument(
-        "--status",
-        type=Path,
-        default=_DEFAULT_STATUS,
-        help="path to cross-repo-status.json (default: repo-root copy)",
-    )
+    wave_state.add_status_argument(parser)
     parser.add_argument(
         "--repo",
         action="append",

--- a/.claude/lib/lifecycle.py
+++ b/.claude/lib/lifecycle.py
@@ -106,13 +106,11 @@ if str(_LIB_DIR) not in sys.path:
 import upsert_status_keys  # noqa: E402
 import wave_merge_model  # noqa: E402
 import wave_seq  # noqa: E402
+import wave_state  # noqa: E402
 import wave_status  # noqa: E402
 
-# Repo root = two parents above .claude/lib/ (lib -> .claude -> root). Same
-# anchor as wave_seq / wave_merge_model / wave_status so the default status path
-# is correct from any cwd or worktree with no `git rev-parse` subprocess.
-_REPO_ROOT = _LIB_DIR.parents[1]
-_DEFAULT_STATUS = _REPO_ROOT / "cross-repo-status.json"
+_REPO_ROOT = wave_state.REPO_ROOT
+_DEFAULT_STATUS = wave_state.DEFAULT_STATUS_PATH
 
 
 # ============================================================================
@@ -179,8 +177,11 @@ def _persist(
     return upsert_status_keys.main(argv)
 
 
-def _load_status(status_path: Path) -> dict:
-    return json.loads(status_path.read_text())
+# Shared status reader (main#1119). Writes still go through `_persist` ->
+# `upsert_status_keys.main`, which is text-surgical and reads the raw file
+# itself — deliberately NOT routed through this loader (wave_state module
+# docstring § READ ONLY).
+_load_status = wave_state.load_status
 
 
 # ============================================================================
@@ -392,13 +393,7 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     top = parser.add_subparsers(dest="group", required=True)
 
-    def _status_opt(p: argparse.ArgumentParser) -> None:
-        p.add_argument(
-            "--status",
-            type=Path,
-            default=_DEFAULT_STATUS,
-            help="path to cross-repo-status.json (default: repo-root copy)",
-        )
+    _status_opt = wave_state.add_status_argument
 
     # wave ...
     wave = top.add_parser("wave", help="wave allocator + lifecycle transitions")

--- a/.claude/lib/red_sweep.py
+++ b/.claude/lib/red_sweep.py
@@ -46,6 +46,7 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
+import gh
 from org_repos import ALL_REPOS as CANONICAL_REPOS
 from org_repos import MAIN_REPO as _MAIN_REPO
 from org_repos import ORG as _ORG
@@ -77,10 +78,9 @@ DEFAULT_MAX_AGE_HOURS = 24.0
 _GH_ERRORS = (subprocess.CalledProcessError, OSError)
 
 
-def _run_gh(args: list[str]) -> str:
-    """Run ``gh <args>`` (explicit arg list, never a shell string — main#688)."""
-    proc = subprocess.run(["gh", *args], capture_output=True, text=True, check=True)
-    return proc.stdout
+# Shared gh shim (main#1119). Still raises the raw CalledProcessError/OSError
+# that `_GH_ERRORS` above catches — see gh.py § Error behaviour.
+_run_gh = gh.run_gh
 
 
 def _utcnow() -> datetime:

--- a/.claude/lib/tests/test_wave_state.py
+++ b/.claude/lib/tests/test_wave_state.py
@@ -271,6 +271,56 @@ class CacheInvalidationOnRewrite(_CacheIsolated):
                 )
             self.assertGreater(wave_state.cache_info().uncacheable, 0)
 
+    def test_a_write_landing_during_the_read_is_never_cached(self) -> None:
+        """The post-read re-stat, without which a torn read gets pinned.
+
+        If a write lands between the pre-read `stat()` and the end of
+        `read_text()`, the bytes we parsed belong to the OLD file while the
+        file on disk has moved on. Caching that parse under the PRE-read stat
+        key leaves a stale entry addressed by a key the file has already left
+        — and the moment the file's stat key returns to that value, the stale
+        parse is served.
+
+        Found by mutation: deleting `key_after == key` from `load_status`
+        survived the rest of this suite, and a direct probe of both variants
+        showed they genuinely diverge on this sequence. Not an equivalent
+        mutant — a real hole, and this is the test that closes it.
+        """
+        original_tick = 1_000 * _ONE_SECOND_NS + 5
+        with TemporaryDirectory() as td:
+            path = Path(td) / "cross-repo-status.json"
+            _write(path, {"wave_29_final_pr_count": 1})
+            _pin_mtime(path, original_tick)
+
+            real_read_text = Path.read_text
+            fired: list[bool] = []
+
+            def interposing_read_text(self, *args, **kwargs):  # noqa: ANN001
+                text = real_read_text(self, *args, **kwargs)
+                if not fired and os.path.samefile(self, path):
+                    fired.append(True)
+                    _write(path, {"wave_29_final_pr_count": 2})
+                    _pin_mtime(path, 2_000 * _ONE_SECOND_NS + 5)
+                return text
+
+            with mock.patch.object(wave_state, "_now_ns", lambda: 9_000 * _ONE_SECOND_NS):
+                with mock.patch.object(Path, "read_text", interposing_read_text):
+                    first = wave_state.load_status(path)
+
+            self.assertTrue(fired, "the interposed write never ran — test is inert")
+            self.assertEqual(first["wave_29_final_pr_count"], 1)
+
+            # Bring the file's stat key back to the pre-read value with a THIRD
+            # content. A cache entry stored under that key would surface now.
+            _write(path, {"wave_29_final_pr_count": 3})
+            _pin_mtime(path, original_tick)
+            with mock.patch.object(wave_state, "_now_ns", lambda: 9_000 * _ONE_SECOND_NS):
+                self.assertEqual(
+                    wave_state.load_status(path)["wave_29_final_pr_count"],
+                    3,
+                    "a parse taken across a concurrent write was cached and re-served",
+                )
+
     def test_identical_stat_key_after_a_settled_tick_is_the_documented_boundary(self) -> None:
         """Pins WHY the guard is required, by showing what happens without it.
 

--- a/.claude/lib/tests/test_wave_state.py
+++ b/.claude/lib/tests/test_wave_state.py
@@ -1,0 +1,650 @@
+"""Tests for wave_state — the shared cross-repo-status.json reader (main#1119).
+
+The consolidation this file guards is almost entirely PLUMBING, so these tests
+aim at the hand-offs rather than at arithmetic:
+
+  1. The cache can never serve stale data. Four rewrite shapes, each defeating
+     a DIFFERENT component of the stat key, so deleting any one component
+     fails a test:
+       * different size          -> st_size
+       * SAME size, later mtime  -> st_mtime_ns
+       * atomic rename, OLDER mtime -> st_ino/st_dev
+       * same-tick rewrite with a byte-identical stat key -> the racy-tick guard
+  2. The cache actually engages (otherwise every invalidation test above would
+     pass vacuously, on a loader that never cached anything at all).
+  3. The mapping handed back is not mutated by any caller in this package.
+  4. The `--status` argparse block and `read_repos` behave as the six/two
+     copies they replaced did.
+  5. Writes still go through the text-surgical path — `upsert_status_keys`
+     neither imports this module nor reformats the file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+# Helpers live at .claude/lib/*.py; this test is at .claude/lib/tests/test_*.py.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import gh  # noqa: E402
+import upsert_status_keys  # noqa: E402
+import wave_merge_model  # noqa: E402
+import wave_state  # noqa: E402
+import wave_status  # noqa: E402
+
+_ONE_SECOND_NS = 1_000_000_000
+
+
+def _write(path: Path, payload: dict) -> None:
+    path.write_text(json.dumps(payload))
+
+
+def _pin_mtime(path: Path, mtime_ns: int) -> None:
+    """Force an exact mtime, so a coarse-granularity filesystem can be simulated."""
+    os.utime(path, ns=(mtime_ns, mtime_ns))
+
+
+class _CacheIsolated(unittest.TestCase):
+    """Every test starts from an empty cache and zeroed counters."""
+
+    def setUp(self) -> None:
+        wave_state.invalidate()
+        wave_state.reset_cache_info()
+        self.addCleanup(wave_state.invalidate)
+        self.addCleanup(wave_state.reset_cache_info)
+
+
+class TickSettledPredicate(_CacheIsolated):
+    """The racy-tick guard in isolation (module docstring § racy-tick guard)."""
+
+    def test_subsecond_bits_imply_a_one_nanosecond_tick(self) -> None:
+        mtime = 5 * _ONE_SECOND_NS + 12345  # has sub-second bits
+        self.assertTrue(wave_state._tick_has_settled(mtime, mtime + 1))
+
+    def test_subsecond_timestamp_equal_to_now_is_not_settled(self) -> None:
+        mtime = 5 * _ONE_SECOND_NS + 12345
+        self.assertFalse(wave_state._tick_has_settled(mtime, mtime))
+
+    def test_exact_second_is_treated_as_a_one_second_tick(self) -> None:
+        mtime = 5 * _ONE_SECOND_NS
+        # Half a second later the tick could still absorb another write.
+        self.assertFalse(wave_state._tick_has_settled(mtime, mtime + _ONE_SECOND_NS // 2))
+        # A full second later nothing can reproduce this timestamp.
+        self.assertTrue(wave_state._tick_has_settled(mtime, mtime + _ONE_SECOND_NS))
+
+    def test_future_dated_file_is_never_settled(self) -> None:
+        """Clock skew (network mounts) must not unlock caching."""
+        mtime = 10 * _ONE_SECOND_NS + 7
+        self.assertFalse(wave_state._tick_has_settled(mtime, mtime - _ONE_SECOND_NS))
+
+
+class CacheEngages(_CacheIsolated):
+    """Without this, every invalidation test below would pass vacuously."""
+
+    def test_repeated_loads_of_a_settled_file_parse_once(self) -> None:
+        with TemporaryDirectory() as td:
+            path = Path(td) / "cross-repo-status.json"
+            _write(path, {"current_wave": "wave-29"})
+            _pin_mtime(path, 1_000 * _ONE_SECOND_NS + 5)
+
+            with mock.patch.object(wave_state, "_now_ns", lambda: 2_000 * _ONE_SECOND_NS):
+                for _ in range(5):
+                    self.assertEqual(wave_state.load_status(path)["current_wave"], "wave-29")
+
+            info = wave_state.cache_info()
+            self.assertEqual(info.parses, 1, "cache did not engage — perf claim is unmet")
+            self.assertEqual(info.hits, 4)
+
+    def test_hits_are_the_identical_object_not_a_reparse(self) -> None:
+        with TemporaryDirectory() as td:
+            path = Path(td) / "cross-repo-status.json"
+            _write(path, {"a": 1})
+            _pin_mtime(path, 1_000 * _ONE_SECOND_NS + 5)
+            with mock.patch.object(wave_state, "_now_ns", lambda: 2_000 * _ONE_SECOND_NS):
+                first = wave_state.load_status(path)
+                second = wave_state.load_status(path)
+            self.assertIs(first, second)
+
+    def test_distinct_paths_are_cached_independently(self) -> None:
+        with TemporaryDirectory() as td:
+            a = Path(td) / "a.json"
+            b = Path(td) / "b.json"
+            _write(a, {"which": "a"})
+            _write(b, {"which": "b"})
+            _pin_mtime(a, 1_000 * _ONE_SECOND_NS + 5)
+            _pin_mtime(b, 1_000 * _ONE_SECOND_NS + 5)
+            with mock.patch.object(wave_state, "_now_ns", lambda: 2_000 * _ONE_SECOND_NS):
+                self.assertEqual(wave_state.load_status(a)["which"], "a")
+                self.assertEqual(wave_state.load_status(b)["which"], "b")
+                self.assertEqual(wave_state.load_status(a)["which"], "a")
+
+
+class CacheInvalidationOnRewrite(_CacheIsolated):
+    """THE load-bearing suite: a rewritten file is never served from cache.
+
+    Each test defeats a different component of the stat key, so no single
+    component can be deleted without a failure here.
+    """
+
+    def test_rewrite_changing_size_is_seen(self) -> None:
+        with TemporaryDirectory() as td:
+            path = Path(td) / "cross-repo-status.json"
+            _write(path, {"current_wave": "wave-29"})
+            _pin_mtime(path, 1_000 * _ONE_SECOND_NS + 5)
+            with mock.patch.object(wave_state, "_now_ns", lambda: 2_000 * _ONE_SECOND_NS):
+                self.assertEqual(wave_state.load_status(path)["current_wave"], "wave-29")
+                _write(path, {"current_wave": "wave-30", "extra": [1, 2, 3]})
+                _pin_mtime(path, 1_500 * _ONE_SECOND_NS + 5)
+                self.assertEqual(wave_state.load_status(path)["current_wave"], "wave-30")
+
+    def test_rewrite_preserving_size_is_seen(self) -> None:
+        """The counter-flip case: `5` -> `6` keeps the byte length identical.
+
+        Size alone cannot catch this; only st_mtime_ns can. cross-repo-status
+        .json is full of single-digit counters, so this is the realistic shape.
+        """
+        with TemporaryDirectory() as td:
+            path = Path(td) / "cross-repo-status.json"
+            _write(path, {"wave_29_final_pr_count": 5})
+            before = path.stat().st_size
+            _pin_mtime(path, 1_000 * _ONE_SECOND_NS + 5)
+            with mock.patch.object(wave_state, "_now_ns", lambda: 3_000 * _ONE_SECOND_NS):
+                self.assertEqual(wave_state.load_status(path)["wave_29_final_pr_count"], 5)
+
+                _write(path, {"wave_29_final_pr_count": 6})
+                _pin_mtime(path, 1_500 * _ONE_SECOND_NS + 5)
+                self.assertEqual(path.stat().st_size, before, "fixture must be same-size")
+
+                self.assertEqual(wave_state.load_status(path)["wave_29_final_pr_count"], 6)
+
+    def test_rewrite_changing_only_the_size_is_seen(self) -> None:
+        """Isolates st_size: mtime and inode are held IDENTICAL across the two
+        writes, so nothing but the length can distinguish them. The realistic
+        shape is a coarse-granularity filesystem where both writes land in the
+        same second."""
+        pinned = 4_000 * _ONE_SECOND_NS + 5
+        with TemporaryDirectory() as td:
+            path = Path(td) / "cross-repo-status.json"
+            _write(path, {"current_wave": "wave-29"})
+            _pin_mtime(path, pinned)
+            ino_before = path.stat().st_ino
+
+            with mock.patch.object(wave_state, "_now_ns", lambda: 9_000 * _ONE_SECOND_NS):
+                self.assertEqual(wave_state.load_status(path)["current_wave"], "wave-29")
+
+                _write(path, {"current_wave": "wave-29", "added": "a longer payload"})
+                _pin_mtime(path, pinned)  # same mtime
+                self.assertEqual(path.stat().st_ino, ino_before)  # same inode
+
+                self.assertEqual(wave_state.load_status(path).get("added"), "a longer payload")
+
+    def test_atomic_replace_with_identical_size_and_mtime_is_seen(self) -> None:
+        """Isolates st_ino/st_dev: size AND mtime are held identical across an
+        atomic rename, so only the inode can reveal the swap.
+
+        Contrast with `test_identical_stat_key_after_a_settled_tick_...`, which
+        performs the same size/mtime-preserving swap IN PLACE (inode unchanged)
+        and legitimately serves cache. The pair is what pins the inode's role.
+        """
+        pinned = 5_000 * _ONE_SECOND_NS + 5
+        with TemporaryDirectory() as td:
+            path = Path(td) / "cross-repo-status.json"
+            tmp = Path(td) / "staged.json"
+            _write(path, {"wave_29_final_pr_count": 5})
+            _pin_mtime(path, pinned)
+            ino_before = path.stat().st_ino
+
+            with mock.patch.object(wave_state, "_now_ns", lambda: 9_000 * _ONE_SECOND_NS):
+                self.assertEqual(wave_state.load_status(path)["wave_29_final_pr_count"], 5)
+
+                _write(tmp, {"wave_29_final_pr_count": 6})
+                _pin_mtime(tmp, pinned)
+                self.assertEqual(tmp.stat().st_size, path.stat().st_size)
+                os.replace(tmp, path)
+                self.assertNotEqual(path.stat().st_ino, ino_before)
+                self.assertEqual(path.stat().st_mtime_ns, pinned)
+
+                self.assertEqual(wave_state.load_status(path)["wave_29_final_pr_count"], 6)
+
+    def test_atomic_replace_with_an_older_mtime_is_seen(self) -> None:
+        """write-temp + rename, where the replacement is BACK-dated.
+
+        Neither size nor mtime need move forward here — a rename can install a
+        file whose timestamp is older than the one we cached. Only the inode
+        catches it.
+        """
+        with TemporaryDirectory() as td:
+            path = Path(td) / "cross-repo-status.json"
+            tmp = Path(td) / "staged.json"
+            _write(path, {"current_wave": "wave-29"})
+            _pin_mtime(path, 5_000 * _ONE_SECOND_NS + 5)
+
+            with mock.patch.object(wave_state, "_now_ns", lambda: 9_000 * _ONE_SECOND_NS):
+                self.assertEqual(wave_state.load_status(path)["current_wave"], "wave-29")
+
+                _write(tmp, {"current_wave": "wave-30"})
+                _pin_mtime(tmp, 1_000 * _ONE_SECOND_NS + 5)  # OLDER than the cached entry
+                self.assertEqual(tmp.stat().st_size, path.stat().st_size)
+                os.replace(tmp, path)
+
+                self.assertEqual(wave_state.load_status(path)["current_wave"], "wave-30")
+
+    def test_same_tick_rewrite_on_a_coarse_filesystem_is_seen(self) -> None:
+        """The aliasing case the racy-tick guard exists for.
+
+        Simulates a 1-second-granularity filesystem: both writes are pinned to
+        the SAME exact-second mtime and produce the SAME size, so the stat key
+        is byte-identical across them. The only thing that can save the reader
+        is refusing to cache a timestamp whose tick has not settled.
+
+        Delete the `_tick_has_settled` call from `load_status` and this test
+        fails with the stale value — which is the whole point of it.
+        """
+        tick = 4_000 * _ONE_SECOND_NS  # exact second => coarse-FS shape
+        with TemporaryDirectory() as td:
+            path = Path(td) / "cross-repo-status.json"
+            _write(path, {"wave_29_final_pr_count": 5})
+            _pin_mtime(path, tick)
+
+            # "now" is inside the same second as the write: unsettled.
+            with mock.patch.object(wave_state, "_now_ns", lambda: tick + _ONE_SECOND_NS // 2):
+                self.assertEqual(wave_state.load_status(path)["wave_29_final_pr_count"], 5)
+
+                _write(path, {"wave_29_final_pr_count": 6})
+                _pin_mtime(path, tick)
+
+                key_repeated = wave_state._stat_key(path.stat())
+                self.assertEqual(key_repeated.mtime_ns, tick)
+
+                self.assertEqual(
+                    wave_state.load_status(path)["wave_29_final_pr_count"],
+                    6,
+                    "served a stale parse across an indistinguishable stat key",
+                )
+            self.assertGreater(wave_state.cache_info().uncacheable, 0)
+
+    def test_identical_stat_key_after_a_settled_tick_is_the_documented_boundary(self) -> None:
+        """Pins WHY the guard is required, by showing what happens without it.
+
+        Once a tick has settled, an identical stat key is taken as proof the
+        file is unchanged — so a forcibly back-dated rewrite IS served from
+        cache. That is not a bug to fix at this layer (a settled tick genuinely
+        cannot recur without someone forging timestamps); it is precisely the
+        reason `load_status` refuses to cache an UNSETTLED tick, which is the
+        only window in which this can happen for real.
+        """
+        old = 1_000 * _ONE_SECOND_NS + 5
+        with TemporaryDirectory() as td:
+            path = Path(td) / "cross-repo-status.json"
+            _write(path, {"wave_29_final_pr_count": 5})
+            _pin_mtime(path, old)
+            with mock.patch.object(wave_state, "_now_ns", lambda: 8_000 * _ONE_SECOND_NS):
+                self.assertEqual(wave_state.load_status(path)["wave_29_final_pr_count"], 5)
+                _write(path, {"wave_29_final_pr_count": 6})
+                _pin_mtime(path, old)  # forge the ORIGINAL timestamp back on
+                self.assertEqual(wave_state.load_status(path)["wave_29_final_pr_count"], 5)
+                # ...and an explicit invalidate is the escape hatch for it.
+                wave_state.invalidate(path)
+                self.assertEqual(wave_state.load_status(path)["wave_29_final_pr_count"], 6)
+
+    def test_write_through_upsert_status_keys_is_seen_by_a_later_load(self) -> None:
+        """End-to-end: the real writer, then a real read, in one process.
+
+        This is the shape that actually occurs (`wave_status counters --write`,
+        every `lifecycle` transition) and the one a cache could plausibly break.
+        No `invalidate()` call anywhere — the reader must notice on its own.
+        """
+        with TemporaryDirectory() as td:
+            path = Path(td) / "cross-repo-status.json"
+            # Multi-line, compact-inline — the real file's shape. The writer is
+            # text-surgical, so it needs real line structure to edit.
+            path.write_text('{\n  "current_wave": "wave-29",\n  "wave_29_final_pr_count": 5\n}\n')
+
+            self.assertEqual(wave_state.load_status(path)["wave_29_final_pr_count"], 5)
+            rc = upsert_status_keys.main(["t", str(path), "wave_29_final_pr_count=6"])
+            self.assertEqual(rc, 0)
+            self.assertEqual(wave_state.load_status(path)["wave_29_final_pr_count"], 6)
+
+    def test_invalidate_all_drops_every_path(self) -> None:
+        with TemporaryDirectory() as td:
+            a = Path(td) / "a.json"
+            _write(a, {"v": 1})
+            _pin_mtime(a, 1_000 * _ONE_SECOND_NS + 5)
+            with mock.patch.object(wave_state, "_now_ns", lambda: 5_000 * _ONE_SECOND_NS):
+                wave_state.load_status(a)
+                self.assertEqual(wave_state.cache_info().parses, 1)
+                wave_state.invalidate()
+                wave_state.load_status(a)
+                self.assertEqual(wave_state.cache_info().parses, 2)
+
+
+class LoaderBehaviourIsUnchanged(_CacheIsolated):
+    """The loader must be a drop-in for `json.loads(path.read_text())`."""
+
+    def test_matches_a_direct_parse(self) -> None:
+        with TemporaryDirectory() as td:
+            path = Path(td) / "cross-repo-status.json"
+            payload = {"current_wave": "wave-29", "nested": {"a": [1, 2]}, "n": None}
+            _write(path, payload)
+            self.assertEqual(wave_state.load_status(path), json.loads(path.read_text()))
+
+    def test_missing_file_raises_oserror(self) -> None:
+        with TemporaryDirectory() as td:
+            with self.assertRaises(OSError):
+                wave_state.load_status(Path(td) / "absent.json")
+
+    def test_malformed_json_raises_decode_error(self) -> None:
+        with TemporaryDirectory() as td:
+            path = Path(td) / "cross-repo-status.json"
+            path.write_text("{not json")
+            with self.assertRaises(json.JSONDecodeError):
+                wave_state.load_status(path)
+
+    def test_accepts_a_str_path(self) -> None:
+        """wave_unwrapped's copy coerced with `Path(...)`; str input must work."""
+        with TemporaryDirectory() as td:
+            path = Path(td) / "cross-repo-status.json"
+            _write(path, {"current_wave": "wave-29"})
+            self.assertEqual(wave_state.load_status(str(path))["current_wave"], "wave-29")
+
+    def test_str_and_path_spellings_share_one_cache_entry(self) -> None:
+        with TemporaryDirectory() as td:
+            path = Path(td) / "cross-repo-status.json"
+            _write(path, {"v": 1})
+            _pin_mtime(path, 1_000 * _ONE_SECOND_NS + 5)
+            with mock.patch.object(wave_state, "_now_ns", lambda: 5_000 * _ONE_SECOND_NS):
+                wave_state.load_status(path)
+                wave_state.load_status(str(path))
+            self.assertEqual(wave_state.cache_info().parses, 1)
+
+
+class SharedMappingIsNotMutated(_CacheIsolated):
+    """The cache hands back the real object; nothing in this package may mutate it."""
+
+    def test_public_read_apis_leave_the_mapping_untouched(self) -> None:
+        payload = {
+            "current_wave": "wave-29",
+            "current_phase": "10",
+            "next_wave": "wave-30",
+            "wave_29_repos_in_scope": ["repo-a", "repo-b"],
+            "wave_29_merge_model": "direct-to-main",
+            "wave_29_kicked_off_at": "2026-08-01T00:00:00Z",
+            "owner_decision_gated": ["something"],
+            "phase_10_note": "x",
+        }
+        with TemporaryDirectory() as td:
+            path = Path(td) / "cross-repo-status.json"
+            _write(path, payload)
+            _pin_mtime(path, 1_000 * _ONE_SECOND_NS + 5)
+
+            with mock.patch.object(wave_state, "_now_ns", lambda: 5_000 * _ONE_SECOND_NS):
+                loaded = wave_state.load_status(path)
+                snapshot = json.loads(json.dumps(loaded))
+
+                wave_status.build_digest(path)
+                wave_status.read_repos("29", path)
+                wave_merge_model.read_repos("29", path)
+                wave_merge_model.read_merge_model("29", path)
+
+                self.assertEqual(loaded, snapshot, "a read API mutated the shared mapping")
+                # And the cache is still handing back that same object.
+                self.assertIs(wave_state.load_status(path), loaded)
+
+
+class ReadRepos(_CacheIsolated):
+    """The contract the two verbatim copies had, now asserted once."""
+
+    def _path(self, td: str, payload: dict) -> Path:
+        path = Path(td) / "cross-repo-status.json"
+        _write(path, payload)
+        return path
+
+    def test_returns_the_scope_list(self) -> None:
+        with TemporaryDirectory() as td:
+            path = self._path(td, {"wave_29_repos_in_scope": ["repo-a", "repo-b"]})
+            self.assertEqual(wave_state.read_repos("29", path), ["repo-a", "repo-b"])
+
+    def test_missing_key_raises_keyerror(self) -> None:
+        with TemporaryDirectory() as td:
+            path = self._path(td, {"current_wave": "wave-29"})
+            with self.assertRaises(KeyError):
+                wave_state.read_repos("29", path)
+
+    def test_non_list_value_raises_typeerror(self) -> None:
+        with TemporaryDirectory() as td:
+            path = self._path(td, {"wave_29_repos_in_scope": "repo-a"})
+            with self.assertRaises(TypeError):
+                wave_state.read_repos("29", path)
+
+    def test_entries_are_coerced_to_str(self) -> None:
+        with TemporaryDirectory() as td:
+            path = self._path(td, {"wave_29_repos_in_scope": [1, "b"]})
+            self.assertEqual(wave_state.read_repos("29", path), ["1", "b"])
+
+    def test_wave_prefix_does_not_match_a_longer_ordinal(self) -> None:
+        """`wave_2_` must not resolve against `wave_29_` (the #804 key class)."""
+        with TemporaryDirectory() as td:
+            path = self._path(td, {"wave_29_repos_in_scope": ["repo-a"]})
+            with self.assertRaises(KeyError):
+                wave_state.read_repos("2", path)
+
+    def test_both_module_spellings_are_the_one_function(self) -> None:
+        self.assertIs(wave_status.read_repos, wave_state.read_repos)
+        self.assertIs(wave_merge_model.read_repos, wave_state.read_repos)
+
+
+class StatusArgument(_CacheIsolated):
+    """The `--status` block that had drifted into six copies."""
+
+    def test_defaults_to_the_repo_root_copy(self) -> None:
+        parser = argparse.ArgumentParser()
+        wave_state.add_status_argument(parser)
+        self.assertEqual(parser.parse_args([]).status, wave_state.DEFAULT_STATUS_PATH)
+
+    def test_parses_an_explicit_value_as_a_path(self) -> None:
+        parser = argparse.ArgumentParser()
+        wave_state.add_status_argument(parser)
+        parsed = parser.parse_args(["--status", "/tmp/x.json"])
+        self.assertIsInstance(parsed.status, Path)
+        self.assertEqual(parsed.status, Path("/tmp/x.json"))
+
+    def test_default_path_points_at_cross_repo_status_json(self) -> None:
+        self.assertEqual(wave_state.DEFAULT_STATUS_PATH.name, "cross-repo-status.json")
+        self.assertEqual(wave_state.DEFAULT_STATUS_PATH.parent, wave_state.REPO_ROOT)
+
+    def test_every_consolidated_module_shares_the_one_default(self) -> None:
+        import kickoff_sweep
+        import lifecycle
+        import trust_signals
+        import wave_seq
+        import wave_unwrapped
+
+        for mod in (
+            wave_status,
+            wave_merge_model,
+            wave_unwrapped,
+            lifecycle,
+            wave_seq,
+            trust_signals,
+            kickoff_sweep,
+        ):
+            with self.subTest(module=mod.__name__):
+                self.assertIs(mod._DEFAULT_STATUS, wave_state.DEFAULT_STATUS_PATH)
+
+
+class WritesStayTextSurgical(_CacheIsolated):
+    """main#1119 must not have started routing writes through the loader."""
+
+    def test_upsert_status_keys_does_not_import_wave_state(self) -> None:
+        source = (Path(wave_state.__file__).parent / "upsert_status_keys.py").read_text()
+        self.assertNotIn("wave_state", source)
+
+    def test_compact_inline_shape_survives_a_write(self) -> None:
+        """A json.dumps round-trip would reformat these lines; assert it doesn't."""
+        original = (
+            "{\n"
+            '  "current_wave": "wave-29",\n'
+            '  "wave_29_repos_in_scope": ["repo-a", "repo-b"],\n'
+            '  "wave_29_final_pr_count": 5\n'
+            "}\n"
+        )
+        with TemporaryDirectory() as td:
+            path = Path(td) / "cross-repo-status.json"
+            path.write_text(original)
+
+            rc = upsert_status_keys.main(["t", str(path), "wave_29_final_pr_count=6"])
+            self.assertEqual(rc, 0)
+
+            after = path.read_text()
+            self.assertIn('"wave_29_repos_in_scope": ["repo-a", "repo-b"],', after)
+            self.assertEqual(
+                len(original.splitlines()),
+                len(after.splitlines()),
+                "the write reflowed the file — the compact-inline shape was lost",
+            )
+
+    def test_counters_write_path_preserves_shape_and_is_read_back(self) -> None:
+        """wave_status --write is the real caller; prove both halves at once."""
+        original = (
+            "{\n"
+            '  "current_wave": "wave-29",\n'
+            '  "wave_29_repos_in_scope": ["repo-a"],\n'
+            '  "wave_29_final_pr_count": 1,\n'
+            '  "wave_29_changes_requested_cycles": 1,\n'
+            '  "wave_29_top_concentration_pct": 1\n'
+            "}\n"
+        )
+        with TemporaryDirectory() as td:
+            path = Path(td) / "cross-repo-status.json"
+            path.write_text(original)
+
+            self.assertEqual(wave_state.load_status(path)["wave_29_final_pr_count"], 1)
+            rc = wave_status._write_counters(
+                "29",
+                {
+                    "final_pr_count": 7,
+                    "changes_requested_cycles": 2,
+                    "top_concentration_pct": 43,
+                },
+                path,
+            )
+            self.assertEqual(rc, 0)
+
+            after = path.read_text()
+            self.assertEqual(len(original.splitlines()), len(after.splitlines()))
+            self.assertIn('"wave_29_repos_in_scope": ["repo-a"],', after)
+            self.assertEqual(wave_state.load_status(path)["wave_29_final_pr_count"], 7)
+
+
+class GhShim(unittest.TestCase):
+    """gh.run_gh — the six-way-identical `_run_gh`, and its error contract."""
+
+    def test_invokes_gh_with_an_explicit_arg_list_and_no_shell(self) -> None:
+        seen: dict = {}
+
+        def fake(cmd, *a, **kw):
+            seen["cmd"] = cmd
+            seen["kwargs"] = kw
+            return subprocess.CompletedProcess(cmd, 0, stdout="out", stderr="")
+
+        with mock.patch.object(subprocess, "run", fake):
+            self.assertEqual(gh.run_gh(["pr", "list", "--repo", "o/r"]), "out")
+
+        self.assertIsInstance(seen["cmd"], list)
+        self.assertEqual(seen["cmd"], ["gh", "pr", "list", "--repo", "o/r"])
+        self.assertIsNot(seen["kwargs"].get("shell"), True)
+        self.assertTrue(seen["kwargs"].get("check"))
+        self.assertTrue(seen["kwargs"].get("capture_output"))
+        self.assertTrue(seen["kwargs"].get("text"))
+
+    def test_a_multiword_value_stays_one_argv_element(self) -> None:
+        """The main#688 regression: a joined repo list must not word-split."""
+        seen: dict = {}
+
+        def fake(cmd, *a, **kw):
+            seen["cmd"] = cmd
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        joined = "repo-a repo-b repo-c"
+        with mock.patch.object(subprocess, "run", fake):
+            gh.run_gh(["pr", "list", "--repo", joined])
+        self.assertIn(joined, seen["cmd"])
+        self.assertEqual(len(seen["cmd"]), 5)
+
+    def test_nonzero_exit_propagates_raw_calledprocesserror(self) -> None:
+        """NOT wrapped in GhError — `red_sweep`/`base_pin_drift_sweep` catch the
+        raw type to degrade gracefully, so wrapping would turn a graceful
+        degrade into an unhandled traceback (gh.py § Error behaviour)."""
+
+        def fake(cmd, *a, **kw):
+            raise subprocess.CalledProcessError(1, cmd, stderr="boom")
+
+        with mock.patch.object(subprocess, "run", fake):
+            with self.assertRaises(subprocess.CalledProcessError):
+                gh.run_gh(["pr", "list"])
+
+    def test_missing_gh_binary_propagates_raw_filenotfounderror(self) -> None:
+        def fake(cmd, *a, **kw):
+            raise FileNotFoundError("gh")
+
+        with mock.patch.object(subprocess, "run", fake):
+            with self.assertRaises(FileNotFoundError):
+                gh.run_gh(["pr", "list"])
+
+    def test_red_sweeps_error_tuple_still_matches_what_run_gh_raises(self) -> None:
+        """The exact `except` clause that a wrapped error would have broken."""
+        import red_sweep
+
+        def fake(cmd, *a, **kw):
+            raise subprocess.CalledProcessError(1, cmd, stderr="boom")
+
+        with mock.patch.object(subprocess, "run", fake):
+            try:
+                gh.run_gh(["pr", "list"])
+            except red_sweep._GH_ERRORS:
+                pass
+            else:
+                self.fail("red_sweep._GH_ERRORS no longer catches a gh failure")
+
+    def test_every_consolidated_module_shares_the_one_shim(self) -> None:
+        import kickoff_sweep
+        import red_sweep
+        import wave_unwrapped
+
+        for mod in (wave_status, wave_merge_model, wave_unwrapped, red_sweep, kickoff_sweep):
+            with self.subTest(module=mod.__name__):
+                self.assertIs(mod._run_gh, gh.run_gh)
+
+    def test_verify_deployable_merge_reuses_the_one_gherror(self) -> None:
+        import verify_deployable_merge
+
+        self.assertIs(verify_deployable_merge.GhError, gh.GhError)
+
+    def test_verify_deployable_merge_still_wraps_failures(self) -> None:
+        """Its wrapper is its OWN behaviour and must survive the consolidation."""
+        import verify_deployable_merge
+
+        def fake(cmd, *a, **kw):
+            raise subprocess.CalledProcessError(1, cmd, stderr="boom")
+
+        with mock.patch.object(subprocess, "run", fake):
+            with self.assertRaises(gh.GhError):
+                verify_deployable_merge._run_gh(["api", "x"])
+
+    def test_gh_rest_shim_is_deliberately_not_the_shared_one(self) -> None:
+        """Its different contract (timeout, GhRestError) is load-bearing (#1224)."""
+        import gh_rest
+
+        self.assertIsNot(gh_rest._run_gh, gh.run_gh)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/lib/trust_signals.py
+++ b/.claude/lib/trust_signals.py
@@ -62,10 +62,11 @@ from pathlib import Path
 # wave_status lives alongside this file in .claude/lib/. Running as a script puts
 # this dir on sys.path[0]; the tests add it explicitly.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
+import wave_state  # noqa: E402
 import wave_status  # noqa: E402
 
-_REPO_ROOT = Path(__file__).resolve().parents[2]
-_DEFAULT_STATUS = _REPO_ROOT / "cross-repo-status.json"
+_REPO_ROOT = wave_state.REPO_ROOT
+_DEFAULT_STATUS = wave_state.DEFAULT_STATUS_PATH
 
 # Neutral / default trust score. Decay drifts unsignalled scores back to it.
 NEUTRAL = 3
@@ -460,12 +461,7 @@ def _build_parser() -> argparse.ArgumentParser:
     def _add_pm(p: argparse.ArgumentParser) -> None:
         p.add_argument("phase", help="phase number (P)")
         p.add_argument("wave", help="wave number (M)")
-        p.add_argument(
-            "--status",
-            type=Path,
-            default=_DEFAULT_STATUS,
-            help="path to cross-repo-status.json (default: repo-root copy)",
-        )
+        wave_state.add_status_argument(p)
 
     p_extract = sub.add_parser("extract", help="emit per-engineer signals as JSON")
     _add_pm(p_extract)

--- a/.claude/lib/verify_deployable_merge.py
+++ b/.claude/lib/verify_deployable_merge.py
@@ -61,7 +61,9 @@ import subprocess
 import sys
 import time
 
+import gh
 import yaml
+from gh import GhError  # noqa: F401  (re-export: see the GhError comment below)
 
 # Conclusions GitHub may report on a *completed* run. Anything not in PASS and
 # not pending is treated as a failure — including a completed run with a null
@@ -325,23 +327,27 @@ def aggregate(expected: list[str], runs: list[dict]) -> Aggregate:
 # ---------------------------------------------------------------------------
 
 
-class GhError(RuntimeError):
-    """A gh/API call failed; readiness cannot be determined (exit 2)."""
+# `GhError` is imported from `gh` (see the import block) rather than defined
+# here, so `verify_deployable_merge.GhError is gh.GhError` and an isinstance
+# check works whichever spelling a caller reaches for (main#1119). The name
+# stays bound in this module's namespace, so every existing
+# `verify_deployable_merge.GhError` reference is unaffected.
 
 
 def _run_gh(args: list[str]) -> str:
-    """Run ``gh <args>`` with an explicit arg list (never a shell string).
+    """Run ``gh <args>`` and convert any failure into :class:`GhError`.
 
-    Mirrors ``wave_status._run_gh`` (main#688): no shell means no word-splitting,
-    so a multi-word value can never collapse into a bogus flag.
+    The subprocess call itself is `gh.run_gh` (explicit arg list, never a shell
+    string — main#688). The wrapping is this module's own behaviour and is why
+    it keeps a local `_run_gh`: everywhere else a gh failure propagates raw,
+    but here it must become "readiness cannot be determined" (exit 2).
     """
     try:
-        proc = subprocess.run(["gh", *args], capture_output=True, text=True, check=True)
+        return gh.run_gh(args)
     except FileNotFoundError as exc:  # gh not installed
         raise GhError("gh CLI not found on PATH") from exc
     except subprocess.CalledProcessError as exc:
         raise GhError(f"gh {' '.join(args)} failed: {exc.stderr.strip()}") from exc
-    return proc.stdout
 
 
 def fetch_workflow_files(repo: str, ref: str) -> dict[str, str]:

--- a/.claude/lib/wave_merge_model.py
+++ b/.claude/lib/wave_merge_model.py
@@ -52,12 +52,15 @@ import subprocess
 import sys
 from pathlib import Path
 
-# Repo root = two parents above .claude/lib/ (lib -> .claude -> root). Resolved
-# from this file so the default is correct from any cwd or worktree, with no
-# `git rev-parse` subprocess (which would re-introduce a shell dependency).
-# Same anchor as wave_status.py.
-_REPO_ROOT = Path(__file__).resolve().parents[2]
-_DEFAULT_STATUS = _REPO_ROOT / "cross-repo-status.json"
+# Siblings live alongside this file in .claude/lib/. When this module is run as
+# a script its own directory is already sys.path[0]; the tests add the lib dir
+# explicitly (same bootstrap wave_status.py uses).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import gh  # noqa: E402
+import wave_state  # noqa: E402
+
+_REPO_ROOT = wave_state.REPO_ROOT
+_DEFAULT_STATUS = wave_state.DEFAULT_STATUS_PATH
 
 # The two permitted merge models. A wave is exactly one of these for its whole
 # lifetime; mixing is the bug this module exists to prevent.
@@ -72,23 +75,11 @@ ADVISORY = "advisory"
 VIOLATION = "violation"
 
 
-def _run_gh(args: list[str]) -> str:
-    """Run ``gh <args>`` with an explicit arg list and return stdout.
-
-    Never a shell string and never ``shell=True`` — no shell means no
-    word-splitting, the main#688 contract shared with wave_status.py.
-    """
-    proc = subprocess.run(
-        ["gh", *args],
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-    return proc.stdout
-
-
-def _load_status(status_path: Path) -> dict:
-    return json.loads(status_path.read_text())
+# Shared gh shim + status reader (main#1119). Module-level names, so
+# `wave_merge_model._run_gh` stays the same patchable seam it has always been
+# and `check_reachability`'s `run_gh=_run_gh` default keeps working.
+_run_gh = gh.run_gh
+_load_status = wave_state.load_status
 
 
 def validate_merge_model(model: str) -> str:
@@ -120,20 +111,10 @@ def read_merge_model(wave: str, status_path: Path) -> str | None:
     return validate_merge_model(str(val))
 
 
-def read_repos(wave: str, status_path: Path) -> list[str]:
-    """Return ``wave_{M}_repos_in_scope`` as a list of repo names.
-
-    Raises KeyError if absent — by the time the reachability check runs the
-    wave's scope must already be recorded (same contract as wave_status.py).
-    """
-    data = _load_status(status_path)
-    key = f"wave_{wave}_repos_in_scope"
-    if key not in data:
-        raise KeyError(key)
-    repos = data[key]
-    if not isinstance(repos, list):
-        raise TypeError(f"{key} is not a list: {repos!r}")
-    return [str(r) for r in repos]
+# Was a verbatim copy of wave_status.read_repos; both now resolve to the single
+# definition in wave_state (main#1119). Same contract: KeyError when the wave's
+# scope was never recorded, TypeError when it is present but not a list.
+read_repos = wave_state.read_repos
 
 
 def classify_reachability(
@@ -364,13 +345,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     sub = parser.add_subparsers(dest="command", required=True)
 
-    def _add_status(p: argparse.ArgumentParser) -> None:
-        p.add_argument(
-            "--status",
-            type=Path,
-            default=_DEFAULT_STATUS,
-            help="path to cross-repo-status.json (default: repo-root copy)",
-        )
+    _add_status = wave_state.add_status_argument
 
     p_model = sub.add_parser("model", help="print the declared wave merge model")
     p_model.add_argument("phase", help="phase number (P)")

--- a/.claude/lib/wave_seq.py
+++ b/.claude/lib/wave_seq.py
@@ -65,15 +65,17 @@ CLI:
 from __future__ import annotations
 
 import argparse
-import json
 import re
 import sys
 from pathlib import Path
 
-# Repo root = two parents above .claude/lib/ (lib -> .claude -> root). Resolved
-# from this file so the default status path is correct from any cwd or worktree.
-_REPO_ROOT = Path(__file__).resolve().parents[2]
-_DEFAULT_STATUS = _REPO_ROOT / "cross-repo-status.json"
+# wave_state lives alongside this file in .claude/lib/. Running as a script puts
+# this dir on sys.path[0]; the tests add it explicitly.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import wave_state  # noqa: E402
+
+_REPO_ROOT = wave_state.REPO_ROOT
+_DEFAULT_STATUS = wave_state.DEFAULT_STATUS_PATH
 
 # The counter is seeded at least this high at first allocation, so the first
 # global wave (HISTORICAL_FLOOR + 1 = 16) sits ABOVE every per-phase wave number
@@ -209,8 +211,10 @@ def phase_ordinal(status: dict, phase: int) -> int:
     return count + 1
 
 
-def _load(status_path: Path) -> dict:
-    return json.loads(status_path.read_text())
+# Shared status reader (main#1119). Spelled `_load` here rather than
+# `_load_status` for the same reason it always was — this module's CLI takes the
+# path positionally, not as `--status`.
+_load = wave_state.load_status
 
 
 def _cmd_peek(args: argparse.Namespace) -> int:

--- a/.claude/lib/wave_state.py
+++ b/.claude/lib/wave_state.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""Shared READ access to cross-repo-status.json (main#1119, epic main#1019).
+
+Seven modules independently derived the same ``_DEFAULT_STATUS`` path, four
+defined the same ``_load_status``, two carried a verbatim ``read_repos``, and
+six repeated the same ``--status`` argparse block. This is that surface, once.
+
+READ ONLY — writes must NEVER be routed through this module
+============================================================
+`cross-repo-status.json` is deliberately mixed-style: top-level ``wave_{N}_*``
+keys are compact single-liners while older ``wave_*_scope`` blocks are
+pretty-indented. That shape is load-bearing for reviewability — a
+``json.dumps`` round-trip reformats every compact line into jq's default
+pretty form and turns a two-key update into a ~1755-line cosmetic diff.
+
+So `upsert_status_keys.py` writes **text-surgically**: it reads the raw TEXT,
+edits the specific lines, validates that the text-level result parses to the
+same logical dict as the in-memory result, and writes the TEXT back. It parses
+JSON only to *validate*, never to re-serialise, and it must keep doing so.
+
+**To a future consolidator: do not "finish the job" by routing
+`upsert_status_keys` through :func:`load_status`.** Two independent reasons:
+
+1. It needs the raw text, not a parsed dict — a parsed dict cannot round-trip
+   back to the original formatting.
+2. Its validation parse must reflect the exact bytes it is about to edit. A
+   cached dict is by definition not guaranteed to be those bytes, so feeding
+   it one would make the before/after equality check compare the new text
+   against a *stale* logical baseline — converting the file's strongest
+   corruption guard into a rubber stamp.
+
+`upsert_status_keys.py` is intentionally untouched by main#1119 and imports
+nothing from here.
+
+The cache, and why its key is what it is
+=========================================
+:func:`load_status` memoises the parse per process, keyed on the file's stat
+identity. A cache over a file that the *same process* also rewrites is a
+correctness change, not a perf change, so the invalidation rule is spelled out
+rather than assumed.
+
+**Key = (st_dev, st_ino, st_size, st_mtime_ns)**, recomputed by a fresh
+``stat()`` on *every* call. A stat is microseconds against a ~1.5 ms parse of
+this 343 KB file, so validating on every access costs nothing measurable and
+buys the property that matters: **no caller, and no writer, ever has to
+remember to invalidate.** Coupling the writer to the reader would be one more
+thing to get wrong.
+
+Each key component earns its place:
+
+* ``st_mtime_ns`` — the primary signal; nanosecond field so a sub-second
+  rewrite is visible on any filesystem that records one (measured here:
+  ~0.6 ms granularity).
+* ``st_size`` — catches a same-tick rewrite that changed length, which
+  ``st_mtime_ns`` alone would miss on a coarse filesystem.
+* ``st_ino`` + ``st_dev`` — catch atomic replacement by rename (write-temp +
+  ``mv``), where the new file legitimately carries an *older* mtime than the
+  one we cached. Without the inode, that write would be invisible.
+
+**The racy-tick guard** (the part mtime-keyed caches usually get wrong):
+``st_mtime_ns`` has a nanosecond *field*, not necessarily nanosecond
+*resolution*. On a 1-second-granularity filesystem (ext3, HFS+, some network
+mounts, some CI runners) two writes inside the same second produce an
+identical timestamp; if they also produce an identical size, the key collides
+and we would serve stale data. The size check makes that unlikely, not
+impossible — flipping a counter from ``5`` to ``6`` preserves length exactly,
+and this file is full of small integer counters.
+
+So an entry is cached only once its timestamp tick is **settled** — i.e. no
+future write can still land inside it:
+
+    mtime_ns + granularity <= now_ns
+
+``granularity`` is inferred from the timestamp itself rather than probed: a
+value with sub-second bits proves the filesystem records them (granularity
+~1 ns), while a value on an exact second is treated as possibly-truncated
+(granularity 1 s). Landing on an exact second by chance on a nanosecond
+filesystem costs one skipped cache entry and never costs correctness — the
+inference is deliberately biased toward not caching.
+
+This is the same hazard git handles for its index ("racily clean" entries) and
+the same mitigation: refuse to trust a timestamp that is still current. The
+practical effect is that a write-then-read within the same tick — exactly the
+`/wave-kickoff` and `--write` shapes — is **always re-read from disk**, and
+steady-state reads of a settled file are served from memory.
+
+Consequence to state plainly: "one parse per process" holds for a file whose
+mtime has settled. It deliberately does NOT hold for a file rewritten during
+the same tick, and buying that last parse back would mean trusting a timestamp
+that cannot be trusted.
+
+The returned mapping is SHARED — treat it as read-only
+=======================================================
+:func:`load_status` returns the cached object itself, not a copy; copying a
+490-key dict on every call would spend most of what the cache saves. No caller
+in this package mutates it today (they build new dicts — see
+``wave_status.build_digest``), and ``test_wave_state.py`` pins that invariant
+by deep-comparing the loaded mapping before and after exercising every public
+read API. A caller that needs to mutate must copy first.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any, NamedTuple
+
+# Repo root = two parents above .claude/lib/ (lib -> .claude -> root). Resolved
+# from this file so the default is correct from any cwd or worktree, with no
+# `git rev-parse` subprocess (which would re-introduce a shell dependency).
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_STATUS_PATH = REPO_ROOT / "cross-repo-status.json"
+
+#: Help text for the shared ``--status`` option. Kept as a constant so the six
+#: parsers that used to spell it out individually cannot drift apart again.
+STATUS_ARG_HELP = "path to cross-repo-status.json (default: repo-root copy)"
+
+#: One second in nanoseconds — the assumed granularity of a filesystem whose
+#: mtime lands on an exact second. See module docstring § racy-tick guard.
+_COARSE_GRANULARITY_NS = 1_000_000_000
+
+
+class _StatKey(NamedTuple):
+    """The identity of a particular version of a particular file."""
+
+    dev: int
+    ino: int
+    size: int
+    mtime_ns: int
+
+
+class _Entry(NamedTuple):
+    key: _StatKey
+    data: dict
+
+
+class CacheInfo(NamedTuple):
+    """Observability for the cache, so tests can assert parse counts directly.
+
+    ``parses`` is the number of times the file was actually read and decoded —
+    the quantity main#1119 is about. ``hits`` counts cache-satisfied calls;
+    ``uncacheable`` counts parses that were deliberately NOT cached because the
+    file's timestamp tick had not settled (module docstring § racy-tick guard),
+    which is the number that distinguishes "the cache is working" from "the
+    cache is silently never engaging".
+    """
+
+    hits: int
+    parses: int
+    uncacheable: int
+
+
+_CACHE: dict[str, _Entry] = {}
+_HITS = 0
+_PARSES = 0
+_UNCACHEABLE = 0
+
+
+def _now_ns() -> int:
+    """Wall-clock nanoseconds, as an injectable seam.
+
+    Must be the same clock family as ``st_mtime_ns`` (wall clock, not
+    monotonic) — a monotonic clock cannot be compared against a file
+    timestamp. Indirected through a function so the racy-tick tests can pin
+    "now" instead of racing a real second boundary; the same test-injection
+    pattern as ``_consultation_sentinel._now_seconds``.
+    """
+    return time.time_ns()
+
+
+def _stat_key(st: os.stat_result) -> _StatKey:
+    return _StatKey(st.st_dev, st.st_ino, st.st_size, st.st_mtime_ns)
+
+
+def _tick_has_settled(mtime_ns: int, now_ns: int) -> bool:
+    """True when no future write can still produce ``mtime_ns``.
+
+    Sub-second bits in the timestamp prove the filesystem records them, so the
+    tick is one nanosecond wide and settles as soon as the clock passes it. An
+    exact-second value may have been truncated, so it is treated as a
+    one-second-wide tick that only settles a full second later.
+
+    A future-dated file (``mtime_ns > now_ns``, clock skew on a network mount)
+    fails this check too — a timestamp ahead of our clock is not one we can
+    reason about, so it is never cached.
+    """
+    granularity = 1 if mtime_ns % _COARSE_GRANULARITY_NS else _COARSE_GRANULARITY_NS
+    return mtime_ns + granularity <= now_ns
+
+
+def load_status(status_path: Path | str) -> dict:
+    """Parse `cross-repo-status.json` at ``status_path``, memoised per process.
+
+    Behaviourally identical to the ``json.loads(path.read_text())`` one-liners
+    it replaces, including the exceptions it raises: ``OSError`` if the file
+    cannot be read, ``json.JSONDecodeError`` if it does not parse. A stale
+    cache entry can never be returned — see module docstring § The cache.
+
+    The returned mapping is shared; do not mutate it.
+    """
+    global _HITS, _PARSES, _UNCACHEABLE
+
+    path = Path(status_path)
+    try:
+        st = path.stat()
+    except OSError:
+        # Cannot establish identity — fall through to an uncached read so the
+        # caller sees the real OSError from the read itself, exactly as the
+        # un-cached one-liners did.
+        _PARSES += 1
+        _UNCACHEABLE += 1
+        return json.loads(path.read_text())
+
+    cache_key = os.path.realpath(path)
+    key = _stat_key(st)
+
+    entry = _CACHE.get(cache_key)
+    if entry is not None and entry.key == key:
+        _HITS += 1
+        return entry.data
+
+    text = path.read_text()
+    data = json.loads(text)
+    _PARSES += 1
+
+    # Re-stat AFTER the read: a write that landed mid-read would otherwise be
+    # cached under the pre-read identity, pinning a torn parse for the rest of
+    # the process. If anything moved, serve this result but cache nothing.
+    try:
+        key_after = _stat_key(path.stat())
+    except OSError:
+        _UNCACHEABLE += 1
+        _CACHE.pop(cache_key, None)
+        return data
+
+    if key_after == key and _tick_has_settled(key.mtime_ns, _now_ns()):
+        _CACHE[cache_key] = _Entry(key, data)
+    else:
+        _UNCACHEABLE += 1
+        _CACHE.pop(cache_key, None)
+    return data
+
+
+def invalidate(status_path: Path | str | None = None) -> None:
+    """Drop cached parses — for ``status_path``, or all of them when None.
+
+    Not required for correctness: :func:`load_status` re-stats on every call,
+    so a rewritten file is detected without anyone announcing it. This is an
+    escape hatch for tests and for any future caller that has a reason to force
+    a re-read. Callers must NOT come to depend on it — a writer that has to
+    remember to invalidate is the failure mode the stat-on-every-call design
+    exists to make impossible.
+    """
+    if status_path is None:
+        _CACHE.clear()
+        return
+    _CACHE.pop(os.path.realpath(Path(status_path)), None)
+
+
+def cache_info() -> CacheInfo:
+    """Current hit / parse / uncacheable counters (see :class:`CacheInfo`)."""
+    return CacheInfo(hits=_HITS, parses=_PARSES, uncacheable=_UNCACHEABLE)
+
+
+def reset_cache_info() -> None:
+    """Zero the counters. Test-only; does not touch cached data."""
+    global _HITS, _PARSES, _UNCACHEABLE
+    _HITS = _PARSES = _UNCACHEABLE = 0
+
+
+def add_status_argument(parser: argparse.ArgumentParser, *, flag: str = "--status") -> None:
+    """Add the shared ``--status PATH`` option to ``parser``.
+
+    Identical option in six modules; ``flag`` exists only so a caller can spell
+    it differently without re-deriving the type/default/help triple.
+    """
+    parser.add_argument(flag, type=Path, default=DEFAULT_STATUS_PATH, help=STATUS_ARG_HELP)
+
+
+def read_repos(wave: str, status_path: Path) -> list[str]:
+    """Return ``wave_{M}_repos_in_scope`` as a list of repo names.
+
+    Raises KeyError if the key is absent — by the time any caller runs, the
+    wave's scope must already be recorded, so a missing key is an operator
+    error to surface rather than silently treat as the empty set. Raises
+    TypeError if the value is present but not a list.
+    """
+    data = load_status(status_path)
+    key = f"wave_{wave}_repos_in_scope"
+    if key not in data:
+        raise KeyError(key)
+    repos: Any = data[key]
+    if not isinstance(repos, list):
+        raise TypeError(f"{key} is not a list: {repos!r}")
+    return [str(r) for r in repos]

--- a/.claude/lib/wave_status.py
+++ b/.claude/lib/wave_status.py
@@ -49,18 +49,17 @@ from pathlib import Path
 # is run as a script its own directory is on sys.path[0]; the tests add the
 # lib dir explicitly (mirrors the trust_signals.py -> wave_status.py import).
 sys.path.insert(0, str(Path(__file__).resolve().parent))
+import gh  # noqa: E402
 import wave_merge_model  # noqa: E402
+import wave_state  # noqa: E402
 
 # upsert_status_keys.py lives alongside this file in .claude/lib/. When this
 # module is run as a script its own directory is on sys.path[0]; the tests add
 # the lib dir explicitly. Import lazily inside _write_counters so a missing
 # helper only matters for the --write path.
 
-# Repo root = two parents above .claude/lib/ (lib -> .claude -> root). Resolved
-# from this file so the default is correct from any cwd or worktree, with no
-# `git rev-parse` subprocess (which would re-introduce a shell dependency).
-_REPO_ROOT = Path(__file__).resolve().parents[2]
-_DEFAULT_STATUS = _REPO_ROOT / "cross-repo-status.json"
+_REPO_ROOT = wave_state.REPO_ROOT
+_DEFAULT_STATUS = wave_state.DEFAULT_STATUS_PATH
 
 # A ChangesRequested verdict comment on a PR's issue-comments timeline. Mirrors
 # the regex the pre-#688 bash Step 10.5 block used. The DOUBLED backslash is
@@ -70,41 +69,15 @@ _DEFAULT_STATUS = _REPO_ROOT / "cross-repo-status.json"
 _CHANGES_REQUESTED_RE = "RequestOrReplied:\\\\s*ChangesRequested"
 
 
-def _run_gh(args: list[str]) -> str:
-    """Run ``gh <args>`` with an explicit arg list and return stdout.
-
-    Never a shell string and never ``shell=True`` — this is the whole point of
-    the helper (main#688): no shell means no word-splitting, so a multi-word
-    repo list can never collapse into one bogus ``--repo`` value.
-    """
-    proc = subprocess.run(
-        ["gh", *args],
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-    return proc.stdout
-
-
-def _load_status(status_path: Path) -> dict:
-    return json.loads(status_path.read_text())
-
-
-def read_repos(wave: str, status_path: Path) -> list[str]:
-    """Return ``wave_{M}_repos_in_scope`` as a list of repo names.
-
-    Raises KeyError if the key is absent — by the time any of these subcommands
-    runs the wave's scope must already be recorded, so a missing key is an
-    operator error to surface rather than silently treat as the empty set.
-    """
-    data = _load_status(status_path)
-    key = f"wave_{wave}_repos_in_scope"
-    if key not in data:
-        raise KeyError(key)
-    repos = data[key]
-    if not isinstance(repos, list):
-        raise TypeError(f"{key} is not a list: {repos!r}")
-    return [str(r) for r in repos]
+# The shared gh shim and status reader (main#1119). These stay module-level
+# names rather than becoming direct `gh.run_gh(...)` / `wave_state.load_status(...)`
+# call sites so that `wave_status._run_gh` and `wave_status.read_repos` remain
+# patchable/importable exactly as before — `test_lifecycle` calls
+# `wave_status.read_repos` directly, and the module's own callers below resolve
+# `_run_gh` through the module globals, preserving every existing test seam.
+_run_gh = gh.run_gh
+_load_status = wave_state.load_status
+read_repos = wave_state.read_repos
 
 
 def _kickoff_ts(wave: str, status_path: Path) -> str | None:
@@ -768,23 +741,13 @@ def _build_parser() -> argparse.ArgumentParser:
     def _add_pm(p: argparse.ArgumentParser) -> None:
         p.add_argument("phase", help="phase number (P)")
         p.add_argument("wave", help="wave number (M)")
-        p.add_argument(
-            "--status",
-            type=Path,
-            default=_DEFAULT_STATUS,
-            help="path to cross-repo-status.json (default: repo-root copy)",
-        )
+        wave_state.add_status_argument(p)
 
     p_digest = sub.add_parser(
         "digest",
         help="emit a compact current-wave/phase projection of the status file (session-start)",
     )
-    p_digest.add_argument(
-        "--status",
-        type=Path,
-        default=_DEFAULT_STATUS,
-        help="path to cross-repo-status.json (default: repo-root copy)",
-    )
+    wave_state.add_status_argument(p_digest)
     p_digest.set_defaults(func=_cmd_digest)
 
     p_repos = sub.add_parser("repos", help="emit wave_{M}_repos_in_scope one per line")

--- a/.claude/lib/wave_unwrapped.py
+++ b/.claude/lib/wave_unwrapped.py
@@ -48,10 +48,14 @@ import subprocess
 import sys
 from pathlib import Path
 
-# Repo root = two parents above .claude/lib/ (lib -> .claude -> root). Resolved
-# from this file so the default is correct from any cwd or worktree.
-_REPO_ROOT = Path(__file__).resolve().parents[2]
-_DEFAULT_STATUS = _REPO_ROOT / "cross-repo-status.json"
+# Siblings live alongside this file in .claude/lib/ (same bootstrap as
+# wave_status.py / wave_merge_model.py).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import gh  # noqa: E402
+import wave_state  # noqa: E402
+
+_REPO_ROOT = wave_state.REPO_ROOT
+_DEFAULT_STATUS = wave_state.DEFAULT_STATUS_PATH
 
 # Wrapup-marker key spellings, oldest-to-newest. ANY present-and-non-null value
 # means the wave was wrapped. ``completed_at`` is intentionally absent — see the
@@ -59,24 +63,11 @@ _DEFAULT_STATUS = _REPO_ROOT / "cross-repo-status.json"
 _WRAPUP_MARKERS = ("wrapped_up_at", "wrapup_completed_at", "wrapped_at")
 
 
-def _run_gh(args: list[str]) -> str:
-    """Run ``gh <args>`` with an explicit arg list and return stdout.
-
-    Explicit arg list (never a shell string, never ``shell=True``) so a
-    multi-word value can never word-split under zsh — same contract as
-    ``wave_status._run_gh`` (main#688).
-    """
-    proc = subprocess.run(
-        ["gh", *args],
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-    return proc.stdout
-
-
-def _load_status(status_path: Path) -> dict:
-    return json.loads(Path(status_path).read_text())
+# Shared gh shim + status reader (main#1119). `_load_status` here used to wrap
+# its argument in `Path(...)` before reading, unlike its three siblings;
+# `wave_state.load_status` does the same coercion, so str paths keep working.
+_run_gh = gh.run_gh
+_load_status = wave_state.load_status
 
 
 def current_wave_number(data: dict) -> str | None:
@@ -266,12 +257,7 @@ def _build_parser() -> argparse.ArgumentParser:
     sub = parser.add_subparsers(dest="command", required=True)
 
     p_check = sub.add_parser("check", help="classify the current wave's wrap state")
-    p_check.add_argument(
-        "--status",
-        type=Path,
-        default=_DEFAULT_STATUS,
-        help="path to cross-repo-status.json (default: repo-root copy)",
-    )
+    wave_state.add_status_argument(p_check)
     p_check.add_argument("--phase", default=None, help="phase number (fallback for base branch)")
     p_check.add_argument("--wave", default=None, help="override the current-wave number")
     p_check.add_argument(


### PR DESCRIPTION
Closes #1119. Feeds epic #1019 (references, does not close).

Extracts `.claude/lib/wave_state.py` (shared `cross-repo-status.json` reader) and `.claude/lib/gh.py` (one `run_gh` + `GhError`) from the copies that had accreted across nine modules.

## Re-measured, because the audit is from `3bdd620`

The audit's counts were taken months ago and the tree has moved. Measured at HEAD by AST-hashing each function body with docstrings stripped (`_run_gh` docstrings differ per module while the bodies are byte-identical, so a text diff under-counts):

| Duplicate | Audit said | Actually at HEAD | Note |
|---|---|---|---|
| identical `_run_gh` | 5 | **6** | `base_pin_drift_sweep.py` (#1205, landed same day) is the sixth; `kickoff_sweep.py` was already the fifth |
| `_run_gh` definitions total | — | **8** | the other two (`gh_rest.py`, `verify_deployable_merge.py`) are NOT identical — different contracts |
| identical `_load_status` | 4 | **3** | the audit over-counted: `wave_unwrapped`'s wraps its arg in `Path(...)`, the other three do not |
| `_DEFAULT_STATUS` | ×6 | **×7** | `trust_signals.py` is the seventh |
| `--status` argparse block | ×5 | **×7** (6 modules) | `wave_status.py` has two |
| `read_repos` verbatim | ×2 | **×2** | confirmed |

### The perf premise does not survive re-measurement

The issue states a single `digest` call "parses it repeatedly". **It does not — `build_digest` parses exactly once.** Instrumenting `json.loads`/`read_text` at base:

| call | status-file parses (base) | (head) |
|---|---|---|
| `wave_status digest` | **1** | 1 |
| `wave_status repos` | 1 | 0 (cached) |
| `merged_prs` / `compute_counters` | 4 | 1 |
| `reconciliation_warning` | **6** | 1 |
| `wave_merge_model reachability` | 2+ | 1 |

The file is also **343 KB / 490 keys** now, not 234 KB / 456. A parse costs ~1.5 ms, so the worst path (`reconciliation_warning`, 6 parses) was wasting ~9 ms — on a path that then makes dozens of network `gh` calls. **The real justification for this change is DRY, not speed**, and reviewers should weigh it that way.

## Cache-key decision

Key = **`(st_dev, st_ino, st_size, st_mtime_ns)`**, re-`stat()`ed on **every** call. A stat is microseconds against a ~1.5 ms parse, so validating every time costs nothing measurable and means **no writer ever has to remember to invalidate** — coupling the writer to the reader would be one more thing to get wrong. `invalidate()` exists as an escape hatch, not as a requirement.

Each component is load-bearing and separately tested:
- `st_mtime_ns` — primary signal (measured FS granularity here: ~0.6 ms).
- `st_size` — catches a same-tick rewrite of different length.
- `st_ino`/`st_dev` — catches atomic replace-by-rename, where the new file may carry an **older** mtime.

**Racy-tick guard.** `st_mtime_ns` has a nanosecond *field*, not necessarily nanosecond *resolution*. On a 1-second-granularity filesystem two writes in the same second alias, and if the size also matches (a counter `5`→`6` preserves length exactly — this file is full of those) the key collides and stale data would be served. So an entry is cached only once its tick has **settled**: `mtime_ns + granularity <= now_ns`. Granularity is *inferred from the timestamp itself* — sub-second bits prove the FS records them (~1 ns), an exact second is treated as possibly-truncated (1 s). Landing on an exact second by chance costs one skipped cache entry and never costs correctness; the inference is deliberately biased toward not caching. Same hazard and mitigation as git's "racily clean" index entries.

Stated plainly: **"one parse per process" holds for a file whose mtime has settled, and deliberately does NOT hold for a file rewritten within the current tick** (exactly the `/wave-kickoff` and `--write` shapes). Buying that last parse back would mean trusting a timestamp that cannot be trusted.

## Writes still go through the text-surgical path

`upsert_status_keys.py` is **untouched** and imports nothing from here — asserted by test, not just by intent. `cross-repo-status.json` is deliberately mixed-style; a `json.dumps` round-trip reflows it into a ~1755-line cosmetic diff. Two tests pin it: the compact-inline lines survive a write, and `wave_status._write_counters` (the real caller) preserves line count while the loader reads the new value back.

`wave_state.py`'s docstring carries an explicit **"to a future consolidator: do not finish the job"** section with both reasons — the writer needs raw text, and its before/after equality check must reflect the exact bytes it is about to edit (a cached dict would turn that corruption guard into a rubber stamp).

## Behaviour identity: base-vs-head on real data

Exported `origin/main`'s `.claude/lib` + `.claude/hooks` and ran **19** read-only surfaces under both trees against a **copy** of the real 343 KB `cross-repo-status.json`, diffing stdout byte-for-byte. **All 19 identical**, exit codes included — `digest` (109,039 bytes), `repos` (incl. the KeyError exit-1 path), `wave_seq peek`/`allocate --dry-run`, `merge_model`, `wave_unwrapped check`, `lifecycle`, and all 7 `--help` texts.

The one initial divergence (`kickoff_sweep --help`) was an artifact of my export omitting `.claude/hooks`; confirmed by reproducing the `ModuleNotFoundError` directly, then re-run clean.

## Mutation results — 18/18 killed (verdicts are pytest exit codes)

| # | Mutant | Exit | Killed by |
|---|---|---|---|
| M1 | drop the racy-tick guard | 1 | `test_same_tick_rewrite_on_a_coarse_filesystem_is_seen` |
| M2 | drop `st_size` from the key | 1 | `test_rewrite_changing_only_the_size_is_seen` |
| M3 | drop `st_mtime_ns` | 1 | 3 tests |
| M4 | drop `st_ino` | 1 | `test_atomic_replace_with_identical_size_and_mtime_is_seen` |
| M5 | invert granularity inference | 1 | 3 tests |
| M6 | `settled` off-by-one (drop `+ granularity`) | 1 | 3 tests |
| **M7** | **drop the post-read re-stat** | **1** | **see below** |
| M8 | `read_repos` drops `isinstance` | 1 | `test_non_list_value_raises_typeerror` |
| M9 | `read_repos` returns `[]` on missing key | 1 | 3 tests incl. an existing suite |
| M10 | `--status` drops `type=Path` | 1 | `test_parses_an_explicit_value_as_a_path` |
| M11 | `--status` drops `default` | 1 | `test_defaults_to_the_repo_root_copy` |
| M12 | `run_gh` drops `check=True` | 1 | `test_invokes_gh_with_an_explicit_arg_list_and_no_shell` |
| M13 | `run_gh` passes a shell string | 1 | 37 tests |
| M14 | `run_gh` wraps errors in `GhError` | 1 | 4 tests, incl. an **existing** `GhArgListGuardTest` |
| M15 | `wave_status._run_gh` rebound | 1 | 33 tests |
| M16 | `wave_merge_model.read_repos` rebound | 1 | 3 tests |
| M17 | `run_gh` returns stderr | 1 | 35 tests |

### M7 — the one that mattered

`drop the post-read re-stat` **survived** the first pass. Rather than call the test inert, I built both variants as standalone loaders and drove them through six write-during-read shapes. Five were identical; one **diverged**:

```
revert to the original stat key    restat=(1, 3)   norestat=(1, 1)   *** DIVERGES ***
```

So it is a **genuine hole, not an equivalent mutant**: a write landing between the pre-read `stat()` and the end of `read_text()` gets its parse cached under a key the file has already left, and is served stale the moment the stat key returns to that value. `test_a_write_landing_during_the_read_is_never_cached` now closes it (commit 2), and M7 re-runs as killed.

M14 is worth flagging too: wrapping gh failures in `GhError` breaks an **existing** production test, confirming that `red_sweep`/`base_pin_drift_sweep`'s `_GH_ERRORS = (CalledProcessError, OSError)` handlers are genuinely load-bearing. `gh.run_gh` therefore propagates raw and the docstring says why — a "pure DRY cleanup" that silently converted a graceful degrade into an unhandled traceback is exactly the failure this consolidation must not cause.

## Line count — honest framing

- **Nine existing modules: 99 insertions / 181 deletions = −82 net**, inside the issue's −75–90 target.
- **New shared modules: +389** (`gh.py` 91, `wave_state.py` 298 — the majority is the cache-correctness rationale above), plus **+700** of tests.

So the *duplication* is gone and the touched modules shrank as forecast, but the repo's total line count goes **up**. Worth stating rather than quoting only the −82.

## Scope held deliberately narrow

- **`base_pin_drift_sweep.py` NOT converted** — it is under active rework in #1295 and a 4-line dedup is not worth a merge conflict on a file another agent is rewriting. Follow-up filed as #1322.
- **`gh_rest.py` NOT converted** — different contract on purpose (`timeout=`, no `check=True`, raises `GhRestError` so a REST fallback never masquerades as an empty result, #1224). Pinned by `test_gh_rest_shim_is_deliberately_not_the_shared_one`.
- **`verify_deployable_merge.py`** keeps its wrapper (that wrapping IS its behaviour) but now builds on `gh.run_gh` and imports the one `GhError`, so `verify_deployable_merge.GhError is gh.GhError`.
- **`pr_review_state.py` untouched** (read by #1320's author); `.claude/hooks/_shell_parse.py` and `validate_pr_review.py` untouched (#1316/#1320).

## Verification

- `pre-commit run --all-files` and `--hook-stage pre-push`: **all green** (ruff-format, ruff-lint, actionlint, cspell, fixture-realism, skill-graphql-pagination, checksums-ascii, mypy ×2, pytest ×2, memory/headcount budgets, doc-freshness, office-drift, mermaid-render).
- `pre_commit_ci_sync.py`: `OK: pre-commit config mirrors all CI-enforced checks.`
- Full suite after rebase: **3926 passed, 811 subtests** (exit 0).
- The issue names "the 6 strong per-module suites" — the real blast radius is **10** existing suites plus the new one; all 11 run green (342 passed, 20 subtests).

Rebased on `origin/main` (`e58ccd6`) before opening. No merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
