### PR TITLE
audit(#1117): parametrize 12 test clone groups across 4 hook test files

### DIFF
--- a/.claude/hooks/tests/test_annunaki_monitor.py
+++ b/.claude/hooks/tests/test_annunaki_monitor.py
@@ -21,6 +21,7 @@ import _test_helpers  # noqa: E402,F401
 import annunaki_log as alog  # noqa: E402
 import annunaki_monitor as am  # noqa: E402
 import annunaki_parse as ap  # noqa: E402
+import pytest
 
 
 def _bash_event(command: str, stdout: str = "", stderr: str = "", exit_code: int = 0) -> dict:
@@ -168,31 +169,42 @@ class AnnunakiMonitorTests(unittest.TestCase):
         self.assertIsNone(result)
 
 
-class SilentBooleanTestIdiomTests(unittest.TestCase):
+class TestSilentBooleanIdiom:
     """#474 coverage: documented boolean-test idioms whose by-design failure
     branch is non-zero exit with empty output must NOT produce log entries
     after #473 closed the silent-failure capture path. Each idiom gets a
     NEGATIVE-match test (no log) plus a precedence test that confirms a real
-    stderr-pattern match still wins."""
+    stderr-pattern match still wins.
 
-    def setUp(self):
-        self._saved_env = {
+    Not `unittest.TestCase` (#1117 — G5 clone-group parametrization):
+    `test_negative_match` below is a `pytest.mark.parametrize` table — 12
+    members were a single-statement `self.assertIsNone(am.check(_bash_event(
+    cmd, exit_code=n)))` differing only in `cmd`/`exit_code`. Converting the
+    class required moving `setUp`/`tearDown` to an autouse fixture (the
+    other methods in this class, including the ones NOT in the clone group,
+    depend on the same `ERRORS_FILE`/`_seen_hashes` isolation); every
+    `self.assertX` call in the class — merged or not — was mechanically
+    rewritten to a bare `assert` as a consequence, since a plain class has no
+    `self.assertX`. `ids=` is each original method's bare name."""
+
+    @pytest.fixture(autouse=True)
+    def _isolate_annunaki_state(self):
+        saved_env = {
             "ENVIRONMENT": os.environ.pop("ENVIRONMENT", None),
             "NOORIN_HOOK_TEST_MODE": os.environ.pop("NOORIN_HOOK_TEST_MODE", None),
         }
         am._seen_hashes.clear()
-        self._tmpdir = tempfile.TemporaryDirectory()
-        self._errors_path = Path(self._tmpdir.name) / "errors.jsonl"
-        self._orig_monitor_file = am.ERRORS_FILE
-        self._orig_log_file = alog.ERRORS_FILE
+        tmpdir = tempfile.TemporaryDirectory()
+        self._errors_path = Path(tmpdir.name) / "errors.jsonl"
+        orig_monitor_file = am.ERRORS_FILE
+        orig_log_file = alog.ERRORS_FILE
         am.ERRORS_FILE = self._errors_path
         alog.ERRORS_FILE = self._errors_path
-
-    def tearDown(self):
-        am.ERRORS_FILE = self._orig_monitor_file
-        alog.ERRORS_FILE = self._orig_log_file
-        self._tmpdir.cleanup()
-        for k, v in self._saved_env.items():
+        yield
+        am.ERRORS_FILE = orig_monitor_file
+        alog.ERRORS_FILE = orig_log_file
+        tmpdir.cleanup()
+        for k, v in saved_env.items():
             if v is None:
                 os.environ.pop(k, None)
             else:
@@ -203,78 +215,58 @@ class SilentBooleanTestIdiomTests(unittest.TestCase):
     def test_posix_bracket_silent_exit_not_logged(self):
         """NEG: `[ -d /nonexistent ]` exit 1 silent → no log."""
         result = am.check(_bash_event("[ -d /nonexistent ]", exit_code=1))
-        self.assertIsNone(result)
-        self.assertFalse(self._errors_path.exists())
+        assert result is None
+        assert not self._errors_path.exists()
 
-    def test_bash_double_bracket_silent_exit_not_logged(self):
-        """NEG: `[[ -f /nonexistent ]]` exit 1 silent → no log."""
-        result = am.check(_bash_event("[[ -f /nonexistent ]]", exit_code=1))
-        self.assertIsNone(result)
-
-    def test_test_builtin_silent_exit_not_logged(self):
-        """NEG: `test -f /nonexistent` exit 1 silent → no log."""
-        result = am.check(_bash_event("test -f /nonexistent", exit_code=1))
-        self.assertIsNone(result)
-
-    def test_grep_q_no_match_silent_exit_not_logged(self):
-        """NEG: `grep -q pattern file` non-error miss → no log."""
-        result = am.check(_bash_event("grep -q needle /tmp/haystack.txt", exit_code=1))
-        self.assertIsNone(result)
+    @pytest.mark.parametrize(
+        ("command", "exit_code"),
+        [
+            ("[[ -f /nonexistent ]]", 1),
+            ("test -f /nonexistent", 1),
+            ("grep -q needle /tmp/haystack.txt", 1),
+            ("pgrep nginx", 1),
+            ("pkill -0 nginx", 1),
+            ("which nonexistent-binary", 1),
+            ("command -v nonexistent-binary", 1),
+            ("diff --quiet /tmp/a /tmp/b", 1),
+            ("git diff --quiet", 1),
+            ("[ -f /tmp ]", 0),
+            # NEG: `if [ -f /nonexistent ]; then echo unreachable; fi` exits 0
+            # (false branch, body skipped) → no log. The whole-`if` regex was
+            # removed in #490 because it silenced body failures (gap #3); the
+            # false-branch path is now handled by exit_code=0 not being an
+            # error, not by idiom-skip.
+            ("if [ -f /nonexistent ]; then echo unreachable; fi", 0),
+            # NEG: same shape with `[[`. exit 0 → no log.
+            ("if [[ -f /nonexistent ]]; then echo unreachable; fi", 0),
+        ],
+        ids=[
+            "bash_double_bracket_silent_exit_not_logged",
+            "test_builtin_silent_exit_not_logged",
+            "grep_q_no_match_silent_exit_not_logged",
+            "pgrep_no_match_silent_exit_not_logged",
+            "pkill_no_match_silent_exit_not_logged",
+            "which_not_found_silent_exit_not_logged",
+            "command_v_not_found_silent_exit_not_logged",
+            "diff_quiet_differs_silent_exit_not_logged",
+            "git_diff_quiet_dirty_silent_exit_not_logged",
+            "idiom_exit_zero_not_logged",
+            "if_bracket_conditional_false_branch_exit_zero_not_logged",
+            "if_double_bracket_conditional_false_branch_exit_zero_not_logged",
+        ],
+    )
+    def test_negative_match(self, command, exit_code):
+        """NEG: a documented boolean-test idiom's by-design silent branch
+        (exit-1 miss, or exit-0 false-branch) must not produce a log entry."""
+        result = am.check(_bash_event(command, exit_code=exit_code))
+        assert result is None
 
     def test_grep_q_with_flags_silent_exit_not_logged(self):
         """NEG: `grep -qE` / `grep -qi` variants → no log."""
         for cmd in ("grep -qE '^foo' f.txt", "grep -qi BAR f.txt", "grep -Eq '^foo' f.txt"):
             am._seen_hashes.clear()
             result = am.check(_bash_event(cmd, exit_code=1))
-            self.assertIsNone(result, f"{cmd!r} must not log")
-
-    def test_pgrep_no_match_silent_exit_not_logged(self):
-        """NEG: `pgrep nginx` not-running → no log."""
-        result = am.check(_bash_event("pgrep nginx", exit_code=1))
-        self.assertIsNone(result)
-
-    def test_pkill_no_match_silent_exit_not_logged(self):
-        """NEG: `pkill -0 nginx` not-running → no log."""
-        result = am.check(_bash_event("pkill -0 nginx", exit_code=1))
-        self.assertIsNone(result)
-
-    def test_which_not_found_silent_exit_not_logged(self):
-        """NEG: `which foo` not-installed → no log."""
-        result = am.check(_bash_event("which nonexistent-binary", exit_code=1))
-        self.assertIsNone(result)
-
-    def test_command_v_not_found_silent_exit_not_logged(self):
-        """NEG: `command -v foo` not-installed → no log."""
-        result = am.check(_bash_event("command -v nonexistent-binary", exit_code=1))
-        self.assertIsNone(result)
-
-    def test_diff_quiet_differs_silent_exit_not_logged(self):
-        """NEG: `diff --quiet a b` files differ → no log."""
-        result = am.check(_bash_event("diff --quiet /tmp/a /tmp/b", exit_code=1))
-        self.assertIsNone(result)
-
-    def test_git_diff_quiet_dirty_silent_exit_not_logged(self):
-        """NEG: `git diff --quiet` working tree dirty → no log."""
-        result = am.check(_bash_event("git diff --quiet", exit_code=1))
-        self.assertIsNone(result)
-
-    def test_if_bracket_conditional_false_branch_exit_zero_not_logged(self):
-        """NEG: `if [ -f /nonexistent ]; then echo unreachable; fi` exits 0
-        (false branch, body skipped) → no log. The whole-`if` regex was
-        removed in #490 because it silenced body failures (gap #3); the
-        false-branch path is now handled by exit_code=0 not being an error,
-        not by idiom-skip."""
-        result = am.check(
-            _bash_event("if [ -f /nonexistent ]; then echo unreachable; fi", exit_code=0)
-        )
-        self.assertIsNone(result)
-
-    def test_if_double_bracket_conditional_false_branch_exit_zero_not_logged(self):
-        """NEG: same shape with `[[`. exit 0 → no log."""
-        result = am.check(
-            _bash_event("if [[ -f /nonexistent ]]; then echo unreachable; fi", exit_code=0)
-        )
-        self.assertIsNone(result)
+            assert result is None, f"{cmd!r} must not log"
 
     # --- Precedence: pattern match wins over idiom-on-silent-exit ---
 
@@ -290,11 +282,11 @@ class SilentBooleanTestIdiomTests(unittest.TestCase):
                 exit_code=1,
             )
         )
-        self.assertIsNotNone(result, "stderr pattern match must override idiom skip")
+        assert result is not None, "stderr pattern match must override idiom skip"
         rec = _read_records(self._errors_path)[0]
         # Both signals present: exit_code AND stderr pattern
-        self.assertIn("exit_code=1", rec["matched_patterns"])
-        self.assertTrue(any("fatal" in p for p in rec["matched_patterns"]))
+        assert "exit_code=1" in rec["matched_patterns"]
+        assert any("fatal" in p for p in rec["matched_patterns"])
 
     def test_idiom_with_stdout_pattern_still_logged(self):
         """POS: silent-test idiom that produces a stdout Traceback (would be
@@ -306,20 +298,13 @@ class SilentBooleanTestIdiomTests(unittest.TestCase):
                 exit_code=1,
             )
         )
-        self.assertIsNotNone(result)
+        assert result is not None
 
     def test_real_silent_failure_still_logged(self):
         """POS regression for #472: `false` is NOT in the idiom list, so the
         silent-failure capture path still works for non-idiom commands."""
         result = am.check(_bash_event("false", exit_code=1))
-        self.assertIsNotNone(result, "non-idiom silent failures must still log")
-
-    def test_idiom_exit_zero_not_logged(self):
-        """NEG: idiom command exits 0 (true branch) → no log because not
-        even is_error=True. Sanity check that the idiom filter doesn't get
-        in the way of the happy path."""
-        result = am.check(_bash_event("[ -f /tmp ]", exit_code=0))
-        self.assertIsNone(result)
+        assert result is not None, "non-idiom silent failures must still log"
 
 
 class ConfidenceTaggingTests(unittest.TestCase):

--- a/.claude/hooks/tests/test_annunaki_monitor.py
+++ b/.claude/hooks/tests/test_annunaki_monitor.py
@@ -1321,4 +1321,7 @@ class Rc0PrecisionTests(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main(verbosity=2)
+    # `unittest.main()` would silently skip TestSilentBooleanIdiom (a plain
+    # pytest class, not unittest.TestCase — see its docstring) when this file
+    # is run standalone. `pytest.main` discovers both styles.
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/.claude/hooks/tests/test_block_bare_grep.py
+++ b/.claude/hooks/tests/test_block_bare_grep.py
@@ -7,6 +7,23 @@ Covers every syntactic form a `grep` invocation can take (per
 / heredoc / flag-value NEGATIVES that must NOT trigger, and the documented
 `NOORINA_ALLOW_GREP` override.
 
+`PositiveMatchTests` and `NegativeMatchTests` are `pytest.mark.parametrize`
+tables (#1117 — G5 clone-group parametrization): every member of each
+originally-duplicated group was a single-statement `self.assertTrue(_blocks(cmd))`
+/ `self.assertFalse(_blocks(cmd))` method differing only in `cmd`, so they are
+NOT `unittest.TestCase` (parametrize is silently a no-op on `TestCase`
+methods — verified empirically before converting: a probe class collected 1
+test instead of N). `OverrideTests` and the two non-matching `NegativeMatchTests`
+methods (`test_non_bash_tool`, `test_empty_command`) keep their own bodies:
+they are AST-shape-identical to the parametrized tables (same
+`self.assertFalse(_blocks(...))` call shape) but belong to a semantically
+different scenario (the escape hatch, not "not a grep invocation" /
+"a different tool entirely") — collapsing across that boundary is exactly the
+"structurally identical, not safely mergeable" trap, so they stay separate.
+Every `ids=` entry below is the original method's bare name (the `test_`
+prefix stripped) so each parametrized case is traceable 1:1 back to the test
+it replaces.
+
 Run: ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/test_block_bare_grep.py -v
 """
 
@@ -18,6 +35,8 @@ Run: ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/test_block_bare_grep
 from __future__ import annotations
 
 import unittest
+
+import pytest
 
 import _test_helpers  # noqa: E402,F401
 import _shell_parse  # noqa: E402
@@ -31,142 +50,127 @@ def _blocks(command: str) -> bool:
     return result is not None and result.get("decision") == "block"
 
 
-class PositiveMatchTests(unittest.TestCase):
+class TestPositiveMatch:
     """Real bare-grep invocations MUST be blocked."""
 
-    def test_direct(self):
-        self.assertTrue(_blocks("grep foo file"))
-
-    def test_direct_with_flags(self):
-        self.assertTrue(_blocks('grep -rn "foo" src/'))
-
-    def test_piped(self):
-        # grep as a downstream pipeline segment — the most common real form.
-        self.assertTrue(_blocks("rg foo | grep bar"))
-
-    def test_piped_from_cat(self):
-        self.assertTrue(_blocks("cat file | grep foo"))
-
-    def test_egrep(self):
-        self.assertTrue(_blocks("egrep foo file"))
-
-    def test_fgrep(self):
-        self.assertTrue(_blocks("fgrep foo file"))
-
-    def test_absolute_path(self):
-        self.assertTrue(_blocks("/usr/bin/grep foo file"))
-
-    def test_wrapper_sudo(self):
-        self.assertTrue(_blocks("sudo grep foo /var/log/syslog"))
-
-    def test_wrapper_env_with_assignment(self):
-        self.assertTrue(_blocks("env LC_ALL=C grep foo file"))
-
-    def test_wrapper_time(self):
-        self.assertTrue(_blocks("time grep foo file"))
-
-    def test_wrapper_xargs(self):
-        self.assertTrue(_blocks("echo file | xargs grep foo"))
-
-    def test_wrapper_xargs_replace_flag(self):
-        # `-I {}` takes a value — the `{}` must not be mistaken for the command.
-        self.assertTrue(_blocks("echo file | xargs -I {} grep foo {}"))
-
-    def test_wrapper_command(self):
-        self.assertTrue(_blocks("command grep foo file"))
-
-    def test_wrapper_sudo_login_flag(self):
-        # #1008 review (Weronika): `-i` is BOOLEAN on sudo (login shell), not a
-        # value flag — it must not eat the following `grep` token. Regression.
-        self.assertTrue(_blocks("sudo -i grep foo file"))
-
-    def test_wrapper_sudo_shell_flag(self):
-        self.assertTrue(_blocks("sudo -s grep foo file"))
-
-    def test_wrapper_sudo_mixed_value_and_boolean_flags(self):
-        # `-u root` consumes `root`; `-i` is boolean — grep still resolves.
-        self.assertTrue(_blocks("sudo -u root -i grep foo file"))
-
-    def test_wrapper_sudo_value_flag_still_consumes(self):
-        # `-u root` (value flag) consumes `root`, leaving grep as the command.
-        self.assertTrue(_blocks("sudo -u root grep foo file"))
-
-    def test_wrapper_stdbuf_value_flag_preserved(self):
-        # `-i` IS a value flag on stdbuf (buffer mode) — the per-wrapper dict
-        # must keep that behavior while fixing sudo. `stdbuf -i L grep` still
-        # resolves grep as the command (L is -i's value).
-        self.assertTrue(_blocks("stdbuf -i L grep foo file"))
-
-    def test_wrapper_xargs_s_value_flag_preserved(self):
-        # `-s` is a value flag on xargs (max size) — must still consume its value.
-        self.assertTrue(_blocks("echo f | xargs -s 1000 grep foo"))
-
-    def test_second_segment_of_and_list(self):
-        self.assertTrue(_blocks("rg foo file && grep bar file2"))
-
-    def test_leading_env_assignment(self):
-        self.assertTrue(_blocks("LC_ALL=C grep foo file"))
-
-    def test_override_off_value_still_blocks(self):
-        # An explicit falsey override does NOT open the gate.
-        self.assertTrue(_blocks("NOORINA_ALLOW_GREP=0 grep foo file"))
-
-    @unittest.skipUnless(
-        _shell_parse.bashlex_available(),
-        "command-substitution detection needs the bashlex AST path",
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "grep foo file",
+            'grep -rn "foo" src/',
+            # grep as a downstream pipeline segment — the most common real form.
+            "rg foo | grep bar",
+            "cat file | grep foo",
+            "egrep foo file",
+            "fgrep foo file",
+            "/usr/bin/grep foo file",
+            "sudo grep foo /var/log/syslog",
+            "env LC_ALL=C grep foo file",
+            "time grep foo file",
+            "echo file | xargs grep foo",
+            # `-I {}` takes a value — the `{}` must not be mistaken for the command.
+            "echo file | xargs -I {} grep foo {}",
+            "command grep foo file",
+            # #1008 review (Weronika): `-i` is BOOLEAN on sudo (login shell), not a
+            # value flag — it must not eat the following `grep` token. Regression.
+            "sudo -i grep foo file",
+            "sudo -s grep foo file",
+            # `-u root` consumes `root`; `-i` is boolean — grep still resolves.
+            "sudo -u root -i grep foo file",
+            # `-u root` (value flag) consumes `root`, leaving grep as the command.
+            "sudo -u root grep foo file",
+            # `-i` IS a value flag on stdbuf (buffer mode) — the per-wrapper dict
+            # must keep that behavior while fixing sudo. `stdbuf -i L grep` still
+            # resolves grep as the command (L is -i's value).
+            "stdbuf -i L grep foo file",
+            # `-s` is a value flag on xargs (max size) — must still consume its value.
+            "echo f | xargs -s 1000 grep foo",
+            "rg foo file && grep bar file2",
+            "LC_ALL=C grep foo file",
+            # An explicit falsey override does NOT open the gate.
+            "NOORINA_ALLOW_GREP=0 grep foo file",
+            pytest.param(
+                "x=$(grep foo bar)",
+                id="command_substitution",
+                marks=pytest.mark.skipif(
+                    not _shell_parse.bashlex_available(),
+                    reason="command-substitution detection needs the bashlex AST path",
+                ),
+            ),
+        ],
+        ids=[
+            "direct",
+            "direct_with_flags",
+            "piped",
+            "piped_from_cat",
+            "egrep",
+            "fgrep",
+            "absolute_path",
+            "wrapper_sudo",
+            "wrapper_env_with_assignment",
+            "wrapper_time",
+            "wrapper_xargs",
+            "wrapper_xargs_replace_flag",
+            "wrapper_command",
+            "wrapper_sudo_login_flag",
+            "wrapper_sudo_shell_flag",
+            "wrapper_sudo_mixed_value_and_boolean_flags",
+            "wrapper_sudo_value_flag_still_consumes",
+            "wrapper_stdbuf_value_flag_preserved",
+            "wrapper_xargs_s_value_flag_preserved",
+            "second_segment_of_and_list",
+            "leading_env_assignment",
+            "override_off_value_still_blocks",
+            None,  # the pytest.param above carries its own id
+        ],
     )
