### PR TITLE
fix(commit-identity): resolve stdin-redirect script operand in heredoc write-then-exec correlation

### DIFF
--- a/.claude/hooks/_shell_parse.py
+++ b/.claude/hooks/_shell_parse.py
@@ -1018,9 +1018,20 @@ def _opener_feeds_interpreter(line: str, pos: int, scan: _LineScan) -> bool:
 #     bash "$F"`) or any other divergent spelling defeats it exactly as
 #     variable resolution in general would.
 #   - `bash < FILE` (script fed via stdin redirect rather than a positional
-#     argument) is a different execution mechanism than the positional
-#     `InterpreterInvocation.operands` this correlation reads, and is not
-#     resolved by the pre-existing shape-7 walker either — out of scope here.
+#     argument) IS now covered (main#1170): `parse_interpreter_invocation`
+#     folds a bare `< FILE` redirect into `operands[0]`, the same slot this
+#     correlation already reads via `_script_invocation_targets`, so a heredoc
+#     written to FILE and later fed to an interpreter through `< FILE` (a
+#     `mkfifo`-relayed FIFO, in main#1170's shape, or an ordinary regular
+#     file) reclassifies as CODE without any new correlation machinery. This
+#     resolves main#1287 shape 1 as a byproduct — its shapes 2 (`$(...)`
+#     -produced path) and 3 (`cp` copy indirection) remain unresolved and stay
+#     filed there. The pre-existing shape-7 walker in `validate_commit_identity`
+#     (which reads a script's CONTENT off disk, not this module's path
+#     correlation) is unaffected by this change either way: it fires
+#     PreToolUse, before a same-command heredoc write has run, so the file it
+#     would read never has the relevant content yet regardless of which
+#     operand slot names it.
 #   - The attached-operator redirect form with no surrounding whitespace
 #     (`cat>/tmp/x`, as opposed to `cat > /tmp/x`) is not recognised by
 #     `_segment_write_targets`'s tokenizer, which relies on shlex already
@@ -2096,7 +2107,10 @@ class InterpreterInvocation(NamedTuple):
     `operands` are the tokens after the option run, i.e. what the shell itself
     treats as `<command-string> [$0 $1 ...]` or `<script> [args]`. This is the
     shell-accurate answer and is what a consumer that must resolve a real path
