### PR TITLE
fix(hooks): exempt current-session scratchpad from stale-tmp check (#1352)

### DIFF
--- a/.claude/hooks/block_stale_tmp_message_file.py
+++ b/.claude/hooks/block_stale_tmp_message_file.py
@@ -3,15 +3,15 @@
 
 Refuses commands of the form ``git commit -F /tmp/...`` and ``gh {pr,issue}
 {create,comment,edit} --body-file /tmp/...`` (plus ``gh api ... --input
-/tmp/...``) when the target file's mtime is older than ~30s AND the file is
-not under the CURRENT session's own scratchpad. Such files are almost
-always leftovers from a prior task or session that the current command is
-about to consume by mistake — see ``feedback_tmp_msg_file_stale.md`` for the
-three documented surfaces and the 2026-05-03 ontology-rebuild recurrence
-that motivated this hook.
+/tmp/...``) when the target file's mtime is older than ~30s AND the target
+path does not contain the CURRENT session's id as a path segment. Such
+files are almost always leftovers from a prior task or session that the
+current command is about to consume by mistake — see
+``feedback_tmp_msg_file_stale.md`` for the three documented surfaces and
+the 2026-05-03 ontology-rebuild recurrence that motivated this hook.
 
-Session-scratchpad exemption (#1352)
-=====================================
+Session-identity exemption (#1352)
+===================================
 
 Wave-29 measured **0/11 precision** on the mtime check: every single block
 that wave was a false positive, and all 11 were body files under the
@@ -19,21 +19,41 @@ INVOKING SESSION's own scratchpad
 (``/tmp/claude-<uid>/<repo-slug>/<session-id>/scratchpad/...``) that the
 agent had simply spent more than 30s composing and verifying before
 posting — the write-then-verify-then-post shape, not the same-command
-heredoc shape the original threshold was calibrated for. A file whose path
-contains the CURRENT session's id cannot, by construction, be "a leftover
-from a prior task or session" — that is the hook's own stated threat
-model, and the discriminator (the session id) is already sitting in the
-filename. :func:`_is_current_session_path` checks for that id as a path
-segment and skips the mtime check entirely when it matches — no threshold
-value can substitute for this, because the threshold cannot tell "still
-composing" apart from "abandoned" by age alone (raising it to 15 minutes
-just moves the false-negative/false-positive line, it doesn't remove it;
-see the wave-29 harvested fixtures in
+heredoc shape the original threshold was calibrated for.
+:func:`_is_current_session_path` checks whether the CURRENT session's id
+appears as a path segment anywhere in the target path and, if so, skips
+the mtime check entirely — no threshold value can substitute for this,
+because the threshold cannot tell "still composing" apart from
+"abandoned" by age alone (raising it to 15 minutes just moves the
+false-negative/false-positive line, it doesn't remove it; see the
+wave-29 harvested fixtures in
 ``tests/test_block_stale_tmp_message_file_wave29.py``, several of which
 individually exceed a very generous retuned threshold).
 
-A body file under a DIFFERENT session's scratchpad, or a bare /tmp path
-with no session structure at all, is unaffected — the mtime check (and the
+**What the exemption does and does not guarantee (read this before
+assuming "by construction" covers more than it does):**
+
+A file under the current session's id cannot be a leftover from a *prior
+session* — that is true by construction (only the current session can
+produce a path containing its own id), and it is the entire wave-29
+false-positive class this fix closes. It can **still** be a leftover from
+an *earlier task in the same session*: the check is "does the current
+session's id appear anywhere in the path", not "is the path under the
+current session's scratchpad directory" (issue #1352 proposal 1's
+narrower ask). An 8-hour-old file at
+``/tmp/claude-<uid>/<slug>/<session-id>/scratchpad/verdict_1153_nino.md``
+is exempt just as readily as one written 20 seconds ago. That narrower
+class — a stale file from an earlier task in the SAME session — is
+deliberately surrendered here, not accidentally: wave-29 showed it is
+indistinguishable from "still composing" by age, and produced 0 true
+positives across 11 firings. Hard-coding the scratchpad root path was
+considered and rejected as its own fragility (the root is
+environment/uid-dependent); the id-as-path-segment check trades that
+narrower, position-dependent guarantee for a broader, position-independent
+one that is simpler to reason about and to keep correct.
+
+A body file under a DIFFERENT session's id, or a bare /tmp path with no
+session structure at all, is unaffected — the mtime check (and the
 existing 30s threshold) still applies, preserving the true positive the
 hook exists to catch.
 
@@ -42,12 +62,12 @@ wave-29) does NOT work and CANNOT be made to work by retuning the
 threshold: this is a PreToolUse hook, so it stats the file BEFORE the
 gated Bash command runs — the ``touch`` embedded in that same command has
 not executed yet when the hook checks, so it can never refresh the mtime
-the hook sees. The session-scratchpad exemption above fixes the cases that
-actually occurred in wave-29 (the touched file was always the agent's own
-scratchpad file) as a side effect of being path-identity-based rather than
-mtime-based; for a file NOT under the current session's scratchpad, no
-in-command ``touch`` can ever help, no matter the threshold — see the
-override paths below.
+the hook sees. The session-identity exemption above fixes the cases that
+actually occurred in wave-29 (the touched file was always under the
+agent's own session id) as a side effect of being path-identity-based
+rather than mtime-based; for a file whose path does NOT contain the
+current session's id, no in-command ``touch`` can ever help, no matter the
+threshold — see the override paths below.
 
 Override paths the user can take when blocked:
   - rename the file to a non-/tmp path (e.g. .claude/scratch/msg.txt)
@@ -81,11 +101,11 @@ shlex parse failure (`tokenize` returns None) fails OPEN — the command is
 allowed through and the downstream tool surfaces any real error itself.
 
 Exit codes:
-  0 — allow (no /tmp/* body-file argument, file is under the current
-       session's own scratchpad, file is fresh, file is missing, or shlex
-       parse failed)
-  2 — block (target file mtime older than threshold AND not under the
-       current session's scratchpad)
+  0 — allow (no /tmp/* body-file argument, target path contains the
+       current session's id as a path segment, file is fresh, file is
+       missing, or shlex parse failed)
+  2 — block (target file mtime older than threshold AND target path does
+       NOT contain the current session's id as a path segment)
 """
 
 from __future__ import annotations
@@ -226,10 +246,18 @@ def _is_current_session_path(path: str, session_id: str) -> bool:
     under a path containing the session's UUID as a segment (e.g.
     ``/tmp/claude-<uid>/<repo-slug>/<session-id>/scratchpad/...``). A
     /tmp/* file whose path contains the CURRENT session's id cannot, by
-    construction, be a leftover from a prior task or session — that is the
-    hook's own stated threat model (#1352). Matching on `session_id` as a
-    path SEGMENT (not a substring) avoids a session id that happens to be a
-    substring of an unrelated directory name from spuriously matching.
+    construction, be a leftover from a PRIOR SESSION — only the current
+    session can produce a path containing its own id. That is the narrower,
+    true guarantee; it is NOT "cannot be a leftover from a prior task in
+    the same session" — this check matches the session id ANYWHERE in the
+    path, not just under the session's scratchpad directory, so an old file
+    from an earlier task this same session is exempt too. That broader
+    exemption is intentional (see module docstring "What the exemption
+    does and does not guarantee", #1352) — the id-as-any-segment shape
+    trades a scratchpad-path-dependent guarantee for a simpler,
+    position-independent one. Matching on `session_id` as a path SEGMENT
+    (not a substring) avoids a session id that happens to be a substring of
+    an unrelated directory name from spuriously matching.
     """
     if not session_id:
         return False

--- a/.claude/hooks/block_stale_tmp_message_file.py
+++ b/.claude/hooks/block_stale_tmp_message_file.py
@@ -3,22 +3,68 @@
 
 Refuses commands of the form ``git commit -F /tmp/...`` and ``gh {pr,issue}
 {create,comment,edit} --body-file /tmp/...`` (plus ``gh api ... --input
-/tmp/...``) when the target file's mtime is older than ~30s. Such files are
-almost always leftovers from a prior task or session that the current command
-is about to consume by mistake — see ``feedback_tmp_msg_file_stale.md`` for
-the three documented surfaces and the 2026-05-03 ontology-rebuild recurrence
+/tmp/...``) when the target file's mtime is older than ~30s AND the file is
+not under the CURRENT session's own scratchpad. Such files are almost
+always leftovers from a prior task or session that the current command is
+about to consume by mistake — see ``feedback_tmp_msg_file_stale.md`` for the
+three documented surfaces and the 2026-05-03 ontology-rebuild recurrence
 that motivated this hook.
+
+Session-scratchpad exemption (#1352)
+=====================================
+
+Wave-29 measured **0/11 precision** on the mtime check: every single block
+that wave was a false positive, and all 11 were body files under the
+INVOKING SESSION's own scratchpad
+(``/tmp/claude-<uid>/<repo-slug>/<session-id>/scratchpad/...``) that the
+agent had simply spent more than 30s composing and verifying before
+posting — the write-then-verify-then-post shape, not the same-command
+heredoc shape the original threshold was calibrated for. A file whose path
+contains the CURRENT session's id cannot, by construction, be "a leftover
+from a prior task or session" — that is the hook's own stated threat
+model, and the discriminator (the session id) is already sitting in the
+filename. :func:`_is_current_session_path` checks for that id as a path
+segment and skips the mtime check entirely when it matches — no threshold
+value can substitute for this, because the threshold cannot tell "still
+composing" apart from "abandoned" by age alone (raising it to 15 minutes
+just moves the false-negative/false-positive line, it doesn't remove it;
+see the wave-29 harvested fixtures in
+``tests/test_block_stale_tmp_message_file_wave29.py``, several of which
+individually exceed a very generous retuned threshold).
+
+A body file under a DIFFERENT session's scratchpad, or a bare /tmp path
+with no session structure at all, is unaffected — the mtime check (and the
+existing 30s threshold) still applies, preserving the true positive the
+hook exists to catch.
+
+The ``touch <path> && gh ... --body-file <path>`` "workaround" (observed in
+wave-29) does NOT work and CANNOT be made to work by retuning the
+threshold: this is a PreToolUse hook, so it stats the file BEFORE the
+gated Bash command runs — the ``touch`` embedded in that same command has
+not executed yet when the hook checks, so it can never refresh the mtime
+the hook sees. The session-scratchpad exemption above fixes the cases that
+actually occurred in wave-29 (the touched file was always the agent's own
+scratchpad file) as a side effect of being path-identity-based rather than
+mtime-based; for a file NOT under the current session's scratchpad, no
+in-command ``touch`` can ever help, no matter the threshold — see the
+override paths below.
 
 Override paths the user can take when blocked:
   - rename the file to a non-/tmp path (e.g. .claude/scratch/msg.txt)
   - pass ``--message`` / ``--body`` inline instead of from a file
-  - use a /tmp path that is genuinely fresh (Write the file again, then re-run
-    the command — the freshness window resets to the new mtime)
+  - use a /tmp path that is genuinely fresh: re-run the Write tool call to
+    refresh the mtime, THEN issue the gh/git command as a SEPARATE,
+    subsequent tool call — a shell ``touch`` inside the SAME command being
+    gated cannot help (see above); the refresh must happen in a prior tool
+    call the hook has already seen.
 
-The 30-second threshold is configurable via the ``STALE_TMP_THRESHOLD_SECONDS``
-constant. Chosen as a balance between: long enough that a Write+Bash batched
-in parallel always passes (Bash sees the file at <1s mtime), short enough that
-a leftover file from a prior task in the same session is reliably caught.
+The 30-second threshold (``STALE_TMP_THRESHOLD_SECONDS``) still governs the
+non-exempted case: long enough that a Write+Bash batched in parallel always
+passes (Bash sees the file at <1s mtime), short enough that a leftover file
+from a prior task is reliably caught. It is deliberately NOT retuned by
+this fix — the session exemption above removes the guesswork for the case
+that was actually producing false positives, rather than trading one guess
+for another.
 
 Parser pattern (#316)
 =====================
@@ -35,9 +81,11 @@ shlex parse failure (`tokenize` returns None) fails OPEN — the command is
 allowed through and the downstream tool surfaces any real error itself.
 
 Exit codes:
-  0 — allow (no /tmp/* body-file argument, or file is fresh, or file missing,
-       or shlex parse failed)
-  2 — block (target file mtime older than threshold)
+  0 — allow (no /tmp/* body-file argument, file is under the current
+       session's own scratchpad, file is fresh, file is missing, or shlex
+       parse failed)
+  2 — block (target file mtime older than threshold AND not under the
+       current session's scratchpad)
 """
 
 from __future__ import annotations
@@ -150,6 +198,44 @@ def _extract_tmp_paths(command: str) -> list[str]:
     return paths
 
 
+def _session_id(input_data: dict) -> str:
+    """Resolve a stable session identifier for the current PreToolUse call.
+
+    Priority (mirrors ``validate_edit_completion.py``'s ``_session_id``):
+      1. ``input_data["session_id"]`` (Claude Code hook-input convention)
+      2. Filename stem of ``input_data["transcript_path"]``
+      3. ``""`` (no exemption possible without a stable id — fails closed,
+         i.e. the mtime check still applies)
+    """
+    sid = input_data.get("session_id")
+    if isinstance(sid, str) and sid:
+        return sid
+    tpath = input_data.get("transcript_path")
+    if isinstance(tpath, str) and tpath:
+        try:
+            return Path(tpath).stem
+        except (OSError, ValueError):
+            return ""
+    return ""
+
+
+def _is_current_session_path(path: str, session_id: str) -> bool:
+    """True if `session_id` appears as a full path segment of `path`.
+
+    The Claude Code scratchpad convention nests session-scoped tmp files
+    under a path containing the session's UUID as a segment (e.g.
+    ``/tmp/claude-<uid>/<repo-slug>/<session-id>/scratchpad/...``). A
+    /tmp/* file whose path contains the CURRENT session's id cannot, by
+    construction, be a leftover from a prior task or session — that is the
+    hook's own stated threat model (#1352). Matching on `session_id` as a
+    path SEGMENT (not a substring) avoids a session id that happens to be a
+    substring of an unrelated directory name from spuriously matching.
+    """
+    if not session_id:
+        return False
+    return session_id in Path(path).parts
+
+
 def _is_stale(path: str, now: float | None = None) -> bool:
     """True if the file exists and its mtime is older than the threshold."""
     try:
@@ -189,8 +275,13 @@ def check(input_data: dict) -> dict | None:
     if not tmp_paths:
         return None
 
+    session_id = _session_id(input_data)
     now = time.time()
-    stale = [p for p in tmp_paths if _is_stale(p, now=now)]
+    stale = [
+        p
+        for p in tmp_paths
+        if not _is_current_session_path(p, session_id) and _is_stale(p, now=now)
+    ]
     if not stale:
         return None
 
@@ -205,9 +296,15 @@ def check(input_data: dict) -> dict | None:
             f"{offending}\n\n"
             "This is the /tmp/* race captured in `feedback_tmp_msg_file_stale.md`: "
             "a Write+Bash pair batched in parallel can let Bash consume a stale "
-            "file written days ago. To proceed, take one of:\n"
-            "  1. Re-write the message/body to the same path (Write tool) and re-run "
-            "this command — the freshness window resets.\n"
+            "file written days ago. Files under YOUR OWN current session's "
+            "scratchpad are already exempt from this check regardless of age — "
+            "this file is not one of those, so a threshold or `touch` cannot "
+            "help: this hook stats the file BEFORE your command runs, so a "
+            "`touch` inside the SAME command being gated can never refresh the "
+            "mtime it sees. To proceed, take one of:\n"
+            "  1. Re-run the Write tool call to refresh the message/body at the "
+            "same path, THEN issue the git/gh command as a SEPARATE, later tool "
+            "call — the freshness window resets to the new mtime.\n"
             "  2. Use a non-/tmp path (e.g. .claude/scratch/msg.txt) so the hook "
             "no longer matches.\n"
             "  3. Pass the content inline with `--message`/`-m` (git) or "

--- a/.claude/hooks/tests/test_block_stale_tmp_message_file_wave29.py
+++ b/.claude/hooks/tests/test_block_stale_tmp_message_file_wave29.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Wave-29 harvested false-positive fixtures for block_stale_tmp_message_file (#1352).
+
+`block_stale_tmp_message_file` scored 0/11 precision in wave-29 — every one
+of the 11 blocks the hook fired was a false positive: a PR/review body the
+invoking agent had just authored, in its OWN session-scoped scratchpad
+(`/tmp/claude-<uid>/<repo-slug>/<session-uuid>/scratchpad/...`), simply
+because the agent spent more than `STALE_TMP_THRESHOLD_SECONDS` (30s)
+between writing the body and posting it (the write-then-verify-then-post
+shape, not the same-command heredoc shape the threshold was calibrated
+for). The literal scratchpad paths from wave-29 no longer exist on disk
+(session-scoped, long since cleaned up) so these fixtures reconstruct the
+REPORTED SHAPE from the issue #1352 table — command form, body-file
+description, and (for the one row where it's known) the body filename —
+using synthetic session UUIDs. What matters for this hook is the shape
+(session-id embedded in the /tmp path + an mtime past the threshold), which
+these fixtures reproduce exactly.
+
+Each of the 11 must ALLOW post-fix. Pre-fix, every one of them BLOCKS —
+see the PR body for the captured pre-fix pytest failure output.
+
+Row 8 (`touch <file> && gh pr create ...`) gets its OWN dedicated test
+class below (``TouchWorkaroundOrderingDefectTests``) with an extreme mtime
+age specifically to demonstrate that a threshold-only fix (e.g. raising
+30s to 15 minutes) could NOT close the ordering defect — only a
+session-identity-based exemption can, because no finite threshold
+distinguishes "the operator is still composing the body" from "this file
+is a stale leftover" when both look like a large mtime gap. The hook stats
+the file BEFORE the gated Bash command runs, so a `touch` embedded in the
+very command being gated can never refresh the mtime the hook sees.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import time
+import unittest
+import uuid
+from pathlib import Path
+
+import _test_helpers  # noqa: E402,F401
+import block_stale_tmp_message_file as hook  # noqa: E402
+
+
+def _touch(path: str, age_seconds: float) -> None:
+    """Create the file and stamp it with mtime = now - age_seconds."""
+    Path(path).write_text("body", encoding="utf-8")
+    target = time.time() - age_seconds
+    os.utime(path, (target, target))
+
+
+def _scratchpad_dir(session_id: str) -> str:
+    """Build a synthetic session-scoped scratchpad dir matching the real
+    Claude Code convention: /tmp/claude-<uid>/<repo-slug>/<session-id>/scratchpad.
+    """
+    base = tempfile.mkdtemp(dir="/tmp", prefix=f"claude-1000-noorinalabs-main-{session_id}-")
+    scratch = os.path.join(base, session_id, "scratchpad")
+    os.makedirs(scratch, exist_ok=True)
+    return scratch
+
+
+def _bash(command: str, session_id: str) -> dict:
+    return {
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+        "session_id": session_id,
+    }
+
+
+class Wave29HarvestedFalsePositiveTests(unittest.TestCase):
+    """The 11 wave-29 blocks from issue #1352 — all false positives.
+
+    Every row is a body file under the AUTHORING agent's OWN
+    session-scoped scratchpad, aged past the 30s threshold because the
+    agent spent real time composing/verifying the body before posting.
+    Post-fix, all 11 must ALLOW. Pre-fix, all 11 BLOCK (see PR body for
+    the captured failure).
+    """
+
+    def _assert_allowed_pre_fix_blocked(self, command: str, session_id: str) -> None:
+        result = hook.check(_bash(command, session_id))
+        self.assertIsNone(
+            result,
+            f"wave-29 false positive not fixed: {command!r} still blocks: {result}",
+        )
+
+    def test_row1_gh_pr_comment_verdict_1153_nino(self):
+        """07-28T00:11:52Z — gh pr comment 1153 --body-file verdict_1153_nino.md"""
+        sid = str(uuid.uuid4())
+        scratch = _scratchpad_dir(sid)
+        body = f"{scratch}/verdict_1153_nino.md"
+        _touch(body, age_seconds=180)
+        self._assert_allowed_pre_fix_blocked(f"gh pr comment 1153 --body-file {body}", sid)
+
+    def test_row2_gh_pr_create_sferreira_1131(self):
+        """07-30T03:23:51Z — gh pr create (S.Ferreira/1131)"""
+        sid = str(uuid.uuid4())
+        scratch = _scratchpad_dir(sid)
+        body = f"{scratch}/pr_body_1131.md"
+        _touch(body, age_seconds=90)
+        self._assert_allowed_pre_fix_blocked(f"gh pr create --title x --body-file {body}", sid)
+
+    def test_row3_gh_pr_create_wmwangi_1140(self):
+        """07-30T03:24:38Z — gh pr create (W.Mwangi/1140)"""
+        sid = str(uuid.uuid4())
+        scratch = _scratchpad_dir(sid)
+        body = f"{scratch}/pr_body_1140.md"
+        _touch(body, age_seconds=95)
+        self._assert_allowed_pre_fix_blocked(f"gh pr create --title x --body-file {body}", sid)
+
+    def test_row4_gh_pr_create_nhakim_1160(self):
+        """07-30T03:30:59Z — gh pr create (N.Hakim/1160)"""
+        sid = str(uuid.uuid4())
+        scratch = _scratchpad_dir(sid)
+        body = f"{scratch}/pr_body_1160.md"
+        _touch(body, age_seconds=150)
+        self._assert_allowed_pre_fix_blocked(f"gh pr create --title x --body-file {body}", sid)
+
+    def test_row5_gh_pr_create_nkavtaradze_1149(self):
+        """07-30T03:42:21Z — gh pr create (N.Kavtaradze/1149)"""
+        sid = str(uuid.uuid4())
+        scratch = _scratchpad_dir(sid)
+        body = f"{scratch}/pr_body_1149.md"
+        _touch(body, age_seconds=200)
+        self._assert_allowed_pre_fix_blocked(f"gh pr create --title x --body-file {body}", sid)
+
+    def test_row6_gh_pr_create_nkavtaradze_1204(self):
+        """08-03T03:36:48Z — gh pr create (N.Kavtaradze/1204)"""
+        sid = str(uuid.uuid4())
+        scratch = _scratchpad_dir(sid)
+        body = f"{scratch}/pr_body_1204.md"
+        _touch(body, age_seconds=110)
+        self._assert_allowed_pre_fix_blocked(f"gh pr create --title x --body-file {body}", sid)
+
+    def test_row7_gh_pr_create_nkhoury_1180_first_attempt(self):
+        """08-03T03:37:42Z — gh pr create (N.Khoury/1180), first attempt"""
+        sid = str(uuid.uuid4())
+        scratch = _scratchpad_dir(sid)
+        body = f"{scratch}/pr_body_1180.md"
+        _touch(body, age_seconds=60)
+        self._assert_allowed_pre_fix_blocked(f"gh pr create --title x --body-file {body}", sid)
+
+    # Row 8 (the touch-workaround retry of 1180) is its own dedicated test
+    # class below — TouchWorkaroundOrderingDefectTests.
+
+    def test_row9_gh_pr_create_avirtanen_1142(self):
+        """08-03T03:50:59Z — gh pr create (A.Virtanen/1142)"""
+        sid = str(uuid.uuid4())
+        scratch = _scratchpad_dir(sid)
+        body = f"{scratch}/pr_body_1142.md"
+        _touch(body, age_seconds=125)
+        self._assert_allowed_pre_fix_blocked(f"gh pr create --title x --body-file {body}", sid)
+
+    def test_row10_gh_pr_create_wzielinska_1168(self):
+        """08-03T17:25:59Z — gh pr create (W.Zielinska/1168)"""
+        sid = str(uuid.uuid4())
+        scratch = _scratchpad_dir(sid)
+        body = f"{scratch}/pr_body_1168.md"
+        _touch(body, age_seconds=140)
+        self._assert_allowed_pre_fix_blocked(f"gh pr create --title x --body-file {body}", sid)
+
+    def test_row11_gh_pr_create_avirtanen_1119(self):
+        """08-03T18:27:57Z — gh pr create (A.Virtanen/1119)"""
+        sid = str(uuid.uuid4())
+        scratch = _scratchpad_dir(sid)
+        body = f"{scratch}/pr_body_1119.md"
+        _touch(body, age_seconds=300)
+        self._assert_allowed_pre_fix_blocked(f"gh pr create --title x --body-file {body}", sid)
+
+
+class TouchWorkaroundOrderingDefectTests(unittest.TestCase):
+    """Row 8 — the touch-workaround from #1352, isolated as its own defect.
+
+    08-03T03:37:46Z: N.Khoury's session retried `gh pr create` for #1180 as
+    `touch <file> && gh pr create --title x --body-file <file>` after the
+    first attempt (row 7 above) was blocked. It was STILL blocked. A
+    PreToolUse hook stats the target file's mtime BEFORE the gated Bash
+    command executes — the `touch` inside that same command has not run
+    yet when the hook checks, so it cannot possibly refresh the mtime the
+    hook sees. No amount of raising `STALE_TMP_THRESHOLD_SECONDS` fixes
+    this: the file's mtime, AS THE HOOK SEES IT, never changes no matter
+    how long the threshold is. Only recognizing that the path is under the
+    invoking session's OWN scratchpad — independent of any mtime check at
+    all — closes it.
+
+    The mtime here is set to 2 hours, deliberately far beyond any
+    plausible retuned threshold (the issue's own proposal #2 suggests
+    10-15 minutes), to prove a threshold-only fix could not have closed
+    this row even in principle.
+    """
+
+    def test_touch_workaround_defeated_by_pretooluse_ordering_still_needs_session_exemption(
+        self,
+    ):
+        sid = str(uuid.uuid4())
+        scratch = _scratchpad_dir(sid)
+        body = f"{scratch}/pr_body_1180.md"
+        _touch(body, age_seconds=2 * 3600)  # 2h — beyond any sane retuned threshold
+        cmd = f"touch {body} && gh pr create --title x --body-file {body}"
+        result = hook.check(_bash(cmd, sid))
+        self.assertIsNone(
+            result,
+            "ordering defect not fixed: the touch-prefixed retry for the "
+            f"agent's own session scratchpad file still blocks: {result}",
+        )
+
+
+class TruePositivePreservedTests(unittest.TestCase):
+    """Acceptance criterion: exemption must NOT swallow genuine leftovers."""
+
+    def test_different_session_scratchpad_stale_still_blocks(self):
+        """A body file under a DIFFERENT session's scratchpad, stale, must
+        still block — it is not (by construction) exempt just because it
+        superficially looks like a scratchpad path."""
+        my_session = str(uuid.uuid4())
+        other_session = str(uuid.uuid4())
+        scratch = _scratchpad_dir(other_session)
+        body = f"{scratch}/leftover.md"
+        _touch(body, age_seconds=3600)
+        result = hook.check(_bash(f"gh pr create --title x --body-file {body}", my_session))
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+
+    def test_bare_tmp_path_stale_still_blocks(self):
+        """A bare /tmp/msg.txt (no session structure at all), stale, must
+        still block — the true positive the hook exists for."""
+        sid = str(uuid.uuid4())
+        with tempfile.TemporaryDirectory(dir="/tmp") as td:
+            msg = f"{td}/msg.txt"
+            _touch(msg, age_seconds=120)
+            result = hook.check(_bash(f"git commit -F {msg}", sid))
+            self.assertIsNotNone(result)
+            assert result is not None
+            self.assertEqual(result["decision"], "block")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/hooks/tests/test_block_stale_tmp_message_file_wave29.py
+++ b/.claude/hooks/tests/test_block_stale_tmp_message_file_wave29.py
@@ -236,5 +236,75 @@ class TruePositivePreservedTests(unittest.TestCase):
             self.assertEqual(result["decision"], "block")
 
 
+class ResidualBehaviorTests(unittest.TestCase):
+    """MF2 (PR #1384 merge-gate review, Aino Virtanen): the post-fix residual
+    behavior — a non-exempt file, `touch`-prefixed, must still block, AND
+    the rewritten block message must actually say `touch` cannot help
+    rather than merely block silently — was untested. Mutant M4 (revert
+    the message text to the old misleading `touch`-implying advice, change
+    nothing else) passed all 55 pre-existing assertions with zero
+    complaint, because none of them asserted on message CONTENT. These do.
+
+    Also closes mutant M2 (the `touch &&` prefix in
+    ``TouchWorkaroundOrderingDefectTests`` is inert — deleting it produces
+    byte-identical results) by making a test where the touch prefix and the
+    session id genuinely do NOT matter to the outcome, paired with one
+    where the session-SEGMENT-vs-substring distinction genuinely does
+    (mutant M3: `session_id in path` in place of
+    `session_id in Path(path).parts`).
+    """
+
+    def test_non_exempt_touch_prefixed_retry_still_blocks_and_message_says_touch_cannot_help(
+        self,
+    ):
+        """The residual the docstring claims: for a file NOT under the
+        current session's id, an in-command `touch` cannot help — it still
+        blocks, and the message says so instead of advising the touch.
+
+        Not vacuous: reverting the block message to the old `touch`-implying
+        advice (mutant M4, PR #1384 review) leaves `decision == "block"`
+        unchanged but trips the two `assertIn` checks below — see the PR
+        body for the captured failure output against that mutant.
+        """
+        mine = str(uuid.uuid4())
+        other = str(uuid.uuid4())
+        body = f"{_scratchpad_dir(other)}/leftover.md"
+        _touch(body, age_seconds=2 * 3600)
+        cmd = f"touch {body} && gh pr create --title x --body-file {body}"
+        result = hook.check(_bash(cmd, mine))
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+        reason = result["reason"]
+        self.assertIn(
+            "BEFORE your command runs",
+            reason,
+            "message must explain the PreToolUse ordering, not imply touch helps",
+        )
+        self.assertIn(
+            "SEPARATE",
+            reason,
+            "message must point at the remedy that actually works (a prior, "
+            "separate Write tool call), not an in-command touch",
+        )
+
+    def test_session_id_substring_not_segment_still_blocks(self):
+        """Mutant M3 guard: `session_id in path` (substring) must NOT count
+        as exempt — only `session_id in Path(path).parts` (a full path
+        SEGMENT) does. A directory name that merely CONTAINS the session id
+        as a substring (e.g. `x-<sid>-y`) is not a path the current session
+        actually produced under its own id and must still block."""
+        sid = str(uuid.uuid4())
+        with tempfile.TemporaryDirectory(dir="/tmp") as td:
+            sub = os.path.join(td, f"x-{sid}-y")
+            os.makedirs(sub, exist_ok=True)
+            body = f"{sub}/f.md"
+            _touch(body, age_seconds=120)
+            result = hook.check(_bash(f"git commit -F {body}", sid))
+            self.assertIsNotNone(result)
+            assert result is not None
+            self.assertEqual(result["decision"], "block")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Fixes #1352 — `block_stale_tmp_message_file` scored **0/11 precision in wave-29**: every block that wave was a false positive. All 11 were body files under the invoking agent's OWN session-scoped scratchpad (`/tmp/claude-<uid>/<slug>/<session-id>/scratchpad/...`), blocked because composing + verifying the body took longer than the 30s threshold — the write-verify-post shape, not the same-command heredoc shape the threshold was calibrated for.

Two distinct defects, both closed here:

1. **Threshold doesn't discriminate.** 0/11 says 30s (or any single number) can't tell "still composing" from "abandoned leftover" by age alone.
2. **The `touch` workaround is defeated by PreToolUse ordering.** `touch <file> && gh pr create --body-file <file>` in one Bash call still blocked (wave-29 row 8) because this is a PreToolUse hook — it stats the file BEFORE the gated command runs, so the `touch` inside that same command hasn't executed yet when the hook checks. No threshold retune fixes this either.

## Fix

Exempt `/tmp/*` paths that contain the **current session's id as a path segment** from the mtime check entirely (`_session_id` / `_is_current_session_path` in `block_stale_tmp_message_file.py`). A file under the current session's own id cannot be a leftover from a *prior session* — that is true by construction and is the entire wave-29 false-positive class this fix closes. (It is **not** true that such a file can never be a leftover from an *earlier task in the same session* — that narrower class is deliberately surrendered, not accidentally claimed; see "MF1" below for why the docstring now says this explicitly instead of overclaiming.)

- **Threshold left at 30s, not retuned.** Per the issue's own recommendation ("prefer 1, which removes the guesswork rather than retuning it") — raising the number is still a guess and doesn't touch the ordering defect. See "Why not just retune the threshold" below for evidence a retune is actively worse, not merely a weaker fix.
- **True positives preserved:** a body file under a *different* session's id, or a bare `/tmp/msg.txt` with no session structure, still blocks unchanged.
- **Ordering defect resolved as a side effect + messaging fixed:** the wave-29 `touch` retry targeted the agent's own scratchpad file, so it now passes via the same path-identity exemption — no mtime check, no touch needed. For files genuinely outside the current session's id, no in-command `touch` can ever help (still true post-fix, and still correctly blocks) — the block message and docstring now say this explicitly instead of implying a Write-tool refresh will work for a file the hook never saw written.

## Why not just retune the threshold (M1)

Credit: Aino Virtanen's merge-gate review ran this mutant and it's the strongest evidence in this PR that retuning is not a viable cheaper alternative, not merely an inferior one.

**Mutant M1** — base (pre-fix) hook, `STALE_TMP_THRESHOLD_SECONDS` raised from 30 to 900 (the issue's own suggested 10–15 min), run against this PR's harvested test file:

```
FAILED ...::TouchWorkaroundOrderingDefectTests::test_touch_workaround_defeated_by_pretooluse_ordering...
FAILED ...::TruePositivePreservedTests::test_bare_tmp_path_stale_still_blocks
2 failed, 11 passed
```

A 15-minute threshold clears the 10 harvested wave-29 rows, still fails row 8 (the ordering defect — no age-based rule ever closes it), **and stops blocking the 2-minute bare-`/tmp` true positive** — the one case the hook exists to catch. A retune buys precision by spending the exact true positive it's supposed to protect. The session-identity exemption in this PR keeps both: head is 13/13 (now 15/15, see MF2 below) with both true-positive controls green, and the 42 pre-existing tests in `test_block_stale_tmp_message_file.py` + `_parser.py` are untouched and green throughout.

## Pre-fix failure output (captured against unmodified `main`)

11 new tests in `.claude/hooks/tests/test_block_stale_tmp_message_file_wave29.py` — 10 harvested wave-29 rows (row 8's touch-workaround gets its own dedicated test, described below) — run against the pre-fix hook:

```
FAILED .claude/hooks/tests/test_block_stale_tmp_message_file_wave29.py::Wave29HarvestedFalsePositiveTests::test_row10_gh_pr_create_wzielinska_1168
FAILED .claude/hooks/tests/test_block_stale_tmp_message_file_wave29.py::Wave29HarvestedFalsePositiveTests::test_row11_gh_pr_create_avirtanen_1119
FAILED .claude/hooks/tests/test_block_stale_tmp_message_file_wave29.py::Wave29HarvestedFalsePositiveTests::test_row1_gh_pr_comment_verdict_1153_nino
FAILED .claude/hooks/tests/test_block_stale_tmp_message_file_wave29.py::Wave29HarvestedFalsePositiveTests::test_row2_gh_pr_create_sferreira_1131
FAILED .claude/hooks/tests/test_block_stale_tmp_message_file_wave29.py::Wave29HarvestedFalsePositiveTests::test_row3_gh_pr_create_wmwangi_1140
FAILED .claude/hooks/tests/test_block_stale_tmp_message_file_wave29.py::Wave29HarvestedFalsePositiveTests::test_row4_gh_pr_create_nhakim_1160
FAILED .claude/hooks/tests/test_block_stale_tmp_message_file_wave29.py::Wave29HarvestedFalsePositiveTests::test_row5_gh_pr_create_nkavtaradze_1149
FAILED .claude/hooks/tests/test_block_stale_tmp_message_file_wave29.py::Wave29HarvestedFalsePositiveTests::test_row6_gh_pr_create_nkavtaradze_1204
FAILED .claude/hooks/tests/test_block_stale_tmp_message_file_wave29.py::Wave29HarvestedFalsePositiveTests::test_row7_gh_pr_create_nkhoury_1180_first_attempt
FAILED .claude/hooks/tests/test_block_stale_tmp_message_file_wave29.py::Wave29HarvestedFalsePositiveTests::test_row9_gh_pr_create_avirtanen_1142
FAILED .claude/hooks/tests/test_block_stale_tmp_message_file_wave29.py::TouchWorkaroundOrderingDefectTests::test_touch_workaround_defeated_by_pretooluse_ordering_still_needs_session_exemption
========================= 11 failed, 2 passed in 0.36s =========================
```

(The 2 passes pre-fix are `TruePositivePreservedTests` — a different-session-scratchpad file and a bare `/tmp` file, both correctly still blocking; they stay green post-fix too, confirming no regression on the true positive. Independently reproduced by the reviewer against the unmodified base — see Ruling 2 in her review.)

Representative failure (row 5 — mtime 3m 20s):

```
AssertionError: {'decision': 'block', 'reason': 'BLOCKED: stale /tmp/* file passed to git/gh body-file flag.
The following file(s) have an mtime older than 30s — likely leftovers from a prior task or session:
  - /tmp/claude-1000-noorinalabs-main-<sid>-r4g3k4zi/<sid>/scratchpad/pr_body_1149.md (mtime 3m 20s ago)
...
```

**`TouchWorkaroundOrderingDefectTests`** uses a **2-hour** mtime deliberately — far beyond any plausible retuned threshold (the issue's own proposal #2 suggests 10-15 min) — specifically to prove a threshold-only fix could not have closed this row even in principle (confirmed independently by mutant M1 above). Pre-fix it still blocks at 2h regardless; post-fix it passes because the exemption is path-identity-based, not age-based.

## Post-fix

All 15 tests in the new file pass (11 wave-29 defect tests + 2 true-positive regression tests + 2 residual-behavior tests added for MF2), plus the full existing suite is unchanged:

```
.claude/hooks/tests/test_block_stale_tmp_message_file_wave29.py ............... [100%]
15 passed in 0.30s

.claude/hooks/tests/ — 2830 passed, 806 subtests passed
.claude/lib/tests/   — 1370 passed, 141 subtests passed
```

## Precision before/after (wave-29 dataset)

| | Before | After |
|---|---|---|
| Precision on the 11 wave-29 blocks | 0/11 (0%) | 11/11 (100%) allowed, matching ground truth |
| True positive (different-session / bare-tmp stale file) | blocks | still blocks (unchanged) |

## Acceptance criteria (from #1352)

- [x] All 11 wave-29 commands allowed.
- [x] A body file under a different session's scratchpad, or a bare `/tmp/msg.txt` older than the threshold, still blocks.
- [x] `touch <f> && gh … --body-file <f>` now passes for the wave-29 case (agent's own session id); for a genuinely different-session file the block message no longer implies touch would help — and this residual is now asserted directly (MF2).
- [x] Docstring justifies the mechanism (session-identity exemption) against the write-verify-post workflow, explains why threshold-retuning alone can't close the ordering defect (M1), states the threshold is deliberately left unchanged, and states the narrower true guarantee rather than a broader one it doesn't enforce (MF1).

## Update — addressed merge-gate review (`f6f5d1b` → `e4f6d00`)

Aino Virtanen's merge-gate review requested two must-fixes on `f6f5d1b`; both are addressed additively (no rebase/force-push) at head `e4f6d00473594e4c13669d140a9af3a9807e81a0`:

- **MF1 (docstring overclaim):** `_is_current_session_path` matches the session id as *any* path segment, not just under the scratchpad directory, so an old file from an earlier task in the same session is exempt too — wider than the module docstring's original "by construction... prior task or session" claim and wider than issue #1352 proposal 1's "under the invoking session's scratchpad directory" ask. The behavior is unchanged (the reviewer judged the broadening defensible — hard-coding the scratchpad root would be its own fragility) but the docstring, `_is_current_session_path`'s docstring, and the exit-code summary now state the true, narrower guarantee (cannot be a leftover from a **prior session**) and name the surrendered class (a leftover from an **earlier task in the same session**) explicitly, with the wave-29 0/11-true-positives justification for why that trade is deliberate.
- **MF2 (untested residual + message):** added `ResidualBehaviorTests::test_non_exempt_touch_prefixed_retry_still_blocks_and_message_says_touch_cannot_help` (asserts the block decision AND the message content — `"BEFORE your command runs"` / `"SEPARATE"` — for a `touch`-prefixed retry on a file that is NOT under the current session's id) and `::test_session_id_substring_not_segment_still_blocks` (a session id that is only a path-name *substring*, not a full segment, must still block — closes the reviewer's mutant-M3 gap). Confirmed the message assertion is genuinely trippable, not vacuous: ran it against a local mutant with the block message reverted to the old `"Just touch the file inside the same command and re-run."` text (the reviewer's mutant M4) —

  ```
  === MUTANT M4 (message reverted to old misleading advice) reason text ===
  BLOCKED: stale /tmp/* file passed to git/gh body-file flag.
  The following file(s) have an mtime older than 30s — likely leftovers from a prior task or session:
    - /tmp/claude-1000-noorinalabs-main-<sid>-0audqybn/<sid>/scratchpad/leftover.md (mtime 2h 0m ago)

  Just `touch` the file inside the same command and re-run.

  === new-test assertions against the mutant ===
  assertIn('BEFORE your command runs', reason) -> FAIL
  assertIn('SEPARATE', reason) -> FAIL

  CONFIRMED: the new message assertions are trippable -- they FAIL
  against mutant M4, proving they are not vacuously-true string checks.
  ```

  Both new tests pass against the real (unmutated) head hook.

Full suite at `e4f6d00`: 57 tests across the three stale-tmp-message test files (was 55), full hooks suite 2830 passed (was 2828), full local⇄CI parity (`pre-commit run --all-files` + `--hook-stage push`) green.

## Notes / adjacent findings (not filed as new issues per wave-30 intake constraint)

- The literal wave-29 scratchpad file paths/session UUIDs no longer exist on disk (session-scoped, long since cleaned up) — the harvested fixtures reconstruct the reported SHAPE (command form, body-file description, and the one known filename `verdict_1153_nino.md`) with synthetic UUIDs. What the hook's logic depends on (session-id-as-path-segment + mtime) is reproduced exactly; only the literal historical UUIDs are synthetic.
- The hook's docstring/`feedback_tmp_msg_file_stale.md` reference points at a memory note that appears to no longer exist under that name in this repo (only referenced from archived promotion-audit logs) — flagged for awareness; the reviewer filed this as **#1395** (tech-debt) since it's pre-existing and out of scope for this fix.
- Reviewer's non-blocking nit (not addressed, reviewer said not to hold the merge for it): `_session_id`'s `transcript_path`-stem fallback doesn't help a subagent whose transcript filename doesn't embed the session id — it fails closed (pre-fix behavior) rather than breaking, and the primary `session_id`-key branch was independently confirmed live in production by the reviewer.

## CI

Full local⇄CI parity run in this worktree before each push: `pre-commit run --all-files` + `pre-commit run --all-files --hook-stage push` (ruff-format, ruff-lint, actionlint, cspell, mypy, mypy-skills, pytest, pytest-skills, memory-budget, headcount-budget, doc-freshness, office-drift, mermaid-render, checksums-ascii) — all green at `e4f6d00`. `python3 .claude/lib/pre_commit_ci_sync.py .` — OK.

---
Requesting review from **Aino Virtanen** (Standards & Quality Lead, merge gate) and **Nino Kavtaradze** — both need to re-confirm against `e4f6d00473594e4c13669d140a9af3a9807e81a0`.