-    def test_command_substitution(self):
-        self.assertTrue(_blocks("x=$(grep foo bar)"))
+    def test_blocks(self, command):
+        assert _blocks(command)
 
 
-class NegativeMatchTests(unittest.TestCase):
+class TestNegativeMatch:
     """The tools we want, and data-position 'grep', must NOT trigger."""
 
-    def test_rg(self):
-        self.assertFalse(_blocks("rg foo file"))
-
-    def test_ripgrep(self):
-        self.assertFalse(_blocks("ripgrep foo file"))
-
-    def test_ast_grep(self):
-        self.assertFalse(_blocks("ast-grep -p 'foo(bar)' src/"))
-
-    def test_pgrep(self):
-        self.assertFalse(_blocks("pgrep -f myproc"))
-
-    def test_zgrep(self):
-        self.assertFalse(_blocks("zgrep foo file.gz"))
-
-    def test_git_grep(self):
-        # git's own tracked-file search — `git` is the command, not `grep`.
-        self.assertFalse(_blocks("git grep foo"))
-
-    def test_echo_data_position(self):
-        self.assertFalse(_blocks('echo "use grep for this"'))
-
-    def test_gh_body_flag_value(self):
-        self.assertFalse(_blocks('gh pr create --body "we mention grep in prose"'))
-
-    def test_heredoc_body(self):
-        cmd = "cat > /tmp/x.md <<'EOF'\nDo not use grep here.\nEOF"
-        self.assertFalse(_blocks(cmd))
-
-    def test_filename_containing_grep(self):
-        self.assertFalse(_blocks("cat grepped_output.txt"))
-
-    def test_word_containing_grep(self):
-        self.assertFalse(_blocks("echo pgrep"))
-
-    def test_no_grep_at_all(self):
-        self.assertFalse(_blocks("rg foo src/"))
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "rg foo file",
+            "ripgrep foo file",
+            "ast-grep -p 'foo(bar)' src/",
+            "pgrep -f myproc",
+            "zgrep foo file.gz",
+            # git's own tracked-file search — `git` is the command, not `grep`.
+            "git grep foo",
+            'echo "use grep for this"',
+            'gh pr create --body "we mention grep in prose"',
+            "cat > /tmp/x.md <<'EOF'\nDo not use grep here.\nEOF",
+            "cat grepped_output.txt",
+            "echo pgrep",
+            "rg foo src/",
+        ],
+        ids=[
+            "rg",
+            "ripgrep",
+            "ast_grep",
+            "pgrep",
+            "zgrep",
+            "git_grep",
+            "echo_data_position",
+            "gh_body_flag_value",
+            "heredoc_body",
+            "filename_containing_grep",
+            "word_containing_grep",
+            "no_grep_at_all",
+        ],
+    )
+    def test_does_not_block(self, command):
+        assert not _blocks(command)
 
     def test_non_bash_tool(self):
