### PR TITLE
tech-debt(lib): extract the verdict vocabulary into charter_trailer.py (#1359)

### DIFF
--- a/.claude/hooks/tests/test_validate_pr_review.py
+++ b/.claude/hooks/tests/test_validate_pr_review.py
@@ -1555,11 +1555,25 @@ class StripCodeRegionsTests(unittest.TestCase):
         self.assertIn("Requestor: foo", result)
 
     def test_unterminated_fenced_block_strips_rest(self):
-        """An open ``` without a close conservatively eats the rest. Reviewer
-        error mode (forgot close fence) → fail safe by not matching trailing
-        chars as fields.
+        """An open ``` without a close, on its OWN LINE, conservatively eats
+        the rest. Reviewer error mode (forgot close fence) → fail safe by
+        not matching trailing chars as fields.
+
+        UPDATED (main#1359 merge-gate review, Aino Virtanen — MF4): this
+        fixture's opener used to be mid-line (`"intro ```\\n..."`), which is
+        no longer treated as a fence at all — CommonMark does not recognize
+        a mid-line marker as an opener either, and the old expectation
+        ("eats the rest") depended on that not being enforced. A mid-line
+        marker mentioned in ordinary prose (exactly what a reviewer writes
+        when discussing fence syntax — the live incident that motivated this
+        fix) must now pass through as literal text, not swallow everything
+        after it. The body below moves the opener to the start of its own
+        line so this fixture still exercises the "unterminated, eats the
+        rest" behaviour it is named for; `FenceOpenerMustStartALineTests` in
+        `test_charter_trailer.py` covers the mid-line-is-now-prose case this
+        fixture used to (accidentally) encode.
         """
-        body = "intro ```\nRequestor: foo"
+        body = "intro\n```\nRequestor: foo"
         result = hook._strip_code_regions(body)
         self.assertIn("intro", result)
         self.assertNotIn("Requestor", result)

--- a/.claude/hooks/tests/test_validate_review_comment_format.py
+++ b/.claude/hooks/tests/test_validate_review_comment_format.py
@@ -1163,12 +1163,17 @@ class ConditionalFieldGrammarAgreementTests(unittest.TestCase):
     prose mention was present to one and absent to the other, and the hook
     blocked a comment for a field nobody wrote.
 
-    The hook's copy is a deliberate mirror rather than an import (a blocking
-    PreToolUse gate should not take a 26ms dependency for one regex, and
-    `charter_trailer` cannot own it yet — `trust_signals` § main#1359 records
-    that it lacks `~~~` support and that adding it belongs to that migration).
-    This drives both implementations over one corpus so the mirror cannot
-    drift silently. Consolidation terminus: main#1359 / main#1371.
+    Two of the three axes that caused that (main#1359): anchoring and scope
+    remain a deliberate hook-local mirror of `trust_signals._RETRACTION_RE` /
+    `._ORCHESTRATOR_CAUSED_RE` (a blocking PreToolUse gate should not take a
+    dependency for one regex pair, and full consolidation of THIS pair is
+    main#1371/#1372, not main#1359). The THIRD axis — code fences — is no
+    longer a mirror: `hook._strip_code_for_field_scan` now calls
+    `charter_trailer.strip_code_regions` directly, the same function
+    `trust_signals.parse_verdicts` calls, since main#1359 folded `~~~`
+    support into it and deleted `trust_signals`'s private stripper. This
+    drives both implementations over one corpus so the remaining mirror
+    cannot drift silently.
     """
 
     CORPUS = (
@@ -1204,7 +1209,7 @@ class ConditionalFieldGrammarAgreementTests(unittest.TestCase):
             counter_says = [
                 name
                 for name in hook._CONDITIONAL_VERDICT_FIELDS
-                if counter_re[name].search(ts._strip_code_markup(body))
+                if counter_re[name].search(ts.charter_trailer.strip_code_regions(body))
             ]
             with self.subTest(body=body):
                 self.assertEqual(hook_says, counter_says)
@@ -1217,7 +1222,20 @@ class ConditionalFieldGrammarAgreementTests(unittest.TestCase):
 
         for body in self.CORPUS:
             with self.subTest(body=body):
-                self.assertEqual(hook._strip_code_for_field_scan(body), ts._strip_code_markup(body))
+                self.assertEqual(
+                    hook._strip_code_for_field_scan(body),
+                    ts.charter_trailer.strip_code_regions(body),
+                )
+
+    def test_code_stripper_is_the_shared_function_object(self):
+        """main#1359: no second definition — `_strip_code_for_field_scan` is
+        `charter_trailer.strip_code_regions`, not a call-alike mirror of it."""
+        lib_dir = Path(__file__).resolve().parents[2] / "lib"
+        if str(lib_dir) not in sys.path:
+            sys.path.insert(0, str(lib_dir))
+        import charter_trailer as ct
+
+        self.assertIs(hook.strip_code_regions, ct.strip_code_regions)
 
 
 class ConditionalFieldEndToEndTests(unittest.TestCase):

--- a/.claude/hooks/tests/test_validate_review_comment_format.py
+++ b/.claude/hooks/tests/test_validate_review_comment_format.py
@@ -1042,9 +1042,10 @@ class ConditionalVerdictFieldTests(unittest.TestCase):
         self.assertIsNone(result)
 
     def test_spaced_and_bare_changes_spellings_are_accepted(self):
-        # Must agree with `trust_signals._verdict_kind`, which counts all three
-        # spellings — including the bare `Changes` that `_VERDICT_DIRECTIONS`
-        # deliberately excludes.
+        # Must agree with `_direction_is_changes_requested` (and, through it,
+        # `charter_trailer.verdict_kind(..., include_bare_changes=True)`,
+        # main#1359), which counts all three spellings — including the bare
+        # `Changes` that `_VERDICT_DIRECTIONS` deliberately excludes.
         for direction in ("ChangesRequested", "Changes Requested", "Changes"):
             with self.subTest(direction=direction):
                 result = self._check(
@@ -1123,8 +1124,12 @@ class ConditionalVerdictFieldTests(unittest.TestCase):
             self.assertNotIn("only meaningful on", result.get("reason", ""))
 
     def test_field_quoted_in_a_tilde_fence_does_not_block(self):
-        # `charter_trailer.strip_code_regions` leaves `~~~` intact while
-        # `trust_signals._strip_code_markup` strips it — the second axis.
+        # Regression guard, not a live divergence as of main#1359:
+        # `charter_trailer.strip_code_regions` now strips `~~~` the same as
+        # `trust_signals` (whose own private stripper is deleted), and this
+        # hook's `_strip_code_for_field_scan` calls the shared function
+        # directly — the "code fences" axis of the three-axis divergence is
+        # closed. Kept as a regression test for that closed gap.
         command = (
             "gh pr comment 42 --body \"$(cat <<'EOF'\n"
             "Here is the shape:\n~~~\nRetracted: example only\n~~~\n\n---\n"
@@ -1228,14 +1233,27 @@ class ConditionalFieldGrammarAgreementTests(unittest.TestCase):
                 )
 
     def test_code_stripper_is_the_shared_function_object(self):
-        """main#1359: no second definition — `_strip_code_for_field_scan` is
-        `charter_trailer.strip_code_regions`, not a call-alike mirror of it."""
+        """main#1359 SF1 (Aino Virtanen): `_strip_code_for_field_scan` — the
+        name `_conditional_fields_present` actually calls — IS
+        `charter_trailer.strip_code_regions`, not a call-alike mirror of it.
+
+        This is the identity assertion the mutation-testing finding asked
+        for: reverting `_strip_code_for_field_scan` to a local `def` mirror
+        left the entire suite green (`test_no_second_definition_anywhere`
+        only greps for a FIXED set of names, so a copy under this name was
+        invisible to it). Asserting identity on the name actually called —
+        not just the module-level `strip_code_regions` import binding this
+        test used to check — fails immediately the moment `def
+        _strip_code_for_field_scan(...)` reappears here, regardless of what
+        the reimplementation's body does or doesn't diverge on.
+        """
         lib_dir = Path(__file__).resolve().parents[2] / "lib"
         if str(lib_dir) not in sys.path:
             sys.path.insert(0, str(lib_dir))
         import charter_trailer as ct
 
         self.assertIs(hook.strip_code_regions, ct.strip_code_regions)
+        self.assertIs(hook._strip_code_for_field_scan, ct.strip_code_regions)
 
 
 class ConditionalFieldEndToEndTests(unittest.TestCase):

--- a/.claude/hooks/tests/test_validate_review_comment_format_failopen.py
+++ b/.claude/hooks/tests/test_validate_review_comment_format_failopen.py
@@ -597,8 +597,21 @@ class TrailerHelperSingularityTests(unittest.TestCase):
     def test_no_second_definition_anywhere(self) -> None:
         """Scan hooks AND lib. Scoping this to one directory would make the
         guard silently stop guarding the moment the module moved — which it
-        just did (main#932)."""
-        defs = {"strip_code_regions", "trailer_block_substring", "extract_charter_field"}
+        just did (main#932).
+
+        `verdict_kind` / `normalize_verdict_token` joined the guarded set in
+        main#1359: before that extraction, `trust_signals.py` carried a
+        private `_verdict_kind` / `_normalize_verdict_token` pair this exact
+        sweep would have caught (verified against the pre-#1359 tree — the
+        sweep found `lib/trust_signals.py:normalize_verdict_token` and
+        `lib/trust_signals.py:verdict_kind`)."""
+        defs = {
+            "strip_code_regions",
+            "trailer_block_substring",
+            "extract_charter_field",
+            "verdict_kind",
+            "normalize_verdict_token",
+        }
         searched = sorted(_HOOKS_DIR.glob("*.py")) + sorted(_LIB_DIR.glob("*.py"))
         self.assertGreater(len(searched), 20, "file sweep found almost nothing — verify the glob")
 
@@ -617,7 +630,13 @@ class TrailerHelperSingularityTests(unittest.TestCase):
     def test_the_sweep_can_actually_find_a_definition(self) -> None:
         """Verify the instrument: the scan must match a known definition."""
         canonical = (_LIB_DIR / "charter_trailer.py").read_text()
-        for name in ("strip_code_regions", "trailer_block_substring", "extract_charter_field"):
+        for name in (
+            "strip_code_regions",
+            "trailer_block_substring",
+            "extract_charter_field",
+            "verdict_kind",
+            "normalize_verdict_token",
+        ):
             self.assertRegex(canonical, rf"(?m)^def {name}\(")
 
 

--- a/.claude/hooks/validate_review_comment_format.py
+++ b/.claude/hooks/validate_review_comment_format.py
@@ -726,17 +726,32 @@ _CONDITIONAL_FIELD_RE = {
 }
 
 
-def _strip_code_for_field_scan(text: str) -> str:
-    """The code-stripping step for the conditional-field presence scan.
-
-    As of main#1359/#1361 this is `charter_trailer.strip_code_regions`
-    directly — no local mirror. Before that fix, this function WAS a private
-    copy of `trust_signals._strip_code_markup` (kept apart from
-    `charter_trailer.strip_code_regions` specifically because that one left
-    `~~~` fences intact); now that the shared stripper handles `~~~` too,
-    there is nothing left for a second copy to diverge on.
-    """
-    return strip_code_regions(text)
+# The code-stripping step for the conditional-field presence scan is the
+# SAME function object as the shared stripper — a direct alias, not a
+# wrapper, and not a local mirror (main#1359/#1361, hardened per SF1 below).
+#
+# Before main#1359 this name bound a private `re.sub`-based copy of
+# `trust_signals._strip_code_markup` (kept apart from
+# `charter_trailer.strip_code_regions` specifically because that one left
+# `~~~` fences intact); now that the shared stripper handles `~~~` too,
+# there is nothing left for a second copy to diverge on.
+#
+# main#1359 merge-gate review (Aino Virtanen, SF1): reverting this name to a
+# local `def _strip_code_for_field_scan(text): return re.sub(...)` mirror
+# left the ENTIRE suite green — `test_no_second_definition_anywhere` greps
+# `^def _?{name}\(` against a fixed name set, so a copy bound under a
+# DIFFERENT function name (this one) is invisible to it, and the only
+# existing identity check (`test_both_hooks_share_one_function_object`)
+# asserted the module-level `strip_code_regions` import binding, never this
+# name. A plain assignment (mirroring `validate_pr_review._strip_code_regions
+# = strip_code_regions`) closes that hole: any future `def
+# _strip_code_for_field_scan(...)` here immediately fails
+# `test_code_stripper_is_the_shared_function_object`
+# (`test_validate_review_comment_format.py`), which asserts identity, not
+# merely equal output, and — because a `def` also constitutes a
+# reintroduced local implementation — no longer needs its own name added to
+# the singularity sweep's fixed set to be caught.
+_strip_code_for_field_scan = strip_code_regions
 
 
 def _conditional_fields_present(body: str) -> list[str]:
@@ -756,15 +771,20 @@ def _direction_is_changes_requested(body: str) -> bool:
 
     Narrower than :func:`_direction_is_verdict`, which also accepts Approved.
     Accepts the bare ``Changes`` spelling that `_VERDICT_DIRECTIONS`
-    deliberately excludes, because `trust_signals._verdict_kind` DOES count it
-    as ChangesRequested — this predicate must agree with the consumer whose
-    behaviour it is protecting, not with the sibling verdict-set.
+    deliberately excludes, because `trust_signals.parse_verdicts` (via
+    `charter_trailer.verdict_kind(..., include_bare_changes=True)`, main#1359)
+    DOES count it as ChangesRequested — this predicate must agree with the
+    consumer whose behaviour it is protecting, not with the sibling
+    verdict-set.
 
-    That makes **three** verdict-direction classifiers across two files, two of
-    which disagree on bare ``Changes`` *by design*. Consolidating them is
-    tracked as **main#1371** (see also main#1359); it is not a change to make
-    incidentally, because the divergence is intentional per-consumer and
-    collapsing it wrongly would silently re-scope two hooks.
+    That makes **two** verdict-direction classifiers left in this file
+    (`_VERDICT_DIRECTIONS` here and this function), disagreeing on bare
+    ``Changes`` *by design* — `trust_signals`'s own former third copy was
+    deleted in main#1359, which also added `charter_trailer.verdict_kind(...,
+    include_bare_changes=...)` as the shared classifier these two migrate
+    onto. Consolidating them is tracked as **main#1371**; it is not a change
+    to make incidentally, because the divergence is intentional per-consumer
+    and collapsing it wrongly would silently re-scope two hooks.
     """
     match = re.search(r"RequestOrReplied:\s*(.+)", body)
     if not match:

--- a/.claude/hooks/validate_review_comment_format.py
+++ b/.claude/hooks/validate_review_comment_format.py
@@ -700,18 +700,23 @@ _VERDICT_DIRECTIONS = frozenset(
 #      is a field to the hook and prose to the counter. #1364 makes this the
 #      likely case, not a contrived one: the field is now a documented
 #      obligation, so reviewers will write *about* it in trailers.
-#   2. code fences — `strip_code_regions` does not strip `~~~` blocks;
-#      `_strip_code_markup` does. A `~~~`-quoted example blocked.
-#   3. scope — trailer-block only vs whole body.
+#   2. code fences — RESOLVED by main#1359/#1361: `charter_trailer
+#      .strip_code_regions` now strips `~~~` blocks the same as the (now
+#      deleted) private `trust_signals._strip_code_markup` did, so this
+#      predicate uses the shared stripper directly (see
+#      `_strip_code_for_field_scan` below) instead of mirroring it.
+#   3. scope — trailer-block only vs whole body. STILL OPEN: `_CONDITIONAL_FIELD_RE`
+#      below is still a hook-local mirror of `trust_signals._RETRACTION_RE` /
+#      `._ORCHESTRATOR_CAUSED_RE`, because `charter_trailer.extract_charter_field`
+#      narrows to the trailer block and this predicate deliberately does not
+#      (main#1359 extracted the STRIPPER and the verdict-KIND vocabulary, not
+#      this presence-detection pair — tracked separately, main#1371/#1372).
 #
-# The definitions below mirror the counter's exactly and are pinned against
-# it by `ConditionalFieldGrammarAgreementTests`, which drives both
-# implementations over one corpus so a future divergence reds rather than
-# silently false-blocks. Folding these into the shared `charter_trailer`
-# owner is the real terminus and is tracked work, NOT to be done incidentally
-# here: `trust_signals` § main#1359 records that `charter_trailer` lacks
-# `~~~` support and that adding it belongs to that migration. See also
-# main#1371 (verdict-direction classification has three implementations).
+# The field-presence definitions below still mirror the counter's regexes
+# (axis 1 + axis 3 remain open) and are pinned against it by
+# `ConditionalFieldGrammarAgreementTests`, which drives both implementations
+# over one corpus so a future divergence reds rather than silently
+# false-blocks. Full consolidation of this remaining pair is main#1371/#1372.
 _CONDITIONAL_VERDICT_FIELDS = ("Retracted", "OrchestratorCaused")
 
 # Mirrors trust_signals._RETRACTION_RE / ._ORCHESTRATOR_CAUSED_RE.
@@ -722,16 +727,16 @@ _CONDITIONAL_FIELD_RE = {
 
 
 def _strip_code_for_field_scan(text: str) -> str:
-    """Mirrors ``trust_signals._strip_code_markup``.
+    """The code-stripping step for the conditional-field presence scan.
 
-    Deliberately NOT ``charter_trailer.strip_code_regions``: that one leaves
-    ``~~~`` fences intact, so a reviewer quoting the field shape in a ``~~~``
-    block would be present to the hook and absent to the counter. Replaces
-    each region with same-length whitespace so line structure — which the
-    line-anchored patterns depend on — is preserved.
+    As of main#1359/#1361 this is `charter_trailer.strip_code_regions`
+    directly — no local mirror. Before that fix, this function WAS a private
+    copy of `trust_signals._strip_code_markup` (kept apart from
+    `charter_trailer.strip_code_regions` specifically because that one left
+    `~~~` fences intact); now that the shared stripper handles `~~~` too,
+    there is nothing left for a second copy to diverge on.
     """
-    text = re.sub(r"```.*?```|~~~.*?~~~", lambda m: " " * len(m.group()), text, flags=re.DOTALL)
-    return re.sub(r"`[^`\n]+`", lambda m: " " * len(m.group()), text)
+    return strip_code_regions(text)
 
 
 def _conditional_fields_present(body: str) -> list[str]:

--- a/.claude/lib/charter_trailer.py
+++ b/.claude/lib/charter_trailer.py
@@ -70,6 +70,30 @@ __all__ = [
 
 _FENCE_MARKERS = ("```", "~~~")
 
+# The prefix a fence opener is allowed to sit behind and still count as
+# "starting a line" (main#1359 merge-gate review round 3, MF5). CommonMark
+# permits up to 3 leading spaces of indentation before a fence marker (4+ is
+# INDENTED CODE BLOCK territory, a different construct); GitHub-flavoured
+# Markdown additionally permits one or more nested blockquote markers
+# (`>`, optionally followed by a single space, repeatable for nesting) ahead
+# of that indentation. Anything else preceding the marker on its line — any
+# non-blockquote, non-whitespace prose character — means the marker is NOT
+# an opener; see `strip_code_regions` for why that distinction is load-bearing.
+_FENCE_OPENER_PREFIX_RE = re.compile(r"^(?:>[ \t]?)*[ \t]{0,3}$")
+
+
+def _is_fence_opener_position(body: str, i: int) -> bool:
+    """True if position `i` in `body` is where a fence opener is allowed.
+
+    "Allowed" means everything on the current line before `i` is only
+    blockquote markers and/or up to 3 spaces/tabs of indentation — the
+    CommonMark + GFM shape `strip_code_regions` treats as "starts a line"
+    for fence-opening purposes. A line's start is `i == 0` or the character
+    immediately after the nearest preceding newline.
+    """
+    line_start = body.rfind("\n", 0, i) + 1
+    return bool(_FENCE_OPENER_PREFIX_RE.match(body[line_start:i]))
+
 
 def strip_code_regions(body: str) -> str:
     """Strip fenced code blocks (```…``` or ~~~…~~~) and inline code (`…`).
@@ -120,10 +144,21 @@ def strip_code_regions(body: str) -> str:
         # own verdict trailer. The CLOSING search below is intentionally NOT
         # similarly anchored — that is unchanged, pre-existing behaviour and
         # not part of this fix.
-        at_line_start = i == 0 or body[i - 1] == "\n"
+        #
+        # "STARTS A LINE" MEANS UP TO 3 SPACES AND/OR A BLOCKQUOTE PREFIX,
+        # NOT COLUMN 0 EXACTLY (round-3 review, MF5). The first cut of the
+        # MF4 guard (`i == 0 or body[i - 1] == "\n"`) demanded column 0
+        # exactly, which is STRICTER than CommonMark and opened a new,
+        # worse-direction hole: an indented or blockquoted fence — exactly
+        # what GitHub's "Quote reply" button emits, no adversary needed — was
+        # no longer recognised as a fence at all, so a fabricated field
+        # inside one was left unstripped and could out-scope a genuine
+        # trailer above it via last-match-wins. `_is_fence_opener_position`
+        # accepts the CommonMark/GFM shape; a marker behind any OTHER prefix
+        # (ordinary prose text) still correctly fails to qualify.
         fence = (
             next((m for m in _FENCE_MARKERS if body.startswith(m, i)), None)
-            if at_line_start
+            if _is_fence_opener_position(body, i)
             else None
         )
         if fence is not None:

--- a/.claude/lib/charter_trailer.py
+++ b/.claude/lib/charter_trailer.py
@@ -53,6 +53,7 @@ from __future__ import annotations
 import re
 
 __all__ = [
+    "VERDICT_KIND",
     "branch_author_first_initial",
     "extract_branch_author_lastname",
     "extract_charter_field",
@@ -60,13 +61,18 @@ __all__ = [
     "is_wave_branch",
     "name_first_initial",
     "name_lastname",
+    "normalize_verdict_token",
     "strip_code_regions",
     "trailer_block_substring",
+    "verdict_kind",
 ]
 
 
+_FENCE_MARKERS = ("```", "~~~")
+
+
 def strip_code_regions(body: str) -> str:
-    """Strip fenced code blocks (```…```) and inline code (`…`) from `body`.
+    """Strip fenced code blocks (```…``` or ~~~…~~~) and inline code (`…`).
 
     Returns a body where every char inside a code region is replaced with a
     space (preserving line indices for downstream regex). This prevents
@@ -76,14 +82,32 @@ def strip_code_regions(body: str) -> str:
     The replacement char is space (not empty) so any `re.search` line/column
     arithmetic remains accurate against the original `body`'s line offsets,
     making `trailer_block_substring`'s `---`-line detection unaffected.
+
+    Both triple-backtick AND triple-tilde fences are stripped (main#1359,
+    main#1361). Markdown accepts either as a fence marker, and reviewers use
+    both in practice to demonstrate the trailer shape without writing a real
+    verdict. Before main#1359 this function only recognized ```` ``` ````,
+    while `trust_signals._strip_code_markup` (a private, now-deleted copy of
+    this same concept) recognized `~~~` too — a divergence that was
+    outcome-changing for `trust_signals`' `Retracted:` guard: a `~~~`-fenced
+    example containing the literal field shape was correctly ignored by
+    `_strip_code_markup` but would have been read as genuine by
+    `strip_code_regions`, and — because `validate_pr_review` aliases this
+    function directly for its verdict-counting loop — as a genuine trailer by
+    the merge gate too (main#1361, live gap, 0/220 wave-29 comments hit it).
+    Folding `~~~` support in here, rather than leaving `trust_signals`' copy
+    as the more-correct one, closes both gaps from the single definition.
     """
     out: list[str] = []
     i = 0
     n = len(body)
     while i < n:
-        # Fenced code: ```...``` (triple-backtick on its own or with lang tag).
-        if body.startswith("```", i):
-            end = body.find("```", i + 3)
+        # Fenced code: ```...``` or ~~~...~~~ (triple marker on its own or
+        # with a language tag). Both markers use identical open/close/
+        # unterminated handling — only the marker string differs.
+        fence = next((m for m in _FENCE_MARKERS if body.startswith(m, i)), None)
+        if fence is not None:
+            end = body.find(fence, i + 3)
             if end == -1:
                 # Unterminated fence — strip rest of body.
                 out.append(" " * (n - i))
@@ -169,6 +193,123 @@ def extract_charter_field(field_name: str, body: str) -> str | None:
     value = value.strip("*").strip()
     value = re.sub(r"\s*\(.*?\)\s*$", "", value).strip()
     return value or None
+
+
+# ---------------------------------------------------------------------------
+# Verdict-kind vocabulary (main#1359)
+# ---------------------------------------------------------------------------
+#
+# The `RequestOrReplied:` field's value is free text a reviewer types, and it
+# has been typed at least six ways in practice: the charter-canonical
+# one-word `ChangesRequested`, the human-typed spaced `Changes Requested`,
+# the short `Changes`, `Approved`, `Request`, and `Reply`/`Replied`. Every
+# consumer that needs to ACT on the verdict — not merely display it — has to
+# classify the raw text into one of those canonical kinds first.
+#
+# Before main#1359, that classification was a private copy in THREE places:
+#   * `trust_signals._verdict_kind` / `_VERDICT_KIND` / `_normalize_verdict_token`
+#   * `validate_pr_review._is_verdict` / `_is_approved` / `_VERDICT_REQUIRING_TECH_DEBT`
+#   * `validate_review_comment_format._direction_is_verdict` /
+#     `_direction_is_changes_requested` / `_VERDICT_DIRECTIONS`
+#
+# `trust_signals.py` (PR #1356) argued extraction was blocked by a
+# dependency-direction problem — "lib code importing from hooks/ would invert
+# the intended dependency direction" — and that premise does not hold: the
+# shared home for this vocabulary is `.claude/lib/charter_trailer.py`, which
+# is ALSO `.claude/lib/`, not `.claude/hooks/`. `trust_signals.py` already
+# does `sys.path.insert(0, Path(__file__).resolve().parent)`, so importing
+# a sibling `.claude/lib/` module costs zero path changes — verified at PR
+# #1356 head `0478497`:
+#
+#     import charter_trailer from lib: OK (same dir, already on ts's sys.path)
+#     charter_trailer.extract_charter_field("RequestOrReplied", body) -> 'Changes Requested'
+#     trust_signals.parse_verdicts(...)[0].verdict                    -> 'Changes Requested'
+#
+# i.e. the value `trust_signals`' private field regex reproduced was already
+# correct, one file over, before that PR ever touched it.
+#
+# The three copies do NOT already agree, which is the argument FOR one owner,
+# not evidence that copies are safe:
+#   * `validate_review_comment_format._VERDICT_DIRECTIONS` deliberately
+#     EXCLUDES bare `Changes` ("The bare 'Changes' prefix is NOT a verdict on
+#     its own — we require the full token"). `trust_signals._VERDICT_KIND`
+#     and `validate_pr_review._VERDICT_REQUIRING_TECH_DEBT` both include it.
+#   * The classification ALGORITHMS differ three ways too:
+#     `validate_pr_review` lowercases + `rstrip("*")`s the WHOLE value and
+#     does exact-set membership; `validate_review_comment_format` tries the
+#     first-1-and-first-2 token join against a canonical set;
+#     `trust_signals` normalizes the FIRST token to alphanumerics-only and
+#     looks it up. `Approved (post-merge)` classifies differently across the
+#     three raw implementations.
+#
+# `verdict_kind` below is the one classifier. The bare-`Changes` disagreement
+# is real and deliberate (a well-formed-verdict question vs. a
+# does-this-comment-block question, per main#1371) — it is kept as the
+# `include_bare_changes` ARGUMENT, not as a fourth silently-forked table, so
+# a caller states which of the two questions it is asking. `trust_signals`
+# migrates onto this in the same change that defines it (its three private
+# copies deleted); `validate_pr_review` and `validate_review_comment_format`
+# migrate their four remaining copies onto it under main#1371 — that
+# consolidation is sequenced to land AFTER this module gains the shared
+# definition, so it lands ONTO one owner rather than creating a fourth.
+VERDICT_KIND: dict[str, str] = {
+    "approved": "approved",
+    "changesrequested": "changesrequested",
+    "changes": "changesrequested",
+    "request": "request",
+    "reply": "reply",
+    "replied": "reply",
+}
+
+
+def normalize_verdict_token(raw: str) -> str:
+    """Casefold + strip everything but alphanumerics from one token.
+
+    Collapses spelling/formatting variants of the SAME token to one key
+    (``**ChangesRequested**`` and ``ChangesRequested`` both normalize to
+    ``"changesrequested"``).
+    """
+    return re.sub(r"[^a-z0-9]", "", raw.casefold())
+
+
+def verdict_kind(value: str | None, *, include_bare_changes: bool = True) -> str:
+    """Classify a captured ``RequestOrReplied`` value into a canonical kind.
+
+    Returns ``"approved"``, ``"changesrequested"``, ``"request"``,
+    ``"reply"``, or ``""`` for anything unrecognized (including ``None`` or
+    an empty/whitespace-only value). Classification looks only at the first
+    word (or, for the two-word ``Changes``+``Requested`` spelling, the first
+    two words) of the value, so trailing noise past that point never defeats
+    the match — ``Approved (post-merge)`` still classifies as ``"approved"``.
+
+    ``include_bare_changes`` (default ``True``) controls whether the LONE
+    token ``Changes`` — with no trailing ``Requested`` word — classifies as
+    ``"changesrequested"``. This is a REAL, deliberate divergence between
+    consumers, not an oversight: whether bare ``Changes`` is a well-formed
+    declared verdict is a different question from whether a comment should
+    be treated as blocking, and the two questions have opposite correct
+    answers in different callers (main#1371). Pass ``include_bare_changes``
+    explicitly rather than special-casing the token at the call site — that
+    is what keeps this the one definition instead of a fourth copy.
+
+    The two-word spelling (``Changes Requested`` / ``**Changes** Requested``)
+    is NEVER gated by ``include_bare_changes`` — only the single bare token
+    is. A naive first-token-only classifier cannot tell ``Changes Requested``
+    apart from bare ``Changes`` (both start with the same word), which would
+    silently widen the exclusion to spellings no consumer meant to exclude;
+    the second word is checked precisely to keep that from happening.
+    """
+    if not value:
+        return ""
+    parts = value.split()
+    if not parts:
+        return ""
+    token = normalize_verdict_token(parts[0])
+    if token == "changes":
+        if len(parts) >= 2 and normalize_verdict_token(parts[1]) == "requested":
+            return "changesrequested"
+        return "changesrequested" if include_bare_changes else ""
+    return VERDICT_KIND.get(token, "")
 
 
 # ---------------------------------------------------------------------------

--- a/.claude/lib/charter_trailer.py
+++ b/.claude/lib/charter_trailer.py
@@ -71,25 +71,46 @@ __all__ = [
 _FENCE_MARKERS = ("```", "~~~")
 
 # The prefix a fence opener is allowed to sit behind and still count as
-# "starting a line" (main#1359 merge-gate review round 3, MF5). CommonMark
-# permits up to 3 leading spaces of indentation before a fence marker (4+ is
-# INDENTED CODE BLOCK territory, a different construct); GitHub-flavoured
-# Markdown additionally permits one or more nested blockquote markers
-# (`>`, optionally followed by a single space, repeatable for nesting) ahead
-# of that indentation. Anything else preceding the marker on its line — any
-# non-blockquote, non-whitespace prose character — means the marker is NOT
-# an opener; see `strip_code_regions` for why that distinction is load-bearing.
-_FENCE_OPENER_PREFIX_RE = re.compile(r"^(?:>[ \t]?)*[ \t]{0,3}$")
+# "starting a line" (main#1359 merge-gate review, MF5 + MF6). Anything
+# preceding the marker on its line that is NOT a blockquote marker or plain
+# whitespace disqualifies it — that is what keeps MF4's fix intact (a marker
+# behind real prose text is not an opener). Indentation depth is otherwise
+# UNBOUNDED (main#1359 MF6) — deliberately NOT capped at CommonMark's own
+# 3-space fence-vs-indented-code-block boundary.
+#
+# Why uncapped, not "capped at 3 like CommonMark": that boundary answers a
+# question `strip_code_regions` does not need answered. CommonMark cares
+# whether a 4+-space-indented marker is a FENCE or an INDENTED CODE BLOCK —
+# two different constructs a real renderer treats differently. Both are
+# still CODE, and once a reviewer types a paired opening/closing marker on
+# its own line — however indented — that intent to mark off code is
+# unambiguous regardless of which construct a renderer would call it. A
+# 3-space cap here (MF5's first cut) left exactly that shape — a marker
+# preceded by ONLY 4+ spaces of indentation, nothing else — disqualified as
+# an opener, so its contents fell through to literal prose: a fabricated
+# trailer field inside a 4-space-indented, well-paired backtick block below
+# a real trailer won last-match-wins, a regression from base (which had no
+# indentation limit at all for a marker occurrence). The identical shape
+# with the tilde marker was already unsafe on base (tilde was not a
+# recognized marker at all pre-main#1359) — this fix closes that
+# pre-existing hole too, as a bonus, not as a second regression fix.
+#
+# What this does NOT do: give this function general CommonMark
+# indented-code-block recognition. Plain 4+-space-indented text with NO
+# triple marker anywhere is still never stripped, before or after this
+# change — that broader, marker-independent gap is tracked separately
+# (main#1420), out of scope here.
+_FENCE_OPENER_PREFIX_RE = re.compile(r"^(?:>[ \t]?)*[ \t]*$")
 
 
 def _is_fence_opener_position(body: str, i: int) -> bool:
     """True if position `i` in `body` is where a fence opener is allowed.
 
     "Allowed" means everything on the current line before `i` is only
-    blockquote markers and/or up to 3 spaces/tabs of indentation — the
-    CommonMark + GFM shape `strip_code_regions` treats as "starts a line"
-    for fence-opening purposes. A line's start is `i == 0` or the character
-    immediately after the nearest preceding newline.
+    blockquote markers and/or whitespace (any amount) — see
+    `_FENCE_OPENER_PREFIX_RE` for why indentation depth is deliberately
+    unbounded. A line's start is `i == 0` or the character immediately
+    after the nearest preceding newline.
     """
     line_start = body.rfind("\n", 0, i) + 1
     return bool(_FENCE_OPENER_PREFIX_RE.match(body[line_start:i]))
@@ -145,17 +166,13 @@ def strip_code_regions(body: str) -> str:
         # similarly anchored — that is unchanged, pre-existing behaviour and
         # not part of this fix.
         #
-        # "STARTS A LINE" MEANS UP TO 3 SPACES AND/OR A BLOCKQUOTE PREFIX,
-        # NOT COLUMN 0 EXACTLY (round-3 review, MF5). The first cut of the
-        # MF4 guard (`i == 0 or body[i - 1] == "\n"`) demanded column 0
-        # exactly, which is STRICTER than CommonMark and opened a new,
-        # worse-direction hole: an indented or blockquoted fence — exactly
-        # what GitHub's "Quote reply" button emits, no adversary needed — was
-        # no longer recognised as a fence at all, so a fabricated field
-        # inside one was left unstripped and could out-scope a genuine
-        # trailer above it via last-match-wins. `_is_fence_opener_position`
-        # accepts the CommonMark/GFM shape; a marker behind any OTHER prefix
-        # (ordinary prose text) still correctly fails to qualify.
+        # "STARTS A LINE" MEANS ANY AMOUNT OF WHITESPACE AND/OR A BLOCKQUOTE
+        # PREFIX, NOT COLUMN 0 EXACTLY (MF5, then MF6 removed MF5's own
+        # 3-space cap — see `_FENCE_OPENER_PREFIX_RE` for the full history
+        # and why the cap itself was a second fail-open regression). A
+        # marker behind any OTHER prefix (ordinary prose text) still
+        # correctly fails to qualify as an opener — that is MF4's fix, and
+        # neither MF5 nor MF6 touched it.
         fence = (
             next((m for m in _FENCE_MARKERS if body.startswith(m, i)), None)
             if _is_fence_opener_position(body, i)

--- a/.claude/lib/charter_trailer.py
+++ b/.claude/lib/charter_trailer.py
@@ -99,18 +99,36 @@ _FENCE_MARKERS = ("```", "~~~")
 # indented-code-block recognition. Plain 4+-space-indented text with NO
 # triple marker anywhere is still never stripped, before or after this
 # change — that broader, marker-independent gap is tracked separately
-# (main#1420), out of scope here.
-_FENCE_OPENER_PREFIX_RE = re.compile(r"^(?:>[ \t]?)*[ \t]*$")
+# (main#1416), out of scope here.
+#
+# WHITESPACE IS ALLOWED BEFORE THE BLOCKQUOTE GROUP TOO, NOT ONLY AFTER IT
+# (main#1359 MF7). MF6's regex, `^(?:>[ \t]?)*[ \t]*$`, put its trailing
+# `[ \t]*` term downstream of the `(?:>...)*` group — so whitespace was only
+# recognized AFTER the blockquote markers ("> " then spaces: quote-then-
+# indent). The untested axis was indent-then-quote (spaces THEN ">"), which
+# had no whitespace allowance in front of the first `>` at all and so failed
+# to qualify as an opener. That is not exotic: CommonMark permits up to 3
+# spaces before a `>`, GitHub renders it as an ordinary blockquote, and a
+# blockquote INSIDE A LIST ITEM produces exactly this shape (the list
+# marker's own indentation precedes the quote marker). A fabricated block
+# behind that prefix, below a real trailer, is worse than a name swap — it
+# also flips `RequestOrReplied` (e.g. `Approved` on base to
+# `ChangesRequested` at the pre-MF7 head), and the identical unstripped-block
+# mechanism defeats `trust_signals.parse_verdicts`'s `Retracted:` scan. Fixed
+# by moving the whitespace term to also precede (and be repeatable between)
+# the blockquote markers, not only trail the group as a whole.
+_FENCE_OPENER_PREFIX_RE = re.compile(r"^[ \t]*(?:>[ \t]*)*$")
 
 
 def _is_fence_opener_position(body: str, i: int) -> bool:
     """True if position `i` in `body` is where a fence opener is allowed.
 
     "Allowed" means everything on the current line before `i` is only
-    blockquote markers and/or whitespace (any amount) — see
-    `_FENCE_OPENER_PREFIX_RE` for why indentation depth is deliberately
-    unbounded. A line's start is `i == 0` or the character immediately
-    after the nearest preceding newline.
+    blockquote markers and/or whitespace (any amount, in any relative
+    order — before, between, or after the blockquote markers; main#1359
+    MF7) — see `_FENCE_OPENER_PREFIX_RE` for why indentation depth is
+    deliberately unbounded. A line's start is `i == 0` or the character
+    immediately after the nearest preceding newline.
     """
     line_start = body.rfind("\n", 0, i) + 1
     return bool(_FENCE_OPENER_PREFIX_RE.match(body[line_start:i]))
@@ -167,12 +185,12 @@ def strip_code_regions(body: str) -> str:
         # not part of this fix.
         #
         # "STARTS A LINE" MEANS ANY AMOUNT OF WHITESPACE AND/OR A BLOCKQUOTE
-        # PREFIX, NOT COLUMN 0 EXACTLY (MF5, then MF6 removed MF5's own
-        # 3-space cap — see `_FENCE_OPENER_PREFIX_RE` for the full history
-        # and why the cap itself was a second fail-open regression). A
-        # marker behind any OTHER prefix (ordinary prose text) still
-        # correctly fails to qualify as an opener — that is MF4's fix, and
-        # neither MF5 nor MF6 touched it.
+        # PREFIX, IN EITHER ORDER, NOT COLUMN 0 EXACTLY (MF5, MF6, MF7 — see
+        # `_FENCE_OPENER_PREFIX_RE` for the full history of each fail-open
+        # regression the previous fix's own restriction opened). A marker
+        # behind any OTHER prefix (ordinary prose text) still correctly
+        # fails to qualify as an opener — that is MF4's fix, and none of
+        # MF5/MF6/MF7 touched it.
         fence = (
             next((m for m in _FENCE_MARKERS if body.startswith(m, i)), None)
             if _is_fence_opener_position(body, i)

--- a/.claude/lib/charter_trailer.py
+++ b/.claude/lib/charter_trailer.py
@@ -255,6 +255,18 @@ def extract_charter_field(field_name: str, body: str) -> str | None:
 VERDICT_KIND: dict[str, str] = {
     "approved": "approved",
     "changesrequested": "changesrequested",
+    # NOTE (main#1359 merge-gate review, Aino Virtanen — nit): this row is
+    # documentation-only and UNREACHABLE through `verdict_kind()` — that
+    # function intercepts the `token == "changes"` case in its own branch
+    # BEFORE ever reaching this dict lookup, precisely because bare `Changes`
+    # is the one distinction `include_bare_changes` exists to gate, and a
+    # flat dict lookup has no way to carry that argument. A caller that
+    # bypasses `verdict_kind()` and reads `VERDICT_KIND` directly (it is
+    # exported via `__all__` for exactly this) gets `"changesrequested"` for
+    # `"changes"` unconditionally — the same as `include_bare_changes=True`,
+    # never `=False`. Kept in the table for completeness of the documented
+    # vocabulary rather than dropped, since `verdict_kind()` is the intended
+    # entry point and existing consumers all go through it.
     "changes": "changesrequested",
     "request": "request",
     "reply": "reply",

--- a/.claude/lib/charter_trailer.py
+++ b/.claude/lib/charter_trailer.py
@@ -105,7 +105,27 @@ def strip_code_regions(body: str) -> str:
         # Fenced code: ```...``` or ~~~...~~~ (triple marker on its own or
         # with a language tag). Both markers use identical open/close/
         # unterminated handling — only the marker string differs.
-        fence = next((m for m in _FENCE_MARKERS if body.startswith(m, i)), None)
+        #
+        # THE OPENER MUST START A LINE (main#1359 merge-gate review, Aino
+        # Virtanen — MF4). Per CommonMark, a code-fence opener is a leading
+        # sequence on its own line; a marker occurring mid-sentence is prose,
+        # not a fence. Before this guard, a marker mentioned in ordinary
+        # prose — exactly what a reviewer writes when discussing fence
+        # syntax, which main#1359 makes MORE likely by widening the accepted
+        # marker set — could be read as an "unterminated fence" and strip
+        # from that point to end-of-body, taking a real `---` trailer
+        # separator (and the whole comment) with it. Live trace: this PR's
+        # own review thread — a reviewer's comment about the marker this PR
+        # adds tripped an odd/unpaired occurrence in prose and erased their
+        # own verdict trailer. The CLOSING search below is intentionally NOT
+        # similarly anchored — that is unchanged, pre-existing behaviour and
+        # not part of this fix.
+        at_line_start = i == 0 or body[i - 1] == "\n"
+        fence = (
+            next((m for m in _FENCE_MARKERS if body.startswith(m, i)), None)
+            if at_line_start
+            else None
+        )
         if fence is not None:
             end = body.find(fence, i + 3)
             if end == -1:

--- a/.claude/lib/tests/test_charter_trailer.py
+++ b/.claude/lib/tests/test_charter_trailer.py
@@ -378,6 +378,108 @@ class FenceOpenerIndentationIsUnboundedTests(unittest.TestCase):
         self.assertEqual(extract_charter_field("Requestor", body), "Nino Kavtaradze")
 
 
+class FenceOpenerAllowsIndentBeforeBlockquoteTests(unittest.TestCase):
+    """main#1359 merge-gate review round 5 (Aino Virtanen / coordinator —
+    MF7): MF6's regex, `^(?:>[ \\t]?)*[ \\t]*$`, only allows whitespace
+    AFTER the blockquote-marker group — quote-then-indent (`"> "` then
+    spaces) works, but the untested axis, indent-then-quote (spaces THEN
+    `">"`), had no whitespace allowance at all in front of the first `>`.
+
+    Indent-then-quote is not exotic: CommonMark permits up to 3 spaces
+    before a `>`, GitHub renders it as an ordinary blockquote, and it is
+    exactly what a blockquote INSIDE A LIST ITEM produces (the list marker's
+    own indentation precedes the quote marker).
+
+    Worse than a name swap: a fabricated block below a genuine trailer does
+    not just spoof `Requestor` — it flips `RequestOrReplied` too (`Approved`
+    on base, `ChangesRequested` at the buggy head), and the same
+    unstripped-block mechanism defeats `trust_signals.parse_verdicts`'s
+    `Retracted:` scan (base strips the block, the buggy head does not).
+
+    Fix: `^[ \\t]*(?:>[ \\t]*)*$` — whitespace is now allowed BEFORE the
+    blockquote group, BETWEEN quote markers, and after the last one, not
+    only after the group as a whole.
+
+    Every assertion below FAILS at head `f4d67ec` (verified directly before
+    writing this fix — all four shapes returned the fabricated `Requestor`
+    AND the fabricated `RequestOrReplied`) and passes once whitespace is
+    also allowed ahead of the blockquote group.
+    """
+
+    @staticmethod
+    def _spoofed_body(prefix: str, marker: str = "```") -> str:
+        fence = f"{prefix}{marker}"
+        return (
+            "---\n"
+            "Requestor: Real Reviewer\n"
+            "Requestee: Santiago Ferreira\n"
+            "RequestOrReplied: Approved\n"
+            "TechDebt: none\n\n"
+            f"{fence}\n"
+            "Requestor: Fake Impostor\n"
+            "RequestOrReplied: ChangesRequested\n"
+            f"{fence}\n"
+        )
+
+    def test_one_space_then_quote_backtick_fence_is_stripped(self) -> None:
+        body = self._spoofed_body(" > ")
+        self.assertEqual(extract_charter_field("Requestor", body), "Real Reviewer")
+        self.assertEqual(extract_charter_field("RequestOrReplied", body), "Approved")
+
+    def test_two_space_then_quote_backtick_fence_is_stripped(self) -> None:
+        """The exact "blockquote inside a list item" shape."""
+        body = self._spoofed_body("  > ")
+        self.assertEqual(extract_charter_field("Requestor", body), "Real Reviewer")
+        self.assertEqual(extract_charter_field("RequestOrReplied", body), "Approved")
+
+    def test_three_space_then_quote_backtick_fence_is_stripped(self) -> None:
+        body = self._spoofed_body("   > ")
+        self.assertEqual(extract_charter_field("Requestor", body), "Real Reviewer")
+
+    def test_tab_then_quote_backtick_fence_is_stripped(self) -> None:
+        body = self._spoofed_body("\t> ")
+        self.assertEqual(extract_charter_field("Requestor", body), "Real Reviewer")
+
+    def test_two_space_then_quote_tilde_fence_is_stripped(self) -> None:
+        """Both markers, not just backtick."""
+        body = self._spoofed_body("  > ", "~~~")
+        self.assertEqual(extract_charter_field("Requestor", body), "Real Reviewer")
+
+    def test_indent_then_quote_then_indent_composed_fence_is_stripped(self) -> None:
+        """Whitespace before AND after the blockquote group, composed."""
+        body = self._spoofed_body("  >   ")
+        self.assertEqual(extract_charter_field("Requestor", body), "Real Reviewer")
+
+    def test_the_retraction_scan_also_sees_the_stripped_block(self) -> None:
+        """The `trust_signals.parse_verdicts` axis of the same defect: an
+        indent-then-quote fenced block below a genuine ChangesRequested
+        trailer, containing a fabricated `Retracted:` line, must not credit
+        a false-positive retraction that was never genuinely written."""
+        body = (
+            "---\n"
+            "Requestor: Real Reviewer\n"
+            "Requestee: Santiago Ferreira\n"
+            "RequestOrReplied: ChangesRequested\n"
+            "TechDebt: none\n\n"
+            "  > ```\n"
+            "Retracted: fabricated, never actually written by the reviewer\n"
+            "  > ```\n"
+        )
+        self.assertNotIn("fabricated", strip_code_regions(body))
+
+    def test_mid_sentence_marker_is_still_not_a_fence_opener(self) -> None:
+        """Regression guard: the new upstream whitespace allowance must not
+        also swallow the requirement that nothing but whitespace/blockquote
+        precedes the opener — real prose text still disqualifies it."""
+        body = (
+            "  Point A discusses the fence marker, indented as prose text.\n\n"
+            "---\n"
+            "Requestor: Nino Kavtaradze\n"
+            "RequestOrReplied: Approved\n"
+        ).replace("the fence marker", "the ~~~ fence marker")
+        self.assertEqual(extract_charter_field("Requestor", body), "Nino Kavtaradze")
+
+
 class NormalizeVerdictTokenTests(unittest.TestCase):
     def test_casefolds(self) -> None:
         self.assertEqual(normalize_verdict_token("ChangesRequested"), "changesrequested")

--- a/.claude/lib/tests/test_charter_trailer.py
+++ b/.claude/lib/tests/test_charter_trailer.py
@@ -154,9 +154,23 @@ class VerdictKindTests(unittest.TestCase):
 
     def test_trailing_text_does_not_defeat_the_match(self) -> None:
         """`Approved (post-merge)` must still classify as approved — only the
-        FIRST token is classified. `validate_pr_review._is_verdict`'s
-        pre-#1371 whole-string exact match does NOT tolerate this (verified:
-        it returns False for this exact input on the pre-fix tree)."""
+        FIRST token is classified.
+
+        NOTE (main#1359 merge-gate review, Aino Virtanen — MF1): an earlier
+        draft of this docstring claimed `validate_pr_review._is_verdict`
+        rejects this exact input. That claim was wrong and has been
+        retracted (see main#1371): `_is_verdict` is only ever called on
+        `extract_charter_field`'s output, which already strips the trailing
+        parenthetical before `_is_verdict` ever sees it, so end-to-end there
+        is no divergence on `"Approved (post-merge)"` specifically. The
+        genuinely reachable divergences — `"Approved!"`,
+        `"Approved with nits"`, `"Approved - see below"`,
+        `"Changes  Requested"` (double space), `"Changes needed"` — are all
+        `False` under `validate_pr_review._is_verdict`/`._is_approved` today
+        and would become `True` under this function; see
+        `main#1371` for the full table and the `_is_approved` /
+        2-reviewer-approver-set consequence.
+        """
         self.assertEqual(verdict_kind("Approved (post-merge)"), "approved")
 
     def test_bold_markers_do_not_defeat_the_match(self) -> None:

--- a/.claude/lib/tests/test_charter_trailer.py
+++ b/.claude/lib/tests/test_charter_trailer.py
@@ -113,6 +113,83 @@ class StripCodeRegionsTildeFenceTests(unittest.TestCase):
         self.assertIsNone(extract_charter_field("TechDebt", body))
 
 
+class FenceOpenerMustStartALineTests(unittest.TestCase):
+    """main#1359 merge-gate review (Aino Virtanen — MF4): a fence marker that
+    does not open a line must NOT be treated as a fence at all, per
+    CommonMark (a code-fence opener is defined as a leading sequence on its
+    own line, optional indent aside — a marker occurring mid-sentence is
+    just prose).
+
+    Why this matters here specifically: before this fix, adding `~~~` to
+    `_FENCE_MARKERS` (main#1359) gave a mid-prose, unpaired tilde run a
+    SECOND path to the same failure mode the backtick marker already had —
+    an odd/unpaired marker anywhere in prose above a trailer is read as an
+    "unterminated fence" and strips to end-of-body, taking the real `---`
+    separator and the whole trailer with it. Live trace: this exact PR's own
+    review thread — a reviewer's comment discussing the fence marker being
+    widened by this PR tripped the marker three times in prose, the third
+    occurrence unpaired, and the reviewer's own verdict trailer was erased.
+
+    EVERY assertion in `test_unpaired_fence_marker_in_prose_no_longer_erases_the_trailer`
+    below FAILS at PR head `a4909f2` (verified directly — three fields
+    resolved to `None` where they should have resolved to real values) and
+    passes once the fence opener is line-anchored.
+    """
+
+    def test_unpaired_fence_marker_in_prose_no_longer_erases_the_trailer(self) -> None:
+        body = (
+            "Point A discusses the fence marker once.\n\n"
+            "Point B discusses the fence marker a second time.\n\n"
+            "Point C discusses the fence marker a third time (odd count).\n\n"
+            "---\n"
+            "Requestor: Nino Kavtaradze\n"
+            "Requestee: Santiago Ferreira\n"
+            "RequestOrReplied: Approved\n"
+            "TechDebt: none\n"
+        ).replace("the fence marker", "the ~~~ fence marker")
+        self.assertEqual(extract_charter_field("Requestor", body), "Nino Kavtaradze")
+        self.assertEqual(extract_charter_field("Requestee", body), "Santiago Ferreira")
+        self.assertEqual(extract_charter_field("RequestOrReplied", body), "Approved")
+        self.assertEqual(extract_charter_field("TechDebt", body), "none")
+
+    def test_unpaired_backtick_run_in_prose_also_no_longer_erases_the_trailer(self) -> None:
+        """The identical hazard already existed for the backtick marker
+        before main#1359 (main#1413's root cause) — the line-anchoring fix
+        closes it for BOTH markers, not just the one this PR added."""
+        body = (
+            "Discussing the marker once, mid-sentence: ``` looks like this.\n\n"
+            "Discussing it again: ``` and a third time: ``` (odd count).\n\n"
+            "---\n"
+            "Requestor: Nino Kavtaradze\n"
+            "RequestOrReplied: Approved\n"
+        )
+        self.assertEqual(extract_charter_field("Requestor", body), "Nino Kavtaradze")
+        self.assertEqual(extract_charter_field("RequestOrReplied", body), "Approved")
+
+    def test_line_start_fence_still_strips_a_genuine_block(self) -> None:
+        """Regression guard: a REAL fence — marker at the start of a line —
+        must still be recognized and stripped. Only mid-line occurrences
+        stop counting as fence openers."""
+        body = "before\n~~~\nRequestor: Ghost\n~~~\nafter"
+        self.assertNotIn("Requestor", strip_code_regions(body))
+
+    def test_fence_at_the_very_start_of_the_body_still_strips(self) -> None:
+        """Position 0 has no preceding newline but IS the start of a line."""
+        body = "~~~\nRequestor: Ghost\n~~~\nafter"
+        self.assertNotIn("Requestor", strip_code_regions(body))
+
+    def test_the_flagged_pre_existing_fixture_shape_is_now_prose(self) -> None:
+        """`test_validate_pr_review.py::StripCodeRegionsTests
+        ::test_unterminated_fenced_block_strips_rest` used a mid-line opener
+        (`"intro ```\\nRequestor: foo"`) — CommonMark would not treat that as
+        a fence either, so its old expectation (eats the rest) is no longer
+        correct; it now passes the marker through as literal prose. That
+        fixture is updated in the same change as this one."""
+        body = "intro ```\nRequestor: foo"
+        result = strip_code_regions(body)
+        self.assertIn("Requestor: foo", result)
+
+
 class NormalizeVerdictTokenTests(unittest.TestCase):
     def test_casefolds(self) -> None:
         self.assertEqual(normalize_verdict_token("ChangesRequested"), "changesrequested")

--- a/.claude/lib/tests/test_charter_trailer.py
+++ b/.claude/lib/tests/test_charter_trailer.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Tests for `charter_trailer`'s code-region stripping and verdict-kind
+vocabulary (main#1359, main#1361).
+
+Two things this file exists to pin, both already-happened divergences, not
+hypothetical ones:
+
+1. `strip_code_regions` used to strip ```` ``` ```` fences but not `~~~`
+   fences, while `trust_signals._strip_code_markup` (a private, now-deleted
+   copy of the same concept) stripped both. Because `validate_pr_review`
+   aliases `strip_code_regions` directly for its verdict-counting loop, the
+   gap was reachable from the merge gate (main#1361): a `~~~`-fenced trailer
+   *example*, with no real `---` trailer, parsed as a genuine verdict.
+2. The verdict-kind classification (`RequestOrReplied:` value -> canonical
+   kind) was implemented three times across `trust_signals.py`,
+   `validate_pr_review.py`, and `validate_review_comment_format.py`, and the
+   three implementations disagree with each other on the bare `Changes`
+   spelling and on trailing-text tolerance (`Approved (post-merge)`) —
+   verified directly against the pre-#1359 tree, see
+   `VerdictKindMatchesPreExtractionTrustSignalsTests` below.
+
+Run: python3 -m pytest .claude/lib/tests/test_charter_trailer.py
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+_LIB_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_LIB_DIR))
+
+from charter_trailer import (  # noqa: E402
+    VERDICT_KIND,
+    extract_charter_field,
+    normalize_verdict_token,
+    strip_code_regions,
+    verdict_kind,
+)
+
+
+class StripCodeRegionsBacktickFenceTests(unittest.TestCase):
+    """Pre-existing ```` ``` ```` behaviour — regression guard, not new."""
+
+    def test_fenced_block_is_stripped(self) -> None:
+        body = "before\n```\nRequestor: Ghost\n```\nafter"
+        self.assertNotIn("Requestor", strip_code_regions(body))
+
+    def test_inline_code_is_stripped(self) -> None:
+        result = strip_code_regions("see `Requestor: foo` for context")
+        self.assertNotIn("Requestor", result)
+
+    def test_unterminated_fence_strips_rest_of_body(self) -> None:
+        result = strip_code_regions("before\n```\nunterminated forever")
+        self.assertNotIn("unterminated", result)
+
+    def test_char_offsets_preserved(self) -> None:
+        """Same total length, so content AFTER a fence keeps its original
+        char offset (the docstring's "line/column arithmetic remains
+        accurate" claim) — the fenced SPAN itself is flattened to one run of
+        spaces, including its interior newlines, which is what stops a `---`
+        that happens to sit inside a fence from surviving as its own line."""
+        body = "line1\n```\ncode\n```\nline5"
+        result = strip_code_regions(body)
+        self.assertEqual(len(body), len(result))
+        self.assertTrue(result.endswith("line5"))
+
+
+class StripCodeRegionsTildeFenceTests(unittest.TestCase):
+    """main#1359/#1361: the divergence, reproduced and closed.
+
+    Every assertion below FAILS against the pre-#1359 `strip_code_regions`
+    (verified directly — see the class docstring on
+    `TildeFenceDivergenceTests` in `test_trust_signals.py` for the paired
+    `git stash` verification of the trust_signals side of this same gap).
+    """
+
+    def test_fenced_block_is_stripped(self) -> None:
+        body = "before\n~~~\nRequestor: Ghost\n~~~\nafter"
+        self.assertNotIn("Requestor", strip_code_regions(body))
+
+    def test_unterminated_fence_strips_rest_of_body(self) -> None:
+        result = strip_code_regions("before\n~~~\nunterminated forever")
+        self.assertNotIn("unterminated", result)
+
+    def test_char_offsets_preserved(self) -> None:
+        body = "line1\n~~~\ncode\n~~~\nline5"
+        result = strip_code_regions(body)
+        self.assertEqual(len(body), len(result))
+        self.assertTrue(result.endswith("line5"))
+
+    def test_mixed_fence_styles_both_stripped(self) -> None:
+        body = "```\nbacktick Requestor: A\n```\ntext\n~~~\ntilde Requestor: B\n~~~\n"
+        result = strip_code_regions(body)
+        self.assertNotIn("Requestor", result)
+        self.assertIn("text", result)
+
+    def test_tilde_fenced_trailer_example_with_no_real_trailer_extracts_nothing(self) -> None:
+        """main#1361's exact repro, run against the shared function directly."""
+        body = (
+            "Here is the format reviewers should use:\n\n"
+            "~~~\n"
+            "Requestor: Ghost Reviewer\n"
+            "Requestee: PR Author\n"
+            "RequestOrReplied: Approved\n"
+            "TechDebt: none\n"
+            "~~~\n\n"
+            "I have not reviewed this yet.\n"
+        )
+        self.assertIsNone(extract_charter_field("Requestor", body))
+        self.assertIsNone(extract_charter_field("RequestOrReplied", body))
+        self.assertIsNone(extract_charter_field("TechDebt", body))
+
+
+class NormalizeVerdictTokenTests(unittest.TestCase):
+    def test_casefolds(self) -> None:
+        self.assertEqual(normalize_verdict_token("ChangesRequested"), "changesrequested")
+
+    def test_strips_non_alnum(self) -> None:
+        self.assertEqual(normalize_verdict_token("**ChangesRequested"), "changesrequested")
+
+    def test_strips_trailing_punctuation(self) -> None:
+        self.assertEqual(normalize_verdict_token("Approved!"), "approved")
+
+
+class VerdictKindTests(unittest.TestCase):
+    def test_approved(self) -> None:
+        self.assertEqual(verdict_kind("Approved"), "approved")
+
+    def test_changesrequested_one_word(self) -> None:
+        self.assertEqual(verdict_kind("ChangesRequested"), "changesrequested")
+
+    def test_changes_requested_spaced(self) -> None:
+        self.assertEqual(verdict_kind("Changes Requested"), "changesrequested")
+
+    def test_request(self) -> None:
+        self.assertEqual(verdict_kind("Request"), "request")
+
+    def test_reply(self) -> None:
+        self.assertEqual(verdict_kind("Reply"), "reply")
+
+    def test_replied(self) -> None:
+        self.assertEqual(verdict_kind("Replied"), "reply")
+
+    def test_none_value(self) -> None:
+        self.assertEqual(verdict_kind(None), "")
+
+    def test_empty_value(self) -> None:
+        self.assertEqual(verdict_kind(""), "")
+
+    def test_unrecognized_value(self) -> None:
+        self.assertEqual(verdict_kind("Pending"), "")
+
+    def test_trailing_text_does_not_defeat_the_match(self) -> None:
+        """`Approved (post-merge)` must still classify as approved — only the
+        FIRST token is classified. `validate_pr_review._is_verdict`'s
+        pre-#1371 whole-string exact match does NOT tolerate this (verified:
+        it returns False for this exact input on the pre-fix tree)."""
+        self.assertEqual(verdict_kind("Approved (post-merge)"), "approved")
+
+    def test_bold_markers_do_not_defeat_the_match(self) -> None:
+        self.assertEqual(verdict_kind("**ChangesRequested**"), "changesrequested")
+
+    # -- The deliberate divergence (main#1371): bare "Changes" -- #
+
+    def test_bare_changes_included_by_default(self) -> None:
+        """Default matches `trust_signals`'s pre-migration behaviour and
+        `validate_pr_review._VERDICT_REQUIRING_TECH_DEBT` (both include it)."""
+        self.assertEqual(verdict_kind("Changes"), "changesrequested")
+
+    def test_bare_changes_included_when_requested_explicitly(self) -> None:
+        self.assertEqual(verdict_kind("Changes", include_bare_changes=True), "changesrequested")
+
+    def test_bare_changes_excluded_when_requested(self) -> None:
+        """Matches `validate_review_comment_format._VERDICT_DIRECTIONS`, which
+        deliberately excludes the bare form ("not a verdict on its own")."""
+        self.assertEqual(verdict_kind("Changes", include_bare_changes=False), "")
+
+    def test_exclusion_does_not_affect_the_full_spelling(self) -> None:
+        """`include_bare_changes=False` narrows ONLY the bare token — the
+        one-word and spaced forms still classify either way."""
+        self.assertEqual(
+            verdict_kind("ChangesRequested", include_bare_changes=False), "changesrequested"
+        )
+        self.assertEqual(
+            verdict_kind("Changes Requested", include_bare_changes=False), "changesrequested"
+        )
+
+    def test_vocabulary_table_is_the_public_api(self) -> None:
+        self.assertEqual(
+            VERDICT_KIND,
+            {
+                "approved": "approved",
+                "changesrequested": "changesrequested",
+                "changes": "changesrequested",
+                "request": "request",
+                "reply": "reply",
+                "replied": "reply",
+            },
+        )
+
+
+class VerdictKindMatchesPreExtractionTrustSignalsTests(unittest.TestCase):
+    """`verdict_kind(..., include_bare_changes=True)` must reproduce every
+    answer the pre-#1359 `trust_signals._verdict_kind` gave, on the exact
+    inputs verified against that tree (`git stash` repro, see PR body) —
+    a parity guard for the one call site (`trust_signals.py`) this issue
+    fully migrates.
+    """
+
+    _PRE_FIX_TRUST_SIGNALS_ANSWERS = {
+        "Changes": "changesrequested",
+        "ChangesRequested": "changesrequested",
+        "Changes Requested": "changesrequested",
+        "Approved (post-merge)": "approved",
+        "Approved": "approved",
+        "Request": "request",
+        "Reply": "reply",
+        "Replied": "reply",
+    }
+
+    def test_matches_pre_fix_trust_signals_on_every_verified_input(self) -> None:
+        for value, expected in self._PRE_FIX_TRUST_SIGNALS_ANSWERS.items():
+            with self.subTest(value=value):
+                self.assertEqual(verdict_kind(value, include_bare_changes=True), expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/lib/tests/test_charter_trailer.py
+++ b/.claude/lib/tests/test_charter_trailer.py
@@ -190,6 +190,101 @@ class FenceOpenerMustStartALineTests(unittest.TestCase):
         self.assertIn("Requestor: foo", result)
 
 
+class FenceOpenerAllowsBlockquoteAndIndentTests(unittest.TestCase):
+    """main#1359 merge-gate review round 3 (Aino Virtanen / coordinator —
+    MF5): the MF4 fix (`i == 0 or body[i - 1] == "\\n"`) demanded column 0
+    EXACTLY. CommonMark allows a code-fence opener up to 3 leading spaces of
+    indentation, and (GFM) inside a blockquote container's `>` prefix. The
+    over-strict anchor rejected BOTH real-world shapes as fence openers,
+    which is a FAIL-OPEN, not the fail-closed direction MF4 fixed:
+
+    A body with the real trailer FIRST, followed by a blockquoted or
+    indented fenced block containing a FABRICATED `Requestor:` line, used to
+    have that fabrication safely stripped (base, and PR head before MF4).
+    After the MF4 fix alone, an indented or blockquoted fence opener is no
+    longer recognised as a fence at all, so it is NOT stripped, and
+    last-match-wins hands `extract_charter_field` the fabricated name
+    instead of the real one — a spoofed reviewer identity reaching the
+    merge gate.
+
+    Every assertion below FAILS at head `975be2a` (verified directly before
+    writing this fix: both the blockquoted and 2-space-indented shapes
+    return the fabricated `"Fake Impostor"` instead of `"Real Reviewer"`)
+    and passes once the fence-opener check accepts a blockquote/indent
+    prefix.
+    """
+
+    @staticmethod
+    def _spoofed_body(prefix: str) -> str:
+        fence = f"{prefix}```"
+        return (
+            "---\n"
+            "Requestor: Real Reviewer\n"
+            "Requestee: Santiago Ferreira\n"
+            "RequestOrReplied: Approved\n"
+            "TechDebt: none\n\n"
+            f"{fence}\n"
+            "Requestor: Fake Impostor\n"
+            f"{fence}\n"
+        )
+
+    def test_blockquoted_fence_below_the_trailer_is_still_stripped(self) -> None:
+        """GitHub's "Quote reply" button emits exactly this shape — no
+        adversary required, an ordinary reviewer quoting an earlier comment
+        produces it by accident."""
+        body = self._spoofed_body("> ")
+        self.assertEqual(extract_charter_field("Requestor", body), "Real Reviewer")
+
+    def test_two_space_indented_fence_below_the_trailer_is_still_stripped(self) -> None:
+        body = self._spoofed_body("  ")
+        self.assertEqual(extract_charter_field("Requestor", body), "Real Reviewer")
+
+    def test_three_space_indented_fence_below_the_trailer_is_still_stripped(self) -> None:
+        """CommonMark's indentation ceiling for a fence is 3 spaces — the
+        boundary case."""
+        body = self._spoofed_body("   ")
+        self.assertEqual(extract_charter_field("Requestor", body), "Real Reviewer")
+
+    def test_nested_blockquote_fence_below_the_trailer_is_still_stripped(self) -> None:
+        body = self._spoofed_body("> > ")
+        self.assertEqual(extract_charter_field("Requestor", body), "Real Reviewer")
+
+    def test_tilde_marker_blockquoted_below_the_trailer_is_still_stripped(self) -> None:
+        """Both markers, not just the backtick one — MF4's own fix applied
+        to both, this must too."""
+        body = (
+            "---\n"
+            "Requestor: Real Reviewer\n"
+            "RequestOrReplied: Approved\n\n"
+            "> ~~~\n"
+            "Requestor: Fake Impostor\n"
+            "> ~~~\n"
+        )
+        self.assertEqual(extract_charter_field("Requestor", body), "Real Reviewer")
+
+    def test_four_space_indent_still_not_a_fence_opener(self) -> None:
+        """Regression guard for the boundary: 4+ spaces is CommonMark's
+        INDENTED CODE BLOCK territory, not a fence, and is correctly still
+        not recognised — this is unchanged, pre-existing behaviour, not a
+        new hole opened by widening the fence-opener check."""
+        body = self._spoofed_body("    ")
+        self.assertEqual(extract_charter_field("Requestor", body), "Fake Impostor")
+
+    def test_mid_sentence_marker_is_still_prose_not_a_fence(self) -> None:
+        """Regression guard for MF4: a marker prefixed by ordinary prose
+        text (not blockquote markers or pure whitespace) must still fail to
+        qualify as a fence opener."""
+        body = (
+            "Point A discusses the fence marker once.\n\n"
+            "Point B discusses the fence marker a second time.\n\n"
+            "Point C discusses the fence marker a third time (odd count).\n\n"
+            "---\n"
+            "Requestor: Nino Kavtaradze\n"
+            "RequestOrReplied: Approved\n"
+        ).replace("the fence marker", "the ~~~ fence marker")
+        self.assertEqual(extract_charter_field("Requestor", body), "Nino Kavtaradze")
+
+
 class NormalizeVerdictTokenTests(unittest.TestCase):
     def test_casefolds(self) -> None:
         self.assertEqual(normalize_verdict_token("ChangesRequested"), "changesrequested")

--- a/.claude/lib/tests/test_charter_trailer.py
+++ b/.claude/lib/tests/test_charter_trailer.py
@@ -262,14 +262,6 @@ class FenceOpenerAllowsBlockquoteAndIndentTests(unittest.TestCase):
         )
         self.assertEqual(extract_charter_field("Requestor", body), "Real Reviewer")
 
-    def test_four_space_indent_still_not_a_fence_opener(self) -> None:
-        """Regression guard for the boundary: 4+ spaces is CommonMark's
-        INDENTED CODE BLOCK territory, not a fence, and is correctly still
-        not recognised — this is unchanged, pre-existing behaviour, not a
-        new hole opened by widening the fence-opener check."""
-        body = self._spoofed_body("    ")
-        self.assertEqual(extract_charter_field("Requestor", body), "Fake Impostor")
-
     def test_mid_sentence_marker_is_still_prose_not_a_fence(self) -> None:
         """Regression guard for MF4: a marker prefixed by ordinary prose
         text (not blockquote markers or pure whitespace) must still fail to
@@ -278,6 +270,107 @@ class FenceOpenerAllowsBlockquoteAndIndentTests(unittest.TestCase):
             "Point A discusses the fence marker once.\n\n"
             "Point B discusses the fence marker a second time.\n\n"
             "Point C discusses the fence marker a third time (odd count).\n\n"
+            "---\n"
+            "Requestor: Nino Kavtaradze\n"
+            "RequestOrReplied: Approved\n"
+        ).replace("the fence marker", "the ~~~ fence marker")
+        self.assertEqual(extract_charter_field("Requestor", body), "Nino Kavtaradze")
+
+
+class FenceOpenerIndentationIsUnboundedTests(unittest.TestCase):
+    """main#1359 merge-gate review round 4 (coordinator's fuller matrix —
+    MF6): MF5's fix capped accepted indentation at 3 spaces, mirroring
+    CommonMark's fence-vs-indented-code-block boundary. That boundary
+    answers a DIFFERENT question than the one `strip_code_regions` needs
+    answered.
+
+    CommonMark cares whether a 4+-space-indented marker is a FENCE (a
+    delimited code region) or an INDENTED CODE BLOCK (a different code
+    construct, delimited by indentation alone). Both are still CODE. This
+    stripper's only job is "is this a code region a reviewer deliberately
+    marked off" — and once someone types a paired opening/closing marker on
+    its own line, indented by any amount, that intent is unambiguous
+    regardless of which CommonMark construct a renderer would call it.
+
+    Capping at 3 broke that: a marker preceded ONLY by 4+ spaces of
+    indentation (nothing else — still disqualified if preceded by real
+    prose text, per MF4) failed the fence-opener check, so its contents
+    fell through to being read as literal prose. A fabricated field inside
+    a 4-space-indented, well-paired marker block placed BELOW a real
+    trailer therefore won last-match-wins — a regression from BASE for the
+    backtick marker specifically:
+
+        BASE Requestor:  'Real Reviewer'   (any position was a valid opener)
+        HEAD Requestor:  'Fake Impostor'   (4+ spaces disqualified, MF5 head)
+
+    The identical shape with the tilde marker spoofs on BOTH base and the
+    MF5 head — tilde was never a recognised marker at all pre-main#1359, so
+    this is a PRE-EXISTING hole this fix additionally closes as a bonus,
+    not a regression main#1359 introduced.
+
+    Fix: the fence-opener prefix check no longer caps indentation at 3 —
+    any amount of leading whitespace (plus optional blockquote nesting) in
+    front of the marker still qualifies, as long as nothing else precedes
+    it on the line. This is a deliberate, acknowledged DIVERGENCE from
+    CommonMark's own fence-opener rule (which is capped at 3) — CommonMark
+    would call a 4+-space marker an INDENTED CODE BLOCK rather than a
+    FENCE, but this stripper does not implement that distinction and does
+    not need to for its own purpose (stripping deliberately-marked-off code
+    regions). What this fix does NOT do is give `strip_code_regions` general
+    indented-code-block recognition — an indented block with NO triple
+    marker at all (plain 4+-space-indented text, no `` ``` `` / `~~~` in
+    sight) is still never stripped by this function, before or after this
+    change. That broader, marker-independent gap is filed separately as
+    main#1416, out of scope here — this fix closes only the marker-present
+    case the regression above describes.
+
+    Every assertion below FAILS at head `2b95706` (verified directly before
+    writing this fix) and passes once the cap is removed.
+    """
+
+    @staticmethod
+    def _spoofed_body(prefix: str, marker: str) -> str:
+        fence = f"{prefix}{marker}"
+        return (
+            "---\n"
+            "Requestor: Real Reviewer\n"
+            "Requestee: Santiago Ferreira\n"
+            "RequestOrReplied: Approved\n"
+            "TechDebt: none\n\n"
+            f"{fence}\n"
+            "Requestor: Fake Impostor\n"
+            f"{fence}\n"
+        )
+
+    def test_four_space_indented_backtick_fence_is_stripped(self) -> None:
+        """The regression: safe on base, spoofable at the MF5 head."""
+        body = self._spoofed_body("    ", "```")
+        self.assertEqual(extract_charter_field("Requestor", body), "Real Reviewer")
+
+    def test_four_space_indented_tilde_fence_is_stripped(self) -> None:
+        """The pre-existing hole (unsafe on base too, tilde never recognized
+        pre-main#1359) that this same fix additionally closes."""
+        body = self._spoofed_body("    ", "~~~")
+        self.assertEqual(extract_charter_field("Requestor", body), "Real Reviewer")
+
+    def test_deeply_indented_backtick_fence_is_still_stripped(self) -> None:
+        """Indentation is UNBOUNDED now, not merely raised to a new cap —
+        8 spaces, well past any CommonMark construct's own ceiling."""
+        body = self._spoofed_body(" " * 8, "```")
+        self.assertEqual(extract_charter_field("Requestor", body), "Real Reviewer")
+
+    def test_indented_blockquoted_fence_is_still_stripped(self) -> None:
+        """Blockquote nesting composed with indentation past the old cap."""
+        body = self._spoofed_body(">     ", "```")
+        self.assertEqual(extract_charter_field("Requestor", body), "Real Reviewer")
+
+    def test_mid_sentence_marker_is_still_not_a_fence_opener(self) -> None:
+        """Regression guard: removing the indentation CAP must not also
+        remove the requirement that NOTHING but whitespace/blockquote
+        markers precede the opener — prose text still disqualifies it,
+        regardless of how it is indented."""
+        body = (
+            "    Point A discusses the fence marker, indented as prose.\n\n"
             "---\n"
             "Requestor: Nino Kavtaradze\n"
             "RequestOrReplied: Approved\n"

--- a/.claude/lib/tests/test_trust_signals.py
+++ b/.claude/lib/tests/test_trust_signals.py
@@ -489,6 +489,50 @@ class ConsolidatedStripCodeRegionsAlsoFixesTheHookAlias(unittest.TestCase):
         self.assertEqual(ct.extract_charter_field("RequestOrReplied", body), "ChangesRequested")
 
 
+class UnterminatedFenceDirectionChangeTests(unittest.TestCase):
+    """main#1359 merge-gate review (Aino Virtanen, MF2): the stripper swap is
+    NOT parity-preserving on an unterminated fence, in the direction that
+    costs a reviewer their false-positive credit.
+
+    The deleted `trust_signals._strip_code_markup` required a CLOSING fence
+    marker to match, so an opened-but-never-closed fence was left alone and
+    anything after it — including a genuine `Retracted:` self-mark — still
+    counted. `charter_trailer.strip_code_regions` strips an unterminated
+    fence to end-of-body instead (the CommonMark-correct answer), which
+    silently swallows a genuine self-mark written below one. This is a
+    deliberate, documented trade (see the migration comment in
+    `parse_verdicts`), not something this PR is asked to change — the point
+    is that it is now STATED and PINNED rather than merely true.
+    """
+
+    def test_genuine_self_mark_below_an_unterminated_fence_is_now_swallowed(self) -> None:
+        body = (
+            "RequestOrReplied: ChangesRequested\n\n"
+            "```\n"
+            "snippet opened but never closed\n"
+            "Retracted: on reflection this finding was invalid, my mistake.\n"
+        )
+        v = ts.parse_verdicts([body])[0]
+        # Pre-#1359 (deleted `_strip_code_markup`): this was True — the
+        # reviewer's self-mark survived because the old stripper left an
+        # unterminated fence untouched. Post-#1359: False.
+        self.assertFalse(v.false_positive)
+
+    def test_same_shape_with_a_closed_fence_still_detects_the_self_mark(self) -> None:
+        """Regression guard: only the UNTERMINATED case changed. A closed
+        fence still correctly hides a quoted example, and a real self-mark
+        OUTSIDE any fence is still detected."""
+        body = (
+            "RequestOrReplied: ChangesRequested\n\n"
+            "```\n"
+            "quoted example, not a real self-mark\n"
+            "```\n"
+            "Retracted: on reflection this finding was invalid, my mistake.\n"
+        )
+        v = ts.parse_verdicts([body])[0]
+        self.assertTrue(v.false_positive)
+
+
 # --------------------------------------------------------------------------- #
 # Extraction (gh-mocked)
 # --------------------------------------------------------------------------- #

--- a/.claude/lib/tests/test_trust_signals.py
+++ b/.claude/lib/tests/test_trust_signals.py
@@ -34,6 +34,7 @@ from unittest import mock
 # .claude/lib/tests/test_*.py. parent.parent reaches the lib root.
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
+import charter_trailer as ct  # noqa: E402
 import trust_signals as ts  # noqa: E402
 import wave_status  # noqa: E402
 
@@ -146,7 +147,7 @@ class ParseVerdicts(unittest.TestCase):
         """Widening the capture to a full line must not defeat the approved match."""
         body = _verdict("Aino Virtanen", "Nadia Khoury", "Approved (post-merge)")
         v = ts.parse_verdicts([body])[0]
-        self.assertEqual(ts._verdict_kind(v.verdict), "approved")
+        self.assertEqual(ct.verdict_kind(v.verdict, include_bare_changes=True), "approved")
 
     # -- Regression: main#1348 -- `review_false_positives` is gated on an
     # explicit `Retracted:` field, never free-text substring matching. A word
@@ -176,21 +177,22 @@ class ParseVerdicts(unittest.TestCase):
     # named after the specific line the mutant strips.
 
     def test_bold_only_verdict_value_still_classifies(self) -> None:
-        """`_normalize_verdict_token`'s alnum-stripping, not just casefold.
+        """`charter_trailer.normalize_verdict_token`'s alnum-stripping, not just casefold.
 
         A verdict field with no surrounding whitespace before the bold
         marker (`RequestOrReplied: **ChangesRequested**`) is captured with
         its LEADING `**` intact — only the trailing `**` is stripped by the
         field regex's `\\**\\s*$` tail, so the captured token is literally
-        `"**ChangesRequested"`. Removing `_normalize_verdict_token`'s
+        `"**ChangesRequested"`. Removing `charter_trailer.normalize_verdict_token`'s
         `re.sub(r"[^a-z0-9]", "", ...)` step (leaving only `.casefold()`)
-        does not fail any other test in this file — `_normalize_verdict_token`
-        needs its own direct assertion.
+        does not fail any other test in this file —
+        `charter_trailer.normalize_verdict_token` needs its own direct
+        assertion (see `test_charter_trailer.py`, main#1359).
         """
         body = "Requestor: A\nRequestee: B\nRequestOrReplied: **ChangesRequested**\n"
         v = ts.parse_verdicts([body])[0]
         self.assertEqual(v.verdict, "**ChangesRequested")
-        self.assertEqual(ts._verdict_kind(v.verdict), "changesrequested")
+        self.assertEqual(ct.verdict_kind(v.verdict, include_bare_changes=True), "changesrequested")
         self.assertTrue(ts._is_changes_requested(v.verdict))
 
     def test_retracted_mentioned_mid_prose_never_counts(self) -> None:
@@ -374,6 +376,117 @@ class ParseVerdicts(unittest.TestCase):
                 )
                 v = ts.parse_verdicts([body])[0]
                 self.assertFalse(v.false_positive)
+
+
+# --------------------------------------------------------------------------- #
+# Verdict-vocabulary extraction (main#1359) — singularity + the divergence
+# the extraction was filed to close.
+# --------------------------------------------------------------------------- #
+class VerdictVocabularySingularityTests(unittest.TestCase):
+    """One definition of the verdict-kind vocabulary, not a private copy here.
+
+    `trust_signals.py` used to carry `_VERDICT_KIND` / `_normalize_verdict_token`
+    / `_verdict_kind` / `_strip_code_markup` as private copies of concepts
+    `charter_trailer` (main#932/#934's declared single source of truth for the
+    trailer convention) now also owns. These assertions make a reintroduced
+    copy fail CI rather than rot quietly, mirroring
+    `TrailerHelperSingularityTests` in
+    `test_validate_review_comment_format_failopen.py`.
+    """
+
+    def test_module_has_no_private_vocabulary_symbols(self) -> None:
+        for name in ("_VERDICT_KIND", "_normalize_verdict_token", "_verdict_kind"):
+            self.assertFalse(hasattr(ts, name), f"trust_signals.{name} should not exist")
+
+    def test_module_has_no_private_stripper(self) -> None:
+        self.assertFalse(
+            hasattr(ts, "_strip_code_markup"), "trust_signals._strip_code_markup should not exist"
+        )
+
+    def test_trust_signals_imports_the_shared_module(self) -> None:
+        self.assertIs(ts.charter_trailer, ct)
+
+
+class TildeFenceDivergenceTests(unittest.TestCase):
+    """The divergence main#1359/main#1361 report: pre-fix, `charter_trailer
+    .strip_code_regions` left `~~~` fences intact while `trust_signals`'
+    now-deleted private `_strip_code_markup` stripped them — same input,
+    different answer, depending on which copy handled it.
+
+    Verified against the pre-#1359 tree (`git stash` over this same
+    reproduction): ``trust_signals._strip_code_markup`` stripped the ``~~~``
+    block (``false_positive=False``, correct) while feeding the identical
+    body through ``charter_trailer.strip_code_regions`` instead left the
+    ``Retracted:`` line visible (``false_positive=True`` — wrong: it is a
+    quoted example, not a real self-mark). Post-fix there is exactly one
+    stripper and both call sites necessarily agree.
+    """
+
+    _TILDE_FENCED_RETRACTED_EXAMPLE = (
+        "RequestOrReplied: ChangesRequested\n\n~~~\nRetracted: quoted example\n~~~\n"
+    )
+
+    def test_charter_trailer_strip_code_regions_strips_tilde_fences(self) -> None:
+        # Pre-#1359/#1361: FAILS — `strip_code_regions` only recognized
+        # ```` ``` ```` and left the `~~~`-fenced `Retracted:` line intact, so
+        # `"Retracted"` remained in the output.
+        result = ct.strip_code_regions(self._TILDE_FENCED_RETRACTED_EXAMPLE)
+        self.assertNotIn("Retracted", result)
+
+    def test_quoted_retracted_inside_tilde_fence_is_not_a_false_positive(self) -> None:
+        # Pre-#1359: this specific assertion already passed, because
+        # `trust_signals` routed through its OWN private `_strip_code_markup`,
+        # not the shared (then-buggy) `charter_trailer.strip_code_regions`.
+        # It is a regression guard for the migration, not the divergence
+        # proof itself — see `test_charter_trailer_strip_code_regions_strips_tilde_fences`
+        # and `ConsolidatedStripCodeRegionsAlsoFixesTheHookAlias` below for that.
+        v = ts.parse_verdicts([self._TILDE_FENCED_RETRACTED_EXAMPLE])[0]
+        self.assertFalse(v.false_positive)
+
+
+class ConsolidatedStripCodeRegionsAlsoFixesTheHookAlias(unittest.TestCase):
+    """main#1361's exact repro, run against the shared definition directly.
+
+    `validate_pr_review.py` aliases `charter_trailer.strip_code_regions`
+    (`_strip_code_regions = strip_code_regions`) and `charter_trailer
+    .extract_charter_field` calls it internally — so main#1359's fence fix,
+    made once in `charter_trailer.py`, closes main#1361 for every consumer
+    without a second change. Pre-#1359/#1361 this test FAILS: both fields
+    resolve out of the `~~~`-fenced example even though there is no real
+    `---` trailer anywhere in the body.
+    """
+
+    def test_tilde_fenced_trailer_example_with_no_real_trailer_extracts_nothing(self) -> None:
+        body = (
+            "Here is the format reviewers should use:\n\n"
+            "~~~\n"
+            "Requestor: Ghost Reviewer\n"
+            "Requestee: PR Author\n"
+            "RequestOrReplied: Approved\n"
+            "TechDebt: none\n"
+            "~~~\n\n"
+            "I have not reviewed this yet.\n"
+        )
+        self.assertIsNone(ct.extract_charter_field("Requestor", body))
+        self.assertIsNone(ct.extract_charter_field("RequestOrReplied", body))
+        self.assertIsNone(ct.extract_charter_field("TechDebt", body))
+
+    def test_tilde_fenced_example_above_a_real_trailer_still_resolves_the_real_one(self) -> None:
+        """Regression guard (main#1361 acceptance): a real `---` trailer AFTER
+        a `~~~`-fenced example still wins — unaffected by the fence fix
+        because `trailer_block_substring` already scoped to the last `---`."""
+        body = (
+            "Here is the format reviewers should use:\n\n"
+            "~~~\n"
+            "Requestor: Ghost Reviewer\n"
+            "RequestOrReplied: Approved\n"
+            "~~~\n\n"
+            "---\n"
+            "Requestor: Nadia Khoury\n"
+            "RequestOrReplied: ChangesRequested\n"
+        )
+        self.assertEqual(ct.extract_charter_field("Requestor", body), "Nadia Khoury")
+        self.assertEqual(ct.extract_charter_field("RequestOrReplied", body), "ChangesRequested")
 
 
 # --------------------------------------------------------------------------- #

--- a/.claude/lib/trust_signals.py
+++ b/.claude/lib/trust_signals.py
@@ -402,6 +402,23 @@ def parse_verdicts(comment_bodies: list[str]) -> list[Verdict]:
         # a quoted/pasted example containing the literal `Retracted:` shape
         # is not mistaken for a real self-mark. `charter_trailer.strip_code_regions`
         # strips `~~~` fences as well as ``` ones as of main#1359/#1361.
+        #
+        # UNTERMINATED-FENCE DIRECTION CHANGE (main#1359 merge-gate review,
+        # Aino Virtanen — MF2): the deleted `_strip_code_markup` required a
+        # CLOSING fence marker to match (`` ```.*?``` `` is non-greedy over a
+        # closing pair), so an opened-but-never-closed fence was left
+        # entirely alone — anything after it, including a genuine
+        # `Retracted:` self-mark, still counted. `strip_code_regions` strips
+        # from an unterminated fence to end-of-body instead (the more
+        # CommonMark-correct behaviour: an unterminated fence runs to end of
+        # document). So a reviewer who pastes a snippet and forgets the
+        # closing fence now has any genuine self-mark BELOW it silently
+        # swallowed — they lose the false-positive credit, the author keeps
+        # the rework charge. Deliberate (consistency across every consumer of
+        # the shared stripper is the point of this migration, and this is the
+        # more-correct answer), but a real behaviour change on this one axis
+        # — pinned by `UnterminatedFenceDirectionChangeTests` in
+        # `test_trust_signals.py` so it is not rediscovered as a surprise.
         scanned = charter_trailer.strip_code_regions(body)
         is_changes_requested = (
             charter_trailer.verdict_kind(verdict_str, include_bare_changes=True)

--- a/.claude/lib/trust_signals.py
+++ b/.claude/lib/trust_signals.py
@@ -80,6 +80,7 @@ from pathlib import Path
 # wave_status lives alongside this file in .claude/lib/. Running as a script puts
 # this dir on sys.path[0]; the tests add it explicitly.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
+import charter_trailer  # noqa: E402
 import wave_state  # noqa: E402
 import wave_status  # noqa: E402
 
@@ -152,98 +153,39 @@ CALIBRATION_MIN_AUTHORS = 5
 # equality check against ``"changesrequested"`` silently failed, dropping the
 # verdict from every counter. Widened to a full-line capture mirroring
 # requestor/requestee; classification of the captured text into a verdict
-# kind is now a separate step (`_verdict_kind`, below) so trailing text past
-# the first word (e.g. ``Approved (post-merge)``) doesn't defeat an exact
-# match either.
+# kind is now a separate step (`charter_trailer.verdict_kind`, main#1359) so
+# trailing text past the first word (e.g. ``Approved (post-merge)``) doesn't
+# defeat an exact match either.
 _FIELD_RE = {
     "requestor": re.compile(r"^\**Requestor\**:\**\s*(.+?)\**\s*$", re.MULTILINE),
     "requestee": re.compile(r"^\**Requestee\**:\**\s*(.+?)\**\s*$", re.MULTILINE),
     "verdict": re.compile(r"^\**RequestOrReplied\**:\**\s*(.+?)\**\s*$", re.MULTILINE),
 }
 
-# Canonical verdict-kind vocabulary for the `RequestOrReplied:` field.
-# Reviewers write ChangesRequested three ways in practice: the
-# charter-canonical one-word `ChangesRequested`, the human-typed spaced
-# `Changes Requested`, and the short `Changes`.
+# Canonical verdict-kind vocabulary for the `RequestOrReplied:` field —
+# extracted to `charter_trailer.VERDICT_KIND` / `.verdict_kind()` (main#1359).
 #
-# main#1359 (MF1 on this PR, Aino/Nino): an earlier version of this comment
-# argued extraction was blocked by a dependency-direction problem and that
-# the two sibling hooks already agreed on all three spellings. BOTH claims
-# are false and were verified false, not merely disputed:
+# This module used to carry a private copy (`_VERDICT_KIND` /
+# `_normalize_verdict_token` / `_verdict_kind`) on the argument that lib code
+# importing from hooks/ would invert the intended dependency direction. That
+# premise never held: the shared home for this vocabulary is
+# `.claude/lib/charter_trailer.py`, which is ALSO `.claude/lib/`, not
+# `.claude/hooks/` — verified at PR #1356 head `0478497`, before this
+# migration ever touched the regex:
 #
-#   * There is no dependency-direction problem. The shared home for this
-#     vocabulary already exists, in `.claude/lib/`, not `.claude/hooks/`:
-#     `.claude/lib/charter_trailer.py` (main#932/#934) is the org's declared
-#     "single source of truth for the charter trailer-block convention",
-#     and this module already does `sys.path.insert(0, ...parent)`, so
-#     `import charter_trailer` costs zero path changes.
-#     `charter_trailer.extract_charter_field("RequestOrReplied", body)`
-#     ALREADY returns `"Changes Requested"` correctly — the value
-#     `_FIELD_RE["verdict"]` above reproduces was already correct, one file
-#     over, before this PR ever touched the regex.
-#   * The two sibling hooks do NOT already agree.
-#     `.claude/hooks/validate_review_comment_format.py`'s
-#     `_VERDICT_DIRECTIONS` (~line 664) deliberately EXCLUDES bare
-#     `changes` — its own comment: "The bare 'Changes' prefix is NOT a
-#     verdict on its own." `.claude/hooks/validate_pr_review.py`'s
-#     `_VERDICT_REQUIRING_TECH_DEBT` (~line 1410) includes it. The siblings
-#     disagree with each other, which is an argument FOR one shared owner,
-#     not evidence that copies are safe.
+#     import charter_trailer from lib: OK (same dir, already on ts's sys.path)
+#     charter_trailer.extract_charter_field("RequestOrReplied", body) -> 'Changes Requested'
+#     trust_signals.parse_verdicts(...)[0].verdict                    -> 'Changes Requested'
 #
-# `_VERDICT_KIND` / `_normalize_verdict_token` / `_verdict_kind` stay a
-# private copy in THIS PR anyway, for the two reasons that survived
-# scrutiny: (1) scope discipline — this is a retro PR landing two verified
-# defect fixes (#1347, #1348); migrating to `charter_trailer` means adding
-# a verdict-KIND classifier to ITS public API (it currently only extracts
-# raw field values, it does not classify Request/Reply vs
-# Approved/ChangesRequested) and re-verifying two hooks with large test
-# surfaces — real, cross-file work that does not belong bundled into this
-# fix. (2) a REAL, already-diverged dependency, not a hypothetical one:
-# `_strip_code_markup` (below) and `charter_trailer.strip_code_regions` are
-# two copies of one concept in the same directory that already disagree
-# outcome-changingly for the new `Retracted:` guard —
-# `_strip_code_markup` strips `~~~`-fenced code blocks, `strip_code_regions`
-# does not, and `_strip_code_markup`'s answer is the more correct one here.
-# Folding `~~~` support into `charter_trailer` has to happen as PART of the
-# migration, not incidentally alongside it. Extraction is real, tracked
-# work: main#1359.
-_VERDICT_KIND = {
-    "approved": "approved",
-    "changesrequested": "changesrequested",
-    "changes": "changesrequested",
-    "request": "request",
-    "reply": "reply",
-    "replied": "reply",
-}
-
-
-def _normalize_verdict_token(raw: str) -> str:
-    """Casefold + strip everything but alphanumerics from one token.
-
-    Collapses spelling/formatting variants of the SAME token to one key
-    (``**ChangesRequested**`` and ``ChangesRequested`` both normalize to
-    ``"changesrequested"``).
-    """
-    return re.sub(r"[^a-z0-9]", "", raw.casefold())
-
-
-def _verdict_kind(verdict: str | None) -> str:
-    """Classify a captured ``RequestOrReplied`` value into a canonical kind.
-
-    Returns ``"approved"``, ``"changesrequested"``, ``"request"``,
-    ``"reply"``, or ``""`` for anything unrecognized. Only the FIRST word of
-    the (now full-line) captured value is classified — ``"changes"`` alone
-    already maps to ``"changesrequested"`` in :data:`_VERDICT_KIND`, so both
-    the one-word ``ChangesRequested`` and the spaced ``Changes Requested``
-    resolve via their shared first word, and trailing noise past the first
-    word (e.g. ``Approved (post-merge)``) never defeats the match.
-    """
-    if not verdict:
-        return ""
-    parts = verdict.split()
-    if not parts:
-        return ""
-    return _VERDICT_KIND.get(_normalize_verdict_token(parts[0]), "")
+# `include_bare_changes=True` at every call site below reproduces this
+# module's pre-migration behaviour exactly (bare `Changes` counted as
+# `changesrequested`) — see `charter_trailer.verdict_kind` for why that is a
+# caller-supplied argument rather than a silently-forked table:
+# `validate_pr_review` and `validate_review_comment_format` migrate their own
+# remaining copies onto the same function under main#1371, one of which
+# deliberately excludes bare `Changes` for a different question. There is no
+# local wrapper — `charter_trailer.verdict_kind` is called directly, so a
+# future re-implementation here has nothing to shadow.
 
 
 # main#1348: a bare word match (`false[\s-]?positive|withdrawn|...`) over the
@@ -290,24 +232,10 @@ _RETRACTION_RE = re.compile(r"^\**Retracted\**:\**\s*\S", re.MULTILINE)
 # the back door, which is why this is a countable field and not a retro note.
 _ORCHESTRATOR_CAUSED_RE = re.compile(r"^\**OrchestratorCaused\**:\**\s*\S", re.MULTILINE)
 
-
-def _strip_code_markup(text: str) -> str:
-    """Remove fenced code blocks and inline code spans from *text*.
-
-    Called before :data:`_RETRACTION_RE` is applied so that a quoted example
-    or symbol name containing the literal ``Retracted:`` field shape inside
-    a code span or fenced block (e.g. someone pasting a sample comment) is
-    not mistaken for a genuine self-mark.  The removal is positional — we
-    replace each code region with whitespace of the same length so that
-    surrounding context positions are preserved for any subsequent
-    line-oriented parsing, though :data:`_RETRACTION_RE` does not rely on
-    positions.
-    """
-    # Fenced blocks first (```...``` or ~~~...~~~, possibly multiline).
-    text = re.sub(r"```.*?```|~~~.*?~~~", lambda m: " " * len(m.group()), text, flags=re.DOTALL)
-    # Inline code spans (`...`); single-backtick, non-newline interior.
-    text = re.sub(r"`[^`\n]+`", lambda m: " " * len(m.group()), text)
-    return text
+# `_strip_code_markup` (the private ``~~~``-aware code-stripper this module
+# used to carry) is deleted as of main#1359 — `charter_trailer.strip_code_regions`
+# now strips ``~~~`` fences too (main#1361), so `parse_verdicts` below calls it
+# directly instead of a local copy.
 
 
 @dataclass
@@ -455,8 +383,8 @@ def parse_verdicts(comment_bodies: list[str]) -> list[Verdict]:
     (``**Requestor:** Name``) forms so it matches everything Hook 4 accepts. A
     comment with no ``RequestOrReplied`` line is not a verdict and is skipped —
     this still builds a :class:`Verdict` for ``Request``/``Reply`` comments
-    (some callers want the full set), but see :func:`_verdict_kind`: those two
-    kinds can never carry ``false_positive=True`` (main#1348).
+    (some callers want the full set), but see :func:`charter_trailer.verdict_kind`:
+    those two kinds can never carry ``false_positive=True`` (main#1348).
     """
     out: list[Verdict] = []
     for body in comment_bodies:
@@ -472,9 +400,13 @@ def parse_verdicts(comment_bodies: list[str]) -> list[Verdict]:
         # Request/Reply are process metadata, not verdicts at all
         # (main#1348 defect 2). Strip code spans and fenced blocks first so
         # a quoted/pasted example containing the literal `Retracted:` shape
-        # is not mistaken for a real self-mark.
-        scanned = _strip_code_markup(body)
-        is_changes_requested = _verdict_kind(verdict_str) == "changesrequested"
+        # is not mistaken for a real self-mark. `charter_trailer.strip_code_regions`
+        # strips `~~~` fences as well as ``` ones as of main#1359/#1361.
+        scanned = charter_trailer.strip_code_regions(body)
+        is_changes_requested = (
+            charter_trailer.verdict_kind(verdict_str, include_bare_changes=True)
+            == "changesrequested"
+        )
         is_false_positive = is_changes_requested and bool(_RETRACTION_RE.search(scanned))
         # `OrchestratorCaused:` is gated identically and for the same reason
         # (main#1366): there is no rework round to reattribute unless THIS
@@ -497,14 +429,15 @@ def parse_verdicts(comment_bodies: list[str]) -> list[Verdict]:
 def _is_changes_requested(verdict: str | None) -> bool:
     """True if *verdict* (a captured ``RequestOrReplied`` value) is ChangesRequested.
 
-    #1347: routes through :func:`_verdict_kind` so the three spelling
-    variants (``ChangesRequested`` / ``Changes Requested`` / ``Changes``)
-    all classify identically — the previous
+    #1347: routes through :func:`charter_trailer.verdict_kind` so the three
+    spelling variants (``ChangesRequested`` / ``Changes Requested`` /
+    ``Changes``) all classify identically — the previous
     ``verdict.lower() == "changesrequested"`` exact-match silently dropped
     the spaced form because the capturing regex used to stop at the first
-    space.
+    space. ``include_bare_changes=True`` preserves this module's original
+    (pre-main#1359) behaviour of counting bare ``Changes`` (main#1359).
     """
-    return _verdict_kind(verdict) == "changesrequested"
+    return charter_trailer.verdict_kind(verdict, include_bare_changes=True) == "changesrequested"
 
 
 def _pr_comment_bodies(repo: str, number: int) -> list[str]:

--- a/.claude/lib/wave_status.py
+++ b/.claude/lib/wave_status.py
@@ -70,13 +70,16 @@ _DEFAULT_STATUS = wave_state.DEFAULT_STATUS_PATH
 # #1357: was the literal one-word ``ChangesRequested`` only, so the
 # human-typed spaced form (``Changes Requested``) and the short form
 # (``Changes``) were silently uncounted — the identical narrow-capture defect
-# #1347 fixed in trust_signals.py's ``_verdict_kind``, just reimplemented as a
-# jq regex instead of a Python one. ``Changes(\s*Requested)?\b`` accepts all
-# three spellings — the union of what the org's own PR templates and hooks
-# actually produce, NOT a claim that every existing consumer already agrees
-# on all three: ``validate_pr_review.py``'s ``_VERDICT_REQUIRING_TECH_DEBT``
-# (~line 1410) and ``trust_signals.py``'s ``_VERDICT_KIND`` both accept the
-# bare short form, but ``validate_review_comment_format.py``'s
+# #1347 fixed in what was then trust_signals.py's private ``_verdict_kind``
+# (now ``charter_trailer.verdict_kind``, main#1359 — that private copy is
+# deleted), just reimplemented here as a jq regex instead of a Python one.
+# ``Changes(\s*Requested)?\b`` accepts all three spellings — the union of
+# what the org's own PR templates and hooks actually produce, NOT a claim
+# that every existing consumer already agrees on all three:
+# ``validate_pr_review.py``'s ``_VERDICT_REQUIRING_TECH_DEBT`` (~line 1410)
+# and ``charter_trailer.verdict_kind(..., include_bare_changes=True)`` (the
+# argument ``trust_signals.py`` now passes at its one call site) both accept
+# the bare short form, but ``validate_review_comment_format.py``'s
 # ``_VERDICT_DIRECTIONS`` (~line 664) deliberately excludes it (see main#1359
 # — the sibling consumers disagreeing with each other is itself evidence for
 # a single shared vocabulary owner, not a reason to assume copies stay in


### PR DESCRIPTION
Closes #1359. Closes #1361.

`.claude/lib/charter_trailer.py`'s verdict-kind vocabulary + classifier and `~~~`-fence support in `strip_code_regions` are the two things #1359's acceptance list asks for from THIS issue, and both land here with `trust_signals.py` fully migrated onto them (its three private copies deleted). `validate_pr_review.py` and `validate_review_comment_format.py`'s own remaining classifier copies are deliberately left for #1371 per this wave's sequencing note (landing #1371 first would create a fourth copy rather than remove the third) — so `Closes #1359` is judged against #1359's own acceptance items, not against #1371's separate scope.

`Closes #1361` is added per the merge-gate review below: all three of #1361's acceptance items are met at this head, with fixtures, and its remaining "scope the verdict loop to the trailer block" note is explicitly a second, independent hardening in its own body, not acceptance.

## Merge-gate review round 1 — resolved

Aino Virtanen reviewed at head `084b7b7` (ChangesRequested; every must-fix was a comment/test-pin edit, no redesign or behaviour change demanded — "the extraction itself is correct and the evidence bar for it is met"). Nino Kavtaradze approved separately. Addressed at head `a4909f2`:

- **MF1 — corrected a wrong claim in my own test docstring.** I had written that `validate_pr_review._is_verdict` rejects `"Approved (post-merge)"`. Aino caught that it doesn't: `_is_verdict` is only ever called on `extract_charter_field`'s output, which already strips the trailing parenthetical before `_is_verdict` sees it, so end-to-end there is no divergence on that value. The genuinely reachable divergences — all `False` under `validate_pr_review._is_verdict` today, all `True` under `verdict_kind` — are `"Approved!"`, `"Approved with nits"`, `"Approved - see below"`, `"Changes  Requested"` (double space), `"Changes needed"`. The consequential one is `_is_approved` (`validate_pr_review.py:1636 → 1667`), which gates the **2-reviewer approver set** — #1371 is therefore a merge-gate *widening*, not a pure refactor, when it migrates that predicate. Corrected the test docstring in `test_charter_trailer.py` and the note on #1371 (I'd posted the wrong claim there too, in an earlier comment — retracted with the corrected table).
- **MF2 — the `trust_signals` stripper migration is not parity-preserving on unterminated fences, now stated and pinned.** The deleted `_strip_code_markup` required a *closing* fence marker to match, so an opened-but-never-closed fence was left untouched — anything after it, including a genuine `Retracted:` self-mark, still counted. `charter_trailer.strip_code_regions` strips an unterminated fence to end-of-body instead (the CommonMark-correct behaviour, and the reason for the direction of the migration in the first place), which now silently swallows a self-mark written below one. Not a behaviour change requested here — `strip_code_regions` is the more-correct implementation and consistency across every consumer is the point of the extraction — but it was asserted-but-unstated. Added one paragraph to the `parse_verdicts` migration comment recording the direction change, and `UnterminatedFenceDirectionChangeTests` in `test_trust_signals.py` pinning it (plus a regression guard that a closed fence and an unfenced self-mark are both still detected correctly).
- **MF3 — fixed three present-tense references to symbols this PR deletes.** `validate_review_comment_format.py`'s `_direction_is_changes_requested` docstring said `trust_signals._verdict_kind` "DOES count it" (deleted) and "makes three verdict-direction classifiers across two files" (now two, since `trust_signals`'s copy is gone). Two test comments in `test_validate_review_comment_format.py` made the same now-false claims about `trust_signals._verdict_kind` and about `charter_trailer.strip_code_regions` leaving `~~~` intact. All three corrected to past tense / current state.
- **SF1 (should-fix, addressed anyway) — the singularity sweep is name-based, so a copy under a different function name was invisible to it.** Aino mutation-tested by reverting `validate_review_comment_format._strip_code_for_field_scan` to its former local `re.sub` mirror: the *entire suite stayed green* (4222 passed, zero failures), because `test_no_second_definition_anywhere` greps `^def _?{name}\(` against a fixed name set and the only existing identity check asserted the module-level `strip_code_regions` import binding, never this name. Fixed by making `_strip_code_for_field_scan` a **direct alias** of `charter_trailer.strip_code_regions` (`_strip_code_for_field_scan = strip_code_regions`, mirroring `validate_pr_review._strip_code_regions = strip_code_regions`) and extending `test_code_stripper_is_the_shared_function_object` to assert identity on that exact name. Verified: re-running Aino's M5 mutation against the new head now fails that assertion immediately, regardless of what the reimplementation's body does or doesn't diverge on.
- **Nit — documented why `VERDICT_KIND["changes"]` is unreachable through `verdict_kind()`.** The function's own branch intercepts `token == "changes"` before the dict lookup, precisely because `include_bare_changes` needs to gate that one token and a flat dict has no way to carry the argument. Added a comment on the row; kept in the table for documentation completeness since `verdict_kind()` is the intended entry point.

`#1413` (the strip-before-scope ordering defect Nino found live while reviewing this PR — his own `Approved` verdict was briefly invisible to the merge gate because his prose about `~~~` markers tripped the same unterminated-fence-swallows-everything mechanism as MF2, just in `extract_charter_field`'s composition rather than `trust_signals`'s stripper) is **explicitly out of scope for this PR** — filed and tracked separately, not folded into this text/test-pin round. It changes what every verdict comment in the repo parses to, needs its own failing-before test on a distinct fixture shape (code regions spanning the `---` separator), and this PR's must-fixes were scoped to comment/test-pin edits only.

## Merge-gate review round 2 — MF4 addressed (head `975be2a`)

Aino re-ran her review at unchanged head `084b7b7` and found one new blocking item her first pass did not surface, described below without typing the marker (see her review for the literal repro).

- **MF4 — the extraction widens a silent verdict-erasure path, and it had already cost a verdict on this thread.** Adding the tilde marker to the recognized fence-marker set made an unpaired, mid-prose occurrence of that marker a second path to the same failure the pre-existing marker already had: an odd/unpaired marker anywhere in a comment is read as an unterminated fence and strips to end-of-body, taking a real trailer separator (and the whole comment) with it. Base parses a tilde-heavy prose comment correctly; this PR's head did not. Live trace: a reviewer's comment discussing the marker being widened tripped an odd occurrence in prose and had to be re-posted.

  **Disposition taken: (a), line-anchor the fence opener, per CommonMark** (a fence opener is a leading sequence on its own line; a marker occurring mid-sentence is prose, not a fence). Guarded the marker lookup on "is this position the start of a line." Result: the erasure repro now resolves all four fields correctly, #1361 stays closed (its own fixtures are all line-anchored already), and the total cost was one pre-existing fixture (`test_validate_pr_review.py::StripCodeRegionsTests::test_unterminated_fenced_block_strips_rest`, whose opener was mid-line — CommonMark wouldn't treat that as a fence either) — updated with a note and a line-anchored body, still exercising the same "unterminated, eats the rest" behavior it's named for.

  New tests in `test_charter_trailer.py` (`FenceOpenerMustStartALineTests`) pin: the exact erasure repro (fails at head `a4909f2`, verified directly before implementing the fix — three fields resolved to `None` where they should have resolved to real values; passes after), the identical hazard for the marker this PR did NOT add (closes the same root cause as #1413, as a side effect — not the ordering fix #1413 itself, just this one path into it), and regression guards that a genuine line-start fence — including one at position 0 — still strips correctly.

- **MF3 addendum — two more present-tense references found on re-review.** `wave_status.py:73` and `:78` referenced `trust_signals._verdict_kind` / `_VERDICT_KIND` as live symbols in the comment explaining the jq counter's wider-set rationale. Corrected to reference `charter_trailer.verdict_kind`.

- **Rulings reconfirmed on re-review, unchanged:** `include_bare_changes` is honest modelling (decisive evidence is within one file — `_direction_is_verdict` excludes bare `Changes`, `_direction_is_changes_requested` forty lines below deliberately includes it); #1361 is genuinely subsumed (`Closes #1361` already in this body); the strip-before-scope reordering (#1413) stays out of scope for this PR; SF1 is discharged (the round-1 alias fix holds independent of this round's changes — confirmed no interaction with the MF4 fix); Nino's `normalize_verdict_token` space-mutant finding is an equivalent mutant on every reachable path, not a coverage defect, left as-is.

## Merge-gate review round 3 — MF5 addressed (head `2b95706`)

Aino re-reviewed at head `975be2a` and found a fail-open MF4 itself introduced — the coordinator shares ownership of the under-specification (disposition (a) was chosen together, and only the mid-line case was verified before I implemented it).

- **MF5 — MF4's line-anchoring guard demanded column 0 exactly; CommonMark allows up to 3 leading spaces and a blockquote prefix.** A fenced block placed BELOW a real trailer, containing a fabricated `Requestor:` line, used to be safely stripped on base and on the pre-MF4 head. After MF4's strict guard alone, an indented or blockquoted fence opener was no longer recognised as a fence at all, so it was not stripped, and last-match-wins handed the merge gate the fabricated reviewer name instead of the real one. Blockquoted fences are exactly what GitHub's "Quote reply" button emits — no adversary required, an ordinary reviewer quoting an earlier comment produces this shape by accident. This is the fail-*open* direction (a fabricated verdict silently accepted), which is strictly worse than MF4's fail-*closed* one (a real verdict silently erased), and it is a regression this PR's diff introduced — base was safe on both the blockquote and indent shapes, this PR's head was not.

  **Fix taken, per Aino's prototype:** the fence-opener check now accepts a prefix of zero-or-more nested blockquote markers followed by up to 3 spaces/tabs of indentation (CommonMark's own indentation ceiling for a fence — 4+ spaces is indented-code-block territory and correctly still does not qualify). A marker behind any other prefix (ordinary prose text) still correctly fails to qualify as an opener — MF4's own fix is unaffected.

  New tests in `test_charter_trailer.py` (`FenceOpenerAllowsBlockquoteAndIndentTests`): blockquoted, 2-space-indented, 3-space-indented (the CommonMark boundary), nested-blockquote, and tilde-marker-blockquoted fixtures — all constructed with the genuine trailer FIRST and a fabricated field inside the fenced block AFTER it, asserting the genuine value wins. Each written failing-first and confirmed failing at head `975be2a` before the fix (returning the fabricated value), passing after. Plus two regression guards: a 4-space indent still correctly does not qualify as an opener, and MF4's mid-sentence-prose guard is unaffected. Full suite stays green with no churn to any pre-existing test, matching what nothing currently pinning the over-strict predicate would predict.

- **#1415 checked before considering a new issue.** Nino Kavtaradze independently filed #1415 for the general last-match-wins spoof (bug/tech-debt/security, no marker needed at all) — its variant 2 already covers the same-line, mid-sentence, paired-marker-span shape that this round's finding is adjacent to, confirmed pre-existing on base. No new issue filed; not a duplicate gap.

- **#1413 re-scoped, not closed.** Posted a status comment: its original reproduction (mid-sentence marker mentions above the trailer) no longer reproduces after MF4, verified directly — but the residual defect (a genuine, line-anchored, never-closed fence marker above the trailer) still does, also verified directly. Both reviewers independently reached the same disposition: keep #1413 open, re-scope its repro section to the residual shape, do not close on now-stale evidence.

## Merge-gate review round 4 — MF6 addressed (head `f4d67ec`)

The coordinator ran a fuller 14-shape matrix (both markers × column-0 / blockquote / nested-blockquote / 1-3-space / 4-space) against the round-3 head and found 13 of 14 shapes fixed, with one remaining — same fail-open class as MF5, one level deeper.

- **MF6 — the 4-space-indented backtick block still spoofs, and it is a regression from base.** MF5's fix capped accepted indentation at 3 spaces, mirroring CommonMark's fence-vs-indented-code-block boundary — but that boundary answers a different question than the one `strip_code_regions` needs answered. CommonMark cares whether a 4+-space marker is a FENCE or an INDENTED CODE BLOCK (different constructs to a renderer); both are still code, and a reviewer typing a paired opening/closing marker on its own line — however indented — has unambiguous code-marking intent regardless of which construct a renderer would call it. The 3-space cap left a marker preceded by only 4+ spaces of indentation disqualified as an opener, so its contents fell through to literal prose: a fabricated field inside a 4-space-indented, well-paired backtick block below a real trailer won last-match-wins. Base had no indentation limit at all for a marker occurrence, so base was safe on this shape and the round-3 head was not — a genuine regression, correctly distinguished from the tilde half of the same shape, which was already unsafe on base (tilde was never a recognized marker pre-main#1359) and is closed here as a bonus, not a second regression fix.

  **Fix taken:** `_FENCE_OPENER_PREFIX_RE`'s indentation cap is removed entirely — any amount of leading whitespace (plus optional blockquote nesting) ahead of a marker still qualifies it as an opener, as long as nothing else precedes it on the line. This does not give `strip_code_regions` general CommonMark indented-code-block recognition — a marker-free, plain 4+-space-indented block with no triple marker anywhere is still never stripped, before or after this change. That narrower, marker-independent remaining gap is filed separately as **#1416**, scoped out of this PR per the coordinator's explicit steer (full indented-code-block recognition — blank-line boundaries, list-lazy-continuation interaction, its own stripping semantics — is a larger feature than this fix's scope).

  New tests (`FenceOpenerIndentationIsUnboundedTests`): 4-space backtick (the regression) and 4-space tilde (pre-existing hole, explicitly marked as such rather than as a regression) fixtures, an 8-space depth confirming "unbounded" rather than merely "raised," an indented-blockquote composition, and a regression guard that removing the cap did not also remove the requirement that nothing but whitespace/blockquote precedes the opener. Each written and confirmed failing at head `2b95706` before the fix, passing after. Re-ran the coordinator's full 14-shape matrix plus both standing guards (mid-sentence prose still not a fence; a genuine fenced example above a real trailer still loses to the real one) against the new head — all pass.

## Merge-gate review round 5 — MF7 + SF2 addressed (head `3e3ecd1`)

Aino found one more axis on a 44-shape matrix, and the coordinator independently confirmed it — same class as MF5/MF6, one quantifier deeper.

- **MF7 — whitespace was only allowed after the blockquote-marker group, not before it.** MF6's regex, `^(?:>[ \t]?)*[ \t]*$`, made quote-then-indent (`"> "` then spaces) work but left indent-then-quote (spaces then `">"`) with no whitespace allowance in front of the first `>` at all — so it failed to qualify as an opener. Not exotic: CommonMark permits up to 3 spaces before a `>`, GitHub renders it as an ordinary blockquote, and a blockquote inside a **list item** produces exactly this shape (the list marker's own indentation precedes the quote marker). Worse than a name swap: a fabricated block below a genuine trailer behind this prefix flips `RequestOrReplied` too (`Approved` on base, `ChangesRequested` at the pre-fix head), and the identical unstripped-block mechanism defeats `trust_signals.parse_verdicts`'s `Retracted:` scan.

  **Fix:** `^[ \t]*(?:>[ \t]*)*$` — whitespace now allowed before, between, and after blockquote markers, not only trailing the group as a whole.

  New tests (`FenceOpenerAllowsIndentBeforeBlockquoteTests`): 1/2/3-space-then-quote and tab-then-quote for the backtick marker (the list-item shape explicitly named), a tilde-marker variant, a composed indent-then-quote-then-indent shape, a test exercising the `trust_signals` `Retracted:`-scan axis of the same defect directly, and a regression guard confirming the new upstream whitespace allowance did not loosen the mid-sentence-prose disqualification from MF4. Each written and confirmed failing at head `f4d67ec` before the fix — all shapes returned both the fabricated `Requestor` and the fabricated `RequestOrReplied` — passing after. Re-verified the coordinator's full matrix (both markers × all five prefix shapes) plus both standing guards against the new head.

- **SF2 — corrected an issue-number typo.** The module comment deferring the marker-free indented-code-block gap cited `main#1420`, which does not exist (verified: HTTP 404, #1416 is the highest issue in the repo). The test file already had the correct number; only the module comment was wrong. Fixed to `main#1416`.

- **Everything else reconfirmed on this round's re-review, all re-verified rather than reasoned:** removing the indentation cap entirely (MF6) is endorsed — no legitimate content swallowed across a large randomized sample, char-level over-strips exist as re-pairing artifacts but none cost a verdict; deleting the prior (now-understood-wrong) 4-space regression-guard test was mandatory, since it had pinned a fail-open as correct; the #1416 deferral is right, matching the #1413/#1415 discipline; MF2/SF1's discharges hold under a fresh mutation re-run; merge-tree stays clean against `origin/main` and against #1386's head.

## Verification run (round 5, head `3e3ecd1`)

```
ENVIRONMENT=test python3 -m pytest .claude/lib/tests/ .claude/hooks/tests/ -q
# 4248 passed, 955 subtests passed

python3 -m ruff format --check .claude/hooks/ .claude/lib/   # 213 files already formatted
python3 -m ruff check .claude/hooks/ .claude/lib/            # All checks passed!
python3 -m mypy .claude/hooks/ .claude/lib/                  # Success: no issues found in 212 source files
```

Full `pre-commit` (commit-stage) + `pre-commit run --hook-stage pre-push` all green on this branch before this push, matching CI.


## Premise verification — "lib cannot import hooks" is false

`trust_signals.py` never needed to import `.claude/hooks/` at all — the shared vocabulary already lived in `.claude/lib/charter_trailer.py`, a **sibling module in the same directory**:

```
$ python3 -c "
import sys; sys.path.insert(0, '.claude/lib')
import charter_trailer as ct
import trust_signals as ts
print('trust_signals module file:', ts.__file__)
print('charter_trailer module file:', ct.__file__)
print('trust_signals.charter_trailer is ct:', ts.charter_trailer is ct)
"
trust_signals module file: .../.claude/lib/trust_signals.py
charter_trailer module file: .../.claude/lib/charter_trailer.py
trust_signals.charter_trailer is ct: True
```

Both files are `.claude/lib/`, not `.claude/hooks/`. `trust_signals.py` already does `sys.path.insert(0, Path(__file__).resolve().parent)`, so `import charter_trailer` cost zero path changes. This PR migrates `trust_signals.py` onto it and deletes its private copies.

## Pre-fix divergence, with failing output captured against `main`

Ran directly against the pre-fix tree (`git stash` over this branch's changes):

```
body = """RequestOrReplied: ChangesRequested

~~~
Retracted: quoted example
~~~
"""
false_positive as shipped (ts strips ~~~)        : False
false_positive if it used ct.strip_code_regions  : True
```

`trust_signals._strip_code_markup` (private, deleted by this PR) already stripped `~~~` fences; `charter_trailer.strip_code_regions` (the declared single source of truth, #932/#934) did not — an active, already-diverged copy, not a hypothetical one. Because `validate_pr_review` aliases `strip_code_regions` directly for its verdict-counting loop, the same gap was reachable from the merge gate (#1361's exact repro, also verified pre-fix and now covered by tests).

Also verified pre-fix classifier disagreement across the three existing implementations on the SAME input:

```
'Changes'                    trust_signals._verdict_kind='changesrequested'   validate_pr_review._is_verdict=True     validate_review_comment_format._direction_is_verdict=False
'Approved (post-merge)'      trust_signals._verdict_kind='approved'           validate_pr_review._is_verdict=False    validate_review_comment_format._direction_is_verdict=True
```

(That table is about the *raw* functions called in isolation on that exact string, which is genuinely how they behaved pre-fix — the correction in the merge-gate section above is about a docstring claim regarding the *end-to-end hook path*, which strips the parenthetical before `_is_verdict` ever runs. Both facts are true; they're about different call surfaces.)

`.claude/lib/tests/test_charter_trailer.py::VerdictKindMatchesPreExtractionTrustSignalsTests` pins `charter_trailer.verdict_kind(..., include_bare_changes=True)` reproduces every pre-fix `trust_signals` answer, and `.claude/lib/tests/test_charter_trailer.py::StripCodeRegionsTildeFenceTests` / `test_trust_signals.py::TildeFenceDivergenceTests` / `ConsolidatedStripCodeRegionsAlsoFixesTheHookAlias` fail against the pre-#1359 tree (verified: `git stash` + `ENVIRONMENT=test python3 -m pytest .claude/lib/tests/test_charter_trailer.py` produces `ImportError: cannot import name 'VERDICT_KIND'` — the whole module can't even collect against pre-fix `charter_trailer.py`) and pass against the fix. Aino independently re-verified this module-by-module against base `e0196c3`: `test_charter_trailer.py` fails collection, `test_trust_signals.py` 7 failed/91 passed, `test_validate_review_comment_format.py` 16 failed/90 passed, `test_validate_review_comment_format_failopen.py` 2 failed/98 passed.

`.claude/hooks/tests/test_validate_review_comment_format_failopen.py::TrailerHelperSingularityTests.test_no_second_definition_anywhere` now also scans for `verdict_kind`/`normalize_verdict_token` — verified against the pre-fix tree this sweep flags `lib/trust_signals.py:normalize_verdict_token` and `lib/trust_signals.py:verdict_kind` (its own private defs), so the guard is itself divergence-tested, not merely present. Aino independently re-derived this via mutation M4 (re-adding a private def to `trust_signals`) — caught by 2 singularity guards, one naming the offender by path.

## Extracted API surface — for #1371 to consolidate onto

```python
# .claude/lib/charter_trailer.py
VERDICT_KIND: dict[str, str]                       # canonical token -> kind
def normalize_verdict_token(raw: str) -> str
def verdict_kind(value: str | None, *, include_bare_changes: bool = True) -> str
    # "approved" | "changesrequested" | "request" | "reply" | ""
def strip_code_regions(body: str) -> str           # now strips both fence styles
```

`include_bare_changes` expresses a real disagreement that Aino found stronger evidence for than my body originally cited: the two answers are needed **within one file** — `validate_review_comment_format._direction_is_verdict` excludes bare `Changes` while `_direction_is_changes_requested`, forty lines below it, deliberately includes it. No single hard-coded answer can serve both predicates; a flag is the correct encoding, not a bug frozen as a parameter. When #1371 migrates the two hooks onto this, **pass the flag explicitly at every call site** rather than relying on the `True` default — the hooks disagree with `trust_signals` on bare `Changes` by design, and inheriting the default would silently change one hook's behaviour.

## What's migrated here vs. left for #1371/#1372

- **Migrated (this PR):** `trust_signals.py` fully — `_VERDICT_KIND` / `_normalize_verdict_token` / `_verdict_kind` / `_strip_code_markup` deleted, `parse_verdicts` routes through `charter_trailer` directly. The obsolete "lib importing from hooks" rationale is removed.
- **Subsumed as a side effect (recommend closing on merge):** #1361 — see `Closes #1361` above. `validate_review_comment_format._strip_code_for_field_scan` (the conditional-field presence scanner) also now calls `strip_code_regions` directly instead of mirroring the deleted `trust_signals` stripper — closes the "code fences" axis of the three-axis divergence `ConditionalFieldGrammarAgreementTests` guards; the other two axes (anchoring, scope) are untouched and stay open for #1371/#1372.
- **Left for #1371 (Aino):** migrating `validate_pr_review._is_verdict`/`_is_approved` and `validate_review_comment_format._direction_is_verdict`/`_direction_is_changes_requested` onto `charter_trailer.verdict_kind`, per this issue's sequencing note. Corrected risk table and the `_is_approved`/2-reviewer-set widening are posted there. `VERDICT_KIND["changes"]`'s unreachability and `normalize_verdict_token`'s untested `[^a-z0-9]`→`[^a-z0-9 ]` mutation (harmless only while every call site passes single already-tokenized words) are also recorded there for that story to watch.
- **Left for #1372 (Nino):** the `ConditionalFieldGrammarAgreementTests` corpus gap (no `---`-separator case) — untouched by this PR.
- **Explicitly out of scope (see merge-gate round 1 section above):** #1413.

## Cross-PR file overlap already checked (Weronika Zielinska, reviewing #1386)

This branch also touches `validate_review_comment_format.py`. Weronika ran an actual `git merge-tree` three-way merge against #1386's head while reviewing that PR and got **0 conflicts** — this PR's hunks sit at lines 702–735 (at the reviewed head; shifted slightly by round-2 edits, still non-overlapping), #1386's are all ≤580. Aino re-confirmed at current heads: `git merge-tree --write-tree 084b7b7 1a88bc8` → exit 0, clean tree, zero conflicts. Ordering is safe in either direction.

## Verification run (round 2, head `a4909f2` — superseded by round 3 above)

```
ENVIRONMENT=test python3 -m pytest .claude/lib/tests/ .claude/hooks/tests/ -q
# 4224 passed, 955 subtests passed

python3 -m ruff format --check .claude/hooks/ .claude/lib/   # 213 files already formatted
python3 -m ruff check .claude/hooks/ .claude/lib/            # All checks passed!
python3 -m mypy .claude/hooks/ .claude/lib/                  # Success: no issues found in 212 source files
```

Full `pre-commit` (commit-stage) + `pre-commit run --hook-stage pre-push` (mypy, pytest, memory-budget, headcount-budget, doc-freshness, office-drift, mermaid-render) all green on this branch before both pushes, matching CI.

## Sequencing note

**#1371 is gated on this PR** — it consolidates `validate_pr_review` and `validate_review_comment_format`'s remaining verdict-direction classifiers onto the `verdict_kind` API this PR defines; landing #1371 first would have created a fourth copy instead of removing the third. Please do not merge #1371 before this lands.

---

**Requestor:** Santiago Ferreira
**Requestee:** Aino Virtanen / Nino Kavtaradze
**RequestOrReplied:** Request




