### PR TITLE
fix(annunaki): recognize gh run view/log and rg-over-a-file as content display

### DIFF
--- a/.claude/hooks/annunaki_monitor.py
+++ b/.claude/hooks/annunaki_monitor.py
@@ -220,7 +220,7 @@ CONTENT_DISPLAY_VERBS = re.compile(
         cat | head | tail | less | more | bat        # file pagers/dumpers
       | rg                                           # #1354: file-content search/dump
       | git\s+show | git\s+diff | git\s+log          # git content display
-      | gh\s+pr\s+diff | gh\s+pr\s+view               # gh PR content display
+      | gh\s+pr\s+diff | gh\s+pr\s+view              # gh PR content display
       | gh\s+run\s+view | gh\s+run\s+log             # #1354: gh CI-log content display
     )
     \b
@@ -258,13 +258,28 @@ CONTENT_DISPLAY_STDOUT_MERGE = re.compile(r"2>&1")
 # CI-log-read verbs (#1354): `gh run view --log-failed` / `gh run log` are the
 # canonical way to read a failed CI job's log, and routinely need `2>&1 |
 # tail -c N` to bound stdout size while still catching anything `gh` itself
-# writes to stderr (a warning, a rate-limit notice). Unlike `cat`/`head`/etc,
-# there is no "possibly-missing local path" for `gh run view` to probe — a
-# bad run id or network failure surfaces as a real nonzero exit, which the
-# `exit_code != 0` guard above already catches independently of this verb
-# check. So the general `2>&1` disqualifier is scoped away from these two
-# verbs specifically; every other content-display verb (including the new
-# `rg` verb, which is not a CI-log-specific idiom) keeps the disqualifier.
+# writes to stderr (a warning, a rate-limit notice).
+#
+# IMPORTANT — this repo's shell has no `pipefail` (zsh, no `setopt pipefail`
+# in play here), so for the piped canonical form the `exit_code != 0` guard
+# above does NOT independently catch a failing `gh run view`: the observed
+# exit code is the last stage's (`tail`'s), which is 0 even when `gh` itself
+# failed. Measured live: `gh run view <bad-id> --log-failed 2>&1 | tail -c
+# 8000; echo $?` → `0`, with `gh`'s failure text on stdout. So this
+# exemption is NOT "safe because a real failure would still surface via a
+# nonzero exit" — for the piped form, it would not.
+#
+# The exemption is accepted anyway because the residual class is bounded and
+# already low-value: a `gh run view` that itself fails emits either (a) gh's
+# own "failed to get run: HTTP 404: ..." text, which trips NO ERROR_PATTERNS
+# entry at all (dropped identically pre- and post-fix), or (b) a line that
+# DOES match a pattern (e.g. "error connecting to api.github.com"), which
+# pre-fix was retained at confidence=low/category=pipe-mask-suspect (#835) —
+# already excluded from annunaki_parse's genuine-error count — and post-fix
+# is dropped entirely. The loss is confined to uncounted forensic records;
+# no `confidence=high` shape is lost. Every other content-display verb
+# (including the new `rg` verb, which is not a CI-log-specific idiom) keeps
+# the `2>&1` disqualifier unchanged.
 CONTENT_DISPLAY_LOG_READ_VERBS = re.compile(
     r"""
     ^\s*

--- a/.claude/hooks/annunaki_monitor.py
+++ b/.claude/hooks/annunaki_monitor.py
@@ -21,8 +21,12 @@ Input Language:
                   matched pattern is `stdout:No such file or directory`),
                   content-display commands (#596 — exit=0 cat/head/tail/less,
                   `gh api .../contents/...`, or a read of errors.jsonl when the
-                  ONLY signals are stdout-pattern matches in displayed content),
-                  session-dedup hits
+                  ONLY signals are stdout-pattern matches in displayed content;
+                  #1354 extends this to `rg` over any file, `gh run view`/
+                  `gh run log` (a CI-log read, `2>&1` permitted for these two
+                  verbs specifically), and `gh api .../actions/runs/<id>/logs`
+                  — investigating an already-known CI failure is a content
+                  display too, not a fresh error), session-dedup hits
   Flag pass-through: stdin JSON is forwarded verbatim to `check()` by the
                      PostToolUse dispatcher (`post_dispatcher.py`)
   Confidence tag (#729): every logged record carries `confidence` in
@@ -214,8 +218,10 @@ CONTENT_DISPLAY_VERBS = re.compile(
     ^\s*
     (?:
         cat | head | tail | less | more | bat        # file pagers/dumpers
+      | rg                                           # #1354: file-content search/dump
       | git\s+show | git\s+diff | git\s+log          # git content display
-      | gh\s+pr\s+diff | gh\s+pr\s+view              # gh PR content display
+      | gh\s+pr\s+diff | gh\s+pr\s+view               # gh PR content display
+      | gh\s+run\s+view | gh\s+run\s+log             # #1354: gh CI-log content display
     )
     \b
     """,
@@ -227,6 +233,11 @@ CONTENT_DISPLAY_VERBS = re.compile(
 # api invocations are commonly preceded by a variable-assignment prefix and the
 # `contents/` path segment is an unambiguous content-read marker.
 CONTENT_DISPLAY_GH_API_CONTENTS = re.compile(r"\bgh\s+api\b.*\bcontents/")
+
+# `gh api .../actions/runs/<id>/logs` — the raw-logs REST read, the API analog
+# of `gh run view --log-failed` / `gh run log` (#1354). Same content-read
+# reasoning as CONTENT_DISPLAY_GH_API_CONTENTS above.
+CONTENT_DISPLAY_GH_API_LOGS = re.compile(r"\bgh\s+api\b.*\bactions/runs/\d+/logs\b")
 
 # Self-referential meta-capture guard (#596): a command that reads the annunaki
 # error log itself will echo historical records containing "Traceback" etc.
@@ -243,6 +254,25 @@ CONTENT_DISPLAY_ERRORS_LOG = re.compile(r"errors\.jsonl")
 # but is a failed read whose merged error text (or an unrelated Traceback in the
 # merged stream) must still log on its own merits (#517 regression guard).
 CONTENT_DISPLAY_STDOUT_MERGE = re.compile(r"2>&1")
+
+# CI-log-read verbs (#1354): `gh run view --log-failed` / `gh run log` are the
+# canonical way to read a failed CI job's log, and routinely need `2>&1 |
+# tail -c N` to bound stdout size while still catching anything `gh` itself
+# writes to stderr (a warning, a rate-limit notice). Unlike `cat`/`head`/etc,
+# there is no "possibly-missing local path" for `gh run view` to probe — a
+# bad run id or network failure surfaces as a real nonzero exit, which the
+# `exit_code != 0` guard above already catches independently of this verb
+# check. So the general `2>&1` disqualifier is scoped away from these two
+# verbs specifically; every other content-display verb (including the new
+# `rg` verb, which is not a CI-log-specific idiom) keeps the disqualifier.
+CONTENT_DISPLAY_LOG_READ_VERBS = re.compile(
+    r"""
+    ^\s*
+    gh\s+run\s+(?:view|log)
+    \b
+    """,
+    re.VERBOSE,
+)
 
 # The `No such file or directory` stdout match always signals a FAILED
 # filesystem read (a missing path), never error-shaped *content* we want to
@@ -319,7 +349,7 @@ JSON_BODY_LINE = re.compile(r'^\s*[+-]?\s*[{\[]\s*["{]')
 
 
 def _is_content_display(command: str, exit_code: int, matched_patterns: list[str]) -> bool:
-    """Return True if this matches the #596 content-display idiom.
+    """Return True if this matches the #596/#1354 content-display idiom.
 
     All of the following must hold:
       1. exit_code == 0 (the read/display succeeded)
@@ -327,18 +357,23 @@ def _is_content_display(command: str, exit_code: int, matched_patterns: list[str
          no `exit_code=` marker. A stderr pattern or non-zero exit means a real
          failure occurred alongside the display, so this skip does NOT apply.
       3. the command does NOT contain a `2>&1` stdout-merge AND no matched
-         pattern is the `No such file or directory` line. Both mark the #517
-         probe-with-fallback domain (an intentional/failed read of a missing
-         path) rather than displayed error-shaped content, so those cases are
-         left to the probe classifier. The `2>&1` guard catches the command
-         shape; the No-such-file guard catches the matched-signal even when the
-         command shape is absent (e.g. a bare `gh api .../contents/... > file`
-         that failed). Together they keep `cat missing.py 2>&1 | head` and the
-         non-trailer probe outliers from being mis-classified as displays.
+         pattern is the `No such file or directory` line — UNLESS the command
+         is a CI-log-read verb (`gh run view`/`gh run log`, #1354), which is
+         exempted from the `2>&1` sub-check specifically (see
+         CONTENT_DISPLAY_LOG_READ_VERBS). For every other verb, both guards
+         mark the #517 probe-with-fallback domain (an intentional/failed read
+         of a missing path) rather than displayed error-shaped content, so
+         those cases are left to the probe classifier. The `2>&1` guard
+         catches the command shape; the No-such-file guard catches the
+         matched-signal even when the command shape is absent (e.g. a bare
+         `gh api .../contents/... > file` that failed). Together they keep
+         `cat missing.py 2>&1 | head` and the non-trailer probe outliers from
+         being mis-classified as displays.
       4. the command is a recognized content-display operation: a leading
-         display verb (cat/head/tail/less/more/bat, git show|diff|log,
-         gh pr diff|view), a `gh api .../contents/...` read, OR a read of the
-         annunaki errors.jsonl log (self-referential meta-capture).
+         display verb (cat/head/tail/less/more/bat, rg, git show|diff|log,
+         gh pr diff|view, gh run view|log), a `gh api .../contents/...` or
+         `gh api .../actions/runs/<id>/logs` read, OR a read of the annunaki
+         errors.jsonl log (self-referential meta-capture).
 
     Condition 2 is the precedence guard mirroring the silent-boolean-test and
     probe-with-fallback families: any real failure signal bypasses the skip.
@@ -349,13 +384,17 @@ def _is_content_display(command: str, exit_code: int, matched_patterns: list[str
         return False
     if not all(p.startswith("stdout:") for p in matched_patterns):
         return False
-    if CONTENT_DISPLAY_STDOUT_MERGE.search(command):
-        return False
-    if CONTENT_DISPLAY_EXCLUDED_PATTERN in matched_patterns:
-        return False
+    is_log_read_verb = CONTENT_DISPLAY_LOG_READ_VERBS.search(command) is not None
+    if not is_log_read_verb:
+        if CONTENT_DISPLAY_STDOUT_MERGE.search(command):
+            return False
+        if CONTENT_DISPLAY_EXCLUDED_PATTERN in matched_patterns:
+            return False
     if CONTENT_DISPLAY_VERBS.search(command):
         return True
     if CONTENT_DISPLAY_GH_API_CONTENTS.search(command):
+        return True
+    if CONTENT_DISPLAY_GH_API_LOGS.search(command):
         return True
     if CONTENT_DISPLAY_ERRORS_LOG.search(command):
         return True
@@ -556,11 +595,13 @@ def check(input_data: dict) -> dict | None:
     if _is_probe_with_fallback(command, exit_code, matched_patterns):
         return None
 
-    # #596 content-display filter: a command that DISPLAYS content (cat/head/
-    # tail/less of a file, `gh api .../contents/...`, a read of errors.jsonl)
-    # and exits 0 with only stdout-pattern matches is echoing error-shaped
-    # content, not failing. The helper requires exit==0 AND every matched
-    # pattern be a stdout one, so a real stderr/exit-code signal bypasses this.
+    # #596/#1354 content-display filter: a command that DISPLAYS content
+    # (cat/head/tail/less/rg of a file, `gh api .../contents/...` or
+    # `.../actions/runs/<id>/logs`, `gh run view`/`gh run log`, a read of
+    # errors.jsonl) and exits 0 with only stdout-pattern matches is echoing
+    # error-shaped content, not failing. The helper requires exit==0 AND
+    # every matched pattern be a stdout one, so a real stderr/exit-code
+    # signal bypasses this.
     if _is_content_display(command, exit_code, matched_patterns):
         return None
 

--- a/.claude/hooks/tests/test_annunaki_monitor.py
+++ b/.claude/hooks/tests/test_annunaki_monitor.py
@@ -1490,19 +1490,51 @@ class Issue1354CiLogReadTests(unittest.TestCase):
             )
         )
 
-    def test_gh_run_view_genuine_failure_nonzero_exit_still_logged(self):
-        """A `gh run view` that itself fails (bad run id, network error —
-        nonzero exit) is a real failure, not a content display → must still
-        log (content-display requires exit_code == 0)."""
+    def test_gh_run_view_bare_nonzero_exit_still_logged(self):
+        """A BARE (unpiped) `gh run view` that itself fails — nonzero exit
+        propagates directly, no pager in the pipeline — is a real failure,
+        not a content display → must still log. This guards the
+        `exit_code != 0` short-circuit at the top of `_is_content_display`,
+        which fires before any #1354 verb/exemption logic runs; it is NOT a
+        guard on the `2>&1` exemption itself (that requires the piped form,
+        see `test_gh_run_view_piped_failure_no_pipefail_uncounted_drop`
+        below for the shape that actually exercises it, per Nino
+        Kavtaradze's #1385 merge-gate review)."""
         result = am.check(
             _bash_event(
-                "gh run view 99999999 --repo noorinalabs/noorinalabs-main "
-                "--log-failed 2>&1 | tail -c 8000",
+                "gh run view 99999999 --repo noorinalabs/noorinalabs-main --log-failed",
                 stdout="failed to get run: run not found\n",
                 exit_code=1,
             )
         )
         self.assertIsNotNone(result, "a genuinely failed gh run view must still log")
+
+    def test_gh_run_view_piped_failure_no_pipefail_uncounted_drop(self):
+        """The shell-realistic shape of a FAILING piped `gh run view`
+        (#1385 merge-gate MF2): this repo's shell has no `pipefail`, so
+        `gh run view <bad-id> --log-failed 2>&1 | tail -c 8000` exits 0 (the
+        pager's rc) even when `gh` itself failed — measured live. When gh's
+        failure text happens to trip an ERROR_PATTERNS entry (e.g. "error
+        connecting to ..."), the #1354 exemption now suppresses the record
+        entirely. Pre-#1354 this landed at confidence=low/
+        category=pipe-mask-suspect (already excluded from the genuine-error
+        count by annunaki_parse), so the record pinned here documents an
+        accepted, uncounted-forensics-only loss — not a `confidence=high`
+        regression. See the CONTENT_DISPLAY_LOG_READ_VERBS comment for the
+        full trade-off writeup."""
+        result = am.check(
+            _bash_event(
+                "gh run view 99999999 --repo noorinalabs/noorinalabs-main "
+                "--log-failed 2>&1 | tail -c 8000",
+                stdout="error connecting to api.github.com\n",
+                exit_code=0,
+            )
+        )
+        self.assertIsNone(
+            result,
+            "accepted trade-off: a failing piped gh run view with no pipefail is "
+            "indistinguishable from a successful content display and is dropped",
+        )
 
     def test_rg_over_log_with_stderr_pattern_still_logged(self):
         """`rg` over a saved log with a real stderr signal alongside (e.g. an

--- a/.claude/hooks/tests/test_annunaki_monitor.py
+++ b/.claude/hooks/tests/test_annunaki_monitor.py
@@ -1320,6 +1320,269 @@ class Rc0PrecisionTests(unittest.TestCase):
         self.assertEqual(rec["hook"], "annunaki_monitor")
 
 
+class Issue1354CiLogReadTests(unittest.TestCase):
+    """#1354 coverage: `_is_content_display` misses `gh run view`/`gh run log`
+    (a CI-log read) and `rg`-over-a-saved-log — a command that *investigates*
+    an already-known CI failure is captured as a fresh error.
+
+    Fixtures 1-3 are harvested verbatim (command + realistic stdout replaying
+    the actual `error_lines`) from the live `.claude/annunaki/errors.jsonl`
+    wave-29 incident the issue cites: a single failing test
+    (`test_wave_status.py::BaseVsHeadDifferential::
+    test_base_and_head_agree_on_wave_branch_output`, fixed in-wave by
+    `.github/workflows/ci.yml` `fetch-depth: 0`) investigated via `gh run
+    view --log-failed` then two `rg` re-reads of the saved log — three
+    high-confidence `masked-failure` records of one already-fixed incident.
+
+    Precedence siblings: #517 (probe-with-fallback, the `2>&1` guard's
+    original reason for existing) and #596 (the base content-display class
+    this issue extends) — both must be unaffected.
+    """
+
+    def setUp(self):
+        self._saved_env = {
+            "ENVIRONMENT": os.environ.pop("ENVIRONMENT", None),
+            "NOORIN_HOOK_TEST_MODE": os.environ.pop("NOORIN_HOOK_TEST_MODE", None),
+        }
+        am._seen_hashes.clear()
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self._errors_path = Path(self._tmpdir.name) / "errors.jsonl"
+        self._orig_monitor_file = am.ERRORS_FILE
+        self._orig_log_file = alog.ERRORS_FILE
+        am.ERRORS_FILE = self._errors_path
+        alog.ERRORS_FILE = self._errors_path
+
+    def tearDown(self):
+        am.ERRORS_FILE = self._orig_monitor_file
+        alog.ERRORS_FILE = self._orig_log_file
+        self._tmpdir.cleanup()
+        for k, v in self._saved_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    # --- Harvested wave-29 fixtures (errors.jsonl records #206/#208/#209) ---
+
+    # The three records replay the CI job's log text — the pytest failure
+    # summary line contains "returned non-zero exit status 128", which trips
+    # ERROR_PATTERNS' `exit status [1-9]` on stdout even though the *reading*
+    # command itself exited 0.
+    _CI_LOG_TEXT = (
+        "Pytest — hooks and lib test suites\tRun hook and lib tests\t"
+        "2026-07-30T03:24:39.0338201Z E               subprocess.CalledProcessError: "
+        "Command '['git', 'show', "
+        "'b290d611e9e6c59db0bf921ef6a9315090dc2eae:.claude/lib/wave_status.py']' "
+        "returned non-zero exit status 128.\n"
+        "Pytest — hooks and lib test suites\tRun hook and lib tests\t"
+        "2026-07-30T03:24:39.0342317Z FAILED "
+        ".claude/lib/tests/test_wave_status.py::BaseVsHeadDifferential::"
+        "test_base_and_head_agree_on_wave_branch_output - "
+        "subprocess.CalledProcessError: Command '['git', 'show', "
+        "'b290d611e9e6c59db0bf921ef6a9315090dc2eae:.claude/lib/wave_status.py']' "
+        "returned non-zero exit status 128.\n"
+        "Pytest — hooks and lib test suites\tRun hook and lib tests\t"
+        "2026-07-30T03:24:39.0344145Z 1 failed, 3170 passed, 253 subtests passed in 11.61s\n"
+        "Pytest — hooks and lib test suites\tRun hook and lib tests\t"
+        "2026-07-30T03:24:39.1348228Z ##[error]Process completed with exit code 1.\n"
+    )
+
+    def test_harvested_206_gh_run_view_log_failed_not_logged(self):
+        """errors.jsonl record #206 (2026-07-30T03:27:36Z, confidence=high,
+        category=masked-failure): `gh run view <id> --log-failed 2>&1 | tail
+        -c 8000` reading the already-fixed CI failure's log → must NOT log."""
+        result = am.check(
+            _bash_event(
+                "gh run view 30511078888 --repo noorinalabs/noorinalabs-main "
+                "--log-failed 2>&1 | tail -c 8000",
+                stdout=self._CI_LOG_TEXT,
+                exit_code=0,
+            )
+        )
+        self.assertIsNone(result, "gh run view --log-failed of a fixed CI failure must not log")
+        self.assertEqual(_read_records(self._errors_path), [])
+
+    def test_harvested_208_rg_over_saved_tool_results_log_not_logged(self):
+        """errors.jsonl record #208: `rg -n "FAILED|ERROR|..." <saved
+        tool-results log path> | tail -150` re-reading the same CI log →
+        must NOT log."""
+        result = am.check(
+            _bash_event(
+                'rg -n "FAILED|ERROR|assert|passed|failed" '
+                "/home/parameterization/.claude/projects/-home-parameterization-code-"
+                "noorinalabs-main/7df975c7-69e0-47a1-924a-56c4dba896fe/tool-results/"
+                "b5z8thhyg.txt | tail -150",
+                stdout=self._CI_LOG_TEXT,
+                exit_code=0,
+            )
+        )
+        self.assertIsNone(result, "rg over a saved log re-reading a known failure must not log")
+
+    def test_harvested_209_rg_over_saved_log_second_query_not_logged(self):
+        """errors.jsonl record #209: a second `rg` re-read of the same saved
+        log with a different search pattern → must NOT log."""
+        result = am.check(
+            _bash_event(
+                'rg -n "b290d611|CalledProcessError|fatal:|bad object|checkout|'
+                'fetch-depth|actions/checkout" '
+                "/home/parameterization/.claude/projects/-home-parameterization-code-"
+                "noorinalabs-main/7df975c7-69e0-47a1-924a-56c4dba896fe/tool-results/"
+                "b5z8thhyg.txt",
+                stdout=self._CI_LOG_TEXT,
+                exit_code=0,
+            )
+        )
+        self.assertIsNone(result)
+
+    # --- Acceptance criteria (issue #1354) additional verb/shape coverage ---
+
+    def test_gh_run_log_verb_not_logged(self):
+        """`gh run log` (the log-download variant, no `view` subcommand) is
+        the same idiom as `gh run view --log-failed` → must not log."""
+        result = am.check(
+            _bash_event(
+                "gh run log 30511078888 --repo noorinalabs/noorinalabs-main 2>&1 | tail -c 8000",
+                stdout="FAILED tests/test_x.py::test_one - Traceback (most recent call last):\n",
+                exit_code=0,
+            )
+        )
+        self.assertIsNone(result)
+
+    def test_gh_api_actions_runs_logs_not_logged(self):
+        """`gh api .../actions/runs/<id>/logs` — the raw-logs REST read — is
+        the CI-log-read analog of the existing `contents/` allowance."""
+        result = am.check(
+            _bash_event(
+                "gh api repos/noorinalabs/noorinalabs-main/actions/runs/30511078888/logs "
+                "> /tmp/run.zip",
+                stdout="Traceback (most recent call last):\n",
+                exit_code=0,
+            )
+        )
+        self.assertIsNone(result)
+
+    # --- Regression guards: must NOT fail-open on the incidents this fix touches ---
+
+    def test_cat_missing_file_2ampersand1_probe_shape_still_not_content_display(self):
+        """#517 regression guard (AC): a `2>&1` disqualifies the *generic*
+        content-display verbs exactly as before — `cat missing.py 2>&1 |
+        head` is still not classified as content-display by this helper (it
+        is left to the probe-with-fallback classifier, unaffected by this
+        fix's scoped `2>&1` exemption for `gh run view`/`gh run log`)."""
+        self.assertFalse(
+            am._is_content_display(
+                'cat script.py 2>&1 | head -50 || echo "no script"',
+                exit_code=0,
+                matched_patterns=["stdout:Traceback \\(most recent call last\\)"],
+            )
+        )
+
+    def test_gh_pr_view_2ampersand1_still_disqualified(self):
+        """The `2>&1` exemption is scoped to `gh run view`/`gh run log`
+        specifically — `gh pr view ... 2>&1` (not a log-read verb) is still
+        disqualified by the stdout-merge guard, deferring to the probe
+        classifier like every other non-log-read display verb."""
+        self.assertFalse(
+            am._is_content_display(
+                "gh pr view 1185 --repo o/r --json body 2>&1 | head -100",
+                exit_code=0,
+                matched_patterns=["stdout:Traceback \\(most recent call last\\)"],
+            )
+        )
+
+    def test_gh_run_view_genuine_failure_nonzero_exit_still_logged(self):
+        """A `gh run view` that itself fails (bad run id, network error —
+        nonzero exit) is a real failure, not a content display → must still
+        log (content-display requires exit_code == 0)."""
+        result = am.check(
+            _bash_event(
+                "gh run view 99999999 --repo noorinalabs/noorinalabs-main "
+                "--log-failed 2>&1 | tail -c 8000",
+                stdout="failed to get run: run not found\n",
+                exit_code=1,
+            )
+        )
+        self.assertIsNotNone(result, "a genuinely failed gh run view must still log")
+
+    def test_rg_over_log_with_stderr_pattern_still_logged(self):
+        """`rg` over a saved log with a real stderr signal alongside (e.g. an
+        `rg` invocation that also emits a permission error) still logs — the
+        skip requires EVERY matched pattern to be a stdout one."""
+        result = am.check(
+            _bash_event(
+                'rg -n "FAILED" /tmp/some/saved.log',
+                stdout="FAILED tests/test_x.py::test_one\n",
+                stderr="fatal: something genuinely broke\n",
+                exit_code=0,
+            )
+        )
+        self.assertIsNotNone(result, "a real stderr pattern must still log even for rg reads")
+
+    def test_strong_masked_failure_git_push_still_captured_high(self):
+        """AC: the genuine exit-0-failure carve-out (`git push | tail` hiding
+        a REJECTED push) is unaffected by this fix — still captured at
+        confidence=high, category=masked-failure."""
+        result = am.check(
+            _bash_event(
+                "git push origin N.Hakim/x 2>&1 | tail -3",
+                stdout=(
+                    " ! [rejected]        N.Hakim/x -> N.Hakim/x (non-fast-forward)\n"
+                    "error: failed to push some refs\n"
+                ),
+                exit_code=0,
+            )
+        )
+        self.assertIsNotNone(result, "a genuine pipe-masked push rejection must still log")
+        rec = _read_records(self._errors_path)[0]
+        self.assertEqual(rec["confidence"], "high")
+        self.assertEqual(rec["category"], "masked-failure")
+
+    # --- Direct unit tests on the helper ---
+
+    def test_helper_true_on_gh_run_view_log_failed_with_2ampersand1(self):
+        """Direct unit: `gh run view --log-failed 2>&1 | tail` + stdout-only
+        match → True (the core #1354 fix)."""
+        self.assertTrue(
+            am._is_content_display(
+                "gh run view 123 --repo o/r --log-failed 2>&1 | tail -c 8000",
+                exit_code=0,
+                matched_patterns=["stdout:exit status [1-9]"],
+            )
+        )
+
+    def test_helper_true_on_gh_run_log(self):
+        """Direct unit: `gh run log` (no `2>&1`) + stdout-only match → True."""
+        self.assertTrue(
+            am._is_content_display(
+                "gh run log 123 --repo o/r",
+                exit_code=0,
+                matched_patterns=["stdout:Traceback \\(most recent call last\\)"],
+            )
+        )
+
+    def test_helper_true_on_rg_over_a_file(self):
+        """Direct unit: `rg` reading a saved log file + stdout-only match →
+        True (generalizes the errors.jsonl self-referential guard to any
+        file, per the issue's proposed fix #3)."""
+        self.assertTrue(
+            am._is_content_display(
+                'rg -n "FAILED" /tmp/saved.log',
+                exit_code=0,
+                matched_patterns=["stdout:^FAILED"],
+            )
+        )
+
+    def test_helper_true_on_gh_api_actions_logs(self):
+        """Direct unit: `gh api .../actions/runs/<id>/logs` → True."""
+        self.assertTrue(
+            am._is_content_display(
+                "gh api repos/o/r/actions/runs/123/logs",
+                exit_code=0,
+                matched_patterns=["stdout:Traceback \\(most recent call last\\)"],
+            )
+        )
+
+
 if __name__ == "__main__":
     # `unittest.main()` would silently skip TestSilentBooleanIdiom (a plain
     # pytest class, not unittest.TestCase — see its docstring) when this file


### PR DESCRIPTION
## Summary

`_is_content_display` recognized `cat`/`head`/`tail`/`git show`/`gh pr view` as "displaying content, not failing" but not `gh run view --log-failed` / `gh run log` or an `rg` re-read of a saved log — the two things anyone actually uses to diagnose a CI failure. Investigating an already-fixed CI failure was therefore captured as a *fresh* error, at `confidence: "high"` / `category: "masked-failure"` — the monitor's highest-trust class.

Closes #1354.

## Harvested pre-fix false records (from the live `.claude/annunaki/errors.jsonl`)

**Correction (post merge-gate review):** the issue's "17" is correct and reproduces exactly — the earlier revision of this section wrongly said it wasn't reproducible. Nino Kavtaradze cut the log at `2026-08-04T01:28:00` (immediately before the wave-29 retro's own harvest record; #1354 was filed at `01:36:39`) and counted monitor-class `confidence=high` records carrying the issue's stated `error_lines` signature (`CalledProcessError` + `b290d611` + `wave_status`):

```python
import json
recs = [json.loads(l) for l in open(".claude/annunaki/errors.jsonl", encoding="utf-8") if l.strip()]
blob = lambda r: "\n".join(r.get("error_lines", [])) + "\n" + (r.get("stderr_excerpt") or "")
sig  = lambda r: all(s in blob(r) for s in ("CalledProcessError", "b290d611", "wave_status"))
at   = [r for r in recs if r.get("timestamp", "") <= "2026-08-04T01:28:00"]
hi   = [r for r in at if r.get("hook") == "annunaki_monitor" and r.get("confidence") == "high"]
print(len([r for r in hi if sig(r)]), "/", len(hi))   # -> 17 / 52
```

`17 / 52`, exact on both numerator and denominator — I re-ran this myself and got the same result. The log was never pruned; its earliest record is `2026-07-27T02:17:38Z`, three days before the incident.

The gap in the original PR description was a **measurement-method difference**, not missing data: #1354 defines its 17 by an `error_lines` **signature** match; I originally searched by **command shape** and found only the 3 CI-log-read commands below. That command-shape set is the *correct* set for this fix (it's exactly what `_is_content_display` can reach), but it was the *wrong* set to report as "the issue's 17" — all 17 are present in the log, and 3 of them are the fixable shapes:

| # | timestamp | command | pre-fix result |
|---|---|---|---|
| 206 | 2026-07-30T03:27:36Z | `gh run view 30511078888 --repo noorinalabs/noorinalabs-main --log-failed 2>&1 \| tail -c 8000` | logged, `confidence=high`, `category=masked-failure` |
| 208 | 2026-07-30T03:28:11Z | `rg -n "FAILED\|ERROR\|assert\|passed\|failed" <saved tool-results log> \| tail -150` | logged, `confidence=high`, `category=masked-failure` |
| 209 | 2026-07-30T03:28:22Z | `rg -n "b290d611\|CalledProcessError\|fatal:\|bad object\|checkout\|fetch-depth\|actions/checkout" <same saved log>` | logged, `confidence=high`, `category=masked-failure` |

All three are harvested verbatim as regression fixtures (`Issue1354CiLogReadTests.test_harvested_206_*` / `_208_*` / `_209_*`) — command text and replayed `error_lines` content taken directly from the log.

The remaining **14** of the 17 are echoes in command shapes `_is_content_display` cannot reach by design — a leading `cd .../ &&` or `VAR=... &&` setup prefix (the leading-verb anchor is intentional, see the module docstring's "Leading-verb match is anchored" note), a heredoc, and a `gh pr view ... 2>&1 | head` quoting a review comment that happens to echo the failure text. This is #1354's own proposed-fix item 4 (collapsing repeat-echo signatures at read/triage time), which the issue explicitly scopes out of the monitor itself. Nino filed **#1398** to track it so it isn't lost when this PR closes #1354.

## Pre-fix failure output (acceptance bar: a test that FAILS against pre-fix code)

Ran the new `Issue1354CiLogReadTests` class against the pre-fix `_is_content_display`/`CONTENT_DISPLAY_VERBS` (checked out at `main`, before this PR's first commit touching `annunaki_monitor.py`). Nino independently reproduced this exact split test-for-test during merge-gate review.

```
collected 14 items

test_cat_missing_file_2ampersand1_probe_shape_still_not_content_display PASSED   [regression guard — already correct pre-fix]
test_gh_api_actions_runs_logs_not_logged                                FAILED
test_gh_pr_view_2ampersand1_still_disqualified                          PASSED   [regression guard — already correct pre-fix]
test_gh_run_log_verb_not_logged                                         FAILED
test_gh_run_view_genuine_failure_nonzero_exit_still_logged              PASSED   [regression guard — already correct pre-fix]
test_harvested_206_gh_run_view_log_failed_not_logged                    FAILED
test_harvested_208_rg_over_saved_tool_results_log_not_logged            FAILED
test_harvested_209_rg_over_saved_log_second_query_not_logged            FAILED
test_helper_true_on_gh_api_actions_logs                                 FAILED
test_helper_true_on_gh_run_log                                          FAILED
test_helper_true_on_gh_run_view_log_failed_with_2ampersand1             FAILED
test_helper_true_on_rg_over_a_file                                      FAILED
test_rg_over_log_with_stderr_pattern_still_logged                       PASSED   [regression guard — already correct pre-fix]
test_strong_masked_failure_git_push_still_captured_high                 PASSED   [regression guard — already correct pre-fix]

9 failed, 5 passed in 0.39s
```

Representative failure (the harvested #206 fixture — `gh run view --log-failed` of the fixed CI failure was captured as a fresh error):

```
    def test_harvested_206_gh_run_view_log_failed_not_logged(self):
        result = am.check(
            _bash_event(
                "gh run view 30511078888 --repo noorinalabs/noorinalabs-main "
                "--log-failed 2>&1 | tail -c 8000",
                stdout=self._CI_LOG_TEXT,
                exit_code=0,
            )
        )
>       self.assertIsNone(result, "gh run view --log-failed of a fixed CI failure must not log")
E       AssertionError: {'action': 'logged', 'dedup_hash': '14ba125b90d762fee3ff0ace32eea399', 'confidence': 'high', 'category': 'masked-failure'} is not None : gh run view --log-failed of a fixed CI failure must not log
```

The 5 pre-existing-pass cases are the regression guards this PR must *not* break (the #517 probe-with-fallback shape, `gh pr view ...2>&1` staying disqualified, a genuinely-failed bare `gh run view`, an `rg` read with a real stderr signal, and the `git push | tail` REJECTED-push carve-out) — they already passed pre-fix and confirm the new test class isn't just trivially green.

## Fix

- `.claude/hooks/annunaki_monitor.py`:
  - `CONTENT_DISPLAY_VERBS` gains `rg`, `gh run view`, `gh run log`.
  - New `CONTENT_DISPLAY_GH_API_LOGS` for `gh api .../actions/runs/<id>/logs` (the REST analog of the existing `contents/...` allowance).
  - New `CONTENT_DISPLAY_LOG_READ_VERBS` (`gh run view`/`gh run log`) scopes the `2>&1` disqualifier away from those two verbs specifically.
  - Doc comments (module docstring + inline `check()` comment) updated to describe the new class.

### Corrected rationale for the `2>&1` exemption (MF2 — the original rationale was wrong about the shell)

The original comment/PR-body claimed the exemption is safe because "a bad run id or network failure surfaces as a real nonzero exit, which the `exit_code != 0` guard already catches." **Measured live, that's false for the piped canonical form:**

```
$ gh run view 99999999 --repo noorinalabs/noorinalabs-main --log-failed 2>&1 | tail -c 8000
failed to get run: HTTP 404: Not Found (https://api.github.com/repos/.../actions/runs/99999999?...)
$ echo $?
0
```

There's no `pipefail` in this shell, so the observed exit code is `tail`'s (0), not `gh`'s. For `gh run view --log-failed 2>&1 | tail -c N` — the form the comment itself calls canonical, and the one every harvested fixture uses — the `exit_code != 0` guard cannot be what makes this safe.

The exemption is still accepted, for the real reason: a failing `gh run view` emits either (a) gh's own "failed to get run: HTTP 404: ..." text, which trips **no** `ERROR_PATTERNS` entry at all (dropped identically pre- and post-fix — the common case, unchanged), or (b) text that does match a pattern (e.g. "error connecting to api.github.com" on a network failure), which pre-fix landed at `confidence=low`/`category=pipe-mask-suspect` — already excluded from `annunaki_parse`'s genuine-error count — and post-fix is dropped entirely. The loss is confined to uncounted forensic records; no `confidence=high` shape is lost. The `CONTENT_DISPLAY_LOG_READ_VERBS` comment now states this, and `test_gh_run_view_piped_failure_no_pipefail_uncounted_drop` pins the actual (shell-realistic) behavior. The previous `test_gh_run_view_genuine_failure_nonzero_exit_still_logged` used a piped command with `exit_code=1` — a combination this shell cannot produce — so it was relabeled `test_gh_run_view_bare_nonzero_exit_still_logged` with the pipe removed: it correctly guards the `exit_code != 0` short-circuit at the top of `_is_content_display`, just not the `2>&1` exemption specifically.

## Acceptance criteria (from the issue)

- [x] `gh run view <id> --repo <r> --log-failed 2>&1 | tail -c 8000` over a log containing `Traceback` writes no record — `test_harvested_206_*`.
- [x] `rg -n "FAILED" <path-to-saved-log>` writes no record — `test_harvested_208_*` / `test_harvested_209_*` / `test_helper_true_on_rg_over_a_file`.
- [x] The `2>&1` disqualifier still fires for genuine probe-with-fallback shapes (`cat missing.py 2>&1 | head`) — no fail-open regression on #517: `test_cat_missing_file_2ampersand1_probe_shape_still_not_content_display`.
- [x] A genuine pipe-masked failure (`git push | tail` hiding a REJECTED push) is still captured at `confidence: high` — `test_strong_masked_failure_git_push_still_captured_high`.
- [x] The wave-29 records are a regression fixture — **all 17 are present in the live log** (verified: 17/52 by `error_lines` signature, exact); 3 are in the two command shapes `_is_content_display` can reach and are harvested as fixtures above; the other 14 are echoes in shapes the monitor cannot reach by design (leading `cd`/`VAR=` prefixes, heredocs, a `gh pr view ... 2>&1 | head` quoting a comment) — #1354's own proposed-fix item 4, explicitly scoped out, tracked separately at #1398.

## Testing

- `ENVIRONMENT=test PYTHONPATH=.claude/hooks python3 -m pytest .claude/hooks/tests/test_annunaki_monitor.py -v` → 101 passed (16 in `Issue1354CiLogReadTests` — 14 original + 2 added addressing MF2 — all pre-existing tests unaffected).
- `ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/ .claude/lib/tests/ -q` → full suite green.
- `ruff format --check`, `ruff check`, `mypy` on the two changed files → clean.
- Full local⇄CI parity: `pre-commit run` (commit stage) and `pre-commit run --hook-stage push` (mypy + full pytest + memory/headcount budgets + doc-freshness + office-drift + mermaid-render) → all green.
- Nino Kavtaradze's merge-gate review independently replayed all 1158 live `errors.jsonl` records through both classifiers: 13 newly suppressed by adding `rg` (1.1%), zero reverse regressions, all 13 confirmed genuine content reads. Also ran 7 mutations on the new code; 4 killed, 2 survived (tracked non-blocking at #1397 — the No-such-file guard's log-read-verb bypass and the `^\s*` anchor on `CONTENT_DISPLAY_LOG_READ_VERBS`).

## Note on framing (issue's own callout, preserved)

Per the issue: the wave-29 triage brief characterized the 52 `annunaki_monitor` records as "the monitor itself erroring." They are not — `hook: annunaki_monitor` is the writer attribution; every one is `exit_code: 0` / a real capture. 35 of the 52 are the monitor working correctly. This PR only touches the content-display false-positive subclass.

## Non-blocking follow-ups filed during merge-gate review

- **#1397** — two mutation survivors in the new code (behavior is probably correct; should be a stated decision rather than an implicit one).
- **#1398** — the 14 residual wave-29 echoes in command shapes this fix cannot reach (#1354's own scoped-out item 4).
