### PR TITLE
fix(#1138): premise_check precision — 7 false-positive classes (incl. MF1 bare-filename widening)

### DIFF
--- a/.claude/lib/premise_check.py
+++ b/.claude/lib/premise_check.py
@@ -32,18 +32,38 @@ Verdict policy (deterministic):
     deliberately NOT a STOP: a missing local checkout is an environment gap, not
     evidence the premise rotted — a false STOP there would block scope on
     tooling state, the opposite of the gate's purpose.
-  * a ``.claude/``-rooted path that MISSES in a child repo but resolves in the
-    parent (``noorinalabs-main``) -> ``CROSS_REPO`` -> verdict ``WARN`` (main#1047
-    da#427): very often a legitimate reference to org-wide config, worth a
+  * a ``.claude/``/``.github/``-rooted path that MISSES in one repo of an org
+    pair (parent<->child) but resolves in the other -> ``CROSS_REPO`` ->
+    verdict ``WARN`` (main#1047 da#427 child->parent; main#1138 wave-30
+    extends this symmetrically to parent->child, e.g. a ``noorinalabs-main``
+    issue naming a ``.github/workflows/`` file a Track-C story is hoisting
+    FROM a child repo): very often a legitimate cross-repo reference, worth a
     manual look rather than a hard block.
-  * a bare (slash-free) filename that misses at repo root but resolves
-    uniquely elsewhere in the tree -> ``EXISTS`` via a basename fallback
-    (main#1047 da#373).
+  * a relative fragment that misses at its literal location but is a real
+    suffix of some tracked path elsewhere in the tree (a bare basename per
+    main#1047 da#373, or a multi-segment fragment like
+    ``lib/check_agent_liveness.py`` per main#1138's 4th FP class) ->
+    ``EXISTS`` via the suffix fallback.
+  * a path that MISSES but is matched by a ``.gitignore`` rule (main#1138:
+    ``.claude/annunaki/errors.jsonl``) -> ``GITIGNORED`` -> verdict ``WARN``:
+    git can never see a gitignored path tracked, by design, so that alone is
+    not evidence of premise rot.
+  * a path listed in the issue's own ``creates`` array (main#1138 class 2: an
+    issue that PROPOSES to add a file names its own output, not an
+    already-holding premise) -> ``CREATES``, never checked against git, never
+    contributes to the verdict.
   * everything present, or no concrete refs to check -> ``OK``.
 
-An issue may also declare explicit ``paths`` / ``symbols`` arrays (deliberate
-named premises the orchestrator wants asserted even if the body phrasing is too
-loose for auto-extraction); a symbol may be scoped to a pathspec.
+Extraction also rejects three shapes that read as paths but never assert a
+repo premise (main#1138): a filesystem-absolute token (``/tmp/.../*.md`` — no
+``git cat-file`` target is ever absolute), a bare extension with nothing
+before the dot (``.py``, ``.yaml``), and a doc-placeholder filename (``X.md``,
+``foo.py``, ``example.py`` — the "insert your own name here" convention).
+
+An issue may also declare explicit ``paths`` / ``symbols`` / ``creates``
+arrays (deliberate named premises — or declared outputs — the orchestrator
+wants asserted even if the body phrasing is too loose for auto-extraction); a
+symbol may be scoped to a pathspec.
 
 CLI:
   premise_check.py check --issues ISSUES.json [--ref origin/main]
@@ -58,6 +78,9 @@ CLI:
       "symbols": [                              # optional explicit symbols
         {"name": "wave_key_reset", "pathspec": ".claude/lib/"}
       ],
+      "creates": [".claude/lib/org_repos.py"],  # optional: this issue's own
+                                                 # proposed output, exempt
+                                                 # from existence checks
       "repo_dir": "/abs/path",      # optional; overrides repos-root resolution
       "git_ref": "origin/main"      # optional per-issue ref override
     }
@@ -76,7 +99,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from org_repos import ALL_REPOS
+from org_repos import ALL_REPOS, CHILD_REPOS, MAIN_REPO
 
 # Repo root = two parents above .claude/lib/ (lib -> .claude -> root). Resolved
 # from this file so the default repos-root is correct from any cwd or worktree.
@@ -86,12 +109,25 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 EXISTS = "exists"
 MISSING = "missing"
 UNVERIFIABLE = "unverifiable"
-# A `.claude/`-rooted path that misses in a CHILD repo but resolves in the
-# parent (`noorinalabs-main`) — very often a legitimate reference to org-wide
-# config from a child-repo issue (main#1047 da#427). Treated as WARN, not
-# STOP: the reference is real, but reading it against the wrong repo is worth
-# a manual look, not a hard block.
+# A shared-root path (`.claude/`, `.github/`) that misses in one repo of an
+# org pair but resolves in the other — very often a legitimate cross-repo
+# reference (main#1047 da#427: child names a parent-owned org-wide config
+# path; main#1138 wave-30: a `noorinalabs-main` issue names a
+# `.github/workflows/` file a Track-C story is hoisting FROM a child repo,
+# i.e. the parent side of the same reference). Treated as WARN, not STOP: the
+# reference is real, but reading it against the wrong repo is worth a manual
+# look, not a hard block.
 CROSS_REPO = "cross_repo"
+# A path that git can never see tracked because it is deliberately
+# `.gitignore`d (main#1138 wave-30: `.claude/annunaki/errors.jsonl`) — cannot
+# be confirmed present via `git cat-file`, by design, so a bare MISSING would
+# read as premise rot on every single check forever. WARN, not STOP: the
+# reference may well be legitimate, but git cannot verify it either way.
+GITIGNORED = "gitignored"
+# An issue's own declared *output* (its `creates` array — main#1138 class 2):
+# a path this issue proposes to add, not a premise it asserts already holds.
+# Never checked against git, never contributes to the verdict.
+CREATES = "creates"
 
 # Per-issue verdicts.
 OK = "ok"
@@ -174,10 +210,31 @@ _KNOWN_ROOT_COMPONENTS = frozenset(
     }
 ) | frozenset(ALL_REPOS)
 
+# Root prefixes shared org-wide between the parent (`noorinalabs-main`) and
+# every child repo — org-wide tooling config (`.claude/`) and CI workflow
+# definitions (`.github/`, main#1138 wave-30: Track C hoists per-repo
+# `.github/workflows/*.yml` into `noorinalabs-main`). A path under one of
+# these that misses in one repo of an org pair but resolves in the other is
+# the CROSS_REPO downgrade's trigger set, symmetric in both directions
+# (child names a parent path: main#1047 da#427; parent names a child path:
+# main#1138).
+_CROSS_REPO_SHARED_PREFIXES = (".claude/", ".github/")
+
 # Known git refs / ref prefixes: `origin/main`, `refs/heads/x`, `HEAD` are
 # never file paths even though `origin/main` contains a slash (main#1047).
 _GIT_REF_LITERALS = frozenset({"HEAD"})
 _GIT_REF_PREFIXES = ("origin/", "refs/")
+
+# Doc-placeholder filenames used purely for illustration across this org's own
+# issues/docs (main#1138 wave-30 class: `X.md` is the exact stand-in main#1352
+# used for "insert your body-file path here"; the rest are the generic
+# prose convention). A token whose STEM (the part before the final dot,
+# case-insensitively) is exactly one of these is never asserted as a real
+# path, however plausible its extension looks. Deliberately narrow — a real
+# short name like `gh.py` or `db.py` is untouched.
+_PLACEHOLDER_STEMS = frozenset(
+    {"foo", "bar", "baz", "example", "sample", "placeholder", "dummy", "lorem"}
+)
 
 
 def _all_components_numeric(tok: str) -> bool:
@@ -200,14 +257,22 @@ def looks_like_path(token: str) -> bool:
     premise-rot purely because prose like ``A/B``, ``recall/precision``, or the
     git ref ``origin/main`` contains a ``/``). A token is accepted only when it
     is whitespace-free, path-character-only, not a bare git ref, not an
