### PR TITLE
fix(#1355): distinguish unconfigured promotion target from threshold-wait

### DIFF
--- a/.claude/skills/promotion-audit/helpers.py
+++ b/.claude/skills/promotion-audit/helpers.py
@@ -908,13 +908,32 @@ def classify_section(
     threshold = signals.get("threshold", 5)
 
     if invocations < threshold:
+        # #1355: "wait for more operator-invoked runs" is only an accurate
+        # message when there is something an operator COULD invoke — i.e.
+        # a skill already scaffolded on disk at the prospective slug. For
+        # the common not-yet-promoted case (no `promoted-to` back-reference,
+        # no skill directory), the invocation count is structurally 0
+        # forever: promotion (creating the skill) is a deliberate human
+        # act, not something that accrues from waiting. Distinguish the
+        # two so the reader isn't told to wait for something that cannot
+        # arrive on its own.
+        target_configured = bool(signals.get("target_configured", 0))
+        if target_configured:
+            reason = "Invocation threshold not met; wait for more operator-invoked runs"
+        else:
+            reason = (
+                "Promotion target not configured — no skill exists at this slug yet, "
+                "so invocations cannot accrue; scaffolding the skill (a deliberate "
+                "human act) is required before this becomes evaluable"
+            )
         return Decision(
             kind="KEPT",
             item_id=f"{os.path.basename(section.path)} § {section.heading}",
             from_tier="charter",
             to_tier="skill",
             signal=f"skill_invocations={invocations} < {threshold}",
-            reason="Invocation threshold not met; wait for more operator-invoked runs",
+            reason=reason,
+            extra={"target_configured": target_configured},
         )
 
     return Decision(

--- a/.claude/skills/promotion-audit/run.py
+++ b/.claude/skills/promotion-audit/run.py
@@ -251,8 +251,21 @@ def run_audit(
     for sec in sections:
         slug = _section_signal_slug(sec)
         invocations = h.count_skill_invocations(slug, paths.repo_root)
+        # #1355: whether the prospective skill actually exists on disk yet
+        # gates which KEPT message classify_section renders — see the
+        # docstring on that branch. A not-yet-created skill (the common
+        # case for a not-yet-promoted section) can never accrue
+        # invocations, so "wait for more runs" would be misleading.
+        target_configured = os.path.isdir(os.path.join(paths.skills_dir, slug))
         decisions.append(
-            h.classify_section(sec, {"skill_invocations": invocations, "threshold": threshold})
+            h.classify_section(
+                sec,
+                {
+                    "skill_invocations": invocations,
+                    "threshold": threshold,
+                    "target_configured": int(target_configured),
+                },
+            )
         )
 
     # skill → hook (always DECIDE)

--- a/.claude/skills/promotion-audit/tests/test_helpers.py
+++ b/.claude/skills/promotion-audit/tests/test_helpers.py
@@ -789,6 +789,44 @@ class ClassifySectionTests(unittest.TestCase):
         d = h.classify_section(_make_section(promotion_target="hook"), {})
         self.assertEqual(d.kind, "KEPT")
 
+    def test_threshold_not_met_unconfigured_target_is_not_a_wait_message(self) -> None:
+        """#1355: a section whose prospective skill does not exist yet on
+        disk (`target_configured` false/absent) can never accumulate
+        invocations — the skill has nothing to invoke. The KEPT reason
+        must say the target is not configured, NOT tell the reader to
+        wait for more operator-invoked runs (a state that cannot arrive
+        for an artifact that doesn't exist).
+
+        Pre-fix, `classify_section` renders the identical
+        'Invocation threshold not met; wait for more operator-invoked
+        runs' message regardless of whether the target skill exists —
+        this assertion fails against that implementation."""
+        d = h.classify_section(
+            _make_section(), {"skill_invocations": 0, "threshold": 5, "target_configured": 0}
+        )
+        self.assertEqual(d.kind, "KEPT")
+        self.assertNotIn("wait for more operator-invoked runs", d.reason)
+        self.assertIn("not configured", d.reason.lower())
+
+    def test_threshold_not_met_configured_target_still_says_wait(self) -> None:
+        """NEG: once the target skill actually exists on disk (configured,
+        just below the invocation threshold), 'wait for more
+        operator-invoked runs' is an accurate message and must be kept."""
+        d = h.classify_section(
+            _make_section(), {"skill_invocations": 1, "threshold": 5, "target_configured": 1}
+        )
+        self.assertEqual(d.kind, "KEPT")
+        self.assertIn("wait for more operator-invoked runs", d.reason)
+
+    def test_threshold_not_met_target_configured_defaults_false(self) -> None:
+        """Absent `target_configured` in signals defaults to unconfigured
+        (the common case: prospective-only slug, skill never scaffolded) —
+        callers that don't wire the new signal get the safe, accurate
+        message rather than silently reverting to the misleading one."""
+        d = h.classify_section(_make_section(), {"skill_invocations": 0, "threshold": 5})
+        self.assertEqual(d.kind, "KEPT")
+        self.assertIn("not configured", d.reason.lower())
+
 
 # ---------------------------------------------------------------------------
 # Classification — skill

--- a/.claude/skills/promotion-audit/tests/test_run.py
+++ b/.claude/skills/promotion-audit/tests/test_run.py
@@ -196,6 +196,31 @@ class EmptySlugRegression(unittest.TestCase):
         self.assertEqual(result.counts()["AUTO"], 0)
         self.assertEqual(result.counts()["DECIDE"], 0)
 
+    def test_unpromoted_section_with_no_skill_on_disk_reports_not_configured(self) -> None:
+        """#1355: the fixture's 'Some Procedure' section has no matching
+        skill directory (`some-procedure/`) anywhere under
+        `.claude/skills/` — the driver must wire `target_configured=False`
+        through to `classify_section` so the KEPT reason says the target
+        isn't configured, not that the reader should wait for more runs."""
+        paths, _ = _make_fixture_repo(self.tmp)
+        result = run.run_audit(paths, wave_name="p5-wave-5", audit_date="2026-06-16")
+        sec_decisions = [d for d in result.decisions if d.from_tier == "charter"]
+        self.assertEqual(len(sec_decisions), 1)
+        self.assertNotIn("wait for more operator-invoked runs", sec_decisions[0].reason)
+        self.assertIn("not configured", sec_decisions[0].reason.lower())
+
+    def test_section_with_skill_already_scaffolded_reports_wait(self) -> None:
+        """NEG: once the prospective slug's skill directory actually
+        exists on disk (created but not yet linked via `promoted-to:`),
+        the driver must report `target_configured=True` and preserve the
+        accurate 'wait for more operator-invoked runs' message."""
+        paths, _ = _make_fixture_repo(self.tmp)
+        os.makedirs(os.path.join(paths.skills_dir, "some-procedure"), exist_ok=True)
+        result = run.run_audit(paths, wave_name="p5-wave-5", audit_date="2026-06-16")
+        sec_decisions = [d for d in result.decisions if d.from_tier == "charter"]
+        self.assertEqual(len(sec_decisions), 1)
+        self.assertIn("wait for more operator-invoked runs", sec_decisions[0].reason)
+
 
 class FixtureAuditShape(unittest.TestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
Refs #1355

**Requested reviewers:** @Nadia Khoury (Program Director, peer reviewer + merge-gate) · @Aino Virtanen (Standards & Quality Lead, secondary reviewer)

## Problem

`.claude/skills/promotion-audit/helpers.py::classify_section` renders the identical KEPT reason — `"Invocation threshold not met; wait for more operator-invoked runs"` — whenever `skill_invocations < threshold`, regardless of whether the target skill exists on disk yet.

For every one of the **25 charter sections** whose `promotion_target: skill` and whose `promoted_to` back-reference is blank (i.e. not yet promoted — the only population that reaches this branch, since `ALREADY-PROMOTED` intercepts anything with a set `promoted_to` earlier in `classify_section`), the "wait" message is actively misleading: a skill that doesn't exist yet cannot accrue invocations no matter how long an operator waits. Scaffolding the skill is a deliberate human act (per the acceptance bar for this wave — this fix intentionally does **not** force any section into eligibility), not a threshold that crosses on its own.

The `main#690` blank-slug guard in `count_skill_invocations` (empty skill-name slug → 0, never the all-commits count) is correct and untouched — it's what makes the invocation signal land on an honest `0` for these sections in the first place. This PR only fixes what happens *after* that correct `0` is computed: the message shouldn't tell the reader to wait for something structurally incapable of arriving.

## Fix

- `helpers.py::classify_section` now reads a `target_configured` signal. When `invocations < threshold`:
  - **configured** (a skill directory already exists at the prospective slug, just not yet linked via `promoted-to:`): keeps the accurate `"wait for more operator-invoked runs"` message.
  - **unconfigured** (no skill scaffolded at that slug at all — the common not-yet-promoted case): renders `"Promotion target not configured — no skill exists at this slug yet, so invocations cannot accrue; scaffolding the skill (a deliberate human act) is required before this becomes evaluable"`.
- `run.py`'s driver wires `target_configured = os.path.isdir(skills_dir/slug)` for each charter section into the `classify_section` call.

## Test — fails against pre-fix implementation

Added `ClassifySectionTests.test_threshold_not_met_unconfigured_target_is_not_a_wait_message` (+ a defaulting-behavior sibling) to `.claude/skills/promotion-audit/tests/test_helpers.py`, plus a `run.py`-level wiring pair in `test_run.py`. **Three** tests fail against pre-fix, not two — `test_run.py::EmptySlugRegression::test_unpromoted_section_with_no_skill_on_disk_reports_not_configured` also fails against base (an omission in the original PR description, corrected here per merge-gate review):

```
$ python3 -m unittest test_helpers.ClassifySectionTests -v
...
test_threshold_not_met_target_configured_defaults_false ... FAIL
test_threshold_not_met_unconfigured_target_is_not_a_wait_message ... FAIL

======================================================================
FAIL: test_threshold_not_met_target_configured_defaults_false
----------------------------------------------------------------------
Traceback (most recent call last):
  ...
AssertionError: 'not configured' not found in 'invocation threshold not met; wait for more operator-invoked runs'

======================================================================
FAIL: test_threshold_not_met_unconfigured_target_is_not_a_wait_message
----------------------------------------------------------------------
Traceback (most recent call last):
  ...
AssertionError: 'wait for more operator-invoked runs' unexpectedly found in 'Invocation threshold not met; wait for more operator-invoked runs'

----------------------------------------------------------------------
Ran 8 tests in 0.001s

FAILED (failures=2)

$ python3 -m unittest test_run.EmptySlugRegression -v
...
test_unpromoted_section_with_no_skill_on_disk_reports_not_configured ... FAIL

======================================================================
FAIL: test_unpromoted_section_with_no_skill_on_disk_reports_not_configured
----------------------------------------------------------------------
Traceback (most recent call last):
  ...
AssertionError: 'wait for more operator-invoked runs' unexpectedly found in 'Invocation threshold not met; wait for more operator-invoked runs'

----------------------------------------------------------------------
Ran 6 tests in 0.319s

FAILED (failures=1)
```

Post-fix: all 8 `ClassifySectionTests` pass, all 6 `EmptySlugRegression` tests pass (including `test_section_with_skill_already_scaffolded_reports_wait`, which passes both pre- and post-fix by construction — it exercises the configured-target branch, whose message is unchanged), and the full skill suite (`test_helpers.py` + `test_run.py` + `test_smoke.py`) is green: **107/107**.

## Verified against live repo state

```
$ python3 .claude/skills/promotion-audit/run.py wave-30 --json | ...
charter decisions: 114
not configured count: 25     # exactly the 25 skill-target sections with blank promoted_to
wait-message count: 0        # none currently have a scaffolded skill on disk
counts: {'ALREADY-PROMOTED': 23, 'AUTO': 0, 'DECIDE': 0, 'KEPT': 248, 'SUPERSEDED': 1}
```

**How many of the 25 become genuinely evaluable after this fix: 0** — none currently has a skill directory scaffolded at its prospective slug, so all 25 correctly render "not configured" rather than the misleading "wait" message. That's the intended, non-forced outcome: this fix corrects the *message*, it does not manufacture eligibility. A section becomes evaluable only once a human scaffolds the target skill (setting `promoted_to` / creating `.claude/skills/{slug}/`), at which point `target_configured` flips true and the genuine "wait for more operator-invoked runs" message (with a real, accruing invocation count) takes over.

## Adjacent observation (not filed — Wave-30 intake is tight)

The `skill → hook` tier (`classify_skill`) has no equivalent ambiguity: `skills` are discovered by scanning `.claude/skills/` on disk (`read_all_skills`), so a `Skill` record only ever exists for a skill that's already configured — the "unconfigured target" case structurally cannot occur there. No follow-up needed.

## CI / local parity

Full pre-commit set (commit-stage + `--hook-stage pre-push`) green locally, plus the sync-drift gate (`pre_commit_ci_sync.py`):
```
ruff-format .............. Passed
ruff-lint ................ Passed
checksums-ascii .......... Passed
mypy / mypy-skills ....... Passed
pytest / pytest-skills ... Passed
memory-budget ............ Passed
headcount-budget ......... Passed
doc-freshness (advisory) . Passed
office-drift .............. Passed
mermaid-render ............ Passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)



Closes #1355
