### PR TITLE
fix(#1350): terminate the review-comment path token at shell metacharacters

### DIFF
--- a/.claude/hooks/tests/test_validate_review_comment_format.py
+++ b/.claude/hooks/tests/test_validate_review_comment_format.py
@@ -23,6 +23,8 @@ Run: python3 -m unittest discover -s .claude/hooks/tests \
 
 from __future__ import annotations
 
+import json
+import re
 import sys
 import tempfile
 import unittest
@@ -1274,6 +1276,254 @@ class ConditionalFieldEndToEndTests(unittest.TestCase):
             if v.false_positive:
                 sig.review_false_positives += 1
         self.assertEqual(sig.review_false_positives, 1)
+
+
+class PathTokenBoundaryTests(unittest.TestCase):
+    """#1350: the bare path alternative must stop at shell metacharacters.
+
+    `_PATH_TOKEN`'s bare branch was `\\S+`, which stops only at whitespace, and
+    the three write-detection regexes each carried their own copy of it. Every
+    case below FAILS against `6c42709` (pre-fix); none is harvested from a log,
+    they are derived from the tokenizer's own boundary.
+
+    Both directions are pinned, because the token is consumed on both sides of
+    a gate:
+
+      fail-CLOSED  the operand of `--body-file` / `--input` / `body=@` — a glued
+                   `;` makes the hook seek `verdict.md;`, find nothing, and hard
+                   block a conforming charter verdict.
+
+      fail-OPEN    the target of a redirect, read by `_unmodelled_write`. That
+                   guard exists so a write the composer cannot model HARD BLOCKS
+                   instead of falling back to a stale disk read. A glued `;` made
+                   the guard fail to recognise its own path, and `check()`
+                   ALLOWED a command that overwrites the posted payload. This is
+                   the more serious half and was NOT in the filed report.
+
+    `;` is the load-bearing separator: `&&` and `|` are conventionally spaced,
+    `;` is conventionally not, and it is *structurally required* by the
+    `until …; done; gh pr comment …` shape a reviewer uses to defer a verdict
+    past a GraphQL rate limit.
+    """
+
+    VERDICT = (
+        "Looks good.\n\n"
+        "---\n"
+        "Requestor: Nino Kavtaradze\n"
+        "Requestee: Aino Virtanen\n"
+        "RequestOrReplied: Approved\n"
+        "TechDebt: none\n"
+    )
+
+    # A REPLY-direction body. Used as the *stale* disk content in the fail-open
+    # fixture: if the hook wrongly reads it, `_direction_is_verdict` is False
+    # and check() returns None — an ALLOW — with no network call. That makes
+    # the fail-open observable hermetically.
+    STALE_REPLY = (
+        "Thanks.\n\n"
+        "---\n"
+        "Requestor: Nino Kavtaradze\n"
+        "Requestee: Aino Virtanen\n"
+        "RequestOrReplied: Reply\n"
+        "TechDebt: none\n"
+    )
+
+    def _verdict_file(self, td: str, name: str = "verdict.md") -> Path:
+        path = Path(td) / name
+        path.write_text(self.VERDICT)
+        return path
+
+    # ---- fail-CLOSED: separator glued to the flag operand -------------------
+
+    def test_body_file_with_glued_semicolon_is_read(self):
+        """`--body-file X.md; echo done` — the issue headline.
+
+        Pre-fix the path token was `X.md;`, the read failed, and check()
+        blocked with `Cause: \\`…/verdict.md;\\` does not exist`.
+        """
+        with tempfile.TemporaryDirectory() as td:
+            path = self._verdict_file(td)
+            cmd = f"gh pr comment 42 --repo o/r --body-file {path}; echo done"
+            self.assertEqual(hook.extract_comment_body(cmd), self.VERDICT)
+
+    def test_body_file_with_glued_ampersand_is_read(self):
+        """Backgrounding glues `&` to the path exactly as `;` does."""
+        with tempfile.TemporaryDirectory() as td:
+            path = self._verdict_file(td)
+            cmd = f"gh pr comment 42 --repo o/r --body-file {path}& echo done"
+            self.assertEqual(hook.extract_comment_body(cmd), self.VERDICT)
+
+    def test_deferred_post_shape_from_wave29_is_read(self):
+        """The live annunaki shape (2026-07-28T00:19:33Z), issue #1350.
+
+        A reviewer waiting out a GraphQL rate limit before posting. The `;`
+        after the body path is required by the `until … done; <cmd>` grammar,
+        so there is no style workaround: pre-fix this verdict simply could not
+        be posted.
+        """
+        with tempfile.TemporaryDirectory() as td:
+            path = self._verdict_file(td, "verdict1156b.md")
+            cmd = (
+                "nohup sh -c 'until [ \"$(gh api rate_limit "
+                '-q .resources.graphql.remaining)" -gt 100 ]; do sleep 60; done; '
+                f"gh pr comment 1156 --repo noorinalabs/noorinalabs-main --body-file {path}; "
+                "echo posted' >/dev/null 2>&1 &"
+            )
+            self.assertTrue(hook.is_comment_command(cmd))
+            self.assertEqual(hook.extract_comment_body(cmd), self.VERDICT)
+
+    def test_rest_input_with_glued_semicolon_is_read(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "payload.json"
+            path.write_text(json.dumps({"body": self.VERDICT}))
+            cmd = f"gh api -X POST repos/o/r/issues/42/comments --input {path}; echo done"
+            self.assertEqual(hook.extract_rest_comment_body(cmd), self.VERDICT)
+
+    def test_rest_input_inside_command_substitution_is_read(self):
+        """`URL=$(gh api … --input payload.json)` — the `)` is glued.
+
+        `_split_segments` already unwraps `$(` for the *matcher*; body
+        extraction runs on the raw command, so the closing paren reached the
+        path token.
+        """
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "payload.json"
+            path.write_text(json.dumps({"body": self.VERDICT}))
+            cmd = f"URL=$(gh api -X POST repos/o/r/issues/42/comments --input {path})"
+            self.assertEqual(hook.extract_rest_comment_body(cmd), self.VERDICT)
+
+    def test_rest_field_at_path_with_glued_semicolon_is_read(self):
+        """`-F body=@X.md;` — the fourth consumer, the bare `body=` value."""
+        with tempfile.TemporaryDirectory() as td:
+            path = self._verdict_file(td)
+            cmd = f"gh api -X POST repos/o/r/issues/42/comments -F body=@{path}; echo done"
+            self.assertEqual(hook.extract_rest_comment_body(cmd), self.VERDICT)
+
+    # ---- fail-OPEN: separator glued to a redirect target --------------------
+
+    def _stale_payload(self, td: str) -> Path:
+        path = Path(td) / "payload.json"
+        path.write_text(json.dumps({"body": self.STALE_REPLY}))
+        return path
+
+    def test_unmodelled_write_still_detected_when_semicolon_glued(self):
+        """`jq … > payload.json; gh api … --input payload.json`.
+
+        Pre-fix `_REDIRECT_WRITE_RE` captured `payload.json;` and compared it
+        against the posted `payload.json`: different strings, so the guard
+        reported no unmodelled write and licensed the disk fallback.
+        """
+        with tempfile.TemporaryDirectory() as td:
+            path = self._stale_payload(td)
+            cmd = (
+                f"jq -Rs '{{body: .}}' src.md > {path}; "
+                f"gh api -X POST repos/o/r/issues/42/comments --input {path}"
+            )
+            self.assertIsNotNone(hook._unmodelled_write(cmd, str(path)))
+
+    def test_unmodelled_write_still_detected_inside_subshell(self):
+        """A `)` closing a subshell glues to the redirect target the same way."""
+        with tempfile.TemporaryDirectory() as td:
+            path = self._stale_payload(td)
+            cmd = (
+                f"(jq -Rs '{{body: .}}' src.md > {path}) && "
+                f"gh api -X POST repos/o/r/issues/42/comments --input {path}"
+            )
+            self.assertIsNotNone(hook._unmodelled_write(cmd, str(path)))
+
+    def test_unmodelled_tee_still_detected_when_semicolon_glued(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = self._stale_payload(td)
+            cmd = (
+                f"printf x | tee {path}; gh api -X POST repos/o/r/issues/42/comments --input {path}"
+            )
+            self.assertIsNotNone(hook._unmodelled_write(cmd, str(path)))
+
+    def test_check_blocks_glued_jq_write_instead_of_reading_stale_disk(self):
+        """End-to-end: the fail-open, at the decision boundary.
+
+        A conforming-but-STALE `payload.json` sits on disk; the command is
+        about to overwrite it with `jq` output the hook cannot derive. Pre-fix
+        check() returned None — it validated the stale file and ALLOWED a
+        comment it had never seen. It must block.
+        """
+        with tempfile.TemporaryDirectory() as td:
+            path = self._stale_payload(td)
+            cmd = (
+                f"jq -Rs '{{body: .}}' src.md > {path}; "
+                f"gh api -X POST repos/o/r/issues/42/comments --input {path}"
+            )
+            result = hook.check(_bash_input(cmd))
+            assert result is not None, "fail-open: stale disk body was validated and allowed"
+            self.assertEqual(result["decision"], "block")
+            self.assertIn("cannot be read", result["reason"])
+
+    def test_heredoc_write_still_composed_when_semicolon_glued(self):
+        """The heredoc composer shares the token; pin its boundary too.
+
+        `cat > v.md <<'EOF' … EOF; gh pr comment … --body-file v.md` — the
+        heredoc target is followed by `<<`, so this one was already safe by
+        backtracking, but it now stops at the metacharacter directly.
+        """
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "v.md"
+            cmd = (
+                f"cat > {path} <<'EOF'\n"
+                f"{self.VERDICT}EOF\n"
+                f"gh pr comment 42 --repo o/r --body-file {path}; echo done"
+            )
+            self.assertEqual(hook.extract_comment_body(cmd), self.VERDICT)
+
+    # ---- no regression on the quoted branches or on the fail-closed floor ---
+
+    def test_quoted_path_containing_literal_semicolon_still_wins(self):
+        """Acceptance criterion: the quoted alternatives must keep winning.
+
+        Narrowing the BARE branch must not narrow the quoted ones — a path
+        legitimately containing `;` is expressible only by quoting it.
+        """
+        with tempfile.TemporaryDirectory() as td:
+            path = self._verdict_file(td, "has;semi.md")
+            cmd = f"gh pr comment 42 --repo o/r --body-file '{path}'"
+            self.assertEqual(hook.extract_comment_body(cmd), self.VERDICT)
+
+    def test_double_quoted_path_containing_literal_semicolon_still_wins(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = self._verdict_file(td, "has;semi.md")
+            cmd = f'gh pr comment 42 --repo o/r --body-file "{path}"'
+            self.assertEqual(hook.extract_comment_body(cmd), self.VERDICT)
+
+    def test_genuinely_missing_path_still_blocks(self):
+        """Acceptance criterion: no fail-open regression.
+
+        Widening what counts as a path must not turn an unreadable body into
+        an allow — that branch is the whole point of #932.
+        """
+        cmd = "gh pr comment 42 --repo o/r --body-file /nonexistent-1350/verdict.md; echo done"
+        result = hook.check(_bash_input(cmd))
+        assert result is not None
+        self.assertEqual(result["decision"], "block")
+
+    def test_bare_token_rejects_shell_metacharacters(self):
+        """Pin the class itself, so a future edit that reintroduces `\\S+` reds.
+
+        A token that matches a metacharacter is the defect, independent of any
+        one call site.
+        """
+        bare = re.compile(hook._BARE_PATH_TOKEN)
+        for meta in (";", "&", "|", "(", ")", "<", ">", "`", " "):
+            with self.subTest(meta=meta):
+                match = bare.match(f"verdict.md{meta}tail")
+                assert match is not None
+                self.assertEqual(match.group(0), "verdict.md")
+        # `$` and quotes must NOT terminate: env expansion and the trailing
+        # quote of an enclosing `sh -c '…'` both depend on them being consumed
+        # and then handled by `_resolve_body_path`.
+        for kept in ("$", "'", '"'):
+            with self.subTest(kept=kept):
+                match = bare.match(f"verdict.md{kept}x")
+                assert match is not None
+                self.assertEqual(match.group(0), f"verdict.md{kept}x")
 
 
 if __name__ == "__main__":

--- a/.claude/hooks/validate_review_comment_format.py
+++ b/.claude/hooks/validate_review_comment_format.py
@@ -107,6 +107,39 @@ rather than warning. That branch was an advisory, and advisories decay
 five PRs and nine uncountable verdicts. The diagnostic names the remedy:
 write the body to a file and pass a literal `--body-file` path.
 
+Path tokenization (closes #1350)
+================================
+
+Every path above is cut out of the command string by ONE token,
+`_PATH_TOKEN`. Its bare branch was `\\S+` — stop at whitespace — and the three
+write-detection regexes each inlined their own copy of it. `;` is the one
+shell separator convention does NOT space out, so it was routinely glued onto
+the filename, and that single character broke the hook in both directions at
+once:
+
+  fail-CLOSED  `gh pr comment N --body-file verdict.md; echo done` sought
+               `verdict.md;`, found nothing, and hard-blocked a conforming
+               verdict — the charter-prescribed form, in the shape a reviewer
+               is FORCED into when deferring a post past a GraphQL rate limit
+               (`until …; done; gh pr comment …`). No workaround exists there:
+               the `;` is grammar, not style.
+
+  fail-OPEN    `_unmodelled_write` compares a redirect target against the
+               posted path so that an underivable write HARD BLOCKS instead of
+               falling back to a stale disk read. Both sides carried the same
+               tokenizer defect at different offsets, so on
+               `jq … > payload.json; gh api … --input payload.json` one side
+               kept the `;` and the other did not, the guard concluded "not my
+               file", and `check()` ALLOWED — validating a stale `payload.json`
+               while the command overwrote it. The #934 fail-open, reopened by
+               one character of punctuation.
+
+The token now terminates at the characters that terminate an unquoted shell
+word, and all five consumers share the one definition. The two failure
+directions are the argument; the observed counts are not (`feedback_
+passing_repro_masks_bug` — one glued separator is sufficient). See
+`PathTokenBoundaryTests`, every case of which fails against `6c42709`.
+
 Scope boundary: this hook gates comment *creation*, never comment *edits*
 ========================================================================
 
@@ -300,10 +333,47 @@ def extract_pr_number(command: str) -> str | None:
     return None
 
 
+# Characters that TERMINATE an unquoted shell word. A path containing any of
+# these must be quoted or backslash-escaped to survive the shell at all, so a
+# bare token can never legitimately contain one — consuming it into the filename
+# is wrong by construction, not by frequency (#1350).
+#
+# The bare branch was `\S+`, which stops only at whitespace, and every consumer
+# below inherited that. Both failure directions were reproduced on `6c42709`:
+#
+#   fail-CLOSED  `gh pr comment N --body-file verdict.md; echo done` — the
+#                charter-prescribed form — sought `verdict.md;`, found nothing,
+#                and hard-blocked a conforming verdict. `;` is the one separator
+#                shell convention does NOT space out, and it is *structurally
+#                required* by the deferred-post shape a reviewer uses to wait out
+#                a GraphQL rate limit (`until …; done; gh pr comment …`), which
+#                is how this reached the wave-29 annunaki log. Same for `&`
+#                (background) and the `)` closing a `$(…)` or a subshell.
+#
+#   fail-OPEN    worse, and not in the filed report. `_unmodelled_write` exists
+#                so that a write to the posted path the composer cannot model
+#                HARD BLOCKS instead of falling back to a stale disk read. Its
+#                target token had the same `\S+` bare branch, so on
+#                `jq -Rs '{body: .}' x.md > payload.json; gh api … --input
+#                payload.json` the guard compared `payload.json;` against
+#                `payload.json`, did not recognise its own path, and returned
+#                "no unmodelled write". `_body_for_path` then read whatever
+#                stale `payload.json` was on disk and `check()` ALLOWED — the
+#                hook validating one body while the command posts another. That
+#                is precisely the fail-open #934 built this guard to close,
+#                reopened by one character of punctuation.
+#
+# `$` stays IN the class: `-F body=@"$CLAUDE_JOB_DIR/tmp/x.md"` must keep
+# expanding (`_resolve_body_path`). Quote characters also stay in, because
+# `_resolve_body_path` strips them and a trailing `'` from an enclosing
+# `sh -c '…'` must not truncate the path.
+_BARE_PATH_TOKEN = r"[^\s;&|()<>`]+"
+
 # A path as written on a command line: single-quoted, double-quoted, or bare.
-# The quoted alternatives come first so a quoted path containing a space is not
-# truncated at the space by the bare `\S+` branch (#934 review, Wanjiku Mwangi).
-_PATH_TOKEN = r"'[^']*'|\"[^\"]*\"|\S+"
+# The quoted alternatives come first so a quoted path containing a space — or a
+# literal `;` — is not truncated by the bare branch (#934 review, Wanjiku
+# Mwangi; #1350).
+_PATH_TOKEN = r"'[^']*'|\"[^\"]*\"|" + _BARE_PATH_TOKEN
 
 
 def _resolve_body_path(path: str) -> str:
@@ -353,7 +423,7 @@ def _read_body_file(path: str) -> str | None:
 # `<<-EOF`. The delimiter is backreferenced so the body ends at its own terminator.
 # `op` distinguishes truncate (`>`) from append (`>>`) — see `_heredoc_written_body`.
 _HEREDOC_WRITE_RE = re.compile(
-    r"(?P<op>>{1,2})\s*(?P<target>'[^']*'|\"[^\"]*\"|\S+)"
+    r"(?P<op>>{1,2})\s*(?P<target>" + _PATH_TOKEN + r")"
     r"\s*<<-?\s*(?P<quote>['\"]?)(?P<delim>[A-Za-z_][A-Za-z0-9_]*)(?P=quote)[ \t]*\n"
     r"(?P<body>.*?)"
     r"\n(?P=delim)[ \t]*(?:\n|$)",
@@ -365,8 +435,15 @@ _HEREDOC_WRITE_RE = re.compile(
 # posted path that `_HEREDOC_WRITE_RE` does NOT model — `printf … >> f`,
 # `echo … >> f`, `cat note.md >> f`, `jq … > payload.json`, `cat <<'EOF' > f`
 # (redirect after the heredoc), `tee f <<'EOF'`. See `_unmodelled_write`.
-_REDIRECT_WRITE_RE = re.compile(r">>?\s*('[^']*'|\"[^\"]*\"|\S+)")
-_TEE_WRITE_RE = re.compile(r"\btee\s+(?:-a\s+)?('[^']*'|\"[^\"]*\"|\S+)")
+#
+# Both share `_PATH_TOKEN` (#1350). They previously carried their own inline
+# copies of the same alternation, and those copies are what made the fail-open
+# above possible: the guard that compares a write target against the posted path
+# tokenized the two sides with the same defect but at different offsets, so one
+# side kept a glued `;`/`)` and the other did not, and the comparison silently
+# said "different file". Same rule, one definition.
+_REDIRECT_WRITE_RE = re.compile(r">>?\s*(" + _PATH_TOKEN + r")")
+_TEE_WRITE_RE = re.compile(r"\btee\s+(?:-a\s+)?(" + _PATH_TOKEN + r")")
 
 
 class _Unreconstructable:
@@ -561,9 +638,14 @@ def extract_rest_comment_body(command: str) -> str | None:
         if path.strip("'\"") != "-":
             return _body_for_path(command, path)
 
+    # The bare third alternative was `\S+` and carried the #1350 defect too:
+    # `-F body=@verdict.md; echo done` yielded the path `verdict.md;`. It is
+    # `_BARE_PATH_TOKEN` rather than `_PATH_TOKEN` because the quoting here is
+    # already handled by the two preceding alternatives, which understand
+    # backslash escapes that a path token does not.
     field_match = re.search(
         r"(?:--raw-field|--field|-f|-F)\s+body=(?:'((?:[^'\\]|\\.)*)'"
-        r"|\"((?:[^\"\\]|\\.)*)\"|(\S+))",
+        r"|\"((?:[^\"\\]|\\.)*)\"|(" + _BARE_PATH_TOKEN + r"))",
         command,
         re.DOTALL,
     )


### PR DESCRIPTION
Closes #1350

## What

`validate_review_comment_format._PATH_TOKEN` ended its bare alternative at whitespace:

```python
_PATH_TOKEN = r"'[^']*'|\"[^\"]*\"|\S+"
```

Five sites consume a path token, and the three write-detection regexes each carried their **own inline copy** of that same alternation. `;` is the one shell separator convention does not space out, so it was routinely captured into the filename.

## Two failure directions, not one

The filed issue describes the fail-**closed** direction. Reading the code turned up a fail-**open** one in the same token, which is the more serious half and is **not** in the report.

### fail-CLOSED — the issue headline

`gh pr comment N --body-file verdict.md; echo done` sought `verdict.md;`, found nothing, and hard-blocked a conforming charter verdict. The `;` is *structurally required* by the `until …; done; <post>` shape a reviewer is forced into when deferring a post past a GraphQL rate limit, so there was no style workaround — that is how it reached the wave-29 annunaki log.

### fail-OPEN — new finding

`_unmodelled_write` exists (from #934) so that a write to the posted path the composer cannot model **hard blocks** instead of falling back to a stale disk read. It compares a redirect target against the posted path. Both sides carried the same tokenizer defect but at **different offsets**, so on

```
jq -Rs '{body: .}' src.md > payload.json; gh api -X POST …/issues/42/comments --input payload.json
```

one side kept the glued `;` and the other did not, the guard concluded "not my file", `_body_for_path` fell through to disk, and `check()` returned **None — ALLOW**. The hook validated a stale `payload.json` while the command was about to overwrite it with `jq` output. That is precisely the fail-open #934 built the guard to close, reopened by one character of punctuation. A subshell `)` and `tee payload.json;` reproduce it identically.

## Failing-before evidence

`PathTokenBoundaryTests` (15 cases) is **constructed from the tokenizer's own boundary**, not harvested — this defect had no measured false-positive rate. Run against pre-fix `6c42709` with the post-fix test file in place:

```
$ ENVIRONMENT=test python3 -m pytest \
    .claude/hooks/tests/test_validate_review_comment_format.py \
    -k PathTokenBoundaryTests -q

FFFFF..F.FFFFFF                                                          [100%]
12 failed, 3 passed, 90 deselected in 0.52s

FAILED …::PathTokenBoundaryTests::test_bare_token_rejects_shell_metacharacters
FAILED …::PathTokenBoundaryTests::test_body_file_with_glued_ampersand_is_read
FAILED …::PathTokenBoundaryTests::test_body_file_with_glued_semicolon_is_read
FAILED …::PathTokenBoundaryTests::test_check_blocks_glued_jq_write_instead_of_reading_stale_disk
FAILED …::PathTokenBoundaryTests::test_deferred_post_shape_from_wave29_is_read
FAILED …::PathTokenBoundaryTests::test_heredoc_write_still_composed_when_semicolon_glued
FAILED …::PathTokenBoundaryTests::test_rest_field_at_path_with_glued_semicolon_is_read
FAILED …::PathTokenBoundaryTests::test_rest_input_inside_command_substitution_is_read
FAILED …::PathTokenBoundaryTests::test_rest_input_with_glued_semicolon_is_read
FAILED …::PathTokenBoundaryTests::test_unmodelled_tee_still_detected_when_semicolon_glued
FAILED …::PathTokenBoundaryTests::test_unmodelled_write_still_detected_inside_subshell
FAILED …::PathTokenBoundaryTests::test_unmodelled_write_still_detected_when_semicolon_glued
```

The **3 that pass pre-fix are deliberate no-regression controls**, and are stated as such in their docstrings: quoted paths containing a literal `;` must keep winning (×2), and a genuinely missing path must still block. Every case asserting the *defect* is red.

The two load-bearing failures, verbatim:

**fail-closed**

```
    def test_body_file_with_glued_semicolon_is_read(self):
        with tempfile.TemporaryDirectory() as td:
            path = self._verdict_file(td)
            cmd = f"gh pr comment 42 --repo o/r --body-file {path}; echo done"
>           self.assertEqual(hook.extract_comment_body(cmd), self.VERDICT)
E           AssertionError: None != 'Looks good.\n\n---\nRequestor: Nino Kavt[74 chars]ne\n'
```

**fail-open**

```
    def test_check_blocks_glued_jq_write_instead_of_reading_stale_disk(self):
        with tempfile.TemporaryDirectory() as td:
            path = self._stale_payload(td)
            cmd = (
                f"jq -Rs '{{body: .}}' src.md > {path}; "
                f"gh api -X POST repos/o/r/issues/42/comments --input {path}"
            )
            result = hook.check(_bash_input(cmd))
>           assert result is not None, "fail-open: stale disk body was validated and allowed"
E           AssertionError: fail-open: stale disk body was validated and allowed
E           assert None is not None
```

That fixture is hermetic — no network. The stale disk body carries `RequestOrReplied: Reply`, so if the hook wrongly reads it, `_direction_is_verdict` is False and `check()` returns None without ever calling `gh pr view`. The ALLOW is the defect, observable without mocking.

Post-fix: **15 passed**. Full hook suite: **2830 passed, 818 subtests**. Lib suite: **1370 passed, 141 subtests**.

## Live reproduction during this PR

The pre-fix hook blocked **my own `git commit`** for this fix, because the commit message quotes the defective shape in prose:

```
BLOCKED: this command posts a PR comment, but its body cannot be read …
Cause: `verdict.md;` does not exist and no heredoc in this command writes it.
```

Note the trailing `;` inside the backticks — exactly the block quoted in the issue, produced live. That single block is simultaneously an instance of **#1350** (the token ate the `;`) and of **#1174** (prose describing a command was read as a command; the "command" was a `git commit`, not a comment post). I worked around it the charter-prescribed way, `git commit -F <file>`. #1174 is not addressed here — different root cause, separate story.

## The fix

```python
_BARE_PATH_TOKEN = r"[^\s;&|()<>`]+"
_PATH_TOKEN = r"'[^']*'|\"[^\"]*\"|" + _BARE_PATH_TOKEN
```

The excluded characters are exactly those that terminate an unquoted shell word — a path can only contain one by being quoted or escaped, so consuming it is wrong by construction, not by frequency.

`$` and the quote characters deliberately stay **in** the class: `-F body=@"$CLAUDE_JOB_DIR/tmp/x.md"` must keep expanding, and the trailing `'` of an enclosing `sh -c '…'` must reach `_resolve_body_path`, which strips it. `test_bare_token_rejects_shell_metacharacters` pins both halves.

All five consumers now share the one definition — `--body-file`, `--input`, the bare `body=` value, `_HEREDOC_WRITE_RE`'s target, and `_REDIRECT_WRITE_RE` / `_TEE_WRITE_RE`. **The duplication was not incidental to the fail-open, it was the mechanism**: two copies of one rule, applied to the two sides of an equality test, is what let the guard fail to recognise its own path.

## Acceptance criteria (from #1350)

- [x] `--body-file <path>;` and `--body-file <path>&` read the body and validate normally
- [x] The `nohup sh -c 'until …; done; gh pr comment … --body-file X.md; …'` shape is a fixture (`test_deferred_post_shape_from_wave29_is_read`)
- [x] The same fix covers `--input` and the write/append scan — plus `body=@<path>`, a fourth consumer not listed in the issue but carrying the same defect
- [x] A quoted path containing a literal `;` still resolves (single- and double-quoted, both pinned)
- [x] No fail-open regression — and one **pre-existing** fail-open closed

The issue's alternative suggestion (route through the shared `_shell_parse` tokenizer, per #663/#1150) is deliberately **not** taken here: onboarding this hook onto the shared finders changes which invocations it sees at all, which is a scope change to a merge-gating hook and belongs to #1150, not to a token-boundary bug fix. The regex is now correct at its own boundary; migrating it remains available.

## Adjacent findings (noted, not filed — wave-30 intake is tight)

1. **`_split_segments` vs. body extraction operate on different strings.** `is_comment_command` splits on separators; `extract_comment_body` runs on the raw command. That asymmetry is why a `)` from `$( … )` reached the path token at all. Correct today, but it is the shape that made this bug possible.
2. **`validate_commit_identity` has structurally identical bare-token regexes** (`.claude/hooks/validate_commit_identity.py:309`, `:373`, `:386` — `(?P<q>['\"]).*?(?P=q)|\S+` for `-c` payloads, `<<<` heredocs, and `eval`). I did not audit whether the `\S+` branch is exploitable there; the shape is the same and it gates commit identity. Worth a look, but it is a different hook and out of scope for this story.
3. **`_PATH_TOKEN` does not belong in `charter_trailer`.** Coordinating with #1359/#1371 as the brief suggested: those consolidate the *verdict vocabulary* and *trailer* parsing, which is a charter-format concern. This is *shell command* tokenization — a different axis, and folding it into `charter_trailer` would give that module a second unrelated job. If a shared home is wanted, `_shell_parse` is the right one (see #1150). No interaction: this PR touches no `charter_trailer` symbol.

## Gates

Full local⇄CI parity run, all green:

```
ruff-format · ruff-lint · actionlint · cspell · dockerfile-base-pin ·
fixture-realism · skill-graphql-pagination · checksums-ascii ·
mypy · mypy-skills · pytest · pytest-skills · memory-budget ·
headcount-budget · doc-freshness · office-drift · mermaid-render
```

Plus `python3 .claude/lib/pre_commit_ci_sync.py .` → `OK: pre-commit config mirrors all CI-enforced checks.`

## Reviewers

- Peer: @noorinalabs Aino Virtanen (Standards & Quality Lead) — also merge-gate reviewer
- Secondary: Weronika Zielinska (Platform Architect)