-        self.assertIsNone(
-            hook.check({"tool_name": "Edit", "tool_input": {"command": "grep foo file"}})
-        )
+        assert hook.check({"tool_name": "Edit", "tool_input": {"command": "grep foo file"}}) is None
 
     def test_empty_command(self):
-        self.assertIsNone(hook.check(_input("")))
+        assert hook.check(_input("")) is None
 
 
 class OverrideTests(unittest.TestCase):
@@ -197,4 +201,7 @@ class BlockMessageTests(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()
+    # `unittest.main()` would silently skip TestPositiveMatch/TestNegativeMatch
+    # (plain pytest classes, not unittest.TestCase — see module docstring) when
+    # this file is run standalone. `pytest.main` discovers both styles.
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/.claude/hooks/tests/test_enforce_ontology_context.py
+++ b/.claude/hooks/tests/test_enforce_ontology_context.py
@@ -282,4 +282,8 @@ class CoordinatorExemptIsBoundaryStrict(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()
+    # `unittest.main()` would silently skip the pytest.mark.parametrize
+    # classes above (plain classes, not unittest.TestCase — see module
+    # docstring) when this file is run standalone. `pytest.main` discovers
+    # both styles.
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/.claude/hooks/tests/test_enforce_ontology_context.py
+++ b/.claude/hooks/tests/test_enforce_ontology_context.py
@@ -1,6 +1,20 @@
 #!/usr/bin/env python3
 """Tests for enforce_ontology_context — covers #466 coordinator-class exemption.
 
+Four classes below are `pytest.mark.parametrize` tables, not `unittest.TestCase`
+(#1117 — G5 clone-group parametrization): every method in each was a
+single-statement `self.assertIsNone(hook.check(_spawn(prompt)))` (or, for
+`TestIndentedCoordinatorOpenerNotExempt`, the same 3-statement block-assertion
+shape) differing only in `prompt`. Kept per ORIGINAL class boundary rather than
+merged across classes even where the AST shape is identical (e.g.
+`CoordinatorClassExempt` and `WorktreeImplementerWithContextAllowed` both
+reduce to `assertIsNone(check(_spawn(prompt)))`) — each class's docstring
+names a distinct reason the spawn is allowed (coordinator-role exemption vs.
+an explicit ontology-context marker), and collapsing that distinction into one
+flat table is the "structurally identical, not safely mergeable" trap this
+task's brief warns about. `ids=` is each original method's bare name so every
+case is traceable 1:1 back to the test it replaces.
+
 Run: ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/test_enforce_ontology_context.py -v
 """
 
@@ -10,6 +24,7 @@ import unittest
 
 import _test_helpers  # noqa: E402,F401
 import enforce_ontology_context as hook  # noqa: E402
+import pytest
 
 
 def _spawn(prompt: str, isolation: str = "worktree") -> dict:
@@ -56,132 +71,109 @@ class WorktreeImplementerWithoutContextBlocked(unittest.TestCase):
         self.assertIsNotNone(result)
 
 
-class WorktreeImplementerWithContextAllowed(unittest.TestCase):
-    def test_ontology_context_heading_allowed(self):
-        prompt = (
+class TestWorktreeImplementerWithContextAllowed:
+    @pytest.mark.parametrize(
+        "prompt",
+        [
             "## Ontology Context\nServices: user-service\n\n"
-            "You are **Mateo**, Engineer. Implement #123."
-        )
-        self.assertIsNone(hook.check(_spawn(prompt)))
+            "You are **Mateo**, Engineer. Implement #123.",
+            "You are Mateo. Ontology Status: ontology is current. Implement #123.",
+            "You are Mateo. See ontology/services.yaml for context. Implement #123.",
+        ],
+        ids=[
+            "ontology_context_heading_allowed",
+            "status_marker_allowed",
+            "yaml_path_marker_allowed",
+        ],
+    )
+    def test_allowed(self, prompt):
+        assert hook.check(_spawn(prompt)) is None
 
-    def test_status_marker_allowed(self):
-        prompt = "You are Mateo. Ontology Status: ontology is current. Implement #123."
-        self.assertIsNone(hook.check(_spawn(prompt)))
 
-    def test_yaml_path_marker_allowed(self):
-        prompt = "You are Mateo. See ontology/services.yaml for context. Implement #123."
-        self.assertIsNone(hook.check(_spawn(prompt)))
-
-
-class CoordinatorClassExempt(unittest.TestCase):
+class TestCoordinatorClassExempt:
     """Manager / Program Director / TPM / Release Coordinator spawn briefs are
     exempt from ontology-context enforcement even with worktree isolation.
 
     Reproduces the 8-block burst captured 2026-05-17 03:54Z (#466)."""
 
-    def test_manager_for_deploy_exempt(self):
-        prompt = "You are **Bereket Tadesse**, Manager for noorinalabs-deploy. Roster card: ..."
-        self.assertIsNone(hook.check(_spawn(prompt)))
-
-    def test_manager_for_isnad_graph_exempt(self):
-        prompt = (
+    @pytest.mark.parametrize(
+        "prompt",
+        [
+            "You are **Bereket Tadesse**, Manager for noorinalabs-deploy. Roster card: ...",
             "You are **Nadia Boukhari**, Manager for noorinalabs-isnad-graph "
-            "(NOT Nadia Khoury the parent Program Director — different person)."
-        )
-        self.assertIsNone(hook.check(_spawn(prompt)))
-
-    def test_manager_for_ingest_platform_exempt(self):
-        prompt = (
+            "(NOT Nadia Khoury the parent Program Director — different person).",
             "You are **Adaeze Okonkwo**, Manager for noorinalabs-isnad-ingest-platform. "
-            "Roster card: ..."
-        )
-        self.assertIsNone(hook.check(_spawn(prompt)))
-
-    def test_program_director_exempt(self):
-        prompt = "You are **Nadia Khoury**, Program Director for noorinalabs. Coordinate the wave."
-        self.assertIsNone(hook.check(_spawn(prompt)))
-
-    def test_tpm_exempt(self):
-        prompt = "You are **Wanjiku Mwangi**, TPM for noorinalabs. Track timelines."
-        self.assertIsNone(hook.check(_spawn(prompt)))
-
-    def test_technical_program_manager_full_title_exempt(self):
-        prompt = (
+            "Roster card: ...",
+            "You are **Nadia Khoury**, Program Director for noorinalabs. Coordinate the wave.",
+            "You are **Wanjiku Mwangi**, TPM for noorinalabs. Track timelines.",
             "You are **Wanjiku Mwangi**, Technical Program Manager for noorinalabs. "
-            "Track timelines."
-        )
-        self.assertIsNone(hook.check(_spawn(prompt)))
-
-    def test_release_coordinator_exempt(self):
-        prompt = (
-            "You are **Santiago Ferreira**, Release Coordinator for noorinalabs. Sequence rollouts."
-        )
-        self.assertIsNone(hook.check(_spawn(prompt)))
-
-    def test_manager_without_repo_suffix_exempt(self):
-        prompt = "You are **Bereket Tadesse**, Manager. Coordinate the deploy wave."
-        self.assertIsNone(hook.check(_spawn(prompt)))
-
-    def test_manager_without_bold_markdown_exempt(self):
-        prompt = "You are Bereket Tadesse, Manager for noorinalabs-deploy. Coordinate the wave."
-        self.assertIsNone(hook.check(_spawn(prompt)))
-
-    def test_project_lead_exempt_marcia(self):
-        # Marcia Vasquez-Paredes (landing-page) — composer flattens
-        # "Project Lead / Manager" roster title to ", Project Lead".
-        # Was 1 of the 8 captured blocks (#466) that the initial regex missed.
-        prompt = (
+            "Track timelines.",
+            "You are **Santiago Ferreira**, Release Coordinator for noorinalabs. "
+            "Sequence rollouts.",
+            "You are **Bereket Tadesse**, Manager. Coordinate the deploy wave.",
+            "You are Bereket Tadesse, Manager for noorinalabs-deploy. Coordinate the wave.",
+            # Marcia Vasquez-Paredes (landing-page) — composer flattens
+            # "Project Lead / Manager" roster title to ", Project Lead".
+            # Was 1 of the 8 captured blocks (#466) that the initial regex missed.
             "You are **Marcia Vasquez-Paredes**, Project Lead for noorinalabs-landing-page. "
-            "Coordinate the wave."
-        )
-        self.assertIsNone(hook.check(_spawn(prompt)))
-
-    def test_pipeline_manager_exempt_dilara(self):
-        # Dilara (data-acquisition) — Senior VP coordinator with the
-        # "Pipeline Manager" composer-output. Surfaced by Santiago's #469
-        # roster-grep during PR #468 review.
-        prompt = (
+            "Coordinate the wave.",
+            # Dilara (data-acquisition) — Senior VP coordinator with the
+            # "Pipeline Manager" composer-output. Surfaced by Santiago's #469
+            # roster-grep during PR #468 review.
             "You are **Dilara Aydin**, Pipeline Manager for noorinalabs-data-acquisition. "
-            "Coordinate the wave."
-        )
-        self.assertIsNone(hook.check(_spawn(prompt)))
+            "Coordinate the wave.",
+        ],
+        ids=[
+            "manager_for_deploy_exempt",
+            "manager_for_isnad_graph_exempt",
+            "manager_for_ingest_platform_exempt",
+            "program_director_exempt",
+            "tpm_exempt",
+            "technical_program_manager_full_title_exempt",
+            "release_coordinator_exempt",
+            "manager_without_repo_suffix_exempt",
+            "manager_without_bold_markdown_exempt",
+            "project_lead_exempt_marcia",
+            "pipeline_manager_exempt_dilara",
+        ],
+    )
+    def test_exempt(self, prompt):
+        assert hook.check(_spawn(prompt)) is None
 
 
-class CoordinatorExemptHandlesPrependedHeader(unittest.TestCase):
+class TestCoordinatorExemptHandlesPrependedHeader:
     """Coordinator-class exemption must match when the spawn brief prepends
     content (header, task framing, role-card excerpt) before the canonical
     "You are X, Role" opener — `re.MULTILINE` enables `^` to match at line
     starts beyond char 0. Caught by Aino's review blocker #2 on PR #468."""
 
-    def test_coordinator_after_markdown_header_exempt(self):
-        prompt = (
+    @pytest.mark.parametrize(
+        "prompt",
+        [
             "# Wave-tail re-spawn brief\n\n"
-            "You are **Bereket Tadesse**, Manager for noorinalabs-deploy. Coordinate the wave."
-        )
-        self.assertIsNone(hook.check(_spawn(prompt)))
-
-    def test_coordinator_after_task_context_exempt(self):
-        prompt = (
+            "You are **Bereket Tadesse**, Manager for noorinalabs-deploy. Coordinate the wave.",
             "Task context: P3W11 wave-tail cleanup.\n"
             "\n"
             "You are **Adaeze Okonkwo**, Manager for noorinalabs-isnad-ingest-platform. "
-            "Coordinate the wave."
-        )
-        self.assertIsNone(hook.check(_spawn(prompt)))
-
-    def test_coordinator_after_role_card_excerpt_exempt(self):
-        prompt = (
+            "Coordinate the wave.",
             "Roster card excerpt:\n"
             "  Role: Manager for noorinalabs-landing-page\n"
             "  Reports to: Nadia Khoury\n"
             "\n"
             "You are **Marcia Vasquez-Paredes**, Project Lead for noorinalabs-landing-page. "
-            "Coordinate the wave."
-        )
-        self.assertIsNone(hook.check(_spawn(prompt)))
+            "Coordinate the wave.",
+        ],
+        ids=[
+            "coordinator_after_markdown_header_exempt",
+            "coordinator_after_task_context_exempt",
+            "coordinator_after_role_card_excerpt_exempt",
+        ],
+    )
+    def test_exempt(self, prompt):
+        assert hook.check(_spawn(prompt)) is None
 
 
-class IndentedCoordinatorOpenerNotExempt(unittest.TestCase):
+class TestIndentedCoordinatorOpenerNotExempt:
     """The opener must sit at an EXACT line start to exempt. An indented
     `You are X, Manager` line — inside a 4-space code block, a YAML-indented
     example, or a blockquote — is NOT the coordinator's own opener; it's
@@ -190,38 +182,41 @@ class IndentedCoordinatorOpenerNotExempt(unittest.TestCase):
     blocks them (#471). The opener tested here belongs to an Engineer spawn
     with NO ontology context, so the correct outcome is a block."""
 
-    def test_four_space_indented_opener_not_exempt(self):
-        prompt = (
+    @pytest.mark.parametrize(
+        "prompt",
+        [
             "You are **Mateo Salazar**, Engineer. Implement #123. Example brief shape:\n"
-            "    You are **Bereket Tadesse**, Manager for noorinalabs-deploy.\n"
-        )
-        result = hook.check(_spawn(prompt))
-        self.assertIsNotNone(result)
-        assert result is not None
-        self.assertEqual(result["decision"], "block")
-
-    def test_yaml_indented_opener_not_exempt(self):
-        prompt = (
+            "    You are **Bereket Tadesse**, Manager for noorinalabs-deploy.\n",
             "You are **Mateo Salazar**, Engineer. Implement #123. YAML example:\n"
             "brief:\n"
-            "  opener: You are **Bereket Tadesse**, Manager for noorinalabs-deploy\n"
-        )
-        result = hook.check(_spawn(prompt))
-        self.assertIsNotNone(result)
-        assert result is not None
-        self.assertEqual(result["decision"], "block")
-
-    def test_blockquote_indented_opener_not_exempt(self):
-        # Defensive: a blockquote-prefixed opener (`> You are ...`) already
-        # wouldn't match a column-0 anchor; this pins that it stays blocked.
-        prompt = (
+            "  opener: You are **Bereket Tadesse**, Manager for noorinalabs-deploy\n",
+            # Defensive: a blockquote-prefixed opener (`> You are ...`) already
+            # wouldn't match a column-0 anchor; this pins that it stays blocked.
             "You are **Mateo Salazar**, Engineer. Implement #123. Quoted brief:\n"
-            "> You are **Bereket Tadesse**, Manager for noorinalabs-deploy\n"
-        )
+            "> You are **Bereket Tadesse**, Manager for noorinalabs-deploy\n",
+        ],
+        ids=[
+            "four_space_indented_opener_not_exempt",
+            "yaml_indented_opener_not_exempt",
+            "blockquote_indented_opener_not_exempt",
+        ],
+    )
+    def test_not_exempt(self, prompt):
+        # NOTE (#1117 density accounting): the original per-case body had 3
+        # assert-bearing statements — `self.assertIsNotNone(result)`, a bare
+        # `assert result is not None` (mypy narrowing `self.assertIsNotNone`
+        # can't provide), then `self.assertEqual(...)`. The first two were the
+        # SAME not-None check done twice, an artifact of mixing unittest-style
+        # assertions with a bare-assert type-narrower. A plain-pytest class has
+        # no `self.assertX`, so one `assert result is not None` both narrows
+        # the type AND is the check — the duplicate has no pytest equivalent
+        # to preserve. Reported explicitly in the PR body's density table as a
+        # 1-per-case reduction (33 -> 22 raw executions for this group), not a
+        # silent loss: the same 2 distinct facts (not-None, decision==block)
+        # are still checked in every case.
         result = hook.check(_spawn(prompt))
-        self.assertIsNotNone(result)
         assert result is not None
-        self.assertEqual(result["decision"], "block")
+        assert result["decision"] == "block"
 
 
 class CheckIsCrashSafeOnMalformedInput(unittest.TestCase):

--- a/.claude/hooks/tests/test_validate_commit_identity.py
+++ b/.claude/hooks/tests/test_validate_commit_identity.py
@@ -15,6 +15,7 @@ import unittest
 from pathlib import Path
 
 import _test_helpers  # noqa: E402,F401
+import pytest
 import validate_commit_identity as hook  # noqa: E402
 
 
@@ -1346,7 +1347,7 @@ class WrappedCommitIdentityRegression(unittest.TestCase):
         self.assertIsNotNone(hook.check(self._input(self._commit("", identity=False))))
 
 
-class AssignmentAwarePrePassTests(unittest.TestCase):
+class TestAssignmentAwarePrePass:
     """main#1195 — a payload/command-word held in a shell variable defeats
     both the phrase matcher (`_payload_looks_like_commit`) and the direct
     commit-segment finder (`find_git_subcommand`, via `_find_commit_segment`)
@@ -1365,6 +1366,21 @@ class AssignmentAwarePrePassTests(unittest.TestCase):
     checks the SPECIFIC reason string (not a bare substring that survives if
     the wrong row fires), and every ALLOW assertion checks the value is
     `None`, not merely "not exceptional".
+
+    Not `unittest.TestCase` (#1117 — G5 clone-group parametrization): 5
+    `pytest.mark.parametrize` tables below cover 30 of this class's 39
+    original methods, across 5 distinct AST shapes (single-statement ALLOW;
+    single-statement-with-a-`cmd`-variable ALLOW; and 3 different BLOCK
+    shapes distinguished by which combination of a `self.assertIsNotNone`
+    message arg and a trailing `self.assertIn(reason)` line they carried —
+    kept as SEPARATE tables rather than force-fit into one, since collapsing
+    distinct assertion shapes into a shared body is exactly the
+    "structurally identical, not safely mergeable" trap). The remaining 9
+    methods (a unique full-reason-string pin, the `_valid_identity` compliant-
+    commit mirror, `startswith`/`assertTrue` reason-prefix checks, etc.) keep
+    individual bodies — every `self.assertX` in the class, merged or not, was
+    mechanically rewritten to a bare `assert` since a plain class has no
+    `self.assertX`. `ids=` is each original method's bare name.
     """
 
     _input = staticmethod(_test_helpers.bash_input)
@@ -1372,7 +1388,7 @@ class AssignmentAwarePrePassTests(unittest.TestCase):
     def _valid_identity(self) -> tuple[str, str]:
         name = next(iter(hook.ROSTER), None)
         if not name:
-            self.skipTest("local roster is empty")
+            pytest.skip("local roster is empty")
         return name, hook.ROSTER[name]
 
     # --- the issue's own measured shapes -----------------------------------
@@ -1389,15 +1405,14 @@ class AssignmentAwarePrePassTests(unittest.TestCase):
         the `normalize_command_separators` fix.
         """
         result = hook.check(self._input("g=git; $g commit -m x"))
-        self.assertIsNotNone(result, "variable-held command word must be seen as git commit")
+        assert result is not None, "variable-held command word must be seen as git commit"
         assert result is not None
-        self.assertEqual(result["decision"], "block")
-        self.assertEqual(
-            result["reason"],
+        assert result["decision"] == "block"
+        assert result["reason"] == (
             "BLOCKED: git commit missing `-c user.name=` flag. "
             "Charter § Commit Identity requires per-commit identity via -c flags. "
             'Example: git -c user.name="Kwame Asante" '
-            '-c user.email="parametrization+Kwame.Asante@gmail.com" commit -m "..."',
+            '-c user.email="parametrization+Kwame.Asante@gmail.com" commit -m "..."'
         )
 
     def test_direct_typed_variable_command_word_glued_semicolon_valid_identity_allows(
@@ -1412,7 +1427,7 @@ class AssignmentAwarePrePassTests(unittest.TestCase):
         name, email = self._valid_identity()
         cmd = f'g=git; $g -c user.name="{name}" -c user.email="{email}" commit -m x'
         result = hook.check(self._input(cmd))
-        self.assertIsNone(result, f"compliant commit behind $g must be ALLOWED, got: {result}")
+        assert result is None, f"compliant commit behind $g must be ALLOWED, got: {result}"
 
     def test_direct_typed_variable_command_word_spaced_semicolon_blocks(self) -> None:
         """POS: same shape with a space before `;` (`g=git ; $g commit -m x`).
@@ -1425,10 +1440,10 @@ class AssignmentAwarePrePassTests(unittest.TestCase):
         caught independently.
         """
         result = hook.check(self._input("g=git ; $g commit -m x"))
-        self.assertIsNotNone(result)
         assert result is not None
-        self.assertEqual(result["decision"], "block")
-        self.assertIn("missing `-c user.name=` flag", result["reason"])
+        assert result is not None
+        assert result["decision"] == "block"
+        assert "missing `-c user.name=` flag" in result["reason"]
 
     def test_wrapped_bash_dash_c_variable_command_word_blocks(self) -> None:
         """POS: the issue's wrapped shape, `bash -c 'g=git; $g commit -m x'`.
@@ -1440,15 +1455,12 @@ class AssignmentAwarePrePassTests(unittest.TestCase):
         """
         cmd = "bash -c 'g=git; $g commit -m x'"
         result = hook.check(self._input(cmd))
-        self.assertIsNotNone(result, "indirect wrapper hiding a variable command word must block")
+        assert result is not None, "indirect wrapper hiding a variable command word must block"
         assert result is not None
-        self.assertEqual(result["decision"], "block")
-        self.assertTrue(
-            result["reason"].startswith(
-                "BLOCKED: indirect-exec wrapper detected (shell -c) carrying a hidden `git commit`."
-            ),
-            result["reason"],
-        )
+        assert result["decision"] == "block"
+        assert result["reason"].startswith(
+            "BLOCKED: indirect-exec wrapper detected (shell -c) carrying a hidden `git commit`."
+        ), result["reason"]
 
     def test_heredoc_body_variable_command_word_blocks(self) -> None:
         """POS: same indirection inside a heredoc fed to a real interpreter.
@@ -1459,249 +1471,215 @@ class AssignmentAwarePrePassTests(unittest.TestCase):
         """
         cmd = "bash <<'EOF'\ng=git\n$g commit -m x\nEOF"
         result = hook.check(self._input(cmd))
-        self.assertIsNotNone(result)
         assert result is not None
-        self.assertEqual(result["decision"], "block")
-        self.assertIn("indirect-exec", result["reason"])
+        assert result is not None
+        assert result["decision"] == "block"
+        assert "indirect-exec" in result["reason"]
 
     # --- false-positive corpus: ordinary shapes must NOT block -------------
 
-    def test_command_substitution_value_not_resolved_allows(self) -> None:
-        """NEG (the issue's own required sweep item): `d=$(date); echo $d`.
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # (the issue's own required sweep item): `d=$(date); echo $d`.
+            # Command substitution is explicitly out of scope: the value
+            # fails the literal-charset check, so `d` is never captured and
+            # `$d` is left untouched. An ordinary shape; must not block.
+            "d=$(date); echo $d",
+            # Ordinary env-var reuse with no relation to git at all.
+            "FOO=bar; echo $FOO",
+            # `g=$(echo git); $g commit -m x` — command substitution OF the
+            # command word itself. Explicitly out of scope per the issue
+            # (same family as `$(printf git) commit`, strictly harder) —
+            # `g`'s value contains `$` and parens, so it fails the literal
+            # check and is never captured; `$g` stays literal and unresolved.
+            "g=$(echo git); $g commit -m x",
+            # `g=git; $gone commit -m x` — `$gone` is a DIFFERENT variable
+            # from `$g`; the greedy identifier match in the reference regex
+            # captures the name "gone" in full, which was never assigned, so
+            # it is left untouched. Guards against a name-prefix conflation
+            # bug.
+            "g=git; $gone commit -m x",
+            # `set -- git commit; echo $1` — positional parameters (`$1`)
+            # are explicitly out of scope; the capture regex requires a name
+            # starting with a letter or underscore, so `$1` can never be an
+            # assignment target in the first place. `git commit` here is a
+            # DATA argument to `set --`, not an invocation — must not block.
+            "set -- git commit; echo $1",
+            # (main#1195 review round 3, real-shell-verified via printf/marker
+            # proxy): `A=1 B=git $B commit -m z` — a same-segment prefix
+            # assignment is NOT visible to that segment's OWN expansion. `$B`
+            # stays unresolved, so this is not a detected git invocation and
+            # must ALLOW.
+            "A=1 B=git $B commit -m z",
+            # marker proxy: real shell reports `MARKERARG: command not
+            # found` (`$B` unset at expansion time). Must ALLOW; the OLD
+            # code blocked this (false positive).
+            "A=1 B=git $B commit -m z",
+            # `g=echo; g=git $g commit -m x` — marker proxy: real shell runs
+            # `echo commit -m x` (`$g` resolves against the RUNNING state
+            # from the prior segment, `echo`, not this segment's own
+            # `g=git` prefix). Must ALLOW.
+            "g=echo; g=git $g commit -m x",
+            # `g=git & $g commit -m x` — marker proxy: real shell reports
+            # `MARKERARG: command not found` (`g=git` runs as a backgrounded
+            # job in its own subshell; the foreground `$g` is unset).
+            "g=git & $g commit -m x",
+            # `$NEVERASSIGNED commit -m x` — no assignment anywhere in the
+            # command, so `assignments.get(name, m.group(0))` must return
+            # the ORIGINAL text unchanged.
+            "$NEVERASSIGNED commit -m x",
+            # `A=1 B=git ${B} commit -m z` — braced-reference sibling of
+            # row 1. Must ALLOW for the identical real-shell reason.
+            "A=1 B=git ${B} commit -m z",
+            # `A=1 BB=git $BB commit -m z` — multi-char-name sibling of
+            # row 1. Must ALLOW regardless of name length.
+            "A=1 BB=git $BB commit -m z",
+            # Row 2 (control): `g=git bash -c "$g commit -m x"` — marker
+            # proxy: real shell does NOT run `git` (the OUTER shell expands
+            # the double-quoted argument itself, before the prefix takes
+            # effect).
+            'g=git bash -c "$g commit -m x"',
+            # Row 5 (control): `bash -c '$g commit -m x'` with no `g=git`
+            # prefix anywhere. Must ALLOW (`$g` is genuinely unset).
+            "bash -c '$g commit -m x'",
+        ],
+        ids=[
+            "command_substitution_value_not_resolved_allows",
+            "unrelated_assignment_and_reuse_allows",
+            "double_indirection_via_command_substitution_of_command_word_allows",
+            "similarly_named_variable_not_conflated_allows",
+            "positional_parameter_not_treated_as_assignment_target_allows",
+            "same_segment_leading_assignment_not_resolved_allows",
+            "row1_same_segment_prefix_never_reaches_git_allows",
+            "row2_own_prefix_reassignment_does_not_shadow_running_value_allows",
+            "row4_background_assignment_never_reaches_foreground_allows",
+            "unassigned_variable_reference_left_literal_allows",
+            "row1_braced_variant_never_reaches_git_allows",
+            "row1_multichar_name_variant_never_reaches_git_allows",
+            "prefix_in_double_quoted_bash_dash_c_payload_allows",
+            "no_prefix_unset_reference_in_single_quoted_payload_allows",
+        ],
+    )
+    def test_allowed(self, command):
+        assert hook.check(self._input(command)) is None
 
-        Command substitution is explicitly out of scope: the value fails the
-        literal-charset check, so `d` is never captured and `$d` is left
-        untouched. An ordinary shape; must not block.
-        """
-        self.assertIsNone(hook.check(self._input("d=$(date); echo $d")))
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # A quoted, multi-word value merely mentioning "git commit" as
+            # an ARGUMENT (`echo $msg`), not in command position. Prose, not
+            # an invocation.
+            'msg="please git commit this later"; echo $msg',
+            # `cmd="git commit -m z"; $cmd` — a full command line assigned
+            # to a variable, then invoked BARE. Deliberately out of scope
+            # (multi-word values are not resolved).
+            'cmd="git commit -m z"; $cmd',
+            # (truncating-mutant guard): an UNASSIGNED reference sitting
+            # between two literal fragments must be left EXACTLY as typed,
+            # not collapsed to an empty string. `h=other; gi${x}t commit -m
+            # z` — `x` is never assigned.
+            "h=other; gi${x}t commit -m z",
+        ],
+        ids=[
+            "prose_value_with_git_commit_words_not_resolved_allows",
+            "multiword_command_string_value_not_resolved_allows",
+            "unresolved_reference_leaves_exact_literal_not_merely_nonempty",
+        ],
+    )
+    def test_allowed_via_intermediate_cmd_var(self, command):
+        assert hook.check(self._input(command)) is None
 
-    def test_prose_value_with_git_commit_words_not_resolved_allows(self) -> None:
-        """NEG: a quoted, multi-word value merely mentioning "git commit" as
-        an ARGUMENT (`echo $msg`), not in command position.
+    # --- BLOCK shapes: `assertIsNotNone(result, msg)` + `assertIn(reason)` -
 
-        `msg="please git commit this later"; echo $msg` is prose, not an
-        invocation: even resolved, `$msg` lands as an argument to `echo`,
-        never as the first token of a segment, so `find_git_subcommand`
-        (which requires `git` to be that first token) does not fire either
-        way. Pinned as a regression guard that the pre-pass does not change
-        this outcome for an ordinary "argument merely mentions git" shape.
-        """
-        cmd = 'msg="please git commit this later"; echo $msg'
-        self.assertIsNone(hook.check(self._input(cmd)))
-
-    def test_multiword_command_string_value_not_resolved_allows(self) -> None:
-        """NEG: `cmd="git commit -m z"; $cmd` — a full command line assigned
-        to a variable, then invoked BARE (real shell word-splitting would
-        actually run it). This is the test that pins the literal-charset
-        guard itself: the value contains whitespace, so `cmd` is never
-        captured and `$cmd` is left as one unresolved literal token (not
-        equal to `git`), so `find_git_subcommand` does not see a `git`
-        command in command position. Deliberately out of scope (multi-word
-        values are not resolved) — this is a documented boundary, not an
-        oversight: resolving it would reopen the prose-argument
-        false-positive class one level lower (through direct segment
-        matching instead of `_INNER_COMMIT_RE`).
-        """
-        cmd = 'cmd="git commit -m z"; $cmd'
-        self.assertIsNone(hook.check(self._input(cmd)))
-
-    def test_unrelated_assignment_and_reuse_allows(self) -> None:
-        """NEG: ordinary env-var reuse with no relation to git at all."""
-        self.assertIsNone(hook.check(self._input("FOO=bar; echo $FOO")))
-
-    def test_double_indirection_via_command_substitution_of_command_word_allows(
-        self,
-    ) -> None:
-        """NEG: `g=$(echo git); $g commit -m x` — command substitution OF the
-        command word itself. Explicitly out of scope per the issue (same
-        family as `$(printf git) commit`, strictly harder) — `g`'s value
-        contains `$` and parens, so it fails the literal check and is never
-        captured; `$g` stays literal and unresolved.
-        """
-        self.assertIsNone(hook.check(self._input("g=$(echo git); $g commit -m x")))
-
-    def test_similarly_named_variable_not_conflated_allows(self) -> None:
-        """NEG: `g=git; $gone commit -m x` — `$gone` is a DIFFERENT variable
-        from `$g`; the greedy identifier match in the reference regex
-        captures the name "gone" in full, which was never assigned, so it is
-        left untouched. Guards against a name-prefix conflation bug.
-        """
-        self.assertIsNone(hook.check(self._input("g=git; $gone commit -m x")))
-
-    def test_positional_parameter_not_treated_as_assignment_target_allows(self) -> None:
-        """NEG: `set -- git commit; echo $1` — positional parameters (`$1`)
-        are explicitly out of scope; the capture regex requires a name
-        starting with a letter or underscore, so `$1` can never be an
-        assignment target in the first place. `git commit` here is a DATA
-        argument to `set --`, not an invocation — must not block.
-        """
-        self.assertIsNone(hook.check(self._input("set -- git commit; echo $1")))
-
-    # --- multi-assignment / `${NAME}` form coverage -------------------------
-
-    def test_same_segment_leading_assignment_not_resolved_allows(self) -> None:
-        """NEG (main#1195 review round 3, real-shell-verified via
-        printf/marker proxy): `A=1 B=git $B commit -m z` — a same-segment
-        prefix assignment is NOT visible to that segment's OWN expansion.
-        `$B` stays unresolved, so this is not a detected git invocation and
-        must ALLOW. Supersedes the previous (wrong)
-        `test_multiple_leading_assignments_in_one_segment_resolves_second`,
-        which asserted a BLOCK verdict for a misreading of POSIX
-        prefix-assignment scope — a real shell never runs git for this
-        input; the PR body's own bypass-closed table row for this exact
-        string was likewise corrected (see the PR follow-up comment).
-        """
-        self.assertIsNone(hook.check(self._input("A=1 B=git $B commit -m z")))
-
-    def test_two_leading_assignments_resolve_in_later_segment_blocks(self) -> None:
-        """POS: the peeling loop must still consume BOTH leading assignment
-        tokens (`A=1` then `B=git`) in one segment — pinned here where a
-        real shell agrees with the block verdict: once `;` moves the
-        reference into a LATER segment, `B`'s value resolves and the
-        hidden `git commit` is caught.
-        """
-        result = hook.check(self._input("A=1 B=git; $B commit -m z"))
-        self.assertIsNotNone(
-            result, "second leading assignment (B=git) must resolve once used in a later segment"
-        )
+    @pytest.mark.parametrize(
+        ("command", "not_none_msg"),
+        [
+            (
+                "A=1 B=git; $B commit -m z",
+                "second leading assignment (B=git) must resolve once used in a later segment",
+            ),
+            (
+                "g=git; g=echo $g commit -m x",
+                "prior-segment g=git must still resolve at the commit site",
+            ),
+            ("g=git; ${g} commit -m x", "braced ${g} reference must resolve to git"),
+            (
+                "g=git; g=echo ${g} commit -m x",
+                "prior-segment g=git must still resolve via ${g}",
+            ),
+            (
+                "gg=git; gg=echo $gg commit -m x",
+                "prior-segment gg=git must still resolve at the commit site",
+            ),
+            (
+                "for f in a; do g=git; $g commit -m x; done",
+                "do-prefixed segment assignment must still resolve",
+            ),
+        ],
+        ids=[
+            "two_leading_assignments_resolve_in_later_segment_blocks",
+            "row3_own_prefix_reassignment_cannot_hide_prior_running_value_blocks",
+            "braced_variable_reference_form_resolves",
+            "row3_braced_variant_cannot_hide_prior_running_value_blocks",
+            "row3_multichar_name_variant_cannot_hide_prior_running_value_blocks",
+            "for_loop_do_body_assignment_blocks",
+        ],
+    )
+    def test_blocks_with_message_and_reason_substring(self, command, not_none_msg):
+        result = hook.check(self._input(command))
+        assert result is not None, not_none_msg
         assert result is not None
-        self.assertEqual(result["decision"], "block")
-        self.assertIn("missing `-c user.name=` flag", result["reason"])
+        assert result["decision"] == "block"
+        assert "missing `-c user.name=` flag" in result["reason"]
 
-    # --- main#1195 review round 3: the four adversarial rows, marker-proxy
-    # verified against a real shell (printf/marker proxy: a fake `git`
-    # executable on PATH plus real `echo`), pinned exactly as measured -----
+    # --- BLOCK shapes: bare `assertIsNotNone(result)`, no reason check -----
 
-    def test_row1_same_segment_prefix_never_reaches_git_allows(self) -> None:
-        """`A=1 B=git $B commit -m z` — marker proxy: real shell reports
-        `MARKERARG: command not found` (`$B` unset at expansion time). Must
-        ALLOW; the OLD code blocked this (false positive).
-        """
-        self.assertIsNone(hook.check(self._input("A=1 B=git $B commit -m z")))
-
-    def test_row2_own_prefix_reassignment_does_not_shadow_running_value_allows(
-        self,
-    ) -> None:
-        """`g=echo; g=git $g commit -m x` — marker proxy: real shell runs
-        `echo commit -m x` (`$g` resolves against the RUNNING state from the
-        prior segment, `echo`, not this segment's own `g=git` prefix). Must
-        ALLOW; the OLD code blocked this (false positive).
-        """
-        self.assertIsNone(hook.check(self._input("g=echo; g=git $g commit -m x")))
-
-    def test_row3_own_prefix_reassignment_cannot_hide_prior_running_value_blocks(
-        self,
-    ) -> None:
-        """`g=git; g=echo $g commit -m x` — marker proxy: real shell runs
-        the fake `git` executable (`$g` resolves against the RUNNING state
-        from the prior segment, `git`, not this segment's own `g=echo`
-        prefix). Must BLOCK; the OLD code ALLOWED this outright — a LIVE
-        BYPASS with no interpreter wrapper at all, not merely a cosmetic
-        false positive.
-        """
-        result = hook.check(self._input("g=git; g=echo $g commit -m x"))
-        self.assertIsNotNone(result, "prior-segment g=git must still resolve at the commit site")
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "g=git sh -c '$g commit -m x'",
+            "g=git bash -c '${g} commit -m x'",
+            "g=git; bash -c '$g commit -m x'",
+            "for f in a; do gg=git; $gg commit -m x; done",
+        ],
+        ids=[
+            "prefix_in_single_quoted_sh_dash_c_payload_blocks",
+            "prefix_in_single_quoted_braced_payload_blocks",
+            "cross_segment_semicolon_single_quoted_payload_still_blocks",
+            "for_loop_do_body_multichar_name_blocks",
+        ],
+    )
+    def test_blocks_bare(self, command):
+        result = hook.check(self._input(command))
         assert result is not None
-        self.assertEqual(result["decision"], "block")
-        self.assertIn("missing `-c user.name=` flag", result["reason"])
-
-    def test_row4_background_assignment_never_reaches_foreground_allows(self) -> None:
-        """`g=git & $g commit -m x` — marker proxy: real shell reports
-        `MARKERARG: command not found` (`g=git` runs as a backgrounded job
-        in its own subshell; the foreground `$g` is unset). Must ALLOW.
-        """
-        self.assertIsNone(hook.check(self._input("g=git & $g commit -m x")))
-
-    def test_braced_variable_reference_form_resolves(self) -> None:
-        """POS: `${g}` (braced form) must resolve the same as bare `$g`."""
-        result = hook.check(self._input("g=git; ${g} commit -m x"))
-        self.assertIsNotNone(result, "braced ${g} reference must resolve to git")
         assert result is not None
-        self.assertEqual(result["decision"], "block")
-        self.assertIn("missing `-c user.name=` flag", result["reason"])
+        assert result["decision"] == "block"
 
-    def test_unassigned_variable_reference_left_literal_allows(self) -> None:
-        """NEG: `$NEVERASSIGNED commit -m x` — no assignment anywhere in the
-        command, so `assignments.get(name, m.group(0))` must return the
-        ORIGINAL text unchanged, not an empty string or a KeyError. An
-        unresolved variable used as a command word is not a `git` command
-        (whatever it resolves to at runtime, the hook cannot know, and does
-        not need to for THIS shape — nothing here spells `git`).
-        """
-        self.assertIsNone(hook.check(self._input("$NEVERASSIGNED commit -m x")))
-
-    def test_unresolved_reference_leaves_exact_literal_not_merely_nonempty(self) -> None:
-        """NEG (truncating-mutant guard): an UNASSIGNED reference sitting
-        between two literal fragments must be left EXACTLY as typed, not
-        collapsed to an empty string, when substitution runs at all (i.e.
-        when at least one OTHER name in the command WAS assigned, so the
-        `assignments` map is non-empty and the substitution pass executes).
-
-        `h=other; gi${x}t commit -m z` — `x` is never assigned. If the
-        "leave unresolved" fallback ever degraded from returning the
-        original matched text to returning `""`, `${x}` would vanish and the
-        surrounding literal fragments would collapse into `git` by
-        coincidence (`"gi" + "" + "t"` == `"git"`), manufacturing a command
-        word that was never there. Asserting merely `assertIsNotNone` on the
-        wrong branch would pass under exactly this truncating mutant; this
-        asserts the correct (allowed) OUTCOME instead.
-        """
-        cmd = "h=other; gi${x}t commit -m z"
-        self.assertIsNone(hook.check(self._input(cmd)))
-
-    # --- main#1195 round 4, finding 2: row1/row3 must be pinned across
-    # braced AND multi-char-name variants, not just the bare single-char
-    # spelling — a mutant that composes the fix only for `${NAME}` refs, or
-    # only for names longer than one character, survived mutation testing
-    # against the original four rows (290 passed unchanged). Varying the
-    # incidental dimensions here is what makes those mutants die. --------
-
-    def test_row1_braced_variant_never_reaches_git_allows(self) -> None:
-        """`A=1 B=git ${B} commit -m z` — braced-reference sibling of row 1.
-        Real shell: `${B}` is unset at expansion time for the same reason
-        the bare form is (own-segment prefix not yet in effect). Must ALLOW.
-        """
-        self.assertIsNone(hook.check(self._input("A=1 B=git ${B} commit -m z")))
-
-    def test_row1_multichar_name_variant_never_reaches_git_allows(self) -> None:
-        """`A=1 BB=git $BB commit -m z` — multi-char-name sibling of row 1.
-        Must ALLOW for the identical real-shell reason (own-segment prefix
-        not yet in effect at expansion time), regardless of name length.
-        """
-        self.assertIsNone(hook.check(self._input("A=1 BB=git $BB commit -m z")))
-
-    def test_row3_braced_variant_cannot_hide_prior_running_value_blocks(self) -> None:
-        """`g=git; g=echo ${g} commit -m x` — braced-reference sibling of
-        row 3. Real shell: `${g}` resolves against the RUNNING state from
-        the prior segment (`git`), not this segment's own `g=echo` prefix.
-        Must BLOCK.
-        """
-        result = hook.check(self._input("g=git; g=echo ${g} commit -m x"))
-        self.assertIsNotNone(result, "prior-segment g=git must still resolve via ${g}")
+    @pytest.mark.parametrize(
+        "command",
+        [
+            'n=0; while [ "$n" -lt 1 ]; do g=git; $g commit -m x; n=1; done',
+            "if true; then g=git; $g commit -m x; fi",
+            "for f in a; do g=git; ${g} commit -m x; done",
+        ],
+        ids=[
+            "while_loop_do_body_assignment_blocks",
+            "if_then_body_assignment_blocks",
+            "for_loop_do_body_braced_reference_blocks",
+        ],
+    )
+    def test_blocks_bare_second_shape(self, command):
+        result = hook.check(self._input(command))
         assert result is not None
-        self.assertEqual(result["decision"], "block")
-        self.assertIn("missing `-c user.name=` flag", result["reason"])
-
-    def test_row3_multichar_name_variant_cannot_hide_prior_running_value_blocks(
-        self,
-    ) -> None:
-        """`gg=git; gg=echo $gg commit -m x` — multi-char-name sibling of
-        row 3. Must BLOCK for the identical real-shell reason, regardless of
-        name length.
-        """
-        result = hook.check(self._input("gg=git; gg=echo $gg commit -m x"))
-        self.assertIsNotNone(result, "prior-segment gg=git must still resolve at the commit site")
         assert result is not None
-        self.assertEqual(result["decision"], "block")
-        self.assertIn("missing `-c user.name=` flag", result["reason"])
+        assert result["decision"] == "block"
 
     # --- main#1195 round 4, finding 1: same-segment prefix assignment DOES
     # resolve inside a SINGLE-quoted child payload (`bash -c '...'`), because
     # that text is expanded by the CHILD interpreter in an environment the
     # prefix assignment already populated — real-shell-verified with a
-    # marker proxy. All six rows below were measured against a real shell
-    # (fake `git` on PATH, printing a marker iff it actually runs) before
-    # being pinned here. -------------------------------------------------
+    # marker proxy. -------------------------------------------------------
 
     def test_prefix_in_single_quoted_bash_dash_c_payload_blocks(self) -> None:
         """Row 1: `g=git bash -c '$g commit -m x'` — marker proxy: real
@@ -1709,111 +1687,16 @@ class AssignmentAwarePrePassTests(unittest.TestCase):
         round-3 fix's own regression, against this PR's previous head).
         """
         result = hook.check(self._input("g=git bash -c '$g commit -m x'"))
-        self.assertIsNotNone(
-            result, "same-segment prefix feeding a quoted child payload must block"
-        )
+        assert result is not None, "same-segment prefix feeding a quoted child payload must block"
         assert result is not None
-        self.assertEqual(result["decision"], "block")
-        self.assertTrue(
-            result["reason"].startswith(
-                "BLOCKED: indirect-exec wrapper detected (shell -c) carrying a hidden `git commit`."
-            ),
-            result["reason"],
-        )
-
-    def test_prefix_in_double_quoted_bash_dash_c_payload_allows(self) -> None:
-        """Row 2 (control): `g=git bash -c "$g commit -m x"` — marker proxy:
-        real shell does NOT run `git` (the OUTER shell expands the
-        double-quoted argument itself, before the prefix takes effect, same
-        expansion point as a bare same-segment reference). Must ALLOW.
-        """
-        self.assertIsNone(hook.check(self._input('g=git bash -c "$g commit -m x"')))
-
-    def test_prefix_in_single_quoted_sh_dash_c_payload_blocks(self) -> None:
-        """Row 3: `g=git sh -c '$g commit -m x'` — marker proxy: real shell
-        RUNS the fake `git`. Must BLOCK, same as the `bash -c` spelling.
-        """
-        result = hook.check(self._input("g=git sh -c '$g commit -m x'"))
-        self.assertIsNotNone(result)
-        assert result is not None
-        self.assertEqual(result["decision"], "block")
-
-    def test_prefix_in_single_quoted_braced_payload_blocks(self) -> None:
-        """Row 4: `g=git bash -c '${g} commit -m x'` — braced form inside
-        the single-quoted payload. Marker proxy: real shell RUNS the fake
-        `git`. Must BLOCK.
-        """
-        result = hook.check(self._input("g=git bash -c '${g} commit -m x'"))
-        self.assertIsNotNone(result)
-        assert result is not None
-        self.assertEqual(result["decision"], "block")
-
-    def test_no_prefix_unset_reference_in_single_quoted_payload_allows(self) -> None:
-        """Row 5 (control): `bash -c '$g commit -m x'` with no `g=git`
-        prefix anywhere. Marker proxy: real shell does NOT run `git` (`$g`
-        is genuinely unset). Must ALLOW.
-        """
-        self.assertIsNone(hook.check(self._input("bash -c '$g commit -m x'")))
-
-    def test_cross_segment_semicolon_single_quoted_payload_still_blocks(self) -> None:
-        """Row 6: `g=git; bash -c '$g commit -m x'` — the assignment is in
-        an EARLIER segment (`;`, not a same-segment prefix), so it reaches
-        the quoted payload via the pre-existing RUNNING map, unchanged by
-        this round's fix (the running map already applies everywhere,
-        quote-blind). Pinned so a future change to the running map's
-        quote-awareness is caught here.
-        """
-        result = hook.check(self._input("g=git; bash -c '$g commit -m x'"))
-        self.assertIsNotNone(result)
-        assert result is not None
-        self.assertEqual(result["decision"], "block")
+        assert result["decision"] == "block"
+        assert result["reason"].startswith(
+            "BLOCKED: indirect-exec wrapper detected (shell -c) carrying a hidden `git commit`."
+        ), result["reason"]
 
     # --- main#1195 round 4, finding 3 (#1311): a compound-statement leader
     # (`do`, `then`, ...) at a segment's leading position must not hide an
-    # assignment one token to the right — real-shell-verified with a marker
-    # proxy (each row genuinely runs `git commit -m x`), the same defect
-    # class as the wrapped `bash -c` choke point above. ------------------
-
-    def test_for_loop_do_body_assignment_blocks(self) -> None:
-        """`for f in a; do g=git; $g commit -m x; done` — marker proxy: real
-        shell RUNS the fake `git`. Must BLOCK; ALLOWed before the
-        `strip_command_prefixes()` fix (`_leading_literal_assignments` saw
-        `"do"` at the leading position and stopped before ever looking at
-        `g=git` one token to the right).
-        """
-        result = hook.check(self._input("for f in a; do g=git; $g commit -m x; done"))
-        self.assertIsNotNone(result, "do-prefixed segment assignment must still resolve")
-        assert result is not None
-        self.assertEqual(result["decision"], "block")
-        self.assertIn("missing `-c user.name=` flag", result["reason"])
-
-    def test_while_loop_do_body_assignment_blocks(self) -> None:
-        result = hook.check(
-            self._input('n=0; while [ "$n" -lt 1 ]; do g=git; $g commit -m x; n=1; done')
-        )
-        self.assertIsNotNone(result)
-        assert result is not None
-        self.assertEqual(result["decision"], "block")
-
-    def test_if_then_body_assignment_blocks(self) -> None:
-        result = hook.check(self._input("if true; then g=git; $g commit -m x; fi"))
-        self.assertIsNotNone(result)
-        assert result is not None
-        self.assertEqual(result["decision"], "block")
-
-    def test_for_loop_do_body_multichar_name_blocks(self) -> None:
-        """Vary the incidental dimension: a multi-char name (`gg`), not `g`
-        — the exact fixture-narrowness finding 2 (above) is about."""
-        result = hook.check(self._input("for f in a; do gg=git; $gg commit -m x; done"))
-        self.assertIsNotNone(result)
-        assert result is not None
-        self.assertEqual(result["decision"], "block")
-
-    def test_for_loop_do_body_braced_reference_blocks(self) -> None:
-        result = hook.check(self._input("for f in a; do g=git; ${g} commit -m x; done"))
-        self.assertIsNotNone(result)
-        assert result is not None
-        self.assertEqual(result["decision"], "block")
+    # assignment one token to the right. -----------------------------------
 
     def test_for_loop_do_body_single_quoted_child_payload_blocks(self) -> None:
         """Finding 1 and finding 3 compose: a `do`-prefixed segment's own
