### PR TITLE
fix(#1351): validate_labels mints garbage labels — scope the scan to the gh issue create segment (0/3 -> 3/3 precision on the wave-29 corpus)

### DIFF
--- a/.claude/hooks/_shell_parse.py
+++ b/.claude/hooks/_shell_parse.py
@@ -493,7 +493,7 @@ def normalize_command_separators(cmd: str) -> str:
 
 
 @lru_cache(maxsize=256)
-def normalize_command_substitutions(cmd: str) -> str:
+def normalize_command_substitutions(cmd: str, *, separator: str = " ; ") -> str:
     """Quote/escape-aware normalization of command-substitution + subshell edges.
 
     `normalize_command_separators` teaches shlex where one command in a
@@ -522,13 +522,67 @@ def normalize_command_substitutions(cmd: str) -> str:
 
     A `)` at depth 0 is left byte-for-byte alone: an unmatched closer is either
     a `case` pattern arm (`a) …;;`) or a syntax error, and neither is ours to
-    rewrite. Quote/escape awareness is the same rule as
-    `normalize_command_separators` — a `(`/`)`/backtick inside single or double
-    quotes, or behind a backslash, is DATA (a `--title "fix (again)"`, a
-    markdown `` `code` `` span in a `--body`) and is never touched. Quote
-    characters themselves are never added or removed, so a command that
-    tokenized before still tokenizes after, and one that failed still fails
-    (the fail-open contract on `tokenize() is None` is unaffected).
+    rewrite. Quote characters themselves are never added or removed, so a
+    command that tokenized before still tokenizes after, and one that failed
+    still fails (the fail-open contract on `tokenize() is None` is unaffected).
+
+    Quote handling is NOT the same rule as `normalize_command_separators`
+    (main#1414 — read this before adopting this helper)
+    =====================================================================
+
+    That analogy is tempting and wrong, and the difference is one-sided:
+
+        construct                     inside "double quotes", real sh   here
+        ---------------------------   -------------------------------   ----
+        `;`  `|`  `&`   separators     literal — data                    data
+        `$( … )`, backticks            EXECUTED                          data
+
+    A double-quoted command substitution really is a substitution in POSIX
+    shell. This helper deliberately treats it as data anyway, and that choice
+    has a DIRECTION:
+
+      - For a false-positive-sensitive VALIDATOR (`validate_labels`, the only
+        caller today) it is the safe direction, and load-bearing: leaving
+        `--body "$(cat b.md)"` untouched is exactly what stops the common
+        quoted-substitution shape from truncating the segment and costing label
+        recall.
+      - For a BYPASS MATCHER it points the other way. A hook that adopted this
+        helper to find what a command really runs would read a double-quoted
+        substitution handed to `sh -c` as inert text — fail OPEN in a
+        fail-CLOSED context. `_shell_parse` is shared by commit-identity and
+        other blocking matchers, so this is stated here rather than left for an
+        adopter to discover: **do not use this helper as-is in a blocking
+        matcher** without first extending it to double-quoted substitutions.
+
+    Single quotes are not in that hazard — `'$(cat f)'` is genuinely literal in
+    shell, so treating it as data agrees with the shell rather than diverging.
+    `test_double_quoted_substitution_is_deliberately_treated_as_data` pins the
+    divergence so a future change to it is a decision, not an accident.
+
+    `separator` — the two readings of a substitution boundary
+    ==========================================================
+
+    The default ` ; ` SPLITS: the substituted command becomes its own segment,
+    and any flags that followed the closing paren start a further segment. That
+    is the safe reading for a matcher, and the one every caller should use.
+
+    `separator=" "` SPLICES instead: the punctuation is dropped and the
+    substituted command's words merge into the surrounding command's own
+    argument list. That is measurably NOT safe to match on — it makes the
+    substitution's first word look like the value of whatever flag preceded it:
+
+        gh issue create --repo o/r --label $(cat labelfile)
+          split  -> no labels          (the flag's value is not knowable)
+          splice -> label named 'cat'  (the COMMAND NAME, read as a label)
+
+    `cat` is not a label in any repo here, so a caller that validated the
+    spliced reading would BLOCK that command — a false positive manufactured by
+    the parse, which is the whole defect class main#1351 exists to remove. The
+    splice reading is therefore offered for DIFFERENTIAL DIAGNOSIS only: compare
+    it against the split reading to detect that a substitution swallowed some
+    flags, then report that loss rather than acting on the spliced values.
+    `validate_labels._extract_labels` is the reference use. Never validate,
+    block on, or route from a spliced token.
 
     Segment CONTENT is deliberately preserved rather than deleted: the
     substituted command is real work that a gate matcher usually wants to see
@@ -580,22 +634,22 @@ def normalize_command_substitutions(cmd: str) -> str:
             i += 2
             continue
         if cmd[i : i + 2] == "$(":
-            out.append(" ; ")
+            out.append(separator)
             depth += 1
             i += 2
             continue
         if c == "(":
-            out.append(" ; ")
+            out.append(separator)
             depth += 1
             i += 1
             continue
         if c == ")" and depth > 0:
-            out.append(" ; ")
+            out.append(separator)
             depth -= 1
             i += 1
             continue
         if c == "`":
-            out.append(" ; ")
+            out.append(separator)
             i += 1
             continue
         out.append(c)

--- a/.claude/hooks/_shell_parse.py
+++ b/.claude/hooks/_shell_parse.py
@@ -27,6 +27,17 @@ Public API
         validation — fall back to a regex check or a fail-closed decision.
         For warn-only matchers, fail-open on None is acceptable.
 
+    normalize_command_substitutions(cmd) -> str
+        Quote/escape-aware rewrite of command-substitution and subshell edges
+        (`$(`, `(`, the matching `)`, and backticks) into standalone ` ; `
+        separators, so `url=$(gh issue create … --label meta-issue)` survives
+        shlex with the closing paren OFF the last argument and the `gh` OFF the
+        assignment. The shlex-path counterpart of what
+        `iter_command_segments_ast` gets from a real grammar — needed because
+        bashlex is optional AND cannot parse a `<<'EOF'` heredoc at all. A `)`
+        at depth 0 (a `case` arm) is left alone; quoted/escaped parens and
+        backticks are DATA and never touched. main#1351.
+
     strip_heredocs(cmd) -> str
         Removes <<DELIM .. DELIM, <<'DELIM' .. DELIM, <<"DELIM" .. DELIM and
         <<-DELIM .. DELIM heredoc bodies (delimiter is rfc-shell-style: any
@@ -474,6 +485,117 @@ def normalize_command_separators(cmd: str) -> str:
             continue
         if c in (";", "|"):
             out.append(" " + c + " ")
+            i += 1
+            continue
+        out.append(c)
+        i += 1
+    return "".join(out)
+
+
+@lru_cache(maxsize=256)
+def normalize_command_substitutions(cmd: str) -> str:
+    """Quote/escape-aware normalization of command-substitution + subshell edges.
+
+    `normalize_command_separators` teaches shlex where one command in a
+    PIPELINE ends. It says nothing about the other boundary a shell has: the
+    edge of a command SUBSTITUTION or a subshell. shlex.split treats `$(`,
+    `` ` ``, `(` and `)` as ordinary word characters, so the single most common
+    "file the issue, then use its URL" idiom —
+
+        url=$(gh issue create --repo o/r --label tech-debt --label meta-issue)
+
+    tokenizes with the closing paren GLUED to the last argument
+    (`meta-issue)`), and with the first token of the substituted command glued
+    to the assignment (`url=$(gh`). Both are live defects, not hypotheticals:
+    the glued paren made `validate_labels` demand a label literally named
+    `meta-issue)` and block the filing of main#1150 (main#1351), and the glued
+    head hides the invocation from `is_gh_subcommand`/`find_gh_subcommand`
+    entirely, so a matcher anchored on either silently does nothing for every
+    `$(gh …)` / `$(git …)` command that has no wrapper word after the paren.
+
+    This helper rewrites the raw command so those boundaries survive
+    tokenization as their own separators:
+
+      - an unquoted, unescaped `$(` or `(`  -> ` ; ` (and pushes a depth level)
+      - the `)` that CLOSES one of those    -> ` ; `
+      - an unquoted, unescaped backtick     -> ` ; `
+
+    A `)` at depth 0 is left byte-for-byte alone: an unmatched closer is either
+    a `case` pattern arm (`a) …;;`) or a syntax error, and neither is ours to
+    rewrite. Quote/escape awareness is the same rule as
+    `normalize_command_separators` — a `(`/`)`/backtick inside single or double
+    quotes, or behind a backslash, is DATA (a `--title "fix (again)"`, a
+    markdown `` `code` `` span in a `--body`) and is never touched. Quote
+    characters themselves are never added or removed, so a command that
+    tokenized before still tokenizes after, and one that failed still fails
+    (the fail-open contract on `tokenize() is None` is unaffected).
+
+    Segment CONTENT is deliberately preserved rather than deleted: the
+    substituted command is real work that a gate matcher usually wants to see
+    (`url=$(gh issue create …)` genuinely creates an issue). Splitting rather
+    than stripping is what lets `iter_command_segments` hand it to
+    `find_gh_subcommand` as an ordinary segment.
+
+    This is the shlex-path counterpart of what `iter_command_segments_ast`
+    gets for free from a real grammar. It exists because the AST path is not
+    always available: bashlex is optional, and — measured, see
+    `test_bashlex_cannot_parse_quoted_delimiter_heredoc` — it cannot parse a
+    `<<'EOF'` heredoc at all, which is the dominant heredoc form here. A fix
+    that lived only in the AST path would regress to the glued-paren bug on
+    every command carrying a quoted-delimiter heredoc, and on any checkout
+    without bashlex installed.
+
+    Memoized (#1113): pure in `cmd` and returns an immutable `str`.
+    """
+    if not any(ch in cmd for ch in "()`"):
+        return cmd
+    out: list[str] = []
+    i = 0
+    n = len(cmd)
+    quote: str | None = None  # active quote char: "'" or '"', else None
+    depth = 0
+    while i < n:
+        c = cmd[i]
+        if quote is not None:
+            out.append(c)
+            # Inside double quotes a backslash escapes the next char; inside
+            # single quotes nothing is special (shell single-quote semantics).
+            if c == "\\" and quote == '"' and i + 1 < n:
+                out.append(cmd[i + 1])
+                i += 2
+                continue
+            if c == quote:
+                quote = None
+            i += 1
+            continue
+        if c in ("'", '"'):
+            quote = c
+            out.append(c)
+            i += 1
+            continue
+        if c == "\\" and i + 1 < n:
+            # Escaped char (incl. a line continuation) — emit both, verbatim.
+            out.append(c)
+            out.append(cmd[i + 1])
+            i += 2
+            continue
+        if cmd[i : i + 2] == "$(":
+            out.append(" ; ")
+            depth += 1
+            i += 2
+            continue
+        if c == "(":
+            out.append(" ; ")
+            depth += 1
+            i += 1
+            continue
+        if c == ")" and depth > 0:
+            out.append(" ; ")
+            depth -= 1
+            i += 1
+            continue
+        if c == "`":
+            out.append(" ; ")
             i += 1
             continue
         out.append(c)

--- a/.claude/hooks/tests/fixtures/real_label_block_w29a_dollar_paren.txt
+++ b/.claude/hooks/tests/fixtures/real_label_block_w29a_dollar_paren.txt
@@ -1,0 +1,7 @@
+cd /home/parameterization/code/noorinalabs-main
+SP="/tmp/claude-1000/-home-parameterization-code-noorinalabs-main/ede5ec41-7608-420b-b06c-9dd5943d1d43/scratchpad"
+url=$(timeout 90 gh issue create --repo noorinalabs/noorinalabs-main \
+  --title "umbrella: hooks keep hand-rolling command parsing narrower than _shell_parse — #663's invariant is adopted but unenforced (4 instances)" \
+  --body-file "$SP/umbrella-parser.md" \
+  --label tech-debt --label process --label meta-issue)
+echo "$url"

--- a/.claude/hooks/tests/fixtures/real_label_block_w29b_heredoc_lc_backtick.txt
+++ b/.claude/hooks/tests/fixtures/real_label_block_w29b_heredoc_lc_backtick.txt
@@ -1,0 +1,19 @@
+cd /home/parameterization/code/noorinalabs-main
+cat > /tmp/claude-1000/-home-parameterization-code-noorinalabs-main/7df975c7-69e0-47a1-924a-56c4dba896fe/scratchpad/issue-envS.txt <<'BODY'
+## Summary
+
+`env -S '<interpreter> <opts>' '<payload>'` **bypasses the commit-identity gate**, allowing an identity-less `git commit`. Pre-existing on `main`; **not** introduced or worsened by PR #1193, and deliberately left unfixed there.
+
+## Measured (orchestrator, 2026-07-30)
+
+Payloads assembled at runtime and fed through the wrapper:
+
+    env -S bash -lc 'git commit -m x'
+    env -S sh -lc 'git commit -m x'
+
+Any write-up that quotes `bash -lc` inline hits the same shape a third time.
+BODY
+gh issue create --repo noorinalabs/noorinalabs-main \
+  --title "security(commit-identity): env split-string wrapper bypasses the gate — its value IS the command but is modelled as an opaque value flag" \
+  --body-file /tmp/claude-1000/-home-parameterization-code-noorinalabs-main/7df975c7-69e0-47a1-924a-56c4dba896fe/scratchpad/issue-envS.txt \
+  --label bug --label security --label tech-debt 2>&1 | tail -2

--- a/.claude/hooks/tests/fixtures/real_label_block_w29c_heredoc_lc.txt
+++ b/.claude/hooks/tests/fixtures/real_label_block_w29c_heredoc_lc.txt
@@ -1,0 +1,22 @@
+S=/tmp/claude-1000/-home-parameterization-code-noorinalabs-main/f59882d5-3c72-4f52-b53f-e1d9a8016471/scratchpad/nino-1302
+cat > $S/issue_typeset.md <<'MD'
+## Shape
+
+#1305 (folded into #1302) taught `resolve_simple_assignments()` to tolerate one leading assignment keyword:
+
+```python
+_ASSIGNMENT_KEYWORDS = frozenset({"export", "declare"})
+```
+
+`typeset` and `readonly` were deliberately left out and are tested as out of scope. Both are **valid at the top level of a shell command** and both establish a variable a later segment can dereference:
+
+    typeset g=git; $g commit -m x
+    readonly g=git; $g commit -m x
+
+The same holds under a login shell: bash -lc 'typeset g=git; $g commit'
+and zsh -lc 'readonly g=git; $g commit' and sh -lc 'g=git; $g commit'.
+MD
+gh issue create --repo noorinalabs/noorinalabs-main \
+  --title "tech-debt(commit-identity): assignment pre-pass covers export/declare but not typeset/readonly — both are live at top level" \
+  --label tech-debt --label process --label phase-10 \
+  --body-file /tmp/claude-1000/-home-parameterization-code-noorinalabs-main/f59882d5-3c72-4f52-b53f-e1d9a8016471/scratchpad/nino-1302/issue_typeset.md