-    all-numeric fraction, and EITHER:
+    all-numeric fraction, not an absolute filesystem path, not a doc
+    placeholder, and EITHER:
 
-      * it ends in a known code/doc extension (``foo.py``, ``bar/baz.md``), OR
+      * it ends in a known code/doc extension AND has a non-empty stem before
+        that extension (``foo.py``, ``bar/baz.md`` — but not a bare ``.py``
+        with nothing before the dot), OR
       * it contains a ``/`` AND its leading component is a known repo-root
         directory (``src/``, ``docs/``, ``.claude/``, a child-repo name, …).
 
     A slash-containing token with neither signal (e.g. ``ism/kunya``,
-    ``boundary/particle``) is prose, not a path.
+    ``boundary/particle``) is prose, not a path. Every repo this gate checks
+    resolves paths as ``git cat-file -e <ref>:<path>``, which is always
+    repo-*relative* — a token starting with ``/`` is a filesystem-absolute
+    path (main#1138 wave-30: an ephemeral ``/tmp/.../scratchpad/*.md`` quoted
+    verbatim in an issue body) and can never be that kind of path, whatever
+    extension it happens to carry.
     """
     tok = token.strip()
     if not tok or " " in tok or "\t" in tok:
@@ -221,10 +286,35 @@ def looks_like_path(token: str) -> bool:
         return False
     if tok == "/":
         return False
+    # A filesystem-absolute path (main#1138: `/tmp/...`, `/var/...`) is never
+    # a repo-relative git path, regardless of what extension it carries.
+    if tok.startswith("/"):
+        return False
     if tok in _GIT_REF_LITERALS or tok.startswith(_GIT_REF_PREFIXES):
         return False
-    ext = tok.rsplit(".", 1)[-1].lower() if "." in tok else ""
-    if ext in _CODE_EXTENSIONS:
+    # Extension/stem/placeholder checks operate on the final path component
+    # (basename) — NOT the raw token — so a leading dot-directory
+    # (``.claude/lib/``) is never mistaken for a bare-extension token; only
+    # `.claude` (no trailing `/`) IS the basename in that case, and it has no
+    # dot to split on at all.
+    basename = tok.rsplit("/", 1)[-1]
+    stem, dot, ext_raw = basename.rpartition(".")
+    ext = ext_raw.lower() if dot else ""
+    # A bare extension with nothing before the dot (main#1138 class 3: a bare
+    # `.py`/`.yaml` mentioned in prose) is never a path — reject regardless of
+    # what follows.
+    if dot and not stem:
+        return False
+    # A doc-placeholder filename (main#1138 wave-30 class): a whole-word
+    # placeholder stem, or a single UPPERCASE-letter stem (`X.md`, `Y.py` —
+    # the "insert your own name" convention this org's own docs use, e.g.
+    # main#1352's `--body-file X.md`), reads as illustration, not a real
+    # asserted path. Lowercase single-letter stems (`a.py`, `c.py`) are left
+    # alone — this repo's own test fixtures use them as arbitrary real
+    # filenames, and the placeholder convention is specifically uppercase.
+    if stem and (stem.lower() in _PLACEHOLDER_STEMS or (len(stem) == 1 and stem.isupper())):
+        return False
+    if ext in _CODE_EXTENSIONS and stem:
         return True
     if "/" in tok and not _all_components_numeric(tok):
         first = tok.split("/", 1)[0]
@@ -302,20 +392,41 @@ def git_ref_exists(repo_dir: str, ref: str) -> bool:
     return proc.returncode == 0
 
 
-def _basename_resolves(repo_dir: str, ref: str, basename: str) -> bool:
-    """True when some tracked path at ``ref`` ends in ``/<basename>`` (or is it).
+def _suffix_resolves(repo_dir: str, ref: str, candidate: str) -> bool:
+    """True when some tracked path at ``ref`` equals ``candidate`` or ends in
+    ``/<candidate>``.
 
-    Basename fallback (main#1047 da#373): an issue naming a bare filename like
-    ``composition.py`` may not mean the repo root — the file can live at
-    ``src/parse/composition.py``. Only applies to slash-free candidates; a real
-    subpath that misses at its literal location is still MISSING, never
-    re-resolved by searching the whole tree.
+    Suffix fallback (main#1047 da#373 basename case, generalized by main#1138
+    4th FP class): an issue naming a bare filename like ``composition.py``
+    may not mean the repo root — the file can live at
+    ``src/parse/composition.py``. main#1138 widened this from slash-free
+    basenames to any relative fragment: a token like
+    ``lib/check_agent_liveness.py`` misses at its literal (repo-root-relative)
+    location but IS a real suffix of the tracked ``.claude/lib/
+    check_agent_liveness.py`` — the original basename-only fallback never
+    fired for it because the token was not slash-free. A candidate that
+    matches no tracked path anywhere is still MISSING, never re-resolved by
+    a coincidental partial match.
     """
     proc = _run_git(repo_dir, ["ls-tree", "-r", "--name-only", ref])
     if proc.returncode != 0:
         return False
-    suffix = "/" + basename
-    return any(line == basename or line.endswith(suffix) for line in proc.stdout.splitlines())
+    suffix = "/" + candidate
+    return any(line == candidate or line.endswith(suffix) for line in proc.stdout.splitlines())
+
+
+def git_path_is_ignored(repo_dir: str, path: str) -> bool:
+    """True when ``path`` is matched by a ``.gitignore`` rule in ``repo_dir``.
+
+    Checked against the *working tree's* current ``.gitignore`` (there is no
+    "ignored at a historical ref" concept — ignore rules are a property of
+    the tree, not of git history). ``git check-ignore`` exits 0 when the path
+    is ignored, 1 when it is not, and 128 on certain error conditions (all
+    folded into "not ignored" — this is a best-effort downgrade, never a
+    reason to assert MISSING harder).
+    """
+    proc = _run_git(repo_dir, ["check-ignore", "-q", "--", path])
+    return proc.returncode == 0
 
 
 def git_path_status(repo_dir: str, ref: str, path: str) -> str:
@@ -323,17 +434,23 @@ def git_path_status(repo_dir: str, ref: str, path: str) -> str:
 
     Returns :data:`UNVERIFIABLE` when the repo dir or ref cannot be read (an
     environment gap, never treated as premise rot), otherwise :data:`EXISTS` /
-    :data:`MISSING`. A slash-free ``path`` that misses at its literal location
-    gets one more chance via :func:`_basename_resolves` before being declared
-    MISSING (main#1047 basename fallback).
+    :data:`GITIGNORED` / :data:`MISSING`. A relative fragment that misses at
+    its literal location gets one more chance via :func:`_suffix_resolves`
+    before being declared MISSING (main#1047 da#373 / main#1138 suffix
+    fallback). Failing that, a path deliberately excluded from tracking via
+    ``.gitignore`` (main#1138: ``.claude/annunaki/errors.jsonl``) downgrades
+    to :data:`GITIGNORED` rather than MISSING — git can never see it
+    tracked, by design, so a bare MISSING there is not evidence of rot.
     """
     if not git_ref_exists(repo_dir, ref):
         return UNVERIFIABLE
     proc = _run_git(repo_dir, ["cat-file", "-e", f"{ref}:{path}"])
     if proc.returncode == 0:
         return EXISTS
-    if "/" not in path and _basename_resolves(repo_dir, ref, path):
+    if _suffix_resolves(repo_dir, ref, path):
         return EXISTS
+    if git_path_is_ignored(repo_dir, path):
+        return GITIGNORED
     return MISSING
 
 
@@ -368,7 +485,7 @@ SymbolChecker = Callable[[str, str, str, "str | None"], str]
 class CandidateResult:
     kind: str  # "path" | "symbol"
     value: str
-    status: str  # EXISTS | MISSING | UNVERIFIABLE | CROSS_REPO
+    status: str  # EXISTS | MISSING | UNVERIFIABLE | CROSS_REPO | GITIGNORED | CREATES
     pathspec: str | None = None
     note: str | None = None
 
@@ -394,11 +511,15 @@ class IssueResult:
     def cross_repo(self) -> list[CandidateResult]:
         return [c for c in self.candidates if c.status == CROSS_REPO]
 
+    @property
+    def gitignored(self) -> list[CandidateResult]:
+        return [c for c in self.candidates if c.status == GITIGNORED]
+
 
 def _verdict_for(candidates: list[CandidateResult]) -> str:
     if any(c.status == MISSING for c in candidates):
         return STOP
-    if any(c.status in (UNVERIFIABLE, CROSS_REPO) for c in candidates):
+    if any(c.status in (UNVERIFIABLE, CROSS_REPO, GITIGNORED) for c in candidates):
         return WARN
     return OK
 
@@ -445,6 +566,46 @@ def collect_candidates(issue: dict) -> list[tuple[str, str, str | None]]:
     return triples
 
 
+def _cross_repo_downgrade(
+    value: str,
+    repo_name: str,
+    repos_root: Path,
+    git_ref: str,
+    path_checker: PathChecker,
+) -> tuple[str, str] | None:
+    """Second-chance lookup for a MISSING shared-root path in the "other side"
+    of the parent/child pair (main#1047 da#427, extended symmetrically by
+    main#1138 wave-30). Returns ``(CROSS_REPO, note)`` on a hit, else ``None``.
+
+    * child repo, path misses locally -> check the parent (`noorinalabs-main`).
+    * parent repo (`noorinalabs-main`), path misses locally -> check every
+      child repo in turn; the first hit wins.
+
+    Only fires for a path under one of ``_CROSS_REPO_SHARED_PREFIXES`` — a
+    non-shared path missing in the wrong repo is not this class of reference.
+    """
+    if not value.startswith(_CROSS_REPO_SHARED_PREFIXES):
+        return None
+    if repo_name != MAIN_REPO:
+        parent_status = path_checker(str(repos_root), git_ref, value)
+        if parent_status == EXISTS:
+            return (
+                CROSS_REPO,
+                f"resolves in parent repo {MAIN_REPO}, not child repo "
+                f"{repo_name} — verify this is a deliberate cross-repo reference",
+            )
+        return None
+    for child in CHILD_REPOS:
+        child_status = path_checker(str(repos_root / child), git_ref, value)
+        if child_status == EXISTS:
+            return (
+                CROSS_REPO,
+                f"resolves in child repo {child}, not parent repo {MAIN_REPO} — "
+                "verify this is a deliberate cross-repo reference",
+            )
+    return None
+
+
 def check_issue(
     issue: dict,
     repos_root: Path,
@@ -454,33 +615,39 @@ def check_issue(
 ) -> IssueResult:
     """Verify every named premise of one scoped issue against its repo HEAD.
 
-    A `.claude/`-rooted path that MISSES in a child repo gets one more check
-    against the parent (`noorinalabs-main`) before being declared MISSING
-    (main#1047 da#427): a child-repo issue very often names a legitimate
-    org-wide config path. A parent-side hit downgrades that candidate to
-    :data:`CROSS_REPO` (-> WARN), not a bare pass — the reference is real, but
-    checking it against the wrong repo is still worth a manual look.
+    A shared-root (`.claude/`, `.github/`) path that MISSES in one repo of an
+    org pair gets one more check against the other side before being
+    declared MISSING (main#1047 da#427, symmetric extension main#1138
+    wave-30): a child-repo issue very often names a legitimate org-wide
+    config path, and a parent-repo issue can equally name a per-repo
+    workflow file a Track-C-shaped story is consolidating FROM a child. A
+    hit on the other side downgrades that candidate to :data:`CROSS_REPO`
+    (-> WARN), not a bare pass — the reference is real, but checking it
+    against the wrong repo is still worth a manual look.
+
+    An issue's own declared ``creates`` array (main#1138 class 2) exempts
+    those exact paths from verification entirely — they are the issue's
+    proposed output, not an asserted-to-already-exist premise, so a MISSING
+    checker result for one is never even consulted.
     """
     repo_dir = resolve_repo_dir(issue, repos_root)
     git_ref = issue.get("git_ref") or default_ref
-    repo_name = str(issue.get("repo") or "noorinalabs-main")
+    repo_name = str(issue.get("repo") or MAIN_REPO)
+    creates = {normalize_path(str(p)) for p in issue.get("creates", []) or []}
     candidates: list[CandidateResult] = []
     for kind, value, pathspec in collect_candidates(issue):
         if kind == "path":
+            if value in creates:
+                candidates.append(CandidateResult(kind, value, CREATES, pathspec))
+                continue
             status = path_checker(repo_dir, git_ref, value)
             note: str | None = None
-            if (
-                status == MISSING
-                and repo_name != "noorinalabs-main"
-                and value.startswith(".claude/")
-            ):
-                parent_status = path_checker(str(repos_root), git_ref, value)
-                if parent_status == EXISTS:
-                    status = CROSS_REPO
-                    note = (
-                        f"resolves in parent repo noorinalabs-main, not child repo "
-                        f"{repo_name} — verify this is a deliberate cross-repo reference"
-                    )
+            if status == MISSING:
+                downgrade = _cross_repo_downgrade(
+                    value, repo_name, repos_root, git_ref, path_checker
+                )
+                if downgrade is not None:
+                    status, note = downgrade
             candidates.append(CandidateResult(kind, value, status, pathspec, note))
         else:
             status = symbol_checker(repo_dir, git_ref, value, pathspec)
@@ -511,7 +678,9 @@ _STATUS_GLYPH = {
     EXISTS: "ok",
     MISSING: "MISSING",
     UNVERIFIABLE: "unverifiable",
-    CROSS_REPO: "cross-repo (found in parent)",
+    CROSS_REPO: "cross-repo (found in the other repo — see note)",
+    GITIGNORED: "gitignored (never tracked by git — cannot verify)",
+    CREATES: "declared creation (this issue's own output, not checked)",
 }
 
 
@@ -543,11 +712,13 @@ def render_report(results: list[IssueResult]) -> str:
     if warns:
         lines.append(
             f"WARN: {len(warns)} issue(s) could not be fully verified "
-            "(repo not cloned / ref not fetched / unreadable, or a cross-repo "
-            "reference). Verify manually:"
+            "(repo not cloned / ref not fetched / unreadable, a cross-repo "
+            "reference, or a gitignored path). Verify manually:"
         )
         for r in warns:
-            refs = ", ".join(f"{c.kind} {c.value}" for c in r.unverifiable + r.cross_repo)
+            refs = ", ".join(
+                f"{c.kind} {c.value}" for c in r.unverifiable + r.cross_repo + r.gitignored
+            )
             lines.append(f"  - {r.ref} ({r.repo_dir} @ {r.git_ref}): {refs}")
     if not stops and not warns:
         lines.append("All named files/symbols verified present at origin HEAD.")

--- a/.claude/lib/premise_check.py
+++ b/.claude/lib/premise_check.py
@@ -37,8 +37,12 @@ Verdict policy (deterministic):
     verdict ``WARN`` (main#1047 da#427 child->parent; main#1138 wave-30
     extends this symmetrically to parent->child, e.g. a ``noorinalabs-main``
     issue naming a ``.github/workflows/`` file a Track-C story is hoisting
-    FROM a child repo): very often a legitimate cross-repo reference, worth a
-    manual look rather than a hard block.
+    FROM a child repo). On the parent->child direction ONLY, a bare
+    (slash-free) filename also triggers this second chance (main#1138 MF1:
+    the two issues class 1 was reported from, #1110/#1111, name the workflow
+    by bare filename — ``ghcr-publish.yml`` — never the qualified
+    ``.github/workflows/...`` path). Very often a legitimate cross-repo
+    reference, worth a manual look rather than a hard block.
   * a relative fragment that misses at its literal location but is a real
     suffix of some tracked path elsewhere in the tree (a bare basename per
     main#1047 da#373, or a multi-segment fragment like
@@ -581,12 +585,26 @@ def _cross_repo_downgrade(
     * parent repo (`noorinalabs-main`), path misses locally -> check every
       child repo in turn; the first hit wins.
 
-    Only fires for a path under one of ``_CROSS_REPO_SHARED_PREFIXES`` — a
-    non-shared path missing in the wrong repo is not this class of reference.
+    Fires for a path under one of ``_CROSS_REPO_SHARED_PREFIXES`` — a
+    non-shared path missing in the wrong repo is not this class of reference
+    — OR, on the parent->child direction only, for a bare (slash-free)
+    filename (main#1138 MF1: the two issues class 1 was actually reported
+    from, #1110 and #1111, name the workflow file by bare filename —
+    ``ghcr-publish.yml``, ``structural-ontology.yml`` — never the qualified
+    ``.github/workflows/...`` path, so the shared-prefix trigger alone never
+    caught them). Restricted to the parent->child direction: a bare filename
+    is a much weaker signal than a shared-root prefix, and widening it on the
+    child->parent side too would risk downgrading a genuine child-repo STOP
+    on the strength of an unrelated same-named file anywhere in the parent's
+    `.claude/` tree — a risk the parent->child direction already accepts
+    (the file genuinely needs to exist in some specific child, not just
+    somewhere in a huge shared tree) but the reported defect does not
+    require accepting on the other side.
     """
-    if not value.startswith(_CROSS_REPO_SHARED_PREFIXES):
-        return None
+    shared_prefix = value.startswith(_CROSS_REPO_SHARED_PREFIXES)
     if repo_name != MAIN_REPO:
+        if not shared_prefix:
+            return None
         parent_status = path_checker(str(repos_root), git_ref, value)
         if parent_status == EXISTS:
             return (
@@ -594,6 +612,9 @@ def _cross_repo_downgrade(
                 f"resolves in parent repo {MAIN_REPO}, not child repo "
                 f"{repo_name} — verify this is a deliberate cross-repo reference",
             )
+        return None
+    bare_filename = "/" not in value
+    if not (shared_prefix or bare_filename):
         return None
     for child in CHILD_REPOS:
         child_status = path_checker(str(repos_root / child), git_ref, value)

--- a/.claude/lib/tests/test_premise_check.py
+++ b/.claude/lib/tests/test_premise_check.py
@@ -347,6 +347,115 @@ class CheckIssueVerdictTest(unittest.TestCase):
         self.assertEqual(res.verdict, pc.STOP)
 
 
+class Main1138LooksLikePathTest(unittest.TestCase):
+    """main#1138: the false-positive classes the wave-30 scope run hit.
+
+    Pure ``looks_like_path`` classification — no git involved.
+    """
+
+    def test_rejects_bare_extension_token(self) -> None:
+        # main#1138 class 3: a bare extension mentioned in prose (main#1112
+        # flagged a bare `.py`, main#1118 a bare `.yaml`) has no filename stem
+        # before the dot and must not parse as a path.
+        self.assertFalse(pc.looks_like_path(".py"))
+        self.assertFalse(pc.looks_like_path(".yaml"))
+        self.assertFalse(pc.looks_like_path(".md"))
+        # A real dotfile-style stem (non-empty content before the final dot)
+        # must still be accepted.
+        self.assertTrue(pc.looks_like_path("wave_key_reset.py"))
+        self.assertTrue(pc.looks_like_path(".pre-commit-config.yaml"))
+
+    def test_rejects_absolute_tmp_scratchpad_path(self) -> None:
+        # main#1138 wave-30 class: an ephemeral, session-scoped scratchpad
+        # path quoted verbatim in an issue body (the shape wave-29's own
+        # `block_stale_tmp_message_file` false-positive writeup used) is not
+        # a repo-relative path and must never resolve against git HEAD.
+        self.assertFalse(
+            pc.looks_like_path(
+                "/tmp/claude-1000/-home-parameterization-code-noorinalabs-main/"
+                "abc123/scratchpad/verdict_probe.md"
+            )
+        )
+        self.assertFalse(pc.looks_like_path("/tmp/foo.py"))
+        self.assertFalse(pc.looks_like_path("/var/log/out.txt"))
+
+    def test_rejects_deliberate_example_filenames(self) -> None:
+        # main#1138 wave-30 class: a doc-placeholder filename used purely for
+        # illustration (`X.md` is the exact placeholder wave-30's own #1352
+        # used for "insert your body-file path here"; `foo.py`/`example.py`
+        # are the generic org-wide convention) must not assert existence.
+        self.assertFalse(pc.looks_like_path("X.md"))
+        self.assertFalse(pc.looks_like_path("Y.py"))
+        self.assertFalse(pc.looks_like_path("foo.py"))
+        self.assertFalse(pc.looks_like_path("example.py"))
+        # A real, non-placeholder short name must still be accepted.
+        self.assertTrue(pc.looks_like_path("gh.py"))
+
+
+class Main1138VerdictLayerTest(unittest.TestCase):
+    """main#1138: verdict-layer fixes exercised with injected (fake) checkers."""
+
+    def test_cross_repo_symmetric_parent_misses_child_resolves(self) -> None:
+        """main#1138 class 1 (a.k.a. wave-30 "child-repo workflow paths").
+
+        A `noorinalabs-main` issue names a `.github/workflows/` file that is
+        MISSING in the parent but resolves in a child repo — the reverse of
+        the existing child-misses/parent-resolves rule (main#1047 da#427).
+        Must downgrade to CROSS_REPO -> WARN, not STOP.
+        """
+        target = ".github/workflows/ghcr-publish.yml"
+        issue = {"ref": "main#1110", "repo": "noorinalabs-main", "body": f"see `{target}`"}
+
+        def _path(repo_dir: str, _ref: str, _value: str) -> str:
+            # MISSING at the parent (repos_root itself); EXISTS under any
+            # child-repo subdirectory.
+            return pc.MISSING if repo_dir == "/repos" else pc.EXISTS
+
+        res = pc.check_issue(issue, Path("/repos"), "origin/main", _path, _checker({})[1])
+        self.assertEqual(res.verdict, pc.WARN)
+        self.assertEqual(res.candidates[0].status, pc.CROSS_REPO)
+        self.assertIsNotNone(res.candidates[0].note)
+
+    def test_creates_array_prevents_stop_on_proposed_file(self) -> None:
+        """main#1138 class 2: an issue that PROPOSES a file (its own output)
+        must not premise-rot-STOP on that file being absent today.
+
+        main#1118 (G6) named `.claude/lib/org_repos.py` as the artifact it
+        would create; the gate read that as a rotted premise. An explicit
+        ``creates`` array marks the path as a declared creation: never
+        checked against git, never contributes to the verdict.
+        """
+        issue = {
+            "ref": "main#1118",
+            "repo": "noorinalabs-main",
+            "body": "extract the org repo list into `.claude/lib/org_repos.py`",
+            "creates": [".claude/lib/org_repos.py"],
+        }
+        # Checker would report MISSING if it were ever consulted for this
+        # path — proves the fix routes around the checker entirely, not that
+        # the checker happens to return a passing status.
+        res = self._check(issue, {".claude/lib/org_repos.py": pc.MISSING})
+        self.assertEqual(res.verdict, pc.OK)
+        self.assertEqual(res.candidates[0].status, pc.CREATES)
+
+    def test_creates_does_not_suppress_other_missing_paths(self) -> None:
+        # A `creates` entry only exempts the declared path(s); an unrelated
+        # named path that is genuinely missing must still STOP.
+        issue = {
+            "ref": "main#1118",
+            "repo": "noorinalabs-main",
+            "body": "extract into `.claude/lib/org_repos.py`, touches `gone.py`",
+            "creates": [".claude/lib/org_repos.py"],
+        }
+        res = self._check(issue, {".claude/lib/org_repos.py": pc.MISSING, "gone.py": pc.MISSING})
+        self.assertEqual(res.verdict, pc.STOP)
+        self.assertEqual([c.value for c in res.missing], ["gone.py"])
+
+    def _check(self, issue: dict, table: dict[str, str], default: str = pc.EXISTS):
+        path_fn, sym_fn = _checker(table, default)
+        return pc.check_issue(issue, Path("/repos"), "origin/main", path_fn, sym_fn)
+
+
 class ResolveRepoDirTest(unittest.TestCase):
     def test_main_maps_to_root(self) -> None:
         self.assertEqual(pc.resolve_repo_dir({"repo": "noorinalabs-main"}, Path("/r")), "/r")
@@ -482,6 +591,59 @@ class GitIntegrationTest(unittest.TestCase):
             res = pc.check_issue(issue, root, "HEAD")
             self.assertEqual(res.candidates[0].status, pc.MISSING)
             self.assertEqual(res.verdict, pc.STOP)
+
+    def test_gitignored_path_is_warn_not_stop(self) -> None:
+        """main#1138 wave-30 class: a legitimately gitignored path (e.g.
+        `.claude/annunaki/errors.jsonl`) can never be found by
+        `git cat-file`, since it is by design never tracked — that must not
+        read as premise rot. Downgrades to WARN, not STOP.
+        """
+        with TemporaryDirectory() as d:
+            root = Path(d)
+            self._git(root, "init", "-q")
+            self._git(root, "config", "user.email", "t@t")
+            self._git(root, "config", "user.name", "t")
+            (root / ".gitignore").write_text("annunaki/errors.jsonl\n")
+            self._git(root, "add", "-A")
+            self._git(root, "commit", "-q", "-m", "base")
+            (root / "annunaki").mkdir()
+            (root / "annunaki" / "errors.jsonl").write_text("{}\n")
+
+            issue = {
+                "ref": "main#1138",
+                "repo": "noorinalabs-main",
+                "body": "see `annunaki/errors.jsonl`",
+            }
+            res = pc.check_issue(issue, root, "HEAD")
+            self.assertEqual(res.candidates[0].status, pc.GITIGNORED)
+            self.assertEqual(res.verdict, pc.WARN)
+
+    def test_relative_fragment_suffix_resolves_under_claude(self) -> None:
+        """main#1138 4th FP class (not in the issue body): a slash-containing
+        relative fragment (`lib/check_agent_liveness.py`) whose basename
+        fallback never fires because the token is not slash-free, even
+        though the file exists at `.claude/lib/check_agent_liveness.py`.
+        """
+        with TemporaryDirectory() as d:
+            root = Path(d)
+            self._git(root, "init", "-q")
+            self._git(root, "config", "user.email", "t@t")
+            self._git(root, "config", "user.name", "t")
+            nested = root / ".claude" / "lib"
+            nested.mkdir(parents=True)
+            (nested / "check_agent_liveness.py").write_text("x = 1\n")
+            self._git(root, "add", "-A")
+            self._git(root, "commit", "-q", "-m", "base")
+
+            issue = {
+                "ref": "main#1138",
+                "repo": "noorinalabs-main",
+                "body": "the liveness check lives at `lib/check_agent_liveness.py`",
+            }
+            res = pc.check_issue(issue, root, "HEAD")
+            statuses = {c.value: c.status for c in res.candidates}
+            self.assertEqual(statuses["lib/check_agent_liveness.py"], pc.EXISTS)
+            self.assertEqual(res.verdict, pc.OK)
 
     def test_unknown_ref_is_unverifiable(self) -> None:
         with TemporaryDirectory() as d:

--- a/.claude/lib/tests/test_premise_check.py
+++ b/.claude/lib/tests/test_premise_check.py
@@ -416,6 +416,60 @@ class Main1138VerdictLayerTest(unittest.TestCase):
         self.assertEqual(res.candidates[0].status, pc.CROSS_REPO)
         self.assertIsNotNone(res.candidates[0].note)
 
+    def test_cross_repo_bare_filename_main_1110_literal_token(self) -> None:
+        """main#1138 MF1 (merge-gate follow-up, Aino Virtanen): class 1's own
+        reported instances — main#1110 and main#1111 — name the workflow file
+        by BARE filename (``ghcr-publish.yml``), never the qualified
+        ``.github/workflows/...`` path. The class-1 fixture above used the
+        qualified form, which the shared-prefix trigger already caught; the
+        literal #1110 token did not move. This pins the literal token.
+        """
+        issue = {
+            "ref": "main#1110",
+            "repo": "noorinalabs-main",
+            "body": "**C3 — `ghcr-publish.yml` -> reusable build/push/dispatch**",
+        }
+
+        def _path(repo_dir: str, _ref: str, _value: str) -> str:
+            return pc.MISSING if repo_dir == "/repos" else pc.EXISTS
+
+        res = pc.check_issue(issue, Path("/repos"), "origin/main", _path, _checker({})[1])
+        self.assertEqual(res.verdict, pc.WARN)
+        self.assertEqual(res.candidates[0].value, "ghcr-publish.yml")
+        self.assertEqual(res.candidates[0].status, pc.CROSS_REPO)
+
+    def test_cross_repo_bare_filename_not_found_anywhere_still_stops(self) -> None:
+        # Recall guard: a bare filename that is genuinely absent from the
+        # parent AND every child must still STOP — the MF1 widening is a
+        # second chance, not a blanket bare-filename pass.
+        issue = {
+            "ref": "main#705",
+            "repo": "noorinalabs-main",
+            "body": "targets `wave_key_reset.py`",
+        }
+        res = self._check(issue, {"wave_key_reset.py": pc.MISSING})
+        self.assertEqual(res.verdict, pc.STOP)
+
+    def test_cross_repo_bare_filename_not_widened_on_child_to_parent_side(self) -> None:
+        # The MF1 widening is deliberately ONE-DIRECTIONAL (parent->child
+        # only): a child-repo issue naming a bare filename that happens to
+        # exist somewhere in the parent tree must still STOP, not downgrade
+        # — only a shared-root-prefixed path gets the child->parent second
+        # chance (main#1047 da#427's original, narrower rule).
+        issue = {
+            "ref": "da#1",
+            "repo": "noorinalabs-data-acquisition",
+            "body": "see `composition.py`",
+        }
+
+        def _path(repo_dir: str, _ref: str, _value: str) -> str:
+            # MISSING in the child; EXISTS at the parent (repos_root) — but
+            # bare, not shared-prefixed, so must NOT downgrade.
+            return pc.EXISTS if repo_dir == "/repos" else pc.MISSING
+
+        res = pc.check_issue(issue, Path("/repos"), "origin/main", _path, _checker({})[1])
+        self.assertEqual(res.verdict, pc.STOP)
+
     def test_creates_array_prevents_stop_on_proposed_file(self) -> None:
         """main#1138 class 2: an issue that PROPOSES a file (its own output)
         must not premise-rot-STOP on that file being absent today.

--- a/.claude/skills/wave-scope/SKILL.md
+++ b/.claude/skills/wave-scope/SKILL.md
@@ -267,21 +267,30 @@ gate closes that — it is the scope-time twin of [[feedback_spawn_brief_protoco
 The deterministic check is `.claude/lib/premise_check.py`. It auto-extracts
 path-like tokens from each in-scope issue's body (backtick spans + a path-token
 regex), then classifies each token with `looks_like_path` — accepted only when
-it ends in a known code/doc extension, OR contains a `/` **and** its leading
-component is a known repo-root directory (`src/`, `.claude/`, a child-repo
-name, …). A bare `/` is NOT itself evidence of a path (main#1047 — a slash
-alone previously flagged prose like `A/B`, `recall/precision`, and the git ref
-`origin/main` as paths, a 12/12 false-STOP on the wave-26 scope run); git refs
-and all-numeric fractions (`986/650`) are explicitly excluded. It then runs
-`git cat-file -e <ref>:<path>` per path (and `git grep` per
-explicitly-declared symbol) against the repo's origin HEAD — with a basename
-fallback for a slash-free filename that misses at repo root but resolves
-uniquely elsewhere in the tree. Verdicts: a path/symbol the ref can read but
-does not contain → **STOP** (premise rot); a repo/ref that cannot be read at
-all (child not cloned, origin not fetched), or a `.claude/`-rooted path that
-misses in a child repo but resolves in the parent `noorinalabs-main` → **WARN**
-(an environment gap or a likely cross-repo reference, deliberately not a
-STOP); everything present → **OK**.
+it ends in a known code/doc extension AND has a non-empty stem before that
+extension (a bare `.py`/`.yaml` with nothing before the dot is rejected —
+main#1138 class 3), OR contains a `/` **and** its leading component is a known
+repo-root directory (`src/`, `.claude/`, a child-repo name, …). A bare `/` is
+NOT itself evidence of a path (main#1047 — a slash alone previously flagged
+prose like `A/B`, `recall/precision`, and the git ref `origin/main` as paths,
+a 12/12 false-STOP on the wave-26 scope run); git refs, all-numeric fractions
+(`986/650`), filesystem-absolute paths (`/tmp/.../*.md` — main#1138), and
+doc-placeholder filenames (`X.md`, `foo.py`, `example.py` — main#1138) are all
+explicitly excluded. It then runs `git cat-file -e <ref>:<path>` per path (and
+`git grep` per explicitly-declared symbol) against the repo's origin HEAD —
+with a suffix fallback for a relative fragment (bare basename, or a
+multi-segment fragment like `lib/check_agent_liveness.py` — main#1138's 4th
+FP class) that misses at its literal location but resolves uniquely elsewhere
+in the tree. Verdicts: a path/symbol the ref can read but does not contain →
+**STOP** (premise rot); a repo/ref that cannot be read at all (child not
+cloned, origin not fetched), a `.claude/`/`.github/`-rooted path that misses
+in one repo of a parent/child pair but resolves in the other (main#1047
+child→parent, main#1138 wave-30 extends this symmetrically to parent→child),
+or a path matched by a `.gitignore` rule (main#1138: `.claude/annunaki/
+errors.jsonl` — git can never see it tracked, by design) → **WARN** (an
+environment gap or a likely legitimate reference, deliberately not a STOP);
+everything present, or a path the issue's own `creates` array declares as
+its proposed output (main#1138 class 2), → **OK**.
 
 Run it over the actual labeled scope (Step 4 output). Fetch each in-scope repo's
 `origin` first so the check resolves against real HEADs (an unfetched repo only
@@ -325,8 +334,12 @@ WARN-level rows (unverifiable) are surfaced but do not block; verify those
 manually when the named repo could not be read. To declare a concrete symbol (or
 a path the body phrasing is too loose to auto-extract) add explicit `paths` /
 `symbols` arrays to that issue's row before the `jq -s` merge — see the module
-docstring for the per-issue shape. `--warn-only` downgrades a STOP to advisory
-for a dry run, but the gate is a hard STOP by default.
+docstring for the per-issue shape. If an issue's premises include a file it
+proposes to CREATE (main#1138 class 2 — an extraction/consolidation story
+inherently names its own output), add that path to an explicit `creates`
+array on the row so the gate exempts it instead of reading it as rot.
+`--warn-only` downgrades a STOP to advisory for a dry run, but the gate is a
+hard STOP by default.
 
 ### 7. Collect dispositions per item (manual — owner judgment)
 

--- a/.claude/skills/wave-scope/SKILL.md
+++ b/.claude/skills/wave-scope/SKILL.md
@@ -285,7 +285,10 @@ in the tree. Verdicts: a path/symbol the ref can read but does not contain →
 **STOP** (premise rot); a repo/ref that cannot be read at all (child not
 cloned, origin not fetched), a `.claude/`/`.github/`-rooted path that misses
 in one repo of a parent/child pair but resolves in the other (main#1047
-child→parent, main#1138 wave-30 extends this symmetrically to parent→child),
+child→parent, main#1138 wave-30 extends this symmetrically to parent→child —
+including, parent→child only, for a BARE filename with no leading path
+component, since #1110/#1111 name workflow files that way rather than by
+the qualified `.github/workflows/...` path — main#1138 MF1),
 or a path matched by a `.gitignore` rule (main#1138: `.claude/annunaki/
 errors.jsonl` — git can never see it tracked, by design) → **WARN** (an
 environment gap or a likely legitimate reference, deliberately not a STOP);


### PR DESCRIPTION
Closes #1138

## Summary

Fixes the Step 6.5 premise-rot gate (`.claude/lib/premise_check.py`), which was STOPping every Phase-10 scope run on false positives — 5/5 in the issue's own wave-29 run, 6/6 in wave-30's rerun (owner note on `cross-repo-status.json`).

**Seven false-positive classes fixed**, each with a pre-fix-failing regression test: the issue's own three classes, a 4th class confirmed live but not documented in the issue body, and three more found live in the wave-30 rerun.

### The issue's three classes

1. **Cross-repo `.github/workflows/` references** (issue class 1). The `CROSS_REPO` WARN downgrade only checked child->parent (main#1047 da#427). Extended symmetrically: a `noorinalabs-main` issue naming a `.github/workflows/*.yml` file that misses in the parent but resolves in a child repo now also downgrades to WARN, not STOP. Generalized the trigger set to `.claude/` **and** `.github/` (both directions), **and** — added at merge-gate review, see "MF1" below — to a bare (slash-free) filename on the parent->child direction, because that is the literal shape #1110/#1111 use.
2. **Proposed-not-yet-existing artifacts** (issue class 2). An issue's own `creates` array (new, alongside the existing `paths`/`symbols` explicit arrays) declares "this issue's own output" — those paths are never checked against git and never contribute to the verdict, so an extraction/consolidation story naming its own target file no longer reads as premise rot.
3. **Bare extension tokens** (issue class 3). `looks_like_path` now requires a non-empty stem before the extension — computed on the path's **basename**, not the raw token, so `.claude/lib/` (a leading dot-directory) is unaffected. A bare `.py`/`.yaml` mentioned in prose no longer parses as a path.

### 4th class — not in the issue body, confirmed live at wave-30 scope

The basename fallback (main#1047 da#373) only fired for slash-free tokens. Generalized to a **suffix** fallback, so a multi-segment relative fragment like `lib/check_agent_liveness.py` resolves against the tracked `.claude/lib/check_agent_liveness.py`. Confirmed and posted as a comment on #1138.

### Three more classes found live in the wave-30 rerun, not named in the issue body

- **Filesystem-absolute paths** (`/tmp/claude-.../scratchpad/*.md` quoted verbatim in an issue body — the exact shape wave-29's own `block_stale_tmp_message_file` false-positive writeup used). Rejected outright: every path this gate checks resolves via `git cat-file -e <ref>:<path>`, which is always repo-relative, so an absolute token is never that kind of path regardless of extension.
- **A legitimately `.gitignore`d path** (`.claude/annunaki/errors.jsonl`). `git cat-file` can never see it tracked, by design, so a bare MISSING there would STOP forever. New `GITIGNORED` status (WARN, via `git check-ignore`), not MISSING.
- **Deliberate example / placeholder filenames** (`X.md` — the exact placeholder main#1352 uses for "insert your body-file path here"; `foo.py`/`example.py` as the generic convention) are now rejected via a narrow placeholder-stem list, including single-**uppercase**-letter stems (`X`, `Y`) — deliberately excluding lowercase (`a.py`, `c.py` are real filenames used elsewhere in this repo's own tests).

## MF1 fix (merge-gate review, Aino Virtanen) — class 1 widened to the reported bare-filename shape

Aino's first-pass review found the class-1 fixture used the qualified `.github/workflows/ghcr-publish.yml` form, which the shared-prefix trigger already caught — but **#1110 and #1111, the two issues class 1 was actually reported from, name the file by bare filename** (`ghcr-publish.yml`, `structural-ontology.yml`, `structural_ontology.py`), which never satisfied `value.startswith(_CROSS_REPO_SHARED_PREFIXES)`, so those two issues still STOPped identically before and after the first push.

**Fix:** `_cross_repo_downgrade` now also triggers the parent->child second chance for a bare (slash-free) filename — deliberately **one-directional** (parent->child only): a child-repo issue naming a bare filename that happens to exist somewhere in the parent's `.claude/` tree still STOPs (see `test_cross_repo_bare_filename_not_widened_on_child_to_parent_side`), and a bare filename genuinely absent everywhere still STOPs (`test_cross_repo_bare_filename_not_found_anywhere_still_stops`). New regression fixture pinned on the **literal #1110 token**: `test_cross_repo_bare_filename_main_1110_literal_token`.

Re-verified end-to-end against the real, current API bodies of #1110 and #1111 (not a synthetic fixture), using `--repos-root` pointed at a tree with the child repos actually cloned (this PR's own isolated worktree has no child-repo checkouts, so the same run there reports `UNVERIFIABLE`/`MISSING` rather than `CROSS_REPO` — an environment gap, not a logic gap; confirmed by the same run succeeding once child repos are visible):

```
# before MF1 (first push, fb0aeb328) — real #1110/#1111 bodies fetched from the API
[STOP] main#1110  - path `ghcr-publish.yml`: MISSING
[STOP] main#1111  - path `structural-ontology.yml`: MISSING
                  - path `structural_ontology.py`: MISSING

# after MF1 (this push, 922ff6e), --repos-root pointed at a tree with child repos cloned
[WARN] main#1110  - path `ghcr-publish.yml`: cross-repo ... resolves in child repo noorinalabs-isnad-graph
[WARN] main#1111  - path `structural-ontology.yml`: cross-repo ... resolves in child repo noorinalabs-isnad-graph
                  - path `structural_ontology.py`: cross-repo ... resolves in child repo noorinalabs-isnad-graph
```

`Closes #1138` therefore stays accurate at this head, per Aino's guidance.

## Precision, measured against the wave-30 6/6 false-STOP set's classes + MF1

| Class | Before | After |
|---|---|---|
| Cross-repo workflow paths — qualified form | STOP (false) | WARN |
| Cross-repo workflow paths — bare-filename form (#1110/#1111's actual shape, MF1) | STOP (false) | WARN |
| `creates`-declared proposed files | STOP (false) | OK |
| Bare extension tokens (`.py`, `.yaml`) | STOP (false) | rejected at extraction, no candidate |
| Slash-containing relative fragment (`lib/check_agent_liveness.py`) | STOP (false) | OK (suffix-resolved) |
| `/tmp` scratchpad absolute paths | STOP (false) | rejected at extraction, no candidate |
| Gitignored `errors.jsonl` | STOP (false) | WARN |
| Deliberate placeholder filenames (`X.md`, `foo.py`, `example.py`) | STOP (false) | rejected at extraction, no candidate |
| True positive — genuinely deleted `wave_key_reset.py` (#705) | STOP (true) | STOP (true, preserved) |
| True positive — bare filename absent everywhere (parent + all children) | STOP (true) | STOP (true, preserved) |
| True positive — bare filename in a CHILD repo, coincidentally present in parent | STOP (true) | STOP (true, preserved — MF1 is one-directional) |

## Pre-fix failure output (original 8 tests, first push)

Ran the new tests against pre-fix `premise_check.py` (before any change in this PR): all 8 new tests fail, all 40 pre-existing tests still pass.

```
FAILED .claude/lib/tests/test_premise_check.py::Main1138LooksLikePathTest::test_rejects_absolute_tmp_scratchpad_path
FAILED .claude/lib/tests/test_premise_check.py::Main1138LooksLikePathTest::test_rejects_bare_extension_token
FAILED .claude/lib/tests/test_premise_check.py::Main1138LooksLikePathTest::test_rejects_deliberate_example_filenames
FAILED .claude/lib/tests/test_premise_check.py::Main1138VerdictLayerTest::test_creates_array_prevents_stop_on_proposed_file
FAILED .claude/lib/tests/test_premise_check.py::Main1138VerdictLayerTest::test_creates_does_not_suppress_other_missing_paths
FAILED .claude/lib/tests/test_premise_check.py::Main1138VerdictLayerTest::test_cross_repo_symmetric_parent_misses_child_resolves
FAILED .claude/lib/tests/test_premise_check.py::GitIntegrationTest::test_gitignored_path_is_warn_not_stop
FAILED .claude/lib/tests/test_premise_check.py::GitIntegrationTest::test_relative_fragment_suffix_resolves_under_claude
========================= 8 failed, 40 passed in 0.50s =========================
```

Representative assertions:

```
Main1138LooksLikePathTest.test_rejects_bare_extension_token
>       self.assertFalse(pc.looks_like_path(".py"))
E       AssertionError: True is not false

Main1138VerdictLayerTest.test_cross_repo_symmetric_parent_misses_child_resolves
>       self.assertEqual(res.verdict, pc.WARN)
E       AssertionError: 'stop' != 'warn'

Main1138VerdictLayerTest.test_creates_array_prevents_stop_on_proposed_file
>       self.assertEqual(res.verdict, pc.OK)
E       AssertionError: 'stop' != 'ok'

GitIntegrationTest.test_gitignored_path_is_warn_not_stop
>           self.assertEqual(res.candidates[0].status, pc.GITIGNORED)
E           AttributeError: module 'premise_check' has no attribute 'GITIGNORED'

GitIntegrationTest.test_relative_fragment_suffix_resolves_under_claude
>           self.assertEqual(statuses["lib/check_agent_liveness.py"], pc.EXISTS)
E           AssertionError: 'missing' != 'exists'
```

## Pre-MF1 failure output (the 3 new MF1 tests, against the first-push head fb0aeb328)

```
FAILED .claude/lib/tests/test_premise_check.py::Main1138VerdictLayerTest::test_cross_repo_bare_filename_main_1110_literal_token
  AssertionError: 'stop' != 'warn'
```

(`test_cross_repo_bare_filename_not_found_anywhere_still_stops` and `test_cross_repo_bare_filename_not_widened_on_child_to_parent_side` already passed at fb0aeb328 — they pin behavior that MF1 must NOT change, i.e. recall and directionality — so they are not "failing-before" fixtures, they are guard-rails against over-widening the MF1 fix itself.)

## Post-fix (this head, 922ff6e)

```
51 passed in 0.39s
```

All 48 previously-passing tests (40 pre-existing + 8 from the first push) still pass unchanged, plus the 3 new MF1 tests.

## CI / local parity

Ran the complete local check-set before each push (`pre-commit run` + `--hook-stage pre-push`): ruff-format, ruff-lint, actionlint, cspell, mypy (hooks+lib+skills), the full `.claude/lib/tests/` + `.claude/hooks/tests/` pytest suites, the drift-sync gate (`pre_commit_ci_sync.py`), memory-budget, headcount-budget, doc-freshness (advisory), office-drift, mermaid-render. All green. CI on the first push: 21/21 success (independently re-verified by Aino via REST check-runs).

## Reviewers

- Aino Virtanen (peer reviewer, merge-gate)
- Nino Kavtaradze (secondary reviewer, Approved on the first push)