@@ -1822,11 +1705,11 @@ class AssignmentAwarePrePassTests(unittest.TestCase):
         BLOCK.
         """
         result = hook.check(self._input("for f in a; do g=git bash -c '$g commit -m x'; done"))
-        self.assertIsNotNone(
-            result, "do-prefixed same-segment prefix must resolve in the quoted payload"
+        assert result is not None, (
+            "do-prefixed same-segment prefix must resolve in the quoted payload"
         )
         assert result is not None
-        self.assertEqual(result["decision"], "block")
+        assert result["decision"] == "block"
 
 
 if __name__ == "__main__":

--- a/.claude/hooks/tests/test_validate_commit_identity.py
+++ b/.claude/hooks/tests/test_validate_commit_identity.py
@@ -1719,4 +1719,7 @@ class TestAssignmentAwarePrePass:
 
 
 if __name__ == "__main__":
-    unittest.main()
+    # `unittest.main()` would silently skip TestAssignmentAwarePrePass (a
+    # plain pytest class, not unittest.TestCase — see its docstring) when
+    # this file is run standalone. `pytest.main` discovers both styles.
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/.claude/hooks/tests/test_validate_commit_identity.py
+++ b/.claude/hooks/tests/test_validate_commit_identity.py
@@ -1387,8 +1387,14 @@ class TestAssignmentAwarePrePass:
 
     def _valid_identity(self) -> tuple[str, str]:
         name = next(iter(hook.ROSTER), None)
-        if not name:
+        if name is None:
             pytest.skip("local roster is empty")
+        # `pytest.skip` is annotated NoReturn, but CI's mypy job installs only
+        # `mypy types-PyYAML bashlex` (no pytest) — without pytest's stubs,
+        # `pytest.skip` resolves to `Any` and the NoReturn narrowing above
+        # never happens, so `name` stays `str | None` at the return below.
+        # Narrow explicitly instead of relying on stub-dependent inference.
+        assert name is not None
         return name, hook.ROSTER[name]
 
     # --- the issue's own measured shapes -----------------------------------


### PR DESCRIPTION
## Summary

G5 of the code-audit program (#1089). Parametrizes 12 test clone groups (97 merged cases) across 4 files: the 3 the issue names explicitly (`test_annunaki_monitor`, `test_enforce_ontology_context`, `test_validate_commit_identity`) plus `test_block_bare_grep` (biggest single group, 23 members). Net **-114 lines at `2f3a2bf`** (`git diff --shortstat b191a09..2f3a2bf`: 588 insertions, 702 deletions) — stated with the head it was measured against, since two review-fix commits moved this number twice (-130 at the original push, -124 at `d1a3347d`).

## Numbers — both audit figures treated as unverified, re-derived independently

- Audit's cited figure: 92 groups / 2,457 lines.
- #1116 author's own crude pass (full string-strip, deliberately over-groups): 159 groups / 5,418 lines.
- **My own re-derivation, method below: 199 groups / 5,592 lines.**

None of the three is authoritative — they're different normalizations. Mine: parse each `def test_*`, replace every `ast.Constant` LEAF value with a type-tagged placeholder (`<STR>`/`<NUM>`/...) while preserving the constant's *type* and *position* in the statement sequence — everything else (names, calls, control flow, statement order) untouched. A group additionally requires uniform assert-bearing-statement count across all members (a differing count is split into its own subgroup, never silently merged). This is less aggressive than a full string-strip specifically to avoid the trap described below.

## The trap, and how this PR avoided it

Structurally identical is not the same as safely mergeable. Two failure modes avoided:

1. **Cross-class shape collisions.** The detector groups by AST shape alone, ignoring class boundaries. `test_block_bare_grep.py`'s `NegativeMatchTests` (12 members: "not a grep invocation") and `OverrideTests` (2 members: "the documented escape hatch") both reduce to `self.assertFalse(_blocks(cmd))` — same shape, different scenario. Declined every cross-class merge; each parametrize table stays within its original class, whose docstring names one coherent scenario.
2. **`pytest.mark.parametrize` is a silent no-op on `unittest.TestCase` methods.** Verified empirically before converting anything (a probe class collected 1 test instead of 3, no error). Every touched class was therefore converted to plain pytest style — every `self.assertX`, merged or not, mechanically rewritten to a bare `assert`. `test_annunaki_monitor.py`'s `TestSilentBooleanIdiom` additionally required moving `setUp`/`tearDown` to an autouse fixture (all its methods, in and out of the merged group, share that isolation).

## The verification bar

1. **Collected count** — per-file `--collect-only`, identical before/after for all 4 files; repo-wide **4084 -> 4084**.
2. **Node-ID identity** — full path-string identity is impossible once N methods merge into 1 (the function name necessarily changes). The invariant actually enforced: every `ids=` entry is the ORIGINAL bare method name, so each case's new node id (`ClassName::test_x[original_method_name]`) is traceable 1:1 back to what it replaced. Verified per file by diffing the sorted id lists' bracket-suffix set against the removed method-name set.
3. **Assertion density** — NOT raw static AST-text count (that necessarily drops under any real parametrize — collapsing N duplicate `assert` lines into 1 executed N times IS the point). The invariant: execution-weighted density = Σ(body-assert-count × case-count) over every collected id, compared before/after with the same script. All 4 files: **44->44, 47->44 (a disclosed, documented -3: a redundant duplicate not-None check that had no pytest equivalent once `self.assertX` was gone, see `TestIndentedCoordinatorOpenerNotExempt`'s inline comment), 134->134, 193->193.**
4. **Mutation spot-check per group** (4 total, one per file): reverted a real fix (`sudo -i` boolean-flag regression in `block_bare_grep.py`; the `#471` opener-anchor regression in `enforce_ontology_context.py`; dropping `pgrep` from `annunaki_monitor.py`'s idiom list; reintroducing main#1195's own-prefix-assignment bug in `_shell_parse.py`) and confirmed the suite went red specifically via the merged parametrized case, then reverted.
5. **Direct standalone invocation matches `--collect-only`** (added in review — see below): all 4 files' `python3 <file>.py` executed count equals its collected count.

   | File | Direct-run executed | `--collect-only` |
   |---|---|---|
   | `test_block_bare_grep.py` | 41 | 41 |
   | `test_enforce_ontology_context.py` | 37 | 37 |
   | `test_annunaki_monitor.py` | 86 | 86 |
   | `test_validate_commit_identity.py` | 124 | 124 |

## Review fixes (both batched, one push each)

- **Mypy, CI-only.** `_valid_identity`'s `if not name: pytest.skip(...)` relied on `pytest.skip`'s `NoReturn` annotation to narrow `name: str | None` to `str`. CI's mypy job installs only `mypy types-PyYAML bashlex` (no pytest), so that stub is invisible there and the narrowing never happens — passed locally (pytest importable), failed CI. Replaced with an explicit `assert name is not None` that doesn't depend on the stub. Verified against CI's exact dependency set in an isolated venv (mypy 2.3.0, no pytest installed): exit 0.
- **Silent under-run on direct invocation.** Three files still ended with `unittest.main()` after their converted classes went plain-pytest; `unittest.main()` only discovers `TestCase` subclasses, so a bare `python3 <file>.py` silently ran fewer tests than `--collect-only` and still exited 0 (37→17 run, 124→87, 86→69 — no error, no skip notice). `test_block_bare_grep.py` already had the fix from an earlier commit in this PR (`pytest.main([__file__, "-v"])`); applied the same pattern to the other three and verified per the table above.

## Scope discipline

- `test_validate_pr_review.py` untouched — was mid-review on #1337 at spawn time; merged as `4b550cc` during this session, so the file moved out from under scope entirely. Its 14 candidate groups are called out, not attempted.
- Remaining candidate groups filed as #1342 (185 non-excluded groups across 58 files, reconciled to add up — an earlier version of that issue had an internal arithmetic mismatch, fixed after #1344 caught it) with the full per-file breakdown, the same method documented above, and the mutation-testable + direct-invocation verification bar for whoever continues — including a note that `test_validate_workflow_paths_coverage.py` is flagged (same "literal payload is the semantic point" risk) rather than blanket-excluded.

## Test plan

- [x] `ENVIRONMENT=test python3 -m pytest .claude/hooks/tests .claude/lib/tests` — 4084 passed, 881 subtests passed
- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy .claude/hooks .claude/lib` — clean, and independently confirmed against CI's exact pytest-free dependency set
- [x] `python3 .claude/lib/pre_commit_ci_sync.py .` — OK
- [x] Direct invocation of all 4 touched files matches `--collect-only` count (table above)
- [x] Pre-push hooks (mypy, pytest, memory-budget, headcount-budget, doc-freshness, office-drift, mermaid-render) — all passed on push

Closes #1117

🤖 Generated with [Claude Code](https://claude.com/claude-code)