--- a/.claude/hooks/tests/fixtures/real_label_block_w30a_review_heredoc.txt
+++ b/.claude/hooks/tests/fixtures/real_label_block_w30a_review_heredoc.txt
@@ -1,0 +1,4 @@
+cat > /tmp/issueA.md <<'EOF'
+  gh issue create --repo o/r --title t $(cat /tmp/r) --label definitely-not-a-real-label
+EOF
+gh issue create --repo noorinalabs/noorinalabs-main --title "t" --label tech-debt --label bug --body-file /tmp/issueA.md

--- a/.claude/hooks/tests/test_shell_parse.py
+++ b/.claude/hooks/tests/test_shell_parse.py
@@ -161,6 +161,62 @@ class NormalizeCommandSubstitutionsTests(unittest.TestCase):
         cmd = "gh issue create --body 'run `date` and (see below)' --label bug"
         self.assertEqual(sp.normalize_command_substitutions(cmd), cmd)
 
+    def test_double_quoted_substitution_is_deliberately_treated_as_data(self):
+        """A DIVERGENCE from shell semantics, pinned so it stays a decision (main#1414).
+
+        In real `sh` a `$( … )` or backtick inside DOUBLE quotes is executed —
+        unlike `;`/`|`/`&`, which are literal there. This helper treats it as
+        data regardless. That is the safe direction for a validator (it is what
+        preserves label recall on `--body "$(cat b.md)"`) and the UNSAFE
+        direction for a bypass matcher, which would read a double-quoted
+        substitution fed to `sh -c` as inert text. Pinning it here means a
+        future change to double-quote handling has to be deliberate.
+        """
+        for cmd in (
+            'gh issue create --body "$(cat b.md)" --label bug',
+            'gh issue create --body "see `date` output" --label bug',
+        ):
+            with self.subTest(cmd=cmd):
+                self.assertEqual(sp.normalize_command_substitutions(cmd), cmd)
+
+    def test_splice_reading_glues_the_substituted_command_name_to_the_prior_flag(self):
+        """Why `separator=" "` must never be validated (main#1394 review, MF1).
+
+        The splice reading makes a substitution's first word look like the
+        value of the preceding flag. For `--label` that manufactures a label
+        out of a command name, which a validator would then block on.
+        """
+        cmd = "gh issue create --repo o/r --label $(cat labelfile)"
+
+        def label_values(text: str) -> list[str]:
+            """Read labels the way a caller must: SEGMENT first, then walk.
+
+            Walking the raw token list instead is a composition error worth
+            naming, because it is silently wrong rather than loudly wrong: on
+            the split text the token following `--label` is the separator `;`,
+            which is not flag-shaped, so `walk_flag_values` returns `[';']`.
+            `iter_command_segments` is what ends the segment at that separator.
+            (`;` is also in `validate_labels._SHELL_METACHARS`, so even a caller
+            that made this mistake would be caught by the backstop rather than
+            block on a label named `;` — belt and braces, both live.)
+            """
+            tokens = sp.tokenize(text)
+            assert tokens is not None
+            out: list[str] = []
+            for seg in sp.iter_command_segments(tokens):
+                gh = sp.find_gh_subcommand(seg)
+                if gh is None:
+                    continue
+                _globals, rest = gh
+                if rest[:2] == ["issue", "create"]:
+                    out += sp.walk_flag_values(rest, {"--label"})
+            return out
+
+        self.assertEqual(
+            label_values(sp.normalize_command_substitutions(cmd, separator=" ")), ["cat"]
+        )
+        self.assertEqual(label_values(sp.normalize_command_substitutions(cmd)), [])
+
     def test_escaped_paren_is_data(self):
         cmd = r"echo \(not a subshell\)"
         self.assertEqual(sp.normalize_command_substitutions(cmd), cmd)

--- a/.claude/hooks/tests/test_shell_parse.py
+++ b/.claude/hooks/tests/test_shell_parse.py
@@ -99,6 +99,106 @@ class StripHeredocsTests(unittest.TestCase):
         self.assertNotIn("body2", out)
 
 
+class NormalizeCommandSubstitutionsTests(unittest.TestCase):
+    """main#1351 — `$( )` / backtick / subshell edges must survive shlex.
+
+    The defect this closes is measured, not theoretical: shlex glues the
+    closing paren of a command substitution onto the last argument, which made
+    `validate_labels` demand a label named `meta-issue)` and BLOCK the filing
+    of main#1150. The same glue hides the substituted command's head token
+    (`url=$(gh`) from every `gh`/`git` finder in this module.
+    """
+
+    def test_pre_fix_tokenization_glues_the_closing_paren(self):
+        """Pin the raw shlex behaviour this helper exists to correct."""
+        cmd = "url=$(gh issue create --repo o/r --label meta-issue)"
+        self.assertEqual(
+            sp.tokenize(cmd),
+            ["url=$(gh", "issue", "create", "--repo", "o/r", "--label", "meta-issue)"],
+        )
+
+    def test_closing_paren_is_not_glued_to_the_last_argument(self):
+        cmd = "url=$(gh issue create --repo o/r --label meta-issue)"
+        tokens = sp.tokenize(sp.normalize_command_substitutions(cmd))
+        self.assertIn("meta-issue", tokens)
+        self.assertNotIn("meta-issue)", tokens)
+
+    def test_substituted_command_head_becomes_findable(self):
+        """`url=$(gh …)` — the `gh` must reach `find_gh_subcommand`."""
+        cmd = "url=$(gh issue create --repo o/r --label bug)"
+        tokens = sp.tokenize(sp.normalize_command_substitutions(cmd))
+        assert tokens is not None
+        segments = list(sp.iter_command_segments(tokens))
+        found = [sp.find_gh_subcommand(seg) for seg in segments]
+        self.assertIn(
+            ["issue", "create", "--repo", "o/r", "--label", "bug"],
+            [rest for hit in found if hit is not None for _globals, rest in [hit]],
+        )
+
+    def test_backticks_become_separators(self):
+        cmd = "url=`gh issue create --label bug`"
+        tokens = sp.tokenize(sp.normalize_command_substitutions(cmd))
+        assert tokens is not None
+        self.assertIn("bug", tokens)
+        self.assertNotIn("bug`", tokens)
+        self.assertTrue(any(sp.find_gh_subcommand(s) for s in sp.iter_command_segments(tokens)))
+
+    def test_bare_subshell_is_split(self):
+        cmd = "(gh issue create --label bug)"
+        tokens = sp.tokenize(sp.normalize_command_substitutions(cmd))
+        assert tokens is not None
+        self.assertEqual([t for t in tokens if t not in (";",)][:3], ["gh", "issue", "create"])
+
+    def test_parens_inside_double_quotes_are_data(self):
+        """A `--title "fix (again)"` is prose, not a subshell."""
+        cmd = 'gh issue create --title "fix (again)" --label bug'
+        self.assertEqual(sp.normalize_command_substitutions(cmd), cmd)
+        tokens = sp.tokenize(sp.normalize_command_substitutions(cmd))
+        assert tokens is not None
+        self.assertEqual(tokens[4], "fix (again)")
+
+    def test_parens_and_backticks_inside_single_quotes_are_data(self):
+        cmd = "gh issue create --body 'run `date` and (see below)' --label bug"
+        self.assertEqual(sp.normalize_command_substitutions(cmd), cmd)
+
+    def test_escaped_paren_is_data(self):
+        cmd = r"echo \(not a subshell\)"
+        self.assertEqual(sp.normalize_command_substitutions(cmd), cmd)
+
+    def test_unmatched_closing_paren_is_left_alone(self):
+        """A depth-0 `)` is a `case` arm or a syntax error — not ours to rewrite."""
+        cmd = "case $x in\n  a) echo a ;;\nesac"
+        self.assertEqual(sp.normalize_command_substitutions(cmd), cmd)
+
+    def test_nested_substitution_balances(self):
+        cmd = "x=$(basename $(git rev-parse --show-toplevel)) && gh issue create --label bug"
+        tokens = sp.tokenize(sp.normalize_command_substitutions(cmd))
+        assert tokens is not None
+        self.assertNotIn("--show-toplevel))", tokens)
+        self.assertIn("--show-toplevel", tokens)
+        self.assertIn("bug", tokens)
+
+    def test_quote_structure_is_never_changed(self):
+        """A command that failed to tokenize must still fail; one that parsed must still parse.
+
+        The helper only inserts ` ; ` and drops `$(`/`)`/backtick characters —
+        it never adds or removes a quote — so the #661 fail-open on
+        `tokenize() is None` cannot be silently converted into a parse.
+        """
+        broken = "gh issue create --body 'gh's ambient repo (see above)' --label bug"
+        self.assertIsNone(sp.tokenize(broken), "precondition: this must break shlex")
+        self.assertIsNone(sp.tokenize(sp.normalize_command_substitutions(broken)))
+
+    def test_no_paren_or_backtick_is_returned_unchanged(self):
+        cmd = "gh issue create --repo o/r --label bug --label tech-debt"
+        self.assertIs(sp.normalize_command_substitutions(cmd), cmd)
+
+    def test_memoized_value_stable(self):
+        cmd = "url=$(gh issue create --label bug)"
+        first = sp.normalize_command_substitutions(cmd)
+        self.assertEqual(sp.normalize_command_substitutions(cmd), first)
+
+
 class IterCommandSegmentsTests(unittest.TestCase):
     def test_empty(self):
         self.assertEqual(list(sp.iter_command_segments([])), [])

--- a/.claude/hooks/tests/test_validate_labels.py
+++ b/.claude/hooks/tests/test_validate_labels.py
@@ -519,6 +519,22 @@ class DataHeredocBodyIsNotAnOptionListTests(unittest.TestCase):
             result = hook.check(self._input(cmd))
         self.assertIsNone(result, f"unexpected block: {result}")
 
+    def test_unterminated_heredoc_validates_nothing(self):
+        """`strip_data_heredocs` keeps an unterminated body; we must not scan it.
+
+        Its own callers are bypass matchers, for which retaining the body is
+        the safe direction. For a false-positive-sensitive gate it is the
+        unsafe one — the retained prose becomes option tokens, which is
+        defect B again. The command cannot run as written, so there is
+        nothing to pre-flight.
+        """
+        cmd = (
+            "cat > /tmp/x <<'EOF'\n"
+            "gh issue create --label ghost\n"
+            "gh issue create --repo o/r --label bug"
+        )
+        self.assertEqual(hook.extract_labels(cmd), [])
+
     def test_an_interpreter_heredoc_body_is_still_scanned(self):
         """`bash <<'EOF'` is CODE — its `gh issue create` genuinely runs.
 
@@ -606,6 +622,22 @@ class PrecisionRetainedTests(unittest.TestCase):
         self.assertIsNotNone(result, "the $( ) shape is still ungated")
         self.assertEqual(result["decision"], "block")
         self.assertIn("not-a-real-label", result["reason"])
+
+    def test_mid_argument_substitution_loses_coverage_but_never_false_blocks(self):
+        """Pinning the deliberate recall/precision trade, so it is a decision.
+
+        A `$( … )` inside the gh invocation's OWN arguments truncates the
+        segment, so later flags go unvalidated. That is a silent allow, never
+        a block. The alternative — splicing the substitution's words into the
+        outer segment — makes `--repo` resolve to `cat` and would query the
+        wrong repo's label list, i.e. it would trade a recall loss for a
+        false BLOCK. This test exists so a future change that "fixes" the
+        recall has to confront the repo-resolution consequence.
+        """
+        cmd = "gh issue create --repo $(cat /tmp/r) --label not-a-real-label"
+        self.assertEqual(hook.extract_labels(cmd), [])
+        with mock.patch.object(hook, "get_existing_labels", return_value=WAVE29_REAL_LABELS):
+            self.assertIsNone(hook.check(self._input(cmd)))
 
     def test_missing_label_in_a_heredoc_carrying_command_still_blocks(self):
         """The heredoc fix must not blanket-disable the gate for such commands."""

--- a/.claude/hooks/tests/test_validate_labels.py
+++ b/.claude/hooks/tests/test_validate_labels.py
@@ -10,6 +10,7 @@ Or:  python3 .claude/hooks/tests/test_validate_labels.py
 
 from __future__ import annotations
 
+import shlex
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -420,6 +421,17 @@ W29_B_HEREDOC_DASH_LC_BACKTICK = _wave29("w29b_heredoc_lc_backtick")
 
 W29_C_HEREDOC_DASH_LC = _wave29("w29c_heredoc_lc")
 
+# W30-A — 2026-08-11T03:06:00Z, recorded block: `definitely-not-a-real-label`.
+# The only fixture in this corpus with ZERO reconstruction: the log record is
+# 242 bytes, below the 500-byte truncation point, so the file is the complete
+# command exactly as issued. It was produced by Nino Kavtaradze's merge-gate
+# review OF THIS PR — a reduced repro he built while verifying the fix, whose
+# heredoc body quotes a `--label definitely-not-a-real-label` example. The
+# installed PRE-FIX hook blocked him from filing it. Its real labels
+# (`tech-debt`, `bug`) both exist, so this is a fourth false positive, in the
+# wild, in wave 30, on the reviewer, while reviewing the fix for it.
+W30_A_REVIEW_HEREDOC = _wave29("w30a_review_heredoc")
+
 # Every label the three commands really passed. All existed at block time.
 WAVE29_REAL_LABELS = {"bug", "security", "tech-debt", "process", "meta-issue", "phase-10"}
 
@@ -467,6 +479,29 @@ class Wave29FalsePositiveCorpusTests(unittest.TestCase):
     def test_w29c_does_not_block(self):
         self._assert_allowed(W29_C_HEREDOC_DASH_LC)
 
+    def test_w30a_review_heredoc_extracts_only_the_real_labels(self):
+        """The wave-30 instance the review itself produced.
+
+        Its body carries BOTH defect families at once — a `--label` example in
+        heredoc prose AND a mid-argument `$( … )` — so it also pins that the
+        two fixes compose rather than merely coexist.
+        """
+        self.assertEqual(hook.extract_labels(W30_A_REVIEW_HEREDOC), ["tech-debt", "bug"])
+
+    def test_w30a_does_not_block(self):
+        with mock.patch.object(hook, "get_existing_labels", return_value=WAVE29_REAL_LABELS):
+            result = hook.check(self._input(W30_A_REVIEW_HEREDOC))
+        self.assertIsNone(result, f"unexpected block: {result}")
+
+    def test_w30a_substitution_inside_the_data_body_is_not_counted_as_lost(self):
+        """The `$( … )` sits in the heredoc BODY, not in the real invocation.
+
+        Its argument-swallowing does not apply, so the partial-coverage note
+        must stay quiet — otherwise every issue body that quotes a command
+        substitution would carry a spurious "could not check N flags" warning.
+        """
+        self.assertEqual(hook._extract_labels(W30_A_REVIEW_HEREDOC).unvalidated, 0)
+
     def test_no_extracted_label_carries_a_shell_metacharacter(self):
         """Acceptance criterion 4, across the whole corpus.
 
@@ -478,6 +513,7 @@ class Wave29FalsePositiveCorpusTests(unittest.TestCase):
             ("W29-A", W29_A_DOLLAR_PAREN),
             ("W29-B", W29_B_HEREDOC_DASH_LC_BACKTICK),
             ("W29-C", W29_C_HEREDOC_DASH_LC),