-    (the script-invocation check) should use.
+    (the script-invocation check) should use. `operands[0]` also resolves a
+    stdin-redirect script (`bash < FILE`, main#1170/main#1287 shape 1) to
+    `FILE` — see `parse_interpreter_invocation`'s docstring for why that slot,
+    not a separate field, is the shell-accurate place for it.
 
     `words` is every token of the invocation except the `--` sentinel — the set
     the command string is guaranteed to be a member of. It is deliberately a
@@ -2177,6 +2191,23 @@ def parse_interpreter_invocation(segment: list[str]) -> InterpreterInvocation | 
     Returns None when the segment is empty or its head is not one of
     `SHELL_INTERPRETERS` — callers must treat None as "not an interpreter
     invocation", never as "safe".
+
+    Stdin-redirect operand resolution (main#1170 / main#1287 shape 1):
+    `bash < FILE` feeds FILE to the interpreter as its script through the
+    process's own stdin rather than as a positional argument, but it answers
+    the exact same question `operands[0]` exists to answer — "what file does
+    this interpreter execute?" — so the redirect target is folded into
+    `operands` in the `[0]` slot, shell-accurately: any OTHER bare word in the
+    operand region becomes `$1`/`$2`/… passed TO that script, not a second
+    script, so it is never in the running for the `[0]` slot once a stdin
+    target is found. Only the spaced form (`< FILE`, not `<FILE`) is
+    recognised — the same convention `_segment_write_targets` already applies
+    to `>`/`>>` — and only a BARE `<` token qualifies: `<<` (a heredoc opener)
+    is never present here (callers strip it before tokenizing — see
+    `_HEREDOC_OPENER_RE`), and `<(` (process substitution) arrives from shlex
+    fused into one token (`<(cmd)`) whenever it isn't preceded by whitespace,
+    so it can't be mistaken for a bare `<`. The LAST `< FILE` on the line
+    wins, mirroring a real shell's last-redirect-wins semantics.
     """
     tokens = strip_command_prefixes(segment)
     if not tokens:
@@ -2191,7 +2222,22 @@ def parse_interpreter_invocation(segment: list[str]) -> InterpreterInvocation | 
 
     end = _consume_wrapper_options(rest, SHELL_VALUE_OPTIONS, 0)
     has_command_string = _COMMAND_STRING_FLAG in rest[:end]
-    operands = tuple(rest[end:])
+
+    stdin_target: str | None = None
+    other_operands: list[str] = []
+    j = end
+    n = len(rest)
+    while j < n:
+        tok = rest[j]
+        if tok == "<" and j + 1 < n:
+            stdin_target = rest[j + 1]
+            j += 2
+            continue
+        other_operands.append(tok)
+        j += 1
+    operands = (
+        (stdin_target, *other_operands) if stdin_target is not None else tuple(other_operands)
+    )
     words = tuple(t for t in rest if t != "--")
     return InterpreterInvocation(name, has_command_string, operands, words)
 

--- a/.claude/hooks/_shell_parse.py
+++ b/.claude/hooks/_shell_parse.py
@@ -2095,6 +2095,23 @@ _SHELL_VALUE_LETTERS = frozenset("oO")
 # The letter that introduces a command string: `sh -c '<cmd>'`.
 _COMMAND_STRING_FLAG = "-c"
 
+# A bare stdin-redirect operator, fd-0-targeting spellings only (main#1170,
+# widened for main#1326): `<`, `0<`, `<>`, `0<>`. All four are the identical
+# redirect as far as a shell's own script-source resolution is concerned — fd
+# 0 is stdin's default, `<>` (read-write open) still opens the SAME fd, and
+# the explicit `0` prefix is fused to the operator by shlex whenever no space
+# separates them (`0< FILE` -> one token `"0<"`, never `"0"` + `"<"`). All
+# four spellings were verified with a real-shell marker proxy (fake `git` on
+# PATH) under both bash and zsh: `bash 0< s.sh`, `bash <> s.sh`, and
+# `bash 0<> s.sh` all genuinely execute `s.sh`'s body, exactly like the bare
+# `bash < s.sh` main#1170 already covers. A DIFFERENT fd number is a
+# different redirect entirely and must NOT match — `bash 2< s.sh` does not
+# feed `s.sh` to the interpreter as its script (confirmed: the marker never
+# fires), so the leading digit run is restricted to the literal `0`, not
+# `\d*` as #1326's own suggested pattern had it (that pattern would also
+# wrongly swallow `2<`/`9<`/... as if they were stdin sources).
+_STDIN_REDIRECT_RE = re.compile(r"^0?<>?$")
+
 
 class InterpreterInvocation(NamedTuple):
     """A decoded `<shell> [options] [operands ...]` command.
@@ -2108,9 +2125,20 @@ class InterpreterInvocation(NamedTuple):
     treats as `<command-string> [$0 $1 ...]` or `<script> [args]`. This is the
     shell-accurate answer and is what a consumer that must resolve a real path
     (the script-invocation check) should use. `operands[0]` also resolves a
-    stdin-redirect script (`bash < FILE`, main#1170/main#1287 shape 1) to
-    `FILE` — see `parse_interpreter_invocation`'s docstring for why that slot,
-    not a separate field, is the shell-accurate place for it.
+    stdin-redirect script (`bash < FILE`, main#1170/main#1287 shape 1, widened
+    to the `0<`/`<>`/`0<>` spellings by main#1326) to `FILE` — but ONLY when
+    NO other (non-redirect) operand is present anywhere in the invocation. A
+    real shell always prefers an ordinary positional operand over a stdin
+    redirect as its script source, regardless of whether that operand sits
+    before or after the redirect token in the invocation — a stdin redirect
+    is not counted as an argument slot at all, so `bash script.sh < FILE` runs
+    `script.sh` (FILE is just its stdin stream) and `bash < FILE arg1` runs
+    `arg1` (FILE is again just stdin; `arg1` is the only real operand) — real
+    bash and zsh confirmed via marker proxy for both orderings. Only the `-s`
+    option (not currently modeled here — main#1325 review, filed as a
+    follow-up) forces the stdin content itself to be the script even when a
+    positional operand is also present. See `parse_interpreter_invocation`'s
+    docstring for the resolution rule.
 
     `words` is every token of the invocation except the `--` sentinel — the set
     the command string is guaranteed to be a member of. It is deliberately a
@@ -2192,22 +2220,58 @@ def parse_interpreter_invocation(segment: list[str]) -> InterpreterInvocation | 
     `SHELL_INTERPRETERS` — callers must treat None as "not an interpreter
     invocation", never as "safe".
 
-    Stdin-redirect operand resolution (main#1170 / main#1287 shape 1):
-    `bash < FILE` feeds FILE to the interpreter as its script through the
-    process's own stdin rather than as a positional argument, but it answers
-    the exact same question `operands[0]` exists to answer — "what file does
-    this interpreter execute?" — so the redirect target is folded into
-    `operands` in the `[0]` slot, shell-accurately: any OTHER bare word in the
-    operand region becomes `$1`/`$2`/… passed TO that script, not a second
-    script, so it is never in the running for the `[0]` slot once a stdin
-    target is found. Only the spaced form (`< FILE`, not `<FILE`) is
+    Stdin-redirect operand resolution (main#1170 / main#1287 shape 1, widened
+    for main#1326): `bash < FILE` feeds FILE to the interpreter as its script
+    through the process's own stdin rather than as a positional argument, but
+    it answers the exact same question `operands[0]` exists to answer —
+    "what file does this interpreter execute?" — so the redirect target CAN
+    be folded into `operands` in the `[0]` slot.
+
+    Precedence — a positional operand always wins, regardless of position
+    relative to the redirect (main#1325 review round 2, corrected from this
+    function's own first cut): a real shell does not count a stdin redirect
+    as an argument slot at all, so it never competes with an ordinary word for
+    the `[0]` position. Confirmed with a real-shell marker proxy under both
+    bash and zsh, in both orderings:
+
+      - `bash script.sh < FILE` runs `script.sh` — FILE is only script.sh's
+        stdin stream, never a competing script. (This function's FIRST cut
+        got this backwards: it unconditionally promoted the redirect target
+        into `[0]` even when a positional operand was already present,
+        which silently swapped which file gets read for content inspection
+        and which file the write-then-exec correlation watches — a measured
+        BLOCK->ALLOW bypass, a measured ALLOW->BLOCK false positive on the
+        ordinary `bash migrate.sh < input.csv` shape, a BLOCK->ALLOW
+        regression in the on-disk script-content walker for `bash -x s.sh <
+        FILE` / `bash -- s.sh < FILE`, and an over-block reintroducing
+        main#1152's own failure mode for a benign `bash deploy.sh < data.txt`
+        stdin feed. All four were the SAME defect, not four separate ones.)
+      - `bash < FILE arg1` runs `arg1` (which will typically fail to exist,
+        exactly like a real shell) — FILE is still only stdin; `arg1` is the
+        one true operand present, regardless of appearing textually AFTER the
+        redirect token.
+      - `bash < FILE` (no other operand at all) is the only shape where FILE
+        genuinely becomes the executed script — this is the ONLY case the
+        redirect target is promoted into `operands[0]`.
+
+    Only the `-s` option (not modeled here — filed as a follow-up in the
+    main#1325 review) can force the redirect target to be the script even
+    when a positional operand is also present; this function does not special
+    case it, matching its behaviour before this correction.
+
+    Redirect spelling: only the spaced form (`< FILE`, not `<FILE`) is
     recognised — the same convention `_segment_write_targets` already applies
-    to `>`/`>>` — and only a BARE `<` token qualifies: `<<` (a heredoc opener)
-    is never present here (callers strip it before tokenizing — see
+    to `>`/`>>`. The token itself must match `_STDIN_REDIRECT_RE` (`<`, `0<`,
+    `<>`, `0<>` — all four verified to genuinely feed the interpreter's
+    script under both bash and zsh; a different fd number, e.g. `2<`, does
+    NOT and is deliberately excluded). `<<` (a heredoc opener) is never
+    present here (callers strip it before tokenizing — see
     `_HEREDOC_OPENER_RE`), and `<(` (process substitution) arrives from shlex
     fused into one token (`<(cmd)`) whenever it isn't preceded by whitespace,
-    so it can't be mistaken for a bare `<`. The LAST `< FILE` on the line
-    wins, mirroring a real shell's last-redirect-wins semantics.
+    so it can't be mistaken for a bare `<`. The LAST matching redirect token
+    on the line wins for STDIN-TARGET tracking, mirroring a real shell's
+    last-redirect-wins semantics — moot whenever a positional operand is also
+    present, since the redirect target is dropped entirely in that case.
     """
     tokens = strip_command_prefixes(segment)
     if not tokens:
@@ -2229,14 +2293,20 @@ def parse_interpreter_invocation(segment: list[str]) -> InterpreterInvocation | 
     n = len(rest)
     while j < n:
         tok = rest[j]
-        if tok == "<" and j + 1 < n:
+        if _STDIN_REDIRECT_RE.match(tok) and j + 1 < n:
             stdin_target = rest[j + 1]
             j += 2
             continue
         other_operands.append(tok)
         j += 1
+    # A positional operand always wins over a stdin redirect — see the
+    # docstring's "Precedence" section. The redirect target is only promoted
+    # into operands[0] when it is the SOLE operand candidate; otherwise it is
+    # dropped entirely (it names a stdin stream, not an argument or a script).
     operands = (
-        (stdin_target, *other_operands) if stdin_target is not None else tuple(other_operands)
+        tuple(other_operands)
+        if other_operands
+        else ((stdin_target,) if stdin_target is not None else ())
     )
     words = tuple(t for t in rest if t != "--")
     return InterpreterInvocation(name, has_command_string, operands, words)

--- a/.claude/hooks/tests/test_heredoc_relay_downstream.py
+++ b/.claude/hooks/tests/test_heredoc_relay_downstream.py
@@ -767,19 +767,16 @@ class SiblingIssueMeasurementTests(unittest.TestCase):
         cmd = "cat > \\\nnotes.md <<'EOF'\nsome prose about bash -c 'foo'\nEOF"
         _assert_allowed(self, cmd)
 
-    def test_1170_fifo_relay_measured_still_open(self):
-        """main#1170: `mkfifo p; bash < p & cat <<'D' > p` — a structurally
-        different gap (dataflow through a named pipe across a `&`
-        background-job boundary, not a `|`-connected pipeline segment this
-        fix's walk ever reaches). Measured to remain ALLOW after this fix;
-        NOT folded in per the spawn brief's explicit scope boundary. This
-        test pins today's measurement and is expected to start FAILING (in
-        the good direction) once #1170 lands its own fix — at which point it
-        should be deleted, not "fixed" to assert BLOCK, since that fix
-        belongs to #1170's own PR.
-        """
-        cmd = "mkfifo p; bash < p & cat <<'D' > p\n" + REAL_COMMIT + "\nD"
-        _assert_allowed(self, cmd)
+    # test_1170_fifo_relay_measured_still_open removed: main#1170 landed its
+    # own fix (stdin-redirect operand resolution in
+    # `parse_interpreter_invocation`/`_script_invocation_targets`, see
+    # `_shell_parse.py`'s "Explicit scope boundary" comment above
+    # `_segment_write_targets`). Both FIFO shapes from that issue now BLOCK;
+    # coverage moved to `test_heredoc_write_then_exec.py`'s
+    # `StdinRedirectOperandTests` (main#1170 reuses that same write-then-exec
+    # correlation, just with the interpreter's script fed via `< FILE` rather
+    # than a positional operand), per this test's own docstring instruction
+    # to delete rather than flip the assertion here.
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/.claude/hooks/tests/test_heredoc_write_then_exec.py
+++ b/.claude/hooks/tests/test_heredoc_write_then_exec.py
@@ -439,5 +439,335 @@ class StdinRedirectOperandTests(unittest.TestCase):
             self.assertEqual(result["decision"], "block")
 
 
+class PositionalOperandPrecedenceTests(unittest.TestCase):
+    """main#1325 review round 2 (Lucas Ferreira) / main#1325 merge gate (Nino
+    Kavtaradze) — the corpus above varied redirect-presence and
+    operand-presence ONE AT A TIME and never crossed them, which is exactly
+    where the original fix's defect lived: `parse_interpreter_invocation`
+    unconditionally promoted the LAST stdin-redirect target into
+    `operands[0]`, even when a positional operand was ALSO present. Real bash
+    and zsh never let a stdin redirect outrank a positional operand — a
+    redirect is not counted as an argument slot at all, so it can never win
+    against an ordinary word regardless of which side of the redirect token
+    that word sits on. Verified with a real-shell marker proxy, both shells,
+    every ordering below (see `parse_interpreter_invocation`'s docstring
+    "Precedence" section for the full account).
+
+    Crossed axes: {no operand, positional operand} x {no redirect, one
+    redirect, two redirects} x {redirect spelling: `<`, `0<`, `<>`, `0<>`} x
+    {redirect position: before/after/interleaved with the operand} x {-c
+    present, absent} x {shell interpreter, non-shell interpreter}. Every row
+    here is unit-level (`parse_interpreter_invocation` directly, verified
+    against real-shell measurements above); the operationally-significant
+    shapes are additionally pinned through the real `hook.check()` entry
+    point in `WriteThenExecPositionalPrecedenceHookTests` below, each with a
+    positive/negative pair sharing one instrument per #1318.
+    """
+
+    # --- Axis: no operand present --------------------------------------
+
+    def test_no_operand_no_redirect(self):
+        inv = parse_interpreter_invocation(["bash"])
+        self.assertEqual(inv.operands, ())
+
+    def test_no_operand_one_redirect_bare(self):
+        inv = parse_interpreter_invocation(["bash", "<", "F"])
+        self.assertEqual(inv.operands, ("F",))
+
+    def test_no_operand_one_redirect_fd0(self):
+        """main#1326: `0<` is the identical redirect as bare `<` (fd 0 is
+        stdin's default) — real-shell-verified under bash and zsh."""
+        inv = parse_interpreter_invocation(["bash", "0<", "F"])
+        self.assertEqual(inv.operands, ("F",))
+
+    def test_no_operand_one_redirect_readwrite(self):
+        """main#1326: `<>` (read-write open on fd 0) — real-shell-verified."""
+        inv = parse_interpreter_invocation(["bash", "<>", "F"])
+        self.assertEqual(inv.operands, ("F",))
+
+    def test_no_operand_one_redirect_fd0_readwrite(self):
+        """main#1326: `0<>` — real-shell-verified."""
+        inv = parse_interpreter_invocation(["bash", "0<>", "F"])
+        self.assertEqual(inv.operands, ("F",))
+
+    def test_non_stdin_fd_redirect_is_not_mistaken_for_a_stdin_source(self):
+        """`2<` targets fd 2, not fd 0 — real-shell-verified NOT to feed the
+        interpreter's script (the marker never fires). Must not match
+        `_STDIN_REDIRECT_RE`; the widened #1326 pattern is deliberately
+        `0?<>?`, not a bare `\\d*<` which would wrongly swallow this."""
+        inv = parse_interpreter_invocation(["bash", "2<", "F"])
+        self.assertEqual(inv.operands, ("2<", "F"))
+
+    def test_no_operand_two_redirects_last_wins(self):
+        inv = parse_interpreter_invocation(["bash", "<", "A", "<", "B"])
+        self.assertEqual(inv.operands, ("B",))
+
+    def test_no_operand_two_redirects_mixed_spellings_last_wins(self):
+        """Last-wins must hold across spellings, not just within one."""
+        inv = parse_interpreter_invocation(["bash", "<", "A", "0<", "B"])
+        self.assertEqual(inv.operands, ("B",))
+
+    # --- Axis: positional operand present -------------------------------
+
+    def test_positional_no_redirect(self):
+        inv = parse_interpreter_invocation(["bash", "S"])
+        self.assertEqual(inv.operands, ("S",))
+
+    def test_positional_before_one_redirect_bare(self):
+        """The regression Lucas measured: `bash S < F` must run S, not F —
+        confirmed with a real-shell marker proxy under bash and zsh."""
+        inv = parse_interpreter_invocation(["bash", "S", "<", "F"])
+        self.assertEqual(inv.operands, ("S",))
+
+    def test_positional_before_one_redirect_fd0(self):
+        inv = parse_interpreter_invocation(["bash", "S", "0<", "F"])
+        self.assertEqual(inv.operands, ("S",))
+
+    def test_positional_before_one_redirect_readwrite(self):
+        inv = parse_interpreter_invocation(["bash", "S", "<>", "F"])
+        self.assertEqual(inv.operands, ("S",))
+
+    def test_positional_before_one_redirect_fd0_readwrite(self):
+        inv = parse_interpreter_invocation(["bash", "S", "0<>", "F"])
+        self.assertEqual(inv.operands, ("S",))
+
+    def test_positional_after_one_redirect(self):
+        """`bash < F S` — real bash/zsh: the redirect is consumed by the
+        invoking shell before bash ever sees its own argv, so `S` (not `F`)
+        is bash's sole operand and IS what executes — confirmed with a
+        marker proxy (F's marker never fires; S, which doesn't exist as a
+        file, makes the invocation error, exactly matching this resolution)."""
+        inv = parse_interpreter_invocation(["bash", "<", "F", "S"])
+        self.assertEqual(inv.operands, ("S",))
+
+    def test_positional_between_two_redirects(self):
+        inv = parse_interpreter_invocation(["bash", "<", "A", "S", "<", "B"])
+        self.assertEqual(inv.operands, ("S",))
+
+    def test_two_positionals_and_a_redirect_preserve_order(self):
+        """Real shell: every non-redirect word survives, in order, as argv;
+        argv[0] is what executes, argv[1:] are its arguments."""
+        inv = parse_interpreter_invocation(["bash", "S1", "S2", "<", "F"])
+        self.assertEqual(inv.operands, ("S1", "S2"))
+
+    def test_interleaved_two_positionals(self):
+        """`bash S1 < F S2` — confirmed against a real shell (marker proxy,
+        both bash and zsh): S1 fires, F never does."""
+        inv = parse_interpreter_invocation(["bash", "S1", "<", "F", "S2"])
+        self.assertEqual(inv.operands, ("S1", "S2"))
+
+    # --- Axis: -c present ------------------------------------------------
+
+    def test_command_string_with_redirect_still_resolves_the_string_first(self):
+        """`bash -c 'cmd' < F` — the command STRING is the sole non-redirect
+        operand. `has_command_string` routes real callers to `.words`, not
+        `.operands`, but `.operands` itself must still resolve correctly —
+        no redirect leaking into slot 0."""
+        inv = parse_interpreter_invocation(["bash", "-c", "cmd", "<", "F"])
+        self.assertTrue(inv.has_command_string)
+        self.assertEqual(inv.operands, ("cmd",))
+
+    def test_command_string_flag_with_only_a_redirect_present(self):
+        """`bash -c < F` — degenerate (a real shell would error on a missing
+        command-string argument), but must not crash; the redirect target is
+        the sole operand candidate once `-c` itself is consumed as a flag."""
+        inv = parse_interpreter_invocation(["bash", "-c", "<", "F"])
+        self.assertTrue(inv.has_command_string)
+        self.assertEqual(inv.operands, ("F",))
+
+    # --- Axis: non-shell interpreter (degenerate — always None) ---------
+
+    def test_non_shell_interpreter_with_positional_and_redirect_returns_none(self):
+        self.assertIsNone(parse_interpreter_invocation(["mysql", "S", "<", "F"]))
+
+    def test_non_shell_interpreter_with_redirect_only_returns_none(self):
+        self.assertIsNone(parse_interpreter_invocation(["mysql", "<", "F"]))
+
+
+class WriteThenExecPositionalPrecedenceHookTests(unittest.TestCase):
+    """Hook-level (`hook.check()`) confirmation of the crossed-axis cells
+    that actually matter operationally — the two measured regressions from
+    the main#1325 review (Lucas Ferreira: a BLOCK->ALLOW bypass and an
+    ALLOW->BLOCK false positive, both from the same "positional operand +
+    stdin redirect coexist" combination), the shape-7 on-disk-script-content
+    walker regression, and the #1152-recurrence over-block (both found
+    independently by Nino Kavtaradze at the merge gate). Every ALLOW row here
+    has a BLOCK counterpart sharing the exact same command shape and the same
+    `hook.check()`/`classify_heredocs()` instrument, per #1318.
+    """
+
+    def _assert_blocked(self, cmd: str) -> None:
+        result = hook.check(_bash(cmd))
+        self.assertIsNotNone(result, f"must block: {cmd!r}")
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+
+    def _assert_allowed(self, cmd: str) -> None:
+        result = hook.check(_bash(cmd))
+        self.assertIsNone(
+            result,
+            f"must allow: {cmd!r} (got: {result['reason'].splitlines()[0] if result else ''})",
+        )
+
+    # --- Lucas's row 1: positional script wins, redirect target does not ---
+
+    def test_positional_script_with_hidden_commit_still_blocks_despite_trailing_redirect(self):
+        """The bypass: a heredoc writes a hidden commit into the POSITIONAL
+        script; an unrelated trailing `< FILE` redirect must not distract the
+        correlation away from the file that genuinely executes."""
+        self._assert_blocked(
+            f"cat > /tmp/wz1325a_s.sh <<'DELIM'\n{REAL_COMMIT}\nDELIM\n"
+            "bash /tmp/wz1325a_s.sh < /tmp/wz1325a_unrelated.txt"
+        )
+
+    def test_redirect_target_with_hidden_commit_does_not_block_when_a_positional_script_is_present(
+        self,
+    ):
+        """Sharing the same command shape as the row above — only the
+        heredoc's target moves to the redirect file, which does NOT execute
+        once a positional script is present, so this must ALLOW."""
+        self._assert_allowed(
+            f"cat > /tmp/wz1325a2_unrelated.txt <<'DELIM'\n{REAL_COMMIT}\nDELIM\n"
+            "bash /tmp/wz1325a2_s.sh < /tmp/wz1325a2_unrelated.txt"
+        )
+
+    # --- Lucas's row 2: the false positive on the ordinary shape -----------
+
+    def test_ordinary_data_heredoc_fed_to_an_unrelated_script_stays_allowed(self):
+        """`bash migrate.sh < input.csv` — an everyday ops pattern. A heredoc
+        writing benign data into input.csv (never executed as code — only
+        migrate.sh's own stdin) must not falsely correlate."""
+        self._assert_allowed(
+            "cat > /tmp/wz1325b_data.txt <<'DELIM'\nordinary data, not code\nDELIM\n"
+            "bash /tmp/wz1325b_migrate.sh < /tmp/wz1325b_data.txt"
+        )
+
+    def test_hidden_commit_in_the_positional_script_still_blocks_in_the_same_shape(self):
+        """Sharing the exact same command shape as the row above — only the
+        heredoc's target moves to the positional script itself."""
+        self._assert_blocked(
+            f"cat > /tmp/wz1325b_migrate.sh <<'DELIM'\n{REAL_COMMIT}\nDELIM\n"
+            "bash /tmp/wz1325b_migrate.sh < /tmp/wz1325b_data.txt"
+        )
+
+    # --- Nino's shape-7 (on-disk script content walker) regression ---------
+
+    def test_shape7_walker_still_detects_hidden_commit_with_dash_x_flag(self):
+        """`bash -x s.sh < /dev/null` — before the guard, `operands[0]`
+        resolved to `/dev/null` (wrong), so `_read_script_if_safe` inspected
+        the wrong (empty) file and a hidden commit already sitting on disk in
+        `s.sh` went undetected. `-x` breaks `_SCRIPT_INVOKE_RE`'s regex
+        fallback (its `[^\\s\\-<>|;&(]` class rejects a leading `-`), so this
+        shape depends entirely on the tokenized walker resolving
+        `operands[0]` correctly."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as d:
+            script_path = f"{d}/hidden.sh"
+            with open(script_path, "w", encoding="utf-8") as f:
+                f.write(REAL_COMMIT + "\n")
+            result = hook.check(
+                {
+                    "tool_name": "Bash",
+                    "tool_input": {"command": f"bash -x {script_path} < /dev/null", "cwd": d},
+                }
+            )
+            self.assertIsNotNone(result)
+            assert result is not None
+            self.assertEqual(result["decision"], "block")
+
+    def test_shape7_walker_still_detects_hidden_commit_with_dashdash(self):
+        """Same regression, the `--` spelling."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as d:
+            script_path = f"{d}/hidden2.sh"
+            with open(script_path, "w", encoding="utf-8") as f:
+                f.write(REAL_COMMIT + "\n")
+            result = hook.check(
+                {
+                    "tool_name": "Bash",
+                    "tool_input": {"command": f"bash -- {script_path} < /dev/null", "cwd": d},
+                }
+            )
+            self.assertIsNotNone(result)
+            assert result is not None
+            self.assertEqual(result["decision"], "block")
+
+    def test_shape7_unflagged_form_stays_blocked_as_before(self):
+        """The unflagged form was never actually broken — it's caught by the
+        `_SCRIPT_INVOKE_RE` regex fallback regardless of the walker's answer.
+        Pinned here so a future change to that fallback can't silently
+        regress it without a test noticing."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as d:
+            script_path = f"{d}/hidden3.sh"
+            with open(script_path, "w", encoding="utf-8") as f:
+                f.write(REAL_COMMIT + "\n")
+            result = hook.check(
+                {
+                    "tool_name": "Bash",
+                    "tool_input": {"command": f"bash {script_path} < /dev/null", "cwd": d},
+                }
+            )
+            self.assertIsNotNone(result)
+            assert result is not None
+            self.assertEqual(result["decision"], "block")
+
+    # --- Nino's over-block regression (#1152 through a new door) -----------
+
+    def test_benign_stdin_data_fed_to_a_real_script_is_not_swept_into_code(self):
+        """`bash deploy.sh < notes.txt` where notes.txt is ordinary benign
+        data (never executed — only fed to deploy.sh's own stdin). Before the
+        guard, `operands[0]` resolved to `notes.txt` (wrong), which falsely
+        correlated the heredoc write with the interpreter invocation and
+        flipped the DATA heredoc to CODE — main#1152's own failure mode
+        recurring through this new slot."""
+        (span,) = classify_heredocs(
+            "cat > /tmp/wz1325c_notes.txt <<'DELIM'\n"
+            "just some ordinary notes, not code\nDELIM\n"
+            "bash /tmp/wz1325c_deploy.sh < /tmp/wz1325c_notes.txt"
+        )
+        self.assertFalse(span.is_code, "benign stdin data must stay classified as DATA")
+
+    def test_real_commit_hidden_in_the_script_still_flips_to_code_in_the_same_shape(self):
+        """Sharing the same command shape as the row above — only the
+        heredoc's target moves to the executed script itself."""
+        (span,) = classify_heredocs(
+            f"cat > /tmp/wz1325c_deploy.sh <<'DELIM'\n{REAL_COMMIT}\nDELIM\n"
+            "bash /tmp/wz1325c_deploy.sh < /tmp/wz1325c_notes.txt"
+        )
+        self.assertTrue(span.is_code, "a real hidden commit in the executed script must stay CODE")
+
+    # --- Redirect + trailing words, no leading positional -------------------
+    # Lucas's own sweep asserted `bash < FILE arg1 arg2` "correctly starts
+    # blocking" against the UNGUARDED code — true of the VERDICT, but for the
+    # wrong reason: the unguarded code correlated on FILE, which a real shell
+    # never executes once trailing operands are present. Confirmed with a
+    # real-shell marker proxy: `bash < FILE arg1 arg2` attempts to execute
+    # `arg1` (erroring, since arg1 doesn't exist as a file) and FILE's marker
+    # never fires. The corrected rule now correlates on `arg1` (the true
+    # first operand) — what a real shell actually runs.
+
+    def test_redirect_with_trailing_words_does_not_correlate_on_the_redirect_target(self):
+        """A heredoc writing the hidden commit into the redirect TARGET
+        (never actually executed, once trailing words are present) must not
+        block."""
+        self._assert_allowed(
+            f"cat > /tmp/wz1325d_file.txt <<'DELIM'\n{REAL_COMMIT}\nDELIM\n"
+            "bash < /tmp/wz1325d_file.txt /tmp/wz1325d_arg1 /tmp/wz1325d_arg2"
+        )
+
+    def test_redirect_with_trailing_words_blocks_when_commit_is_in_first_trailing_word(self):
+        """Sharing the same command shape — only the heredoc's target moves
+        to the first trailing word, which IS what a real shell attempts to
+        execute in this shape."""
+        self._assert_blocked(
+            f"cat > /tmp/wz1325d_arg1 <<'DELIM'\n{REAL_COMMIT}\nDELIM\n"
+            "bash < /tmp/wz1325d_file.txt /tmp/wz1325d_arg1 /tmp/wz1325d_arg2"
+        )
+
+
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()

--- a/.claude/hooks/tests/test_heredoc_write_then_exec.py
+++ b/.claude/hooks/tests/test_heredoc_write_then_exec.py
@@ -47,6 +47,7 @@ sys.path.insert(0, str(_HOOKS_DIR))
 import validate_commit_identity as hook  # noqa: E402
 from _shell_parse import (  # noqa: E402
     classify_heredocs,
+    parse_interpreter_invocation,
     strip_data_heredocs,
 )
 
@@ -216,6 +217,198 @@ class WriteThenExecMutationCoverageTests(unittest.TestCase):
         append = classify_heredocs(f"cat >> /tmp/x <<'D'\n{REAL_COMMIT}\nD\nbash /tmp/x")[0]
         self.assertTrue(plain.is_code)
         self.assertTrue(append.is_code)
+
+
+class StdinRedirectOperandTests(unittest.TestCase):
+    """main#1170 — `bash < FILE` (script fed via stdin redirect, not a
+    positional operand) escaped the write-then-exec correlation above because
+    `parse_interpreter_invocation` folded the redirect into `operands` as the
+    literal tokens `("<", FILE)` rather than resolving to `FILE` itself, so
+    `_script_invocation_targets` collected the garbage path `"<"` and never
+    saw `FILE`. This is also main#1287 shape 1, filed as an acknowledged gap
+    in that same operand resolution; fixing it here closes both the FIFO
+    relay (main#1170's own shape) and the plain-file form (main#1287 shape
+    1) as the SAME fix — main#1287 shapes 2 (`$(...)`-produced path) and 3
+    (`cp` copy indirection) are untouched and stay filed there, so main#1287
+    itself stays open.
+
+    Hand-verified against a real shell before writing these tests: a marker
+    proxy `git` on PATH (never the real `git`) logs its own invocation to a
+    file; both FIFO shapes below were confirmed to reach that marker under
+    both `bash` and `zsh` (i.e. the body genuinely executes), matching the
+    #1170 issue body's own claim.
+    """
+
+    def _assert_blocked(self, cmd: str) -> None:
+        result = hook.check(_bash(cmd))
+        self.assertIsNotNone(result, f"stdin-redirect relay must block: {cmd!r}")
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+        self.assertIn("indirect-exec", result["reason"])
+
+    def _assert_allowed(self, cmd: str) -> None:
+        result = hook.check(_bash(cmd))
+        self.assertIsNone(
+            result,
+            f"must allow: {cmd!r} (got: {result['reason'].splitlines()[0] if result else ''})",
+        )
+
+    # --- The issue's own shapes -------------------------------------------
+
+    def test_issue_repro_mkfifo_bash_stdin(self):
+        """The exact reproduction from the #1170 issue body."""
+        self._assert_blocked(f"mkfifo p; bash < p & cat <<'D' > p\n{REAL_COMMIT}\nD")
+
+    def test_issue_repro_mkfifo_sh_stdin_via_tee(self):
+        """The issue's second measured shape: `sh` (not `bash`) reading via a
+        FIFO written by `tee` (not `cat`)."""
+        self._assert_blocked(f"mkfifo p2; sh < p2 & tee p2 <<'D' > /dev/null\n{REAL_COMMIT}\nD")
+
+    # --- Same fix, main#1287 shape 1's plain-file (non-FIFO) form ----------
+
+    def test_plain_file_stdin_redirect_no_fifo(self):
+        """main#1287 shape 1 exactly: no `mkfifo`, no backgrounding — just an
+        ordinary regular file written by a heredoc and later fed to `bash`
+        via `< FILE`. Confirms the fix is the SAME correlation, not something
+        FIFO-specific."""
+        self._assert_blocked(f"cat > /tmp/s.txt <<'DELIM'\n{REAL_COMMIT}\nDELIM\nbash < /tmp/s.txt")
+
+    def test_zsh_stdin_redirect(self):
+        self._assert_blocked(f"cat > /tmp/s.txt <<'DELIM'\n{REAL_COMMIT}\nDELIM\nzsh < /tmp/s.txt")
+
+    def test_dot_slash_prefix_normalization_applies_to_stdin_form_too(self):
+        self._assert_blocked(f"cat > ./s.txt <<'DELIM'\n{REAL_COMMIT}\nDELIM\nbash < s.txt")
+
+    def test_positionally_agnostic_stdin_form(self):
+        """Correlation does not require the invocation to come after the
+        write, matching the existing positional-operand form's behaviour."""
+        self._assert_blocked(f"bash < /tmp/s.txt\ncat > /tmp/s.txt <<'DELIM'\n{REAL_COMMIT}\nDELIM")
+
+    def test_flag_before_stdin_redirect(self):
+        """`bash -x < FILE` — a leading option must not shift the redirect out
+        of view; the option-run boundary always halts at a bare `<`."""
+        self._assert_blocked(
+            f"cat > /tmp/s.txt <<'DELIM'\n{REAL_COMMIT}\nDELIM\nbash -x < /tmp/s.txt"
+        )
+
+    def test_env_prefixed_stdin_redirect(self):
+        self._assert_blocked(
+            f"cat > /tmp/s.txt <<'DELIM'\n{REAL_COMMIT}\nDELIM\nenv bash < /tmp/s.txt"
+        )
+
+    def test_last_redirect_wins(self):
+        """`bash < /tmp/other < /tmp/s.txt` — two stdin redirects on one
+        invocation; a real shell honours only the LAST one, and so must this
+        correlation. Written to correlate on the SECOND path only: if the
+        implementation picked the first instead, this would wrongly ALLOW."""
+        self._assert_blocked(
+            f"cat > /tmp/s.txt <<'DELIM'\n{REAL_COMMIT}\nDELIM\nbash < /tmp/other < /tmp/s.txt"
+        )
+
+    def test_classifier_marks_the_span_code(self):
+        (span,) = classify_heredocs(
+            f"cat > /tmp/s.txt <<'DELIM'\n{REAL_COMMIT}\nDELIM\nbash < /tmp/s.txt"
+        )
+        self.assertTrue(span.is_code)
+
+    def test_strip_data_heredocs_keeps_the_body(self):
+        """The other call site of the shared classification decision (the
+        main#1152 drift hazard) — pinned independently, matching the
+        positional-operand form's own coverage above."""
+        cmd = f"cat > /tmp/s.txt <<'DELIM'\n{REAL_COMMIT}\nDELIM\nbash < /tmp/s.txt"
+        out = strip_data_heredocs(cmd)
+        self.assertIn("commit", out)
+
+    # --- False positives: must NOT newly block ------------------------------
+
+    def test_stdin_redirect_to_an_unrelated_file_stays_allowed(self):
+        """`bash < FILE` where FILE is never written by any heredoc in the
+        same command — an everyday ops pattern (`bash < deploy.sh`,
+        `mysql < backup.sql`) — must not be swept in by proximity alone."""
+        self._assert_allowed("cat > /tmp/notes.md <<'EOF'\nsome notes\nEOF\nbash < /tmp/deploy.sh")
+
+    def test_no_heredoc_at_all_stdin_redirect_stays_allowed(self):
+        """The ordinary, extremely common shape this fix must not touch:
+        feeding an EXISTING script to an interpreter via stdin, with no
+        heredoc anywhere in the command."""
+        self._assert_allowed("bash < /tmp/some-existing-deploy.sh")
+
+    def test_non_interpreter_stdin_redirect_is_not_touched(self):
+        """`mysql` is not a `SHELL_INTERPRETERS` member — a heredoc written to
+        a file later fed to a non-shell program via `<` must stay data."""
+        self._assert_allowed(
+            "cat > /tmp/backup.sql <<'EOF'\nSELECT 1;\nEOF\nmysql < /tmp/backup.sql"
+        )
+
+    def test_process_substitution_is_not_mistaken_for_a_bare_redirect(self):
+        """`bash <(cmd)` fuses into ONE shlex token (`<(cmd)`, no internal
+        whitespace) and must not be parsed as a bare `<` redirect — a
+        pre-existing, unrelated matcher (`_PROCESS_SUB_RE`) already handles
+        process substitution; this fix must not double up or misfire on it."""
+        self._assert_allowed("cat > /tmp/notes.md <<'EOF'\nsome notes\nEOF\nbash <(echo hi)")
+
+    def test_process_substitution_followed_by_the_write_target_stays_allowed(self):
+        """`bash <(true) /tmp/s.txt` — real-shell semantics: `/tmp/s.txt` is
+        passed as `$1` to the process-substituted script, NOT executed as the
+        interpreter's own script, so this must stay ALLOW even though
+        `/tmp/s.txt` is also the heredoc's write target. Discriminates a
+        `tok.startswith("<")` mutant from the correct `tok == "<"` exact
+        match: a fused token like `<(true)` merely STARTS with `<` but is not
+        a bare redirect, and a `startswith` mutant would misparse it as one,
+        wrongly promoting `/tmp/s.txt` to `operands[0]` and over-blocking a
+        legitimate command — the false-positive-corpus check this file's
+        standards require."""
+        self._assert_allowed(
+            f"cat > /tmp/s.txt <<'DELIM'\n{REAL_COMMIT}\nDELIM\nbash <(true) /tmp/s.txt"
+        )
+
+    def test_command_string_form_with_a_stdin_redirect_is_unaffected(self):
+        """`bash -c '...' < FILE` — `has_command_string` is True, so this
+        invocation is skipped by the write-then-exec correlation entirely
+        (as it already is for the positional-operand form); adding stdin-
+        redirect resolution must not change that branch's behaviour."""
+        self._assert_allowed(
+            "cat > /tmp/s.txt <<'EOF'\nsome notes\nEOF\nbash -c 'echo hi' < /tmp/s.txt"
+        )
+
+    def test_1152_false_positive_still_allowed(self):
+        """The over-broad-rule false positive this whole family of fixes must
+        never resurrect: an interpreter word appearing earlier in a command
+        that later starts an unrelated data heredoc."""
+        self._assert_allowed("bash build.sh && cat > notes.md <<'EOF'\nsome docs\nEOF")
+
+    # --- Unit-level pins on parse_interpreter_invocation --------------------
+
+    def test_operand_resolves_to_the_redirect_target(self):
+        inv = parse_interpreter_invocation(["bash", "<", "/tmp/s.txt"])
+        self.assertEqual(inv.operands, ("/tmp/s.txt",))
+        self.assertFalse(inv.has_command_string)
+
+    def test_operand_last_redirect_wins_at_the_primitive(self):
+        inv = parse_interpreter_invocation(["bash", "<", "/tmp/a", "<", "/tmp/b"])
+        self.assertEqual(inv.operands[0], "/tmp/b")
+
+    def test_trailing_bare_redirect_with_nothing_after_does_not_crash(self):
+        """`bash <` with no following token — a malformed/truncated command a
+        real shell would reject, but the parser must not raise."""
+        inv = parse_interpreter_invocation(["bash", "<"])
+        self.assertIsNotNone(inv)
+        self.assertEqual(inv.operands, ("<",))
+
+    def test_process_substitution_token_untouched_at_the_primitive(self):
+        inv = parse_interpreter_invocation(["bash", "<(echo hi)"])
+        self.assertEqual(inv.operands, ("<(echo hi)",))
+
+    def test_process_substitution_with_a_following_operand_untouched(self):
+        """A fused `<(...)` token followed by ANOTHER operand — the case that
+        actually exercises the exact-match guard, since a single-token
+        invocation never reaches the `j + 1 < n` bounds check at all."""
+        inv = parse_interpreter_invocation(["bash", "<(true)", "x"])
+        self.assertEqual(inv.operands, ("<(true)", "x"))
+
+    def test_words_still_superset_of_operands_with_a_redirect(self):
+        inv = parse_interpreter_invocation(["bash", "-x", "<", "/tmp/s.txt"])
+        self.assertTrue(set(inv.operands).issubset(set(inv.words)))
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/.claude/hooks/tests/test_heredoc_write_then_exec.py
+++ b/.claude/hooks/tests/test_heredoc_write_then_exec.py
@@ -410,6 +410,34 @@ class StdinRedirectOperandTests(unittest.TestCase):
         inv = parse_interpreter_invocation(["bash", "-x", "<", "/tmp/s.txt"])
         self.assertTrue(set(inv.operands).issubset(set(inv.words)))
 
+    # --- Incidental side effect: the pre-existing shape-7 script-content
+    # walker in validate_commit_identity.py also reads `operands[0]`
+    # (`_read_script_if_safe(invocation.operands[0], cwd)`), so it silently
+    # benefits from this same resolution for a script that already exists ON
+    # DISK (unlike the write-then-exec case, where the file does not exist
+    # yet when the PreToolUse hook fires). Pinned here as a regression guard,
+    # not claimed as part of main#1170's own scope — it is the SAME operand
+    # slot, read by a completely different, pre-existing consumer.
+
+    def test_incidental_shape_7_now_reads_stdin_redirected_scripts_too(self):
+        """Before this fix: `bash < FILE` left `operands[0] == "<"`, so
+        `_read_script_if_safe` was handed a nonexistent path and the hidden
+        commit in an ALREADY-ON-DISK script went undetected. After: the
+        stdin form is symmetric with the pre-existing, already-trusted
+        positional form (`bash FILE`)."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as d:
+            script_path = f"{d}/existing_script.sh"
+            with open(script_path, "w", encoding="utf-8") as f:
+                f.write(REAL_COMMIT + "\n")
+            result = hook.check(
+                {"tool_name": "Bash", "tool_input": {"command": f"bash < {script_path}", "cwd": d}}
+            )
+            self.assertIsNotNone(result, "on-disk script fed via stdin must still be inspected")
+            assert result is not None
+            self.assertEqual(result["decision"], "block")
+
 
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()


### PR DESCRIPTION
## Summary

Closes #1170.

Both measured shapes in #1170 (mkfifo + backgrounded reader, one written via `cat`, one via `tee`) and #1287 shape 1 (the plain-file form of the same gap, no FIFO) share one root cause: `parse_interpreter_invocation` only ever read an interpreter's script path from a positional argument. For `bash < FILE`, the redirect operator token itself landed in `operands[0]` instead of the file path, so `_script_invocation_targets` (main#1167's write-then-exec correlation) never saw `FILE` and couldn't connect it to a heredoc written to that same path elsewhere in the command.

## How much of this was #1287?

Almost all of it. #1287 named the gap explicitly as its "shape 1" and suggested the exact fix ("teach the operand side to also read a `< FILE` stdin redirect on an interpreter segment") — I applied that suggestion. Measured: implementing it closes both #1170 shapes AND #1287 shape 1 as the identical fix (same function, same slot). #1287 shapes 2 (`$(...)`-produced path) and 3 (`cp` copy indirection) are untouched by this change and remain open in that issue — this PR does not close #1287, only #1170.

## The fix

In `parse_interpreter_invocation` (`.claude/hooks/_shell_parse.py`): a bare `<` token (spaced form only, matching this module's existing `>`/`>>` convention) followed by a word is folded into `operands[0]` — shell-accurately, since the redirect target IS the script the interpreter executes; any other bare word in the operand region becomes a script argument (`$1`, `$2`, …), never a competing script. Last redirect wins, matching real-shell last-redirect-wins semantics. A fused process-substitution token (`<(cmd)`, no internal whitespace) can never be mistaken for a bare `<` since it's a distinct shlex token.

No new correlation machinery — this reuses the exact `_script_invocation_targets`/`_segment_write_targets` correlation main#1167 already built; only the operand-resolution primitive underneath it changes.

## Real-shell marker-proxy verification (before / after)

A fake `git` on `PATH` (never the real `git`) logs its own invocation to a file; the marker fires under both `bash` and `zsh` for both #1170 shapes, confirming the body genuinely executes (matching the issue's own claim):

| shape | bash marker | zsh marker |
|---|---|---|
| `mkfifo p; bash < p &` + heredoc via `cat > p` | fired | fired |
| `mkfifo p2; sh < p2 &` + heredoc via `tee p2` | fired | fired |

Classifier-level before/after (`classify_heredocs(...)`, `is_code`):

| shape | before | after |
|---|---|---|
| FIFO shape 1 (`cat` writer, `bash` reader) | `is_code=False` (DATA) | `is_code=True` (CODE) |
| FIFO shape 2 (`tee` writer, `sh` reader) | `is_code=False` (DATA) | `is_code=True` (CODE) |

Through the real CLI entry point (`validate_commit_identity.check()`), both shapes went BLOCK -> ALLOW at main#1155 (the original regression) and are restored to BLOCK by this PR.

## False-positive corpus (must stay ALLOW)

- `bash < FILE` where FILE is never written by a heredoc in the same command (the everyday `bash < deploy.sh` / `mysql < backup.sql` pattern)
- No heredoc at all, just an ordinary `bash < existing-script.sh`
- A non-`SHELL_INTERPRETERS` program (`mysql`) reading via `<` from a heredoc-written file
- `bash <(cmd)` (process substitution) — including the case where the following operand happens to equal the heredoc's write target (real-shell semantics: that operand becomes `$1` to the substituted script, not the interpreter's own script)
- `bash -c '...' < FILE` (a `-c` command-string form) — unaffected, this branch is already skipped by the correlation regardless of the stdin-redirect change
- The pre-existing #1152 false positive (`bash build.sh && cat > notes.md <<'EOF' ...`)

All of the above are asserted in `test_heredoc_write_then_exec.py::StdinRedirectOperandTests`.

## Mutation testing (real output)

Hand-mutated the new branch in `parse_interpreter_invocation`, ran the new test class each time, reverted:

| Mutant | Result |
|---|---|
| 1. Revert the whole fix (old `operands = tuple(rest[end:])`) | 13 tests failed |
| 2. First-redirect-wins instead of last | 2 tests failed (both dedicated last-wins tests) |
| 3. `tok.startswith("<")` instead of exact `tok == "<"` | Initially survived with a single-token process-substitution test (the bounds guard made it moot); added a two-token fused-`<(...)`-token test and a hook-level test where the following operand equals the write target — both then failed correctly, 2/2 |
| 4. Dropped the `j + 1 < n` bounds guard | 1 test failed — raised `IndexError` instead of degrading gracefully on a trailing bare `<` |

No surviving mutants after the mutation-driven test additions.

## Not covered (filed as follow-up, no wave label)

- #1287 shapes 2 (`$(...)`-produced path) and 3 (`cp` copy indirection) — unaffected, stay filed there.
- #1306(c), #1308, #1314, #1315, #1317, #1318 — untouched by this PR, remain filed under the #1150 umbrella.

## Verification

- `ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/ -q` — 2696 passed, 757 subtests passed, 0 failed.
- `ruff format --check`, `ruff check`, `mypy` — all clean.
- `python3 .claude/lib/pre_commit_ci_sync.py .` — OK, pre-commit mirrors CI.
- Rebased on `origin/main` (`bcb4cf5`) before opening this PR, clean rebase, full suite re-run green after.

Do NOT merge — awaiting review per team process.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0127s4SKmYjUz2iPiwSkxa7k