+            ("W30-A", W30_A_REVIEW_HEREDOC),
         ):
             with self.subTest(case=name):
                 for label in hook.extract_labels(command):
@@ -535,6 +571,15 @@ class DataHeredocBodyIsNotAnOptionListTests(unittest.TestCase):
         )
         self.assertEqual(hook.extract_labels(cmd), [])
 
+    def test_unterminated_heredoc_skip_is_not_silent(self):
+        """MF2: a fail-open added by the fix must announce itself like the rest."""
+        cmd = "cat > /tmp/x <<'EOF'\ngh issue create --repo o/r --label bug"
+        with mock.patch.object(hook, "get_existing_labels", return_value={"bug"}):
+            result = hook.check(self._input(cmd))
+        self.assertIsNotNone(result, "silent fail-open")
+        self.assertEqual(result["decision"], "allow")
+        self.assertIn("unterminated heredoc", result["systemMessage"])
+
     def test_an_interpreter_heredoc_body_is_still_scanned(self):
         """`bash <<'EOF'` is CODE — its `gh issue create` genuinely runs.
 
@@ -559,7 +604,7 @@ class ShellMetacharGuardTests(unittest.TestCase):
             result = hook.check(self._input(cmd))
         self.assertIsNotNone(result)
         self.assertEqual(result["decision"], "allow")
-        self.assertIn("skipped label validation", result["systemMessage"])
+        self.assertIn("validated NO labels", result["systemMessage"])
         self.assertIn("meta-issue)", result["systemMessage"])
 
     def test_metachar_label_never_reaches_a_create_remediation(self):
@@ -573,12 +618,76 @@ class ShellMetacharGuardTests(unittest.TestCase):
         """One garbage token discredits the parse, not merely itself."""
         self.assertEqual(hook.extract_labels("gh issue create --label bug --label 'x)'"), [])
 
+    def test_every_character_in_the_metachar_set_is_load_bearing(self):
+        """Each member of `_SHELL_METACHARS` must be pinned, not just `)`.
+
+        Nino Kavtaradze's per-character mutation of the set (main#1394 review
+        round 2, minor / #1411) found 11 of 12 members inert: every
+        `ShellMetacharGuardTests` case used a `)`-bearing token, so dropping
+        `(`, `` ` ``, `$`, `;`, `|`, `&`, `<`, `>`, `\\n`, `\\r` or `\\\\` from
+        the set was caught by nothing. The guard's own comment claims BOTH
+        wave-29 defect families land here (`meta-issue)` and `` c` ``), and
+        half of that claim was unpinned — the same defect as MF1 in miniature,
+        an artifact asserting more than it demonstrates. One subTest per
+        character closes it.
+        """
+        for char in sorted(hook._SHELL_METACHARS):
+            with self.subTest(char=repr(char)):
+                # INTERIOR placement is required, not incidental: label values
+                # are `.strip()`ed before the guard runs, so a TRAILING `\n` or
+                # `\r` is gone before it can be judged. Appending the character
+                # would make those two subTests fail for a reason that has
+                # nothing to do with the guard.
+                cmd = f"gh issue create --repo o/r --label {shlex.quote('bug' + char + 'x')}"
+                self.assertEqual(
+                    hook.extract_labels(cmd),
+                    [],
+                    f"a label token containing {char!r} was not treated as a mis-parse",
+                )
+
     def test_a_label_with_spaces_is_not_suspect(self):
         """GitHub ships `good first issue`; spaces are legal, metachars are not."""
         self.assertEqual(
             hook.extract_labels("gh issue create --label 'good first issue'"),
             ["good first issue"],
         )
+
+
+class MidArgumentSubstitutionRecallTests(unittest.TestCase):
+    """Exactly how wide the one recall loss is (main#1394 review round 2).
+
+    The reviewer's second pass established that the loss bites only on an
+    UNQUOTED mid-argument substitution, and that the common double-quoted
+    shape keeps full recall. That distinction was missing from the first
+    write-up, which would have led a reader to over-estimate the hole — so it
+    is pinned here rather than only asserted in prose.
+    """
+
+    def test_double_quoted_substitution_costs_no_recall(self):
+        for cmd in (
+            'gh issue create --repo o/r --body "$(cat b.md)" --label bug',
+            'gh issue create --repo o/r --title "$(date)" --label bug --label tech-debt',
+        ):
+            with self.subTest(cmd=cmd):
+                scan = hook._extract_labels(cmd)
+                self.assertIn("bug", scan.labels)
+                self.assertEqual(scan.unvalidated, 0, "no loss should be reported")
+
+    def test_single_quoted_substitution_costs_no_recall(self):
+        cmd = "gh issue create --repo o/r --body '$(cat b.md)' --label bug"
+        scan = hook._extract_labels(cmd)
+        self.assertEqual(scan.labels, ["bug"])
+        self.assertEqual(scan.unvalidated, 0)
+
+    def test_unquoted_substitution_is_the_only_losing_shape(self):
+        for cmd in (
+            "gh issue create --repo o/r --body $(cat b.md) --label bug",
+            "gh issue create --repo o/r --body `cat b.md` --label bug",
+        ):
+            with self.subTest(cmd=cmd):
+                scan = hook._extract_labels(cmd)
+                self.assertEqual(scan.labels, [])
+                self.assertEqual(scan.unvalidated, 1, "the loss must be counted, not silent")
 
 
 class PrecisionRetainedTests(unittest.TestCase):
@@ -624,20 +733,65 @@ class PrecisionRetainedTests(unittest.TestCase):
         self.assertIn("not-a-real-label", result["reason"])
 
     def test_mid_argument_substitution_loses_coverage_but_never_false_blocks(self):
-        """Pinning the deliberate recall/precision trade, so it is a decision.
+        """Pinning the deliberate recall/precision trade, so it stays a decision.
 
-        A `$( … )` inside the gh invocation's OWN arguments truncates the
-        segment, so later flags go unvalidated. That is a silent allow, never
-        a block. The alternative — splicing the substitution's words into the
-        outer segment — makes `--repo` resolve to `cat` and would query the
-        wrong repo's label list, i.e. it would trade a recall loss for a
-        false BLOCK. This test exists so a future change that "fixes" the
-        recall has to confront the repo-resolution consequence.
+        A `$( … )` inside the gh invocation's OWN arguments ends the parseable
+        run of arguments, so later label flags go unvalidated: an allow, never
+        a block — and, since main#1394 review round 2, an allow that SAYS so.
+
+        RETRACTED RATIONALE (main#1394 review round 2, MF1). This test used to
+        justify the trade by claiming the alternative "makes `--repo` resolve
+        to `cat` and would query the wrong repo's label list". That is false.
+        `check` resolves the repo from the RAW command via `extract_repo`,
+        never from these segments, so a splice cannot touch repo resolution;
+        and `extract_repo` on this shape returns `'$(cat'`, which fails the
+        `gh label list` call into the existing allow-with-a-warning branch.
+        The reason is corrected rather than the pin deleted, because the pin
+        is still right — see the sibling test for the hazard that IS real.
         """
         cmd = "gh issue create --repo $(cat /tmp/r) --label not-a-real-label"
         self.assertEqual(hook.extract_labels(cmd), [])
         with mock.patch.object(hook, "get_existing_labels", return_value=WAVE29_REAL_LABELS):
-            self.assertIsNone(hook.check(self._input(cmd)))
+            result = hook.check(self._input(cmd))
+        self.assertIsNotNone(result, "the coverage loss must not be silent")
+        self.assertEqual(result["decision"], "allow")
+        self.assertIn("could not check 1 label flag", result["systemMessage"])
+
+    def test_the_rejected_splice_repair_would_mint_a_label_from_a_command_name(self):
+        """The hazard that actually justifies truncating (MF1, corrected).
+
+        Splicing a substitution's words into the surrounding argument list
+        makes its FIRST WORD look like the value of the preceding flag. For a
+        label flag that is fatal, because a label value is exactly what this
+        hook validates and blocks on:
+
+            gh issue create --repo o/r --label $(cat labelfile)
+              split (shipped) -> no labels     -> allow
+              splice          -> label 'cat'   -> block on a command name
+
+        No other change is needed for that to be live, so the trade is decided
+        on a present hazard rather than on one conditional on #1409. Asserted
+        against the real `_shell_parse` splice reading, not a hand-built list.
+        """
+        from _shell_parse import normalize_command_substitutions, tokenize, walk_flag_values
+
+        cmd = "gh issue create --repo o/r --label $(cat labelfile)"
+
+        # Precondition, read off the real splice reading: under a splice the
+        # label flag's value resolves to the substituted COMMAND's name.
+        spliced_tokens = tokenize(normalize_command_substitutions(cmd, separator=" "))
+        self.assertIsNotNone(spliced_tokens)
+        self.assertEqual(walk_flag_values(spliced_tokens, {"--label", "-l"}), ["cat"])
+
+        # Shipped reading: the flag's value is unknowable, so nothing is claimed.
+        self.assertEqual(hook.extract_labels(cmd), [])
+        with mock.patch.object(hook, "get_existing_labels", return_value=WAVE29_REAL_LABELS):
+            self.assertNotEqual(
+                (hook.check(self._input(cmd)) or {}).get("decision"),
+                "block",
+                "the shipped reading must never block on a computed label value",
+            )
+        self.assertNotIn("cat", hook.extract_labels(cmd))
 
     def test_missing_label_in_a_heredoc_carrying_command_still_blocks(self):
         """The heredoc fix must not blanket-disable the gate for such commands."""

--- a/.claude/hooks/tests/test_validate_labels.py
+++ b/.claude/hooks/tests/test_validate_labels.py
@@ -432,16 +432,30 @@ W29_C_HEREDOC_DASH_LC = _wave29("w29c_heredoc_lc")
 # wild, in wave 30, on the reviewer, while reviewing the fix for it.
 W30_A_REVIEW_HEREDOC = _wave29("w30a_review_heredoc")
 
-# Every label the three commands really passed. All existed at block time.
-WAVE29_REAL_LABELS = {"bug", "security", "tech-debt", "process", "meta-issue", "phase-10"}
+# Every label the four commands really passed. All existed at block time.
+RECORDED_REAL_LABELS = {"bug", "security", "tech-debt", "process", "meta-issue", "phase-10"}
+
+# Retained under the old name: `WAVE29_REAL_LABELS` is referenced widely below
+# and the rename is cosmetic, so both point at one object rather than drifting.
+WAVE29_REAL_LABELS = RECORDED_REAL_LABELS
 
 
-class Wave29FalsePositiveCorpusTests(unittest.TestCase):
-    """The hook's whole wave-29 block population, all three of them false.
+class RecordedFalsePositiveCorpusTests(unittest.TestCase):
+    """Every `validate_labels` block on record, across two waves. All false.
 
-    Precision before: 0/3. After: 3/3. The true-positive guard rails live in
-    `PrecisionRetainedTests` — a gate that stops false-blocking by stopping
-    blocking has not been fixed, it has been removed.
+    Four commands, all harvested from `.claude/annunaki/errors.jsonl`:
+
+      - **Wave 29** — W29-A/B/C, the hook's ENTIRE block population for that
+        wave. Precision before 0/3, after 3/3.
+      - **Wave 30** — W30-A, produced during the merge-gate review of the very
+        PR that fixes this, when the pre-fix hook blocked the reviewer's own
+        filing. Not a wave-29 figure, which is why this class is no longer
+        named for wave 29 (main#1394 review round 3).
+
+    Combined recorded population: 4 blocks, 0 correct, before -> 0 blocks
+    after. The true-positive guard rails live in `PrecisionRetainedTests` — a
+    gate that stops false-blocking by stopping blocking has not been fixed, it
+    has been removed.
     """
 
     _input = staticmethod(_test_helpers.bash_input)
@@ -591,6 +605,13 @@ class DataHeredocBodyIsNotAnOptionListTests(unittest.TestCase):
         self.assertEqual(hook.extract_labels(cmd), ["really-not-a-label"])
 
 
+# The characters `validate_labels._SHELL_METACHARS` is expected to hold, written
+# out INDEPENDENTLY of the implementation. A test that derives its expectation
+# from the code under test cannot detect a change to that code — see the history
+# in `test_every_character_in_the_metachar_set_is_load_bearing`.
+EXPECTED_METACHARS = ("(", ")", "`", "$", ";", "|", "&", "<", ">", "\n", "\r", "\\")
+
+
 class ShellMetacharGuardTests(unittest.TestCase):
     """Layer 3: a metacharacter in a label means WE mis-parsed, not that the
     label is missing. Skip validation, and say so — a gate that quietly stops
@@ -618,20 +639,43 @@ class ShellMetacharGuardTests(unittest.TestCase):
         """One garbage token discredits the parse, not merely itself."""
         self.assertEqual(hook.extract_labels("gh issue create --label bug --label 'x)'"), [])
 
-    def test_every_character_in_the_metachar_set_is_load_bearing(self):
-        """Each member of `_SHELL_METACHARS` must be pinned, not just `)`.
+    def test_metachar_set_membership_matches_the_pinned_literal(self):
+        """The set must equal `EXPECTED_METACHARS`, member for member.
 
-        Nino Kavtaradze's per-character mutation of the set (main#1394 review
-        round 2, minor / #1411) found 11 of 12 members inert: every
-        `ShellMetacharGuardTests` case used a `)`-bearing token, so dropping
-        `(`, `` ` ``, `$`, `;`, `|`, `&`, `<`, `>`, `\\n`, `\\r` or `\\\\` from
-        the set was caught by nothing. The guard's own comment claims BOTH
-        wave-29 defect families land here (`meta-issue)` and `` c` ``), and
-        half of that claim was unpinned — the same defect as MF1 in miniature,
-        an artifact asserting more than it demonstrates. One subTest per
-        character closes it.
+        This assertion is what makes the loop below mean anything, and it is
+        the whole point of keeping the expectation in a LITERAL (main#1394
+        review round 3). Removing a character from `_SHELL_METACHARS` fails
+        here; adding one also fails here, so growing the set is a deliberate
+        act with a matching test edit rather than a silent widening.
         """
-        for char in sorted(hook._SHELL_METACHARS):
+        self.assertEqual(hook._SHELL_METACHARS, frozenset(EXPECTED_METACHARS))
+
+    def test_every_character_in_the_metachar_set_is_load_bearing(self):
+        """Each member of `EXPECTED_METACHARS` must be pinned, not just `)`.
+
+        HISTORY — this test was itself the defect twice (main#1394).
+
+        Round 2 found the guard's coverage claim half-unpinned (#1411): every
+        `ShellMetacharGuardTests` case used a `)`-bearing token, so dropping
+        any other member was caught by nothing. The fix I wrote then iterated
+        `sorted(hook._SHELL_METACHARS)` — **the very set it claims to pin**.
+        Deleting a member deleted its own test case, so the loop shrank in
+        silence and the file still reported all-green. Re-measured under
+        per-character mutation of the head tree, against the FULL hooks suite:
+        11 of 12 members survived deletion, and only `)` was caught — by the
+        wave-29 corpus, not by this test. The docstring meanwhile promised
+        "each member must be pinned": a stated guarantee the mechanism
+        structurally could not deliver, which is precisely the round-1 MF1
+        shape reproduced inside the fix for a round-2 finding.
+
+        The mechanism now: iterate a LITERAL tuple, and assert separately that
+        the set equals it. A deleted member no longer removes its own case —
+        it fails `test_metachar_set_membership_matches_the_pinned_literal`.
+        Verified by re-running the same mutation: 12 of 12 caught, 0 survivors.
+
+        Do not "simplify" this back to iterating `hook._SHELL_METACHARS`.
+        """
+        for char in EXPECTED_METACHARS:
             with self.subTest(char=repr(char)):
                 # INTERIOR placement is required, not incidental: label values
                 # are `.strip()`ed before the guard runs, so a TRAILING `\n` or
@@ -650,6 +694,40 @@ class ShellMetacharGuardTests(unittest.TestCase):
         self.assertEqual(
             hook.extract_labels("gh issue create --label 'good first issue'"),
             ["good first issue"],
+        )
+
+
+class IssueCreateSegmentsContractTests(unittest.TestCase):
+    """`None` (could not parse) and `[]` (parsed, no such command) differ.
+
+    The docstring states the distinction; nothing asserted it, so swapping the
+    early-out's `return []` for `return None` was a surviving mutant
+    (main#1394 review round 3). Both currently lead `check` to allow, which is
+    exactly why this needs a direct test: the contract is for the NEXT reader,
+    and a difference nothing observes is a difference that will be broken.
+    """
+
+    def test_no_gh_in_command_is_an_empty_list_not_none(self):
+        """Parsed fine; there is simply no `gh issue create` here."""
+        result = hook.issue_create_segments("echo hello --label world")
+        self.assertIsNotNone(result, "a parseable command must not report a parse failure")
+        self.assertEqual(result, [])
+
+    def test_gh_present_but_not_issue_create_is_an_empty_list(self):
+        self.assertEqual(hook.issue_create_segments("gh pr create --label bug"), [])
+
+    def test_untokenizable_command_is_none(self):
+        """Genuinely unparseable — the #661 fail-open, distinct from `[]`."""
+        cmd = "gh issue create --label bug --body 'gh's ambient repo'"
+        from _shell_parse import tokenize
+
+        self.assertIsNone(tokenize(cmd), "precondition: this must break shlex")
+        self.assertIsNone(hook.issue_create_segments(cmd))
+
+    def test_a_real_invocation_returns_its_post_verb_tokens(self):
+        self.assertEqual(
+            hook.issue_create_segments("gh issue create --repo o/r --label bug"),
+            [["--repo", "o/r", "--label", "bug"]],
         )
 
 

--- a/.claude/hooks/tests/test_validate_labels.py
+++ b/.claude/hooks/tests/test_validate_labels.py
@@ -11,6 +11,7 @@ Or:  python3 .claude/hooks/tests/test_validate_labels.py
 from __future__ import annotations
 
 import unittest
+from pathlib import Path
 from unittest import mock
 
 import _test_helpers  # noqa: E402,F401
@@ -137,11 +138,34 @@ class NegativeMatchLabelsTests(unittest.TestCase):
             [],
         )
 
-    def test_unrelated_command_returns_empty(self):
-        self.assertEqual(
-            hook.extract_labels("echo hello --label world"),
-            ["world"],  # extract_labels is pure; the gate in check() filters
-        )
+    def test_label_flag_on_a_non_gh_command_is_not_a_label(self):
+        """`echo … --label world` contributes nothing (contract change, main#1351).
+
+        This assertion is inverted from its original form, deliberately. It
+        used to read `["world"]` with the comment "extract_labels is pure; the
+        gate in check() filters" — i.e. extraction matched a `--label` flag
+        ANYWHERE in the command string and relied on a separate `check()`
+        guard to decide whether the command was even a `gh issue create`.
+
+        That split is the defect. The `check()` guard is whole-command
+        (`is_gh_subcommand` over the raw token stream), so it says yes when the
+        words `gh issue create` appear ANYWHERE — including a heredoc body —
+        and then extraction, also whole-command, harvests `-l`-shaped tokens
+        from wherever they happen to sit. Two of the three wave-29 false
+        blocks are exactly that composition: a `bash -lc` in an issue BODY
+        became a label named `c` on a command whose real gh invocation was
+        three lines further down.
+
+        Extraction is now scoped to the `gh issue create` SEGMENT, so a
+        `--label` outside it is not a label, and purity now means "a pure
+        function of the command" rather than "unaware of which command it is".
+        """
+        self.assertEqual(hook.extract_labels("echo hello --label world"), [])
+
+    def test_label_flag_on_a_sibling_command_in_the_same_string(self):
+        """A real `--label` on a DIFFERENT gh subcommand must not leak in."""
+        cmd = "gh issue edit 7 --add-label stale && gh issue create --label bug"
+        self.assertEqual(hook.extract_labels(cmd), ["bug"])
 
 
 class TokenizeFailureFallbackTests(unittest.TestCase):
@@ -326,6 +350,277 @@ class CheckEndToEndTests(unittest.TestCase):
             result = hook.check(self._input("gh issue create --label any"))
         self.assertIsNotNone(result)
         self.assertEqual(result["decision"], "allow")
+
+
+# ---------------------------------------------------------------------------
+# Wave-29 live false-positive corpus (main#1351)
+# ---------------------------------------------------------------------------
+#
+# These are not invented shapes. They are the THREE `validate_labels` blocks
+# recorded in `.claude/annunaki/errors.jsonl` during wave 29 — the hook's
+# entire block population for the wave. All three were false positives: every
+# label the commands actually passed (`bug`, `security`, `tech-debt`,
+# `process`, `meta-issue`, `phase-10`) existed in the repo at the time
+# (verified 2026-08-10 via `gh label list`). Precision was 0/3.
+#
+# The first one blocked the filing of #1150 — the umbrella issue about hooks
+# hand-rolling command parsing, which names THIS hook as un-audited. A gate at
+# zero precision that also blocks the report of its own defect class is the
+# cleanest possible statement of the problem, so it is pinned here rather than
+# paraphrased.
+#
+# PROVENANCE, precisely. `annunaki_log` truncates the `command` it records at
+# 500 characters. The leading bytes of each fixture below are VERBATIM from
+# that record. Where the record is cut off, the continuation is reconstructed
+# from two independent recorded sources, not from imagination:
+#
+#   - the SUCCESSFUL RETRY of the same filing, captured in
+#     `.claude/annunaki/traces.jsonl` roughly a minute after each block, which
+#     supplies the exact `gh issue create` flag tail and label set;
+#   - the recorded BLOCK MESSAGE itself, which pins how many `-lc` occurrences
+#     the elided heredoc body contained and in what shape — `c, c, c` means
+#     three bare `bash -lc`; `c, c, c\`` means the third was inside a markdown
+#     code span, so shlex handed the tokenizer `-lc\``.
+#
+# Each fixture is asserted to reproduce its recorded block message under the
+# PRE-FIX implementation (that check is what makes them regression tests
+# rather than decoration; see the PR body for the captured pre-fix output) and
+# to be allowed under the current one.
+
+# The three commands live as VERBATIM BYTES in `tests/fixtures/`, matching the
+# `real_*` harvested-fixture convention this suite already uses. They are files
+# rather than string literals for two reasons: a recorded command must not be
+# reflowed to satisfy a line-length linter, and a reader comparing a fixture
+# against the log is comparing bytes, not an escaped Python literal.
+#
+#   real_label_block_w29a_dollar_paren.txt        recorded block: meta-issue)
+#   real_label_block_w29b_heredoc_lc_backtick.txt recorded block: c, c, c`
+#   real_label_block_w29c_heredoc_lc.txt          recorded block: c, c, c
+
+_FIXTURES = Path(__file__).resolve().parent / "fixtures"
+
+
+def _wave29(name: str) -> str:
+    """Load a harvested command, refusing to run against a dead instrument."""
+    body = (_FIXTURES / f"real_label_block_{name}.txt").read_text()
+    if "gh issue create" not in body:
+        raise AssertionError(f"fixture {name} lost its gh invocation — the instrument is dead")
+    return body
+
+
+# Capturing the new issue's URL into a variable is the ordinary "create it,
+# then add it to the board" idiom, so W29-A fires on a routine shape.
+W29_A_DOLLAR_PAREN = _wave29("w29a_dollar_paren")
+
+# W29-B's heredoc body is a write-up ABOUT shell parsing, so it quotes
+# `bash -lc` — twice bare and once inside a code span, which is why its third
+# minted label was `` c` ``. The gate is hardest on the work that hardens the
+# gates.
+W29_B_HEREDOC_DASH_LC_BACKTICK = _wave29("w29b_heredoc_lc_backtick")
+
+W29_C_HEREDOC_DASH_LC = _wave29("w29c_heredoc_lc")
+
+# Every label the three commands really passed. All existed at block time.
+WAVE29_REAL_LABELS = {"bug", "security", "tech-debt", "process", "meta-issue", "phase-10"}
+
+
+class Wave29FalsePositiveCorpusTests(unittest.TestCase):
+    """The hook's whole wave-29 block population, all three of them false.
+
+    Precision before: 0/3. After: 3/3. The true-positive guard rails live in
+    `PrecisionRetainedTests` — a gate that stops false-blocking by stopping
+    blocking has not been fixed, it has been removed.
+    """
+
+    _input = staticmethod(_test_helpers.bash_input)
+
+    def _assert_allowed(self, command):
+        with mock.patch.object(hook, "get_existing_labels", return_value=WAVE29_REAL_LABELS):
+            result = hook.check(self._input(command))
+        self.assertIsNone(result, f"unexpected block: {result}")
+
+    def test_w29a_dollar_paren_extracts_meta_issue_without_the_paren(self):
+        """Recorded block demanded a label named `meta-issue)`."""
+        labels = hook.extract_labels(W29_A_DOLLAR_PAREN)
+        self.assertEqual(labels, ["tech-debt", "process", "meta-issue"])
+        self.assertNotIn("meta-issue)", labels)
+
+    def test_w29a_does_not_block_the_filing_of_1150(self):
+        self._assert_allowed(W29_A_DOLLAR_PAREN)
+
+    def test_w29b_heredoc_dash_lc_contributes_no_labels(self):
+        """Recorded block demanded labels `c`, `c`, `c\\``."""
+        labels = hook.extract_labels(W29_B_HEREDOC_DASH_LC_BACKTICK)
+        self.assertEqual(labels, ["bug", "security", "tech-debt"])
+        self.assertNotIn("c", labels)
+        self.assertNotIn("c`", labels)
+
+    def test_w29b_does_not_block(self):
+        self._assert_allowed(W29_B_HEREDOC_DASH_LC_BACKTICK)
+
+    def test_w29c_heredoc_dash_lc_contributes_no_labels(self):
+        """Recorded block demanded labels `c`, `c`, `c`."""
+        labels = hook.extract_labels(W29_C_HEREDOC_DASH_LC)
+        self.assertEqual(labels, ["tech-debt", "process", "phase-10"])
+        self.assertNotIn("c", labels)
+
+    def test_w29c_does_not_block(self):
+        self._assert_allowed(W29_C_HEREDOC_DASH_LC)
+
+    def test_no_extracted_label_carries_a_shell_metacharacter(self):
+        """Acceptance criterion 4, across the whole corpus.
+
+        A label token holding a shell metacharacter can never reach the
+        `gh label create "<token>"` remediation line — the message that, in
+        W29-A, would have had the user mint a junk label named `meta-issue)`.
+        """
+        for name, command in (
+            ("W29-A", W29_A_DOLLAR_PAREN),
+            ("W29-B", W29_B_HEREDOC_DASH_LC_BACKTICK),
+            ("W29-C", W29_C_HEREDOC_DASH_LC),
+        ):
+            with self.subTest(case=name):
+                for label in hook.extract_labels(command):
+                    self.assertFalse(
+                        hook._SHELL_METACHARS.intersection(label),
+                        f"{name}: metacharacter survived into label {label!r}",
+                    )
+
+
+class DataHeredocBodyIsNotAnOptionListTests(unittest.TestCase):
+    """#1174's code-vs-data class, arriving in this hook (main#1351 defect B).
+
+    A heredoc body fed to `cat`/`tee` is DATA. It routinely contains prose
+    about gh commands — that is what a tech-debt write-up IS — and none of it
+    is an option list for the command that follows.
+    """
+
+    _input = staticmethod(_test_helpers.bash_input)
+
+    def test_documented_gh_issue_create_in_a_data_body_does_not_leak(self):
+        cmd = (
+            "cat > /tmp/note.md <<'EOF'\n"
+            "Reproduce with:\n"
+            "\n"
+            "    gh issue create --label ghost-label --title x\n"
+            "EOF\n"
+            "gh issue create --repo o/r --body-file /tmp/note.md --label bug"
+        )
+        self.assertEqual(hook.extract_labels(cmd), ["bug"])
+
+    def test_documented_gh_issue_create_in_a_data_body_does_not_block(self):
+        cmd = (
+            "cat > /tmp/note.md <<'EOF'\n"
+            "    gh issue create --label ghost-label\n"
+            "EOF\n"
+            "gh issue create --repo o/r --body-file /tmp/note.md --label bug"
+        )
+        with mock.patch.object(hook, "get_existing_labels", return_value={"bug"}):
+            result = hook.check(self._input(cmd))
+        self.assertIsNone(result, f"unexpected block: {result}")
+
+    def test_an_interpreter_heredoc_body_is_still_scanned(self):
+        """`bash <<'EOF'` is CODE — its `gh issue create` genuinely runs.
+
+        The complement of the test above, and the reason this uses
+        `strip_DATA_heredocs` rather than `strip_heredocs`: dropping every
+        body would blind the gate to a real invocation.
+        """
+        cmd = "bash <<'EOF'\ngh issue create --repo o/r --label really-not-a-label\nEOF"
+        self.assertEqual(hook.extract_labels(cmd), ["really-not-a-label"])
+
+
+class ShellMetacharGuardTests(unittest.TestCase):
+    """Layer 3: a metacharacter in a label means WE mis-parsed, not that the
+    label is missing. Skip validation, and say so — a gate that quietly stops
+    gating is this hook's own history."""
+
+    _input = staticmethod(_test_helpers.bash_input)
+
+    def test_metachar_label_allows_with_a_visible_note(self):
+        cmd = "gh issue create --repo o/r --label 'meta-issue)'"
+        with mock.patch.object(hook, "get_existing_labels", return_value={"meta-issue"}):
+            result = hook.check(self._input(cmd))
+        self.assertIsNotNone(result)
+        self.assertEqual(result["decision"], "allow")
+        self.assertIn("skipped label validation", result["systemMessage"])
+        self.assertIn("meta-issue)", result["systemMessage"])
+
+    def test_metachar_label_never_reaches_a_create_remediation(self):
+        cmd = "gh issue create --repo o/r --label 'meta-issue)'"
+        with mock.patch.object(hook, "get_existing_labels", return_value={"meta-issue"}):
+            result = hook.check(self._input(cmd))
+        self.assertNotIn("gh label create", result.get("systemMessage", ""))
+        self.assertNotIn("reason", result)
+
+    def test_guard_empties_the_whole_batch_not_just_the_bad_token(self):
+        """One garbage token discredits the parse, not merely itself."""
+        self.assertEqual(hook.extract_labels("gh issue create --label bug --label 'x)'"), [])
+
+    def test_a_label_with_spaces_is_not_suspect(self):
+        """GitHub ships `good first issue`; spaces are legal, metachars are not."""
+        self.assertEqual(
+            hook.extract_labels("gh issue create --label 'good first issue'"),
+            ["good first issue"],
+        )
+
+
+class PrecisionRetainedTests(unittest.TestCase):
+    """The gate must keep doing its job. Every false positive removed above is
+    only a fix if a genuinely missing label still blocks."""
+
+    _input = staticmethod(_test_helpers.bash_input)
+
+    def test_genuinely_missing_label_still_blocks(self):
+        with mock.patch.object(hook, "get_existing_labels", return_value=WAVE29_REAL_LABELS):
+            result = hook.check(
+                self._input(
+                    "gh issue create --repo noorinalabs/noorinalabs-main "
+                    '--title "t" --body "b" --label definitely-not-a-real-label'
+                )
+            )
+        self.assertIsNotNone(result, "the gate stopped gating")
+        self.assertEqual(result["decision"], "block")
+        self.assertIn("definitely-not-a-real-label", result["reason"])
+
+    def test_missing_label_alongside_real_ones_still_blocks(self):
+        with mock.patch.object(hook, "get_existing_labels", return_value=WAVE29_REAL_LABELS):
+            result = hook.check(
+                self._input("gh issue create --label bug --label nope --label tech-debt")
+            )
+        self.assertIsNotNone(result)
+        self.assertEqual(result["decision"], "block")
+        self.assertIn("nope", result["reason"])
+
+    def test_missing_label_inside_dollar_paren_now_blocks(self):
+        """A true positive the PRE-FIX gate silently missed.
+
+        `url=$(gh issue create …)` with no wrapper word after the paren
+        tokenizes with the head glued (`url=$(gh`), so the old whole-command
+        `is_gh_subcommand` guard never matched and `check()` returned early —
+        no validation at all. Scoping fixes precision in BOTH directions:
+        the $( ) shape is now gated for the first time.
+        """
+        with mock.patch.object(hook, "get_existing_labels", return_value=WAVE29_REAL_LABELS):
+            result = hook.check(self._input("url=$(gh issue create --label not-a-real-label)"))
+        self.assertIsNotNone(result, "the $( ) shape is still ungated")
+        self.assertEqual(result["decision"], "block")
+        self.assertIn("not-a-real-label", result["reason"])
+
+    def test_missing_label_in_a_heredoc_carrying_command_still_blocks(self):
+        """The heredoc fix must not blanket-disable the gate for such commands."""
+        cmd = (
+            "cat > /tmp/note.md <<'EOF'\n"
+            "prose mentioning bash -lc and --label ghost\n"
+            "EOF\n"
+            "gh issue create --repo o/r --body-file /tmp/note.md --label not-a-real-label"
+        )
+        with mock.patch.object(hook, "get_existing_labels", return_value=WAVE29_REAL_LABELS):
+            result = hook.check(self._input(cmd))
+        self.assertIsNotNone(result, "the gate stopped gating on heredoc commands")
+        self.assertEqual(result["decision"], "block")
+        self.assertIn("not-a-real-label", result["reason"])
+        self.assertNotIn("ghost", result["reason"])
 
 
 if __name__ == "__main__":

--- a/.claude/hooks/validate_labels.py
+++ b/.claude/hooks/validate_labels.py
@@ -52,14 +52,26 @@ Tokenization (main#1351 — the shared-finder rewrite):
   body, a sibling command, a `--body` value — cannot contribute a label,
   because the scan never looks there.
 
-Fail-open posture (deliberate, and now three-layered):
+Fail-open posture (deliberate — FIVE conditions, only one of them silent):
   A label-existence pre-flight is best-effort — `gh` itself rejects a genuinely
   missing label server-side — whereas a false block stops valid work. So the
-  hook skips validation rather than blocking whenever the parse is not
-  trustworthy: on shlex failure (#661), when no `gh issue create` segment is
-  found, and — main#1351 — when an extracted label carries a shell
-  metacharacter, which is evidence of a mis-parse, not of a missing label. The
-  last case surfaces a systemMessage rather than passing silently.
+  hook allows rather than blocks whenever the parse is not trustworthy:
+
+    1. `gh label list` unavailable (network, or a `--repo` gh rejects)
+                                                     -> allow + warning
+    2. shlex cannot tokenize the command (#661)      -> allow, SILENT
+    3. a label token carries a shell metacharacter   -> allow + systemMessage
+    4. an unterminated heredoc                       -> allow + systemMessage
+    5. label flags after an unquoted mid-argument `$( … )` are unreadable
+                                                     -> note naming the count
+
+  Keep this list, `_extract_labels`, and the Hook 5 entry in
+  `.claude/team/charter/hooks/catalog-01-12.md` in step. It has drifted once
+  already: the catalog said "three" while the code had four (main#1394 review
+  round 2, MF2). Condition 2 is the only silent one, and deliberately so — its
+  trigger is "this Bash command has quoting shlex cannot handle", which is
+  common and usually unrelated to labels, so announcing it would mostly annoy
+  commands that were never being validated.
 
 Exit codes:
   0 — allow (not gh issue create, or all labels exist)
@@ -70,6 +82,7 @@ import json
 import os
 import subprocess
 import sys
+from typing import NamedTuple
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from _hook_main import run_blocking
@@ -153,14 +166,44 @@ def issue_create_segments(command: str) -> list[list[str]] | None:
         retained body's prose would be scanned as option tokens, which is
         defect B all over again. Such a command cannot run as written anyway,
         so there is nothing to pre-flight.
-      - **A `$( … )` in the MIDDLE of a `gh issue create`'s own arguments
-        truncates the segment**, so flags after it are not seen and simply go
-        unvalidated (`--repo $(cat r) --label bug` yields no labels → allow).
-        That is a recall loss, never a false block, and it is the deliberate
-        trade: the alternative — splicing the substitution's words INTO the
-        outer segment — makes `--repo` resolve to `cat`, i.e. it would query
-        the wrong repo's label list and false-block. Losing coverage beats
-        confidently answering with the wrong repo.
+      - **An UNQUOTED `$( … )` in the middle of a `gh issue create`'s own
+        arguments** ends the parseable run of arguments, so flags after it go
+        unvalidated. A recall loss, never a false block — and it is REPORTED
+        rather than silent; see `_extract_labels`.
+
+        The word *unquoted* is load-bearing and the hole is much narrower than
+        it sounds. A substitution inside double quotes — `--body "$(cat b.md)"`,
+        the shape that actually occurs — is left untouched by the normalizer,
+        arrives as one shlex token, and costs NO recall: labels after it are
+        read normally. Measured for both, and pinned by
+        `MidArgumentSubstitutionRecallTests`. Only the bare form
+        (`--body $(cat b.md)`) truncates.
+
+    Why not splice the substitution's words into the outer segment instead
+    (main#1394 review round 2, Nino Kavtaradze — MF1)
+    ================================================================
+
+    An earlier revision of this docstring justified the truncation by claiming
+    a splice "makes `--repo` resolve to `cat`" and would query the wrong repo.
+    **That was false and is retracted.** `check` resolves the repo from the RAW
+    command via `_repo_flag_parse.extract_repo`, never from these segments, so
+    a splice here cannot affect repo resolution at all; and `extract_repo` on
+    that shape returns `'$(cat'`, whose `gh label list` exits non-zero and
+    lands in the existing allow-with-a-warning branch. Measured, both.
+
+    The truncation stands anyway, on a hazard that IS present — one the
+    retracted reason obscured. Splicing makes a substitution's first word look
+    like the value of the flag preceding it, so a label flag whose value is
+    computed:
+
+        gh issue create --repo o/r --label $(cat labelfile)
+          split (shipped) -> no labels        -> allow
+          splice          -> label 'cat'      -> BLOCK, and `cat` is no label
+
+    That is a false block manufactured by the parse — this hook's entire defect
+    class — and it needs no other change to become live. Verified end-to-end
+    through `check` against the real label set. `--label` values are exactly
+    what this hook reads, so the splice is unsafe precisely where it matters.
     """
     # Cheap exact early-out. `find_gh_subcommand` matches only a literal `gh`
     # token, so a command with no `gh` substring cannot produce a segment —
@@ -169,8 +212,6 @@ def issue_create_segments(command: str) -> list[list[str]] | None:
     # like `g=gh; $g issue create` is not resolved either way: the finder needs
     # a literal `gh` in command position.)
     if "gh" not in command:
-        return []
-    if any(not span.terminated for span in classify_heredocs(command)):
         return []
     text = strip_data_heredocs(command)
     text = normalize_command_substitutions(text)
@@ -190,22 +231,8 @@ def issue_create_segments(command: str) -> list[list[str]] | None:
     return found
 
 
-def _extract_labels(command: str) -> tuple[list[str], str | None]:
-    """`(labels, skip_reason)` — the full result `extract_labels` narrows.
-
-    `skip_reason` is None on a trustworthy parse. It is a human-readable
-    explanation when a label token carried a shell metacharacter, in which
-    case `labels` is emptied: the right response to "the tokenizer produced
-    `meta-issue)`" is to distrust the whole parse, not to demand that the user
-    create a label named `meta-issue)`. Returned separately from
-    `extract_labels` so `check` can SAY it skipped instead of failing open in
-    silence — a gate that quietly stops gating is the failure mode this hook's
-    own history is made of.
-    """
-    segments = issue_create_segments(command)
-    if segments is None:
-        return [], None
-
+def _labels_from_segments(segments: list[list[str]]) -> list[str]:
+    """Flatten `--label`/`-l` values out of already-scoped segments."""
     labels: list[str] = []
     for rest in segments:
         for raw in walk_flag_values(rest, _LABEL_FLAGS):
@@ -213,12 +240,105 @@ def _extract_labels(command: str) -> tuple[list[str], str | None]:
                 label = value.strip()
                 if label:
                     labels.append(label)
+    return labels
+
+
+class LabelScan(NamedTuple):
+    """What the parse could establish about a command's labels.
+
+    `skip_reason` — set when NOTHING was validated and the caller should say so.
+    `unvalidated` — how many label flags were swallowed by a mid-argument
+    command substitution: validated nothing, blocked nothing, but the user
+    should know the pre-flight did not cover them.
+    """
+
+    labels: list[str]
+    skip_reason: str | None
+    unvalidated: int
+
+
+def _extract_labels(command: str) -> LabelScan:
+    """The full scan result that `extract_labels` narrows to a label list.
+
+    Every path that stops short of a complete answer reports WHY, so `check`
+    can say it. A gate that quietly stops gating is the failure mode this
+    hook's own history is made of, and shipping new silent fail-opens inside
+    the fix for that would reproduce it (main#1394 review round 2, MF2).
+
+    Three incomplete outcomes, all allow-shaped:
+
+      - shlex could not tokenize the command (#661) — the one skip left
+        deliberately SILENT. It is pre-existing behaviour, and its trigger is
+        "this Bash command has quoting shlex cannot handle", which is common
+        and usually has nothing to do with labels; a message here would fire
+        on unrelated commands. Called out in the charter catalog as the
+        remaining silent case rather than left implicit.
+      - an unterminated heredoc — the body would be read as options.
+      - a label token carrying a shell metacharacter — the right response to
+        "the tokenizer produced `meta-issue)`" is to distrust the whole parse,
+        not to demand the user create a label named `meta-issue)`.
+
+    Plus one PARTIAL outcome: `unvalidated`, measured by differential rather
+    than guessed. The split reading (safe, what we validate) is compared with
+    the splice reading (unsafe, never validated — see
+    `normalize_command_substitutions`); any labels the splice can see that the
+    split cannot were swallowed by a mid-argument substitution. Using the
+    splice ONLY to count what we missed keeps the false-block hazard out of the
+    decision while still making the loss visible.
+    """
+    if any(not span.terminated for span in classify_heredocs(command)):
+        return LabelScan(
+            [],
+            "the command contains an unterminated heredoc, so its body cannot be "
+            "told apart from the option list",
+            0,
+        )
+
+    segments = issue_create_segments(command)
+    if segments is None:
+        return LabelScan([], None, 0)
+
+    labels = _labels_from_segments(segments)
 
     suspect = [label for label in labels if _SHELL_METACHARS.intersection(label)]
     if suspect:
         rendered = ", ".join(repr(label) for label in suspect)
-        return [], f"parsed label token(s) carrying a shell metacharacter: {rendered}"
-    return labels, None
+        return LabelScan([], f"parsed label token(s) carrying a shell metacharacter: {rendered}", 0)
+
+    return LabelScan(labels, None, _count_swallowed_labels(command, labels))
+
+
+def _count_swallowed_labels(command: str, found: list[str]) -> int:
+    """How many label flags a mid-argument `$( … )` hid from the split reading.
+
+    Returns 0 for the overwhelming majority of commands — including
+    `url=$(gh issue create … --label x)`, where the substitution wraps the
+    whole invocation and both readings agree. Only a substitution INSIDE the
+    argument list makes the counts differ.
+
+    The spliced labels are counted and then discarded. They are never returned,
+    validated, or named in a message: the splice reading manufactures a label
+    out of the substituted command's name (`--label $(cat f)` -> `cat`), so
+    surfacing those strings would put a parser artifact in front of the user
+    as though it were their label.
+    """
+    if "$(" not in command and "`" not in command:
+        return 0
+    text = strip_data_heredocs(command)
+    text = normalize_command_substitutions(text, separator=" ")
+    text = normalize_command_separators(text)
+    tokens = tokenize(text)
+    if tokens is None:
+        return 0
+    spliced: list[list[str]] = []
+    for segment in iter_command_segments(tokens):
+        gh = find_gh_subcommand(segment)
+        if gh is None:
+            continue
+        _gh_globals, rest = gh
+        if rest[:2] == ["issue", "create"]:
+            spliced.append(rest[2:])
+    return max(0, len(_labels_from_segments(spliced)) - len(found))
 
 
 def extract_labels(command: str) -> list[str]:
@@ -233,6 +353,26 @@ def extract_labels(command: str) -> list[str]:
     return _extract_labels(command)[0]
 
 
+def _partial_note(scan: LabelScan) -> dict:
+    """Allow, but say that a command substitution hid some label flags.
+
+    Reached only when nothing is being blocked. When the hook DOES block, the
+    same fact is appended to the block reason instead — a user who is already
+    being stopped should not get two separate messages about one command.
+    """
+    n = scan.unvalidated
+    return {
+        "decision": "allow",
+        "systemMessage": (
+            f"NOTE: validate_labels could not check {n} label flag(s) — they follow a "
+            "command substitution inside the `gh issue create` arguments, which ends "
+            "the parseable run of arguments. Nothing is blocked and the labels that "
+            "WERE readable are fine. `gh` still rejects a genuinely missing label "
+            "server-side; run `gh label list` if you want certainty (main#1410)."
+        ),
+    }
+
+
 def check(input_data: dict) -> dict | None:
     """Check labels on gh issue create. Returns result dict if blocking/warning, None if allowed."""
     tool_name = input_data.get("tool_name", "")
@@ -241,20 +381,20 @@ def check(input_data: dict) -> dict | None:
 
     command = input_data.get("tool_input", {}).get("command", "")
 
-    labels, skip_reason = _extract_labels(command)
-    if skip_reason is not None:
+    scan = _extract_labels(command)
+    if scan.skip_reason is not None:
         return {
             "decision": "allow",
             "systemMessage": (
-                f"NOTE: validate_labels skipped label validation — {skip_reason}. "
-                "A shell metacharacter in a label token is evidence this hook "
-                "mis-parsed the command, not evidence of a missing label, so no "
-                "block is raised. `gh` still rejects a genuinely missing label "
-                "server-side. Please report the command shape (main#1351)."
+                f"NOTE: validate_labels validated NO labels — {scan.skip_reason}. "
+                "This is evidence the hook could not parse the command, not "
+                "evidence of a missing label, so no block is raised. `gh` still "
+                "rejects a genuinely missing label server-side. Please report the "
+                "command shape (main#1351)."
             ),
         }
-    if not labels:
-        return None
+    if not scan.labels:
+        return _partial_note(scan) if scan.unvalidated else None
 
     repo = extract_repo(command)
     existing = get_existing_labels(repo=repo)
@@ -267,19 +407,25 @@ def check(input_data: dict) -> dict | None:
             ),
         }
 
-    missing = [label for label in labels if label not in existing]
+    missing = [label for label in scan.labels if label not in existing]
     if not missing:
-        return None
+        return _partial_note(scan) if scan.unvalidated else None
 
     create_repo_flag = f" --repo {repo}" if repo else ""
     suggestions = "\n".join(f'  gh label create "{label}"{create_repo_flag}' for label in missing)
     repo_note = f" in {repo}" if repo else ""
+    partial = (
+        f"\n\nNote: {scan.unvalidated} further label flag(s) follow a command "
+        "substitution and were not checked either way (main#1410)."
+        if scan.unvalidated
+        else ""
+    )
     result = {
         "decision": "block",
         "reason": (
             f"BLOCKED: The following label(s) do not exist{repo_note}: "
             f"{', '.join(missing)}\n"
-            f"Create them first:\n{suggestions}\n\n"
+            f"Create them first:\n{suggestions}{partial}\n\n"
             "See charter § GitHub Label Hygiene: verify labels exist before creating issues."
         ),
     }

--- a/.claude/hooks/validate_labels.py
+++ b/.claude/hooks/validate_labels.py
@@ -75,6 +75,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from _hook_main import run_blocking
 from _repo_flag_parse import extract_repo  # noqa: E402
 from _shell_parse import (  # noqa: E402
+    classify_heredocs,
     find_gh_subcommand,
     iter_command_segments,
     normalize_command_separators,
@@ -142,6 +143,24 @@ def issue_create_segments(command: str) -> list[list[str]] | None:
          newlines and `;`/`|` that were previously inside a body or a
          substitution, and this pass is what turns them into standalone tokens
          `iter_command_segments` can split on.
+
+    Two boundaries, both resolving toward the fail-open this hook already has:
+
+      - **Unterminated heredoc → validate nothing.** `strip_data_heredocs`
+        fails toward KEEPING an unterminated body (its callers are bypass
+        matchers, for which keeping is the safe direction). For a
+        false-positive-sensitive gate the safe direction is the opposite: the
+        retained body's prose would be scanned as option tokens, which is
+        defect B all over again. Such a command cannot run as written anyway,
+        so there is nothing to pre-flight.
+      - **A `$( … )` in the MIDDLE of a `gh issue create`'s own arguments
+        truncates the segment**, so flags after it are not seen and simply go
+        unvalidated (`--repo $(cat r) --label bug` yields no labels → allow).
+        That is a recall loss, never a false block, and it is the deliberate
+        trade: the alternative — splicing the substitution's words INTO the
+        outer segment — makes `--repo` resolve to `cat`, i.e. it would query
+        the wrong repo's label list and false-block. Losing coverage beats
+        confidently answering with the wrong repo.
     """
     # Cheap exact early-out. `find_gh_subcommand` matches only a literal `gh`
     # token, so a command with no `gh` substring cannot produce a segment —
@@ -150,6 +169,8 @@ def issue_create_segments(command: str) -> list[list[str]] | None:
     # like `g=gh; $g issue create` is not resolved either way: the finder needs
     # a literal `gh` in command position.)
     if "gh" not in command:
+        return []
+    if any(not span.terminated for span in classify_heredocs(command)):
         return []
     text = strip_data_heredocs(command)
     text = normalize_command_substitutions(text)

--- a/.claude/hooks/validate_labels.py
+++ b/.claude/hooks/validate_labels.py
@@ -21,12 +21,45 @@ Input Language:
                     comma-separated values inside one flag are split. Body
                     content is NEVER scanned for labels (Bug 2 fix).
 
-Tokenization:
-  The command is split with `shlex.split(..., posix=True)` so quoted argument
-  values become single tokens. We then walk the token list and only treat a
-  token as a label/repo if the PRECEDING token is the corresponding flag.
-  This guarantees that text appearing inside a `--body "..."` heredoc/string
-  cannot leak into label or repo extraction.
+Tokenization (main#1351 — the shared-finder rewrite):
+  The command is normalized, tokenized, split into pipeline segments, and only
+  the segments that ARE a `gh issue create` invocation are scanned for label
+  flags. Everything is done through `_shell_parse`'s finders rather than a
+  private grammar — the #663 / #1150 invariant this hook was named in the
+  umbrella for violating.
+
+  Three passes run before tokenization, each closing one measured defect:
+
+    strip_data_heredocs           A `cat > file <<'BODY' … BODY` body is DATA
+                                  fed to a sink, not an option list (#1174's
+                                  code-vs-data class). Scanning it treated the
+                                  `bash -lc` in a shell-parsing write-up as
+                                  `-l c` and minted a label named `c` — twice
+                                  in wave-29, both false blocks.
+    normalize_command_substitutions
+                                  `url=$(gh issue create … --label meta-issue)`
+                                  glues the closing paren onto the last
+                                  argument, so the hook demanded a label named
+                                  `meta-issue)` and blocked the filing of
+                                  #1150 itself.
+    normalize_command_separators  Newlines / `;` / `|` become real separator
+                                  tokens, without which a multi-line command
+                                  collapses into one segment headed by `cd`
+                                  and the gh invocation is never found.
+
+  Segment scoping is what makes the label scan sound: a `-lc` (or a documented
+  `--label ghost`) anywhere OUTSIDE the `gh issue create` segment — a heredoc
+  body, a sibling command, a `--body` value — cannot contribute a label,
+  because the scan never looks there.
+
+Fail-open posture (deliberate, and now three-layered):
+  A label-existence pre-flight is best-effort — `gh` itself rejects a genuinely
+  missing label server-side — whereas a false block stops valid work. So the
+  hook skips validation rather than blocking whenever the parse is not
+  trustworthy: on shlex failure (#661), when no `gh issue create` segment is
+  found, and — main#1351 — when an extracted label carries a shell
+  metacharacter, which is evidence of a mis-parse, not of a missing label. The
+  last case surfaces a systemMessage rather than passing silently.
 
 Exit codes:
   0 — allow (not gh issue create, or all labels exist)
@@ -35,7 +68,6 @@ Exit codes:
 
 import json
 import os
-import re
 import subprocess
 import sys
 
@@ -43,7 +75,11 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from _hook_main import run_blocking
 from _repo_flag_parse import extract_repo  # noqa: E402
 from _shell_parse import (  # noqa: E402
-    is_gh_subcommand,
+    find_gh_subcommand,
+    iter_command_segments,
+    normalize_command_separators,
+    normalize_command_substitutions,
+    strip_data_heredocs,
     tokenize,
     walk_flag_values,
 )
@@ -51,6 +87,15 @@ from annunaki_log import log_pretooluse_block  # noqa: E402
 
 # Flags whose VALUE is a label list (comma-separated allowed by gh).
 _LABEL_FLAGS = {"--label", "-l"}
+
+# Characters that cannot appear in a correctly-parsed label token. A GitHub
+# label may contain spaces, unicode, emoji and most punctuation — `good first
+# issue` is a real default label — so this set is deliberately restricted to
+# SHELL metacharacters, whose presence means the tokenizer, not the user, put
+# them there. Both wave-29 defect families land here (`meta-issue)`, `` c` ``),
+# which is why this stays as a backstop even though the parse fixes above
+# remove the two known producers.
+_SHELL_METACHARS = frozenset("()`$;|&<>\n\r\\")
 
 
 def get_existing_labels(repo: str | None = None) -> set[str]:
@@ -77,39 +122,94 @@ def get_existing_labels(repo: str | None = None) -> set[str]:
         return set()
 
 
-def extract_labels(command: str) -> list[str]:
-    """Extract label names from --label / -l flags ONLY.
+def issue_create_segments(command: str) -> list[list[str]] | None:
+    """Post-verb tokens of every real `gh issue create` invocation in `command`.
 
-    Uses `shlex.split` to tokenize, then walks tokens. Quoted body content,
-    code blocks, and any text that is part of another flag's value are
-    treated as opaque single tokens and cannot leak into the label set
-    (Bug 2 fix). Comma-separated values within a single flag are split.
+    Returns None when the command cannot be tokenized (shlex failure — the
+    #661 fail-open), and `[]` when it tokenizes but holds no `gh issue create`
+    invocation. Each returned list is the segment's tokens AFTER the
+    `issue create` verbs, ready for `walk_flag_values`.
 
-    Returns an empty list (→ the gate ALLOWS) when shlex tokenization fails
-    (e.g. a malformed/unbalanced quote — typically an apostrophe such as
-    "gh's" inside a single-quoted `--body`). This is the #661 fix: the prior
-    fallback ran a `(?:--label|-l)`-anchored regex over the WHOLE command,
-    which scooped label-shaped tokens out of `--body`/`--title` prose (e.g. a
-    documented ``--label `p{N}-wave-{M}` `` pattern) and FALSE-BLOCKED a
-    legitimate `gh issue create`. Without reliable token boundaries we cannot
-    tell a real `--label` flag from one quoted inside body text, so we
-    deliberately fail OPEN here: the label-existence check is a best-effort
-    pre-flight and `gh` itself rejects a genuinely-missing label server-side,
-    whereas a false block stops valid work. We therefore prefer skipping
-    validation over over-matching. Comma-separated values within a single
-    flag are split.
+    Normalization order matters and is not interchangeable:
+
+      1. `strip_data_heredocs` FIRST, so an inert heredoc body is gone before
+         anything tries to read shell structure out of prose. Bodies fed to an
+         interpreter are deliberately kept — those really are code.
+      2. `normalize_command_substitutions`, so `$( … )` / backtick / subshell
+         boundaries become separators instead of being glued to the tokens on
+         either side.
+      3. `normalize_command_separators` LAST, because steps 1–2 can expose
+         newlines and `;`/`|` that were previously inside a body or a
+         substitution, and this pass is what turns them into standalone tokens
+         `iter_command_segments` can split on.
     """
-    tokens = tokenize(command)
-    if tokens is None:
+    # Cheap exact early-out. `find_gh_subcommand` matches only a literal `gh`
+    # token, so a command with no `gh` substring cannot produce a segment —
+    # this skips the normalization + shlex work for the overwhelming majority
+    # of Bash calls without weakening the match by one command. (Indirection
+    # like `g=gh; $g issue create` is not resolved either way: the finder needs
+    # a literal `gh` in command position.)
+    if "gh" not in command:
         return []
+    text = strip_data_heredocs(command)
+    text = normalize_command_substitutions(text)
+    text = normalize_command_separators(text)
+    tokens = tokenize(text)
+    if tokens is None:
+        return None
 
-    labels = []
-    for raw in walk_flag_values(tokens, _LABEL_FLAGS):
-        for label in raw.split(","):
-            label = label.strip()
-            if label:
-                labels.append(label)
-    return labels
+    found: list[list[str]] = []
+    for segment in iter_command_segments(tokens):
+        gh = find_gh_subcommand(segment)
+        if gh is None:
+            continue
+        _gh_globals, rest = gh
+        if rest[:2] == ["issue", "create"]:
+            found.append(rest[2:])
+    return found
+
+
+def _extract_labels(command: str) -> tuple[list[str], str | None]:
+    """`(labels, skip_reason)` — the full result `extract_labels` narrows.
+
+    `skip_reason` is None on a trustworthy parse. It is a human-readable
+    explanation when a label token carried a shell metacharacter, in which
+    case `labels` is emptied: the right response to "the tokenizer produced
+    `meta-issue)`" is to distrust the whole parse, not to demand that the user
+    create a label named `meta-issue)`. Returned separately from
+    `extract_labels` so `check` can SAY it skipped instead of failing open in
+    silence — a gate that quietly stops gating is the failure mode this hook's
+    own history is made of.
+    """
+    segments = issue_create_segments(command)
+    if segments is None:
+        return [], None
+
+    labels: list[str] = []
+    for rest in segments:
+        for raw in walk_flag_values(rest, _LABEL_FLAGS):
+            for value in raw.split(","):
+                label = value.strip()
+                if label:
+                    labels.append(label)
+
+    suspect = [label for label in labels if _SHELL_METACHARS.intersection(label)]
+    if suspect:
+        rendered = ", ".join(repr(label) for label in suspect)
+        return [], f"parsed label token(s) carrying a shell metacharacter: {rendered}"
+    return labels, None
+
+
+def extract_labels(command: str) -> list[str]:
+    """Label names passed via --label / -l to a `gh issue create` in `command`.
+
+    Scoped to real `gh issue create` segments (main#1351): a `--label` inside
+    another command in the same string, inside a data heredoc body, or inside
+    another flag's value is NOT a label. Comma-separated values within one flag
+    are split. Returns `[]` — the gate then ALLOWS — whenever the parse is not
+    trustworthy; see the module docstring's fail-open posture.
+    """
+    return _extract_labels(command)[0]
 
 
 def check(input_data: dict) -> dict | None:
@@ -120,15 +220,18 @@ def check(input_data: dict) -> dict | None:
 
     command = input_data.get("tool_input", {}).get("command", "")
 
-    tokens = tokenize(command)
-    if tokens is not None:
-        if not is_gh_subcommand(tokens, "issue", "create"):
-            return None
-    else:
-        if not re.search(r"\bgh\s+issue\s+create\b", command):
-            return None
-
-    labels = extract_labels(command)
+    labels, skip_reason = _extract_labels(command)
+    if skip_reason is not None:
+        return {
+            "decision": "allow",
+            "systemMessage": (
+                f"NOTE: validate_labels skipped label validation — {skip_reason}. "
+                "A shell metacharacter in a label token is evidence this hook "
+                "mis-parsed the command, not evidence of a missing label, so no "
+                "block is raised. `gh` still rejects a genuinely missing label "
+                "server-side. Please report the command shape (main#1351)."
+            ),
+        }
     if not labels:
         return None
 

--- a/.claude/team/charter/hooks/catalog-01-12.md
+++ b/.claude/team/charter/hooks/catalog-01-12.md
@@ -40,7 +40,18 @@
 - **Augments:** The label hygiene section. The manual rule to run `gh label list` first is now enforced automatically.
 - **Manual steps remaining:** None — the hook fetches labels and validates automatically.
 - **Scope of the label scan (main#1351):** only the `gh issue create` **segment** is scanned. A `--label` (or a `-lc`, which shlex reads as `-l c`) in a heredoc body fed to `cat`/`tee`, in a sibling command, or inside another flag's value is not a label. `$( )` / backtick / subshell edges are normalized before tokenizing, so `url=$(gh issue create … --label meta-issue)` no longer yields `meta-issue)` — and, as a side effect, that shape is now gated at all (it previously slipped the whole-command guard silently).
-- **Emergency override:** Remove the hook entry from `.claude/settings.json`. Three conditions make the hook ALLOW rather than block, by design — a label pre-flight is best-effort and `gh` rejects a missing label server-side, whereas a false block stops valid work: (1) `gh label list` unavailable (network) → allow with a warning; (2) the command fails to tokenize, e.g. an unbalanced quote (#661) → allow silently; (3) an extracted label carries a shell metacharacter → allow with a systemMessage, since that is evidence the hook mis-parsed rather than evidence of a missing label (main#1351).
+- **Emergency override:** Remove the hook entry from `.claude/settings.json`.
+- **Conditions that ALLOW rather than block — five, by design.** A label pre-flight is best-effort and `gh` rejects a missing label server-side, whereas a false block stops valid work. Only the second is silent; every other one says why, because a gate that quietly stops gating is this hook's own failure history (main#1351, main#1410).
+
+  | # | Condition | Visibility |
+  |---|---|---|
+  | 1 | `gh label list` unavailable (network / bad `--repo`) | allow + warning |
+  | 2 | command fails to tokenize, e.g. an unbalanced quote (#661) | **allow, silent** |
+  | 3 | an extracted label carries a shell metacharacter — evidence the hook mis-parsed, not that a label is missing | allow + systemMessage |
+  | 4 | an unterminated heredoc — its body cannot be told apart from the option list | allow + systemMessage |
+  | 5 | label flags follow a `$( … )` **inside** the `gh issue create` arguments — the parseable run of arguments ends there, so those flags are checked neither way | allow (or block on the others) + a note naming the count |
+
+  Condition 2 stays silent deliberately: it fires on any Bash command whose quoting shlex cannot handle, which is common and usually unrelated to labels, so a message would mostly land on commands that were never being validated. It is listed here rather than left implicit — it was the undocumented one this section was added to fix.
 
 ## Hook 6: Validate Lockfile Paths (`validate_lockfile_paths.py`)
 

--- a/.claude/team/charter/hooks/catalog-01-12.md
+++ b/.claude/team/charter/hooks/catalog-01-12.md
@@ -39,7 +39,8 @@
 - **What it automates:** GitHub Label Hygiene — validates that all `--label` values exist in the repository before `gh issue create` runs.
 - **Augments:** The label hygiene section. The manual rule to run `gh label list` first is now enforced automatically.
 - **Manual steps remaining:** None — the hook fetches labels and validates automatically.
-- **Emergency override:** Remove the hook entry from `.claude/settings.json`. If `gh label list` is unavailable (network issue), the hook allows the command with a warning.
+- **Scope of the label scan (main#1351):** only the `gh issue create` **segment** is scanned. A `--label` (or a `-lc`, which shlex reads as `-l c`) in a heredoc body fed to `cat`/`tee`, in a sibling command, or inside another flag's value is not a label. `$( )` / backtick / subshell edges are normalized before tokenizing, so `url=$(gh issue create … --label meta-issue)` no longer yields `meta-issue)` — and, as a side effect, that shape is now gated at all (it previously slipped the whole-command guard silently).
+- **Emergency override:** Remove the hook entry from `.claude/settings.json`. Three conditions make the hook ALLOW rather than block, by design — a label pre-flight is best-effort and `gh` rejects a missing label server-side, whereas a false block stops valid work: (1) `gh label list` unavailable (network) → allow with a warning; (2) the command fails to tokenize, e.g. an unbalanced quote (#661) → allow silently; (3) an extracted label carries a shell metacharacter → allow with a systemMessage, since that is evidence the hook mis-parsed rather than evidence of a missing label (main#1351).
 
 ## Hook 6: Validate Lockfile Paths (`validate_lockfile_paths.py`)
 

--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -258,3 +258,6 @@ keyspace
 
 # --- generic-prompt pending ledger archive/reset (main#1140) ---
 genericized
+
+# --- validate_labels shared-finder rewrite (main#1351) ---
+metacharacter


### PR DESCRIPTION
Closes #1351.

`validate_labels` minted garbage label names from two independent token-boundary defects. **All 3 blocks the hook raised in wave 29 — its entire block population for the wave — were false positives, and one of them blocked the creation of #1150 itself**, the umbrella issue about hooks hand-rolling command parsing that names this hook as un-audited. Precision was **0/3**.

## The corpus

Harvested from `.claude/annunaki/errors.jsonl`, committed as verbatim bytes under `.claude/hooks/tests/fixtures/` per the existing `real_*` harvested-fixture convention.

| # | Recorded | Shape | Blocked the filing of | Recorded block |
|---|---|---|---|---|
| W29-A | 2026-07-27T21:26:44Z | `url=$(… --label meta-issue)` | **#1150** | `meta-issue)` |
| W29-B | 2026-07-30T03:47:29Z | heredoc body quoting `bash -lc`, one in a code span | #1194 | ``c, c, c` `` |
| W29-C | 2026-08-03T16:11:14Z | heredoc body quoting `bash -lc` ×3 | #1308 | `c, c, c` |

Every label the three commands actually passed — `bug`, `security`, `tech-debt`, `process`, `meta-issue`, `phase-10` — existed in the repo (re-verified 2026-08-10 via `gh label list`). All three were false.

**Provenance.** `annunaki_log` truncates the recorded `command` at 500 chars. Each fixture's leading bytes are verbatim from that record; where the record is cut off, the continuation comes from two other *recorded* sources, not from imagination: the successful retry of the same filing in `traces.jsonl` a minute later (which supplies the exact `gh issue create` flag tail and label set), and the recorded **block message** itself, which pins how many `-lc` occurrences the elided body held and in what shape (`c, c, c` = three bare `bash -lc`; ``c, c, c` `` = the third sat inside a markdown code span, so shlex handed the tokenizer ``-lc` ``). The fixtures are asserted to reproduce their recorded block messages under the pre-fix hook — see below — which is what makes the reconstruction verifiable rather than plausible.

## Pre-fix output (the acceptance bar)

Pre-fix source is `HEAD` before this branch, extracted via `git archive`; the new tests and fixtures are overlaid onto it unchanged.

```
=== W29-A  $( ) paren capture       errors.jsonl 2026-07-27T21:26:44Z  (blocked #1150)
    extract_labels -> ['tech-debt', 'process', 'meta-issue)']
    check()        -> BLOCK
      | BLOCKED: The following label(s) do not exist in noorinalabs/noorinalabs-main: meta-issue)
      | Create them first:
      |   gh label create "meta-issue)" --repo noorinalabs/noorinalabs-main
      |
      | See charter § GitHub Label Hygiene: verify labels exist before creating issues.
    garbage labels minted: ['meta-issue)']   (recorded: ['meta-issue)'])
    == reproduces the recorded wave-29 block byte-for-byte
    verdict: FALSE BLOCK

=== W29-B  heredoc -lc + backtick   errors.jsonl 2026-07-30T03:47:29Z  (blocked #1194)
    extract_labels -> ['c', 'c', 'c`', 'bug', 'security', 'tech-debt']
    check()        -> BLOCK
      | BLOCKED: The following label(s) do not exist in noorinalabs/noorinalabs-main: c, c, c`
      | Create them first:
      |   gh label create "c" --repo noorinalabs/noorinalabs-main
      |   gh label create "c" --repo noorinalabs/noorinalabs-main
      |   gh label create "c`" --repo noorinalabs/noorinalabs-main
      |
      | See charter § GitHub Label Hygiene: verify labels exist before creating issues.
    garbage labels minted: ['c', 'c', 'c`']   (recorded: ['c', 'c', 'c`'])
    == reproduces the recorded wave-29 block byte-for-byte
    verdict: FALSE BLOCK

=== W29-C  heredoc -lc              errors.jsonl 2026-08-03T16:11:14Z  (blocked #1308)
    extract_labels -> ['c', 'c', 'c', 'tech-debt', 'process', 'phase-10']
    check()        -> BLOCK
      | BLOCKED: The following label(s) do not exist in noorinalabs/noorinalabs-main: c, c, c
      | Create them first:
      |   gh label create "c" --repo noorinalabs/noorinalabs-main
      |   gh label create "c" --repo noorinalabs/noorinalabs-main
      |   gh label create "c" --repo noorinalabs/noorinalabs-main
      |
      | See charter § GitHub Label Hygiene: verify labels exist before creating issues.
    garbage labels minted: ['c', 'c', 'c']   (recorded: ['c', 'c', 'c'])
    == reproduces the recorded wave-29 block byte-for-byte
    verdict: FALSE BLOCK

=== TRUE POSITIVE (must still block)
    extract_labels -> ['definitely-not-a-real-label']
    check()        -> BLOCK
      | BLOCKED: The following label(s) do not exist in noorinalabs/noorinalabs-main: definitely-not-a-real-label

precision on the wave-29 population: 0/3 correct blocks
```

Post-fix, same harness, same fixture bytes:

```
=== W29-A ...  extract_labels -> ['tech-debt', 'process', 'meta-issue']   check() -> ALLOW
=== W29-B ...  extract_labels -> ['bug', 'security', 'tech-debt']         check() -> ALLOW
=== W29-C ...  extract_labels -> ['tech-debt', 'process', 'phase-10']     check() -> ALLOW
=== TRUE POSITIVE  extract_labels -> ['definitely-not-a-real-label']      check() -> BLOCK

precision on the wave-29 population: 3/3 correct blocks
```

### The new tests, run against the pre-fix implementation

**At head `1b07be5`: 40 failed test items + 22 subtest failures — `62 failed` in pytest's summary line.**

This figure is *anchored to a head SHA on purpose*, because it is a property of the test set, not of the fix, and it therefore moves every time tests are added. It has gone stale three times in this PR — 29 (pre-round-2 tests), then 46 (round-2 tests, `e84af22`), now 62 (round-3 tests, `1b07be5`) — each time because it was correct when measured and then quietly outlived its measurement. If you are reading this at a later head, re-run rather than trusting the number:

    # materialise pre-fix source, overlay ONLY the head's tests + fixtures
    git archive e0196c3 .claude | tar -x -C <scratch>
    cp .claude/hooks/tests/test_{validate_labels,shell_parse}.py <scratch>/.claude/hooks/tests/
    cp .claude/hooks/tests/fixtures/real_label_block_*.txt <scratch>/.claude/hooks/tests/fixtures/
    cd <scratch>/.claude/hooks
    ENVIRONMENT=test python3 -m pytest tests/test_validate_labels.py tests/test_shell_parse.py -q -p no:randomly

Guard the run, or it will lie to you — this PR produced two green results from dead instruments. Assert the base tree really lacks `normalize_command_substitutions` and `issue_create_segments`, assert the overlaid test files are byte-identical to the head's, and treat *zero* failures as an overlay that did not take rather than as good news.

Abridged list from the round-2 measurement (`e84af22`, when the count was 46):

```
FAILED NegativeMatchLabelsTests::test_label_flag_on_a_non_gh_command_is_not_a_label
SUBFAILED(case='W29-A') Wave29FalsePositiveCorpusTests::test_no_extracted_label_carries_a_shell_metacharacter
SUBFAILED(case='W29-B') Wave29FalsePositiveCorpusTests::test_no_extracted_label_carries_a_shell_metacharacter
SUBFAILED(case='W29-C') Wave29FalsePositiveCorpusTests::test_no_extracted_label_carries_a_shell_metacharacter
FAILED Wave29FalsePositiveCorpusTests::test_w29a_does_not_block_the_filing_of_1150
FAILED Wave29FalsePositiveCorpusTests::test_w29a_dollar_paren_extracts_meta_issue_without_the_paren
FAILED Wave29FalsePositiveCorpusTests::test_w29b_does_not_block
FAILED Wave29FalsePositiveCorpusTests::test_w29b_heredoc_dash_lc_contributes_no_labels
FAILED Wave29FalsePositiveCorpusTests::test_w29c_does_not_block
FAILED Wave29FalsePositiveCorpusTests::test_w29c_heredoc_dash_lc_contributes_no_labels
FAILED DataHeredocBodyIsNotAnOptionListTests::test_documented_gh_issue_create_in_a_data_body_does_not_block
FAILED DataHeredocBodyIsNotAnOptionListTests::test_documented_gh_issue_create_in_a_data_body_does_not_leak
FAILED ShellMetacharGuardTests::test_guard_empties_the_whole_batch_not_just_the_bad_token
FAILED ShellMetacharGuardTests::test_metachar_label_allows_with_a_visible_note
FAILED ShellMetacharGuardTests::test_metachar_label_never_reaches_a_create_remediation
FAILED PrecisionRetainedTests::test_missing_label_in_a_heredoc_carrying_command_still_blocks
FAILED PrecisionRetainedTests::test_missing_label_inside_dollar_paren_now_blocks
FAILED NormalizeCommandSubstitutionsTests::test_backticks_become_separators
FAILED NormalizeCommandSubstitutionsTests::test_bare_subshell_is_split
FAILED NormalizeCommandSubstitutionsTests::test_closing_paren_is_not_glued_to_the_last_argument
FAILED NormalizeCommandSubstitutionsTests::test_escaped_paren_is_data
FAILED NormalizeCommandSubstitutionsTests::test_memoized_value_stable
FAILED NormalizeCommandSubstitutionsTests::test_nested_substitution_balances
FAILED NormalizeCommandSubstitutionsTests::test_no_paren_or_backtick_is_returned_unchanged
FAILED NormalizeCommandSubstitutionsTests::test_parens_and_backticks_inside_single_quotes_are_data
FAILED NormalizeCommandSubstitutionsTests::test_parens_inside_double_quotes_are_data
FAILED NormalizeCommandSubstitutionsTests::test_quote_structure_is_never_changed
FAILED NormalizeCommandSubstitutionsTests::test_substituted_command_head_becomes_findable
FAILED NormalizeCommandSubstitutionsTests::test_unmatched_closing_paren_is_left_alone

29 failed, 233 passed, 136 subtests passed
```

The tests that PASS pre-fix are the deliberate guard rails — the true-positive blocks, the interpreter-heredoc case, and `test_pre_fix_tokenization_glues_the_closing_paren`, which pins the raw shlex behaviour being corrected and would be meaningless if it changed.

## The fix

Three layers, in order of how much work each does.

**1. Shared-finder rewrite (the structural fix).** Label extraction no longer walks the whole token stream with `walk_flag_values`. It runs through `_shell_parse`'s finders — the #663 / #1150 invariant this hook was named for violating:

```
strip_data_heredocs -> normalize_command_substitutions -> normalize_command_separators
  -> tokenize -> iter_command_segments -> find_gh_subcommand, keeping "issue create"
```

Segment scoping is what makes the scan sound: a `-lc`, or a documented `--label ghost`, that sits outside the `gh issue create` segment is not a label, because the scan never looks there. `strip_data_heredocs` (not `strip_heredocs`) drops only bodies fed to `cat`/`tee` — a `bash <<'EOF'` body really is code and stays scannable, pinned by its own test.

**2. `normalize_command_substitutions` — new in `_shell_parse` (first commit).** shlex treats `$(`, backticks and parens as ordinary word characters, so both edges of a command substitution glue to their neighbours. This rewrites them, quote- and escape-aware, into standalone ` ; ` separators. A `)` at depth 0 (a `case` arm) is left alone; quoted/escaped parens are data; quote characters are never added or removed, so the `tokenize() is None` fail-open from #661 is preserved exactly.

It deliberately lives on the shlex path rather than in `iter_command_segments_ast`: bashlex is optional **and** cannot parse a `<<'EOF'` heredoc at all (pinned by `test_bashlex_cannot_parse_quoted_delimiter_heredoc`), which is the dominant heredoc form here — an AST-only fix would regress to the glued-paren bug on exactly the commands that carry one, and on any checkout without bashlex.

**3. Shell-metacharacter backstop.** A label token holding `` ( ) ` $ ; | & < > \ `` or a newline is evidence the *hook* mis-parsed, not that a label is missing, so validation is skipped rather than blocked — acceptance criterion 4: such a token can never reach the `gh label create "<token>"` remediation line. The set is restricted to shell metacharacters on purpose: GitHub ships `good first issue`, so spaces are legal and stay legal. This layer is not load-bearing for W29-C (whose minted labels were a clean `c`) — it is defence in depth for the misparse we have not found yet.

Because the wave's whole subject is gates that quietly stop gating, the skip is **not silent**: `check()` returns `allow` with a systemMessage naming the offending token and asking for the command shape.

## Precision is not bought by weakening the gate

| Case | Pre-fix | Post-fix |
|---|---|---|
| W29-A / B / C (all false) | 3 blocks | 0 blocks |
| genuinely missing literal label | block | block |
| missing label alongside real ones | block | block |
| missing label in a heredoc-carrying command | block (plus `c`, `ghost`) | block (only the real one) |
| `url=$(gh issue create --label not-a-real-label)` | **silently not gated** | **block** |

The last row is a gain, not a wash. Pre-fix, `check()`'s guard was a whole-command `is_gh_subcommand`, which never matched the glued `url=$(gh`, so the hook returned early and validated nothing at all for the most common capture-the-URL shape. Scoping fixes precision in both directions.

## Also in the diff

- `.claude/team/charter/hooks/catalog-01-12.md` — Hook 5's entry gains a "Scope of the label scan" bullet and now enumerates all **five** allow-rather-than-block conditions as a table, marking condition 2 (#661) as the single deliberately-silent case (it previously documented only the `gh label list`-unavailable one). *This line said "three" until review round 3; the count grew with the round-2 changes and was not re-read.*
- `.cspell/project-words.txt` — `metacharacter`.

## Adjacent, deliberately not fixed here (wave-30 intake is tight)

**`extract_repo` is still whole-command while labels are now segment-scoped.** `check()` resolves the repo via `_repo_flag_parse.extract_repo(command)`, which scans the entire string, so a `--repo other/repo` inside a heredoc body or a sibling command can still win and send `gh label list` at the wrong repo. Note the precise condition, established in review: only a **real but wrong** repo produces a block (labels fetch fine, the user's labels are absent from them); a non-`OWNER/REPO` word fails the fetch and allows with a warning. Now filed as #1409. No occurrence of it exists in the log, `extract_repo` is a shared helper with its own last-wins semantics and its own tests, and changing it reaches beyond this hook, so it stays out of this diff. Flagging it rather than filing it, per the wave-30 intake constraint; worth a look during the #1150 umbrella sweep since `validate_review_comment_format` shares the helper.

## Verification

- `ENVIRONMENT=test pytest .claude/hooks/tests/ .claude/lib/tests/ -q` → **4217 passed, 950 subtests passed**
- `pre-commit run --all-files` (commit stage) → all Passed
- `pre-commit run --all-files --hook-stage pre-push` → all Passed (mypy, mypy-skills, pytest, pytest-skills, memory-budget, headcount-budget, doc-freshness, office-drift, mermaid-render)
- `python3 .claude/lib/pre_commit_ci_sync.py .` → `OK: pre-commit config mirrors all CI-enforced checks.`
- Rebased onto `origin/main` (`e0196c3`) before push.

**Reviewers** (charter comment-based review, all agents share one GitHub user so `gh pr review` is hook-blocked — use `gh pr comment` with the charter verdict format):

- **Nino Kavtaradze** — Security Engineer, peer reviewer **and** merge-gate reviewer
- **Santiago Ferreira** — Release Coordinator, secondary reviewer

Implemented by Aino Virtanen, Standards & Quality Lead. I am the implementer here, not a reviewer of this change.

---

## Follow-up in this PR (third commit): two residual boundaries found by adversarial probing

After the corpus went green I probed shapes beyond the three recorded ones. Two were still wrong; both now resolve toward the hook's existing fail-open, and both are pinned by tests.

**1. Unterminated heredoc — was still leaking body prose (fixed).** `strip_data_heredocs` fails toward *keeping* an unterminated body, which is correct for its bypass-matcher callers and exactly wrong here: the retained prose is scanned as option tokens, i.e. defect B again by another route. Measured before the fix:

```
cat > /tmp/x <<'EOF'
gh issue create --label ghost          <- unterminated, body retained
gh issue create --repo o/r --label bug
  -> extract_labels ['ghost', 'bug']   -> would have false-blocked on 'ghost'
```

Now `[]`. The command cannot run as written, so there is nothing to pre-flight. The terminated control still yields `['bug']`.

**2. Mid-argument `$( … )` truncates the segment — deliberately NOT "fixed", pinned instead.**

> **Correction (review round 2).** This section originally justified the trade by claiming the splice repair "makes `--repo` resolve to `cat`, which would query the wrong repo's label list and convert a silent allow into a false block". **That was false and is retracted.** `check()` resolves the repo from the raw command via `extract_repo`, never from these segments, so a splice cannot affect repo resolution at all; `extract_repo` on that shape returns `$(cat`, which `gh label list` rejects outright, landing in the existing allow-with-a-warning branch. The rejected repair is *louder* than what shipped, not a false block. Caught by Nino Kavtaradze; the corrected reasoning follows.

The trade stands, on a hazard the retracted reason was obscuring — and one that needs no other change to be live. A splice makes a substitution's first word look like the value of the flag preceding it, and a label value is exactly what this hook blocks on:

    gh issue create --repo o/r --label $(cat labelfile)
      split (shipped) -> no labels    -> allow
      splice          -> label 'cat'  -> BLOCK on a command name

`cat` is not a label here, and the block is verified end-to-end through `check()` against the real label set. Pinned by `test_the_rejected_splice_repair_would_mint_a_label_from_a_command_name`, which reads the real splice output from `_shell_parse` rather than a hand-built token list.

**The loss is narrower than first described: it bites only on _unquoted_ mid-argument substitutions.** The common double-quoted shape keeps full recall — `--body "$(cat b.md)"` and `--title "$(date)"` both retain every label with zero loss — as does the single-quoted form. Pinned by `MidArgumentSubstitutionRecallTests`.

**And it is no longer silent.** The loss is detected by *differential*: the split reading (validated) is compared against the splice reading (never validated, only counted), so the count is exact while the false-block hazard stays out of the decision.

## End-to-end verification as a real hook process

Not just via imports — the hook run as a subprocess on stdin JSON, against the **live** `gh label list`:

```
$ python3 .claude/hooks/validate_labels.py < w29a.json          # the command that blocked #1150
EXIT=0                                                          # allow

$ python3 .claude/hooks/validate_labels.py < true_positive.json
{"decision": "block", "reason": "BLOCKED: ... do not exist ...: definitely-not-a-real-label ..."}
EXIT=2                                                          # block
```

Suite after the follow-up: **4219 passed, 950 subtests passed**; commit- and push-stage `pre-commit` all Passed; sync-drift gate `OK`.

---

# Review round 2 — corrections (head `e84af22`)

Merge-gate review by Nino Kavtaradze returned `ChangesRequested` with two must-fixes, both about the *record* attached to a deliberate trade rather than about shipped behaviour. Both are addressed in commit 4, additively.

**MF1 — a rationale that did not survive measurement.** Corrected in all four places it appeared (the `issue_create_segments` docstring, the pinning test's docstring, the commit message, and the section above). The retraction is stated rather than silently edited, because the artifact built to make a future engineer confront this trade was confronting them with a consequence that does not exist, and steering them off a repair that is safe today. The trade itself survives on measured grounds; see the corrected section above.

**MF2 — the fix shipped new silent fail-opens while arguing against silent fail-opens.** Both now speak. The condition count is corrected everywhere and, because making the coverage loss non-silent turned it into a condition of its own, there are now **five**, not four:

| # | Condition | Visibility |
|---|---|---|
| 1 | `gh label list` unavailable | allow + warning |
| 2 | command fails to tokenize (#661) | **allow, silent — deliberate** |
| 3 | label token carries a shell metacharacter | allow + systemMessage |
| 4 | unterminated heredoc | allow + systemMessage |
| 5 | label flags after an unquoted mid-argument `$( … )` | note naming the count |

Condition 2 stays silent on purpose: it fires on any Bash command whose quoting shlex cannot handle, which is common and usually unrelated to labels. It is now listed rather than left implicit — it was the undocumented case this section existed to fix. The charter catalog and the module docstring carry the same table plus a keep-in-step note naming this drift.

## Fourth fixture — the review produced a live instance

`real_label_block_w30a_review_heredoc.txt`, harvested from the shared Annunaki log at `2026-08-11T03:06:00Z`. The pre-fix hook blocked the reviewer's own filing *for this PR*, because his heredoc body quoted a `--label` example. Its record is 242 bytes — below the 500-byte truncation point — making it **the only fixture in the corpus with zero reconstruction**. Both its real labels exist, so the recorded population is now **0/4**.

A sibling block at `03:13:17Z` minted a backtick-glued label and stopped the filing of #1414 — the third time this hook has blocked an issue about itself (W29-A blocked #1150). It is truncated at 500 bytes, so it is cited as evidence and *not* committed as a partly-reconstructed fixture. Given MF1, inventing bytes for a nicer fixture is the last thing this PR should do.

## Reviewer minors taken here rather than deferred

- **#1411** — `_SHELL_METACHARS` was 11/12 inert. A subTest per member now pins every character. Writing it surfaced that a trailing newline or carriage return is unreachable, because label values are stripped before the guard runs; the probe must place the character in the interior. Noted in the test so nobody concludes those members are dead.
- **#1414** (classed *security*) — documentation-only, and the misleading sentence is one this PR introduces on new public API in a module shared with blocking matchers. The "same rule as `normalize_command_separators`" analogy is replaced by an explicit statement that a double-quoted substitution is deliberately treated as data, with the direction spelled out — safe for validators, fail-open for bypass matchers, do not adopt as-is — plus a test pinning the divergence. No behaviour change. Not marked closed; the wider adopter audit belongs to the issue.

## A second unmeasured number, self-reported

The reproduction harness printed its post-fix precision from a hardcoded string rather than from the run, and was wrong once the fourth fixture landed (it printed `3/4` for a run with zero false blocks). Now computed from measured results:

    false blocks on the recorded population: 4/4  ->  0/4
    true positive still blocks:              yes  ->  yes
    precision of blocks raised on this set:  1/5  ->  1/1

Same class of defect as MF1, and worth recording rather than quietly fixing.

## Verification at `e84af22`

- Full suite **4230 passed, 969 subtests passed**
- `pre-commit run --all-files` and `--hook-stage pre-push` — all Passed; sync-drift gate `OK`
- CI **21/21 success**
- End-to-end as a real subprocess against live `gh`: all four fixtures `exit 0`, true positive `exit 2`

Not rebased deliberately: additive commits only, so the reviewer's certification target moves forward rather than sideways.

---

# Review round 3 — one must-fix (head `1b07be5`)

Nino Kavtaradze discharged MF1 and MF2 by execution, and raised one new must-fix: **my round-2 fix for #1411 asserted coverage it could not deliver.**

## The defect

The test iterated the very set it was meant to pin:

    for char in sorted(hook._SHELL_METACHARS):

So deleting a member deleted its own test case. The loop shrank, the file stayed green, and the docstring promised *"each member of `_SHELL_METACHARS` must be pinned"* — a guarantee the mechanism was structurally incapable of keeping. That is the round-1 MF1 shape reproduced inside the fix for a round-2 finding, which is why it was a must-fix rather than a minor. I agree on both the classification and the fix.

**Re-measured by per-character mutation of the head tree, scored against the full hooks suite:**

    before:  11 of 12 survived deletion; only `)` was caught,
             and by the wave-29 corpus rather than by this test.
             Each survivor silently dropped 20 subtests to 19.
    after:   12 of 12 caught, 0 survivors.

The review reported 9 survivors; measured here it is 11. Reporting the number I can reproduce rather than the one I was handed — `$` and `` ` `` also survive, because the heredoc strip removes W29-B's backticked token before the guard ever sees it.

**The fix** is the one he specified: iterate a module-level literal `EXPECTED_METACHARS`, and assert separately that `_SHELL_METACHARS` equals it. Removing a member now fails the equality assertion; *adding* one fails it too, so widening the set is a deliberate act with a matching test edit. The docstring carries the history and a do-not-simplify-this-back note.

## Two harness defects found while measuring

Both produced confident green results from dead instruments — the same class as the defect under review, so they are worth stating rather than quietly fixing:

1. My mutation script substituted the frozenset literal with a regex whose `[^)]*` truncated mid-literal, because **the set contains `)`**. Every mutant died at import as `1 error`, which the harness scored as *caught* — a green board from twelve corpses. Now line-based, and every mutant must `compile()`.
2. A later run reported `12/12 caught` off a baseline that was **itself failing** (13 errors, from an incomplete tree copy). The harness now aborts unless the baseline is green.

## The three minors

- **`Wave29FalsePositiveCorpusTests` → `RecordedFalsePositiveCorpusTests`.** The corpus is four fixtures across two waves. The 0/3 → 3/3 figures are correct *for wave 29* and are now scoped to it explicitly, with W30-A accounted separately. `WAVE29_REAL_LABELS` is aliased to the renamed constant rather than duplicated, so the two cannot drift.
- **PR body files-changed line** corrected from "three" conditions to five, with a note saying it went stale in round 2.
- **`IssueCreateSegmentsContractTests`** pins the documented `None` (could not parse) vs `[]` (parsed, no such command) distinction — the one surviving mutation. Verified to kill **both** directions: early-out `[]` → `None`, and tokenize-failure `None` → `[]`. This needed a direct test precisely *because* both currently lead `check()` to allow: a difference nothing observes is a difference that will be broken.

## Verification at `1b07be5`

- Full suite **4235 passed, 969 subtests passed**
- Metachar mutation: **12/12 caught, 0 survivors**, green baseline
- Contract mutation: both mutants caught
- `pre-commit run --all-files` and `--hook-stage pre-push` — all Passed
