### PR TITLE
fix(#1374): distinguish TD-saturated BASE=0 from a healthy intake ratio

### DIFF
--- a/.claude/skills/wave-scope/SKILL.md
+++ b/.claude/skills/wave-scope/SKILL.md
@@ -419,8 +419,17 @@ echo "un-scheduled TD pool: $POOL  |  target: $TARGET"
 ```
 
 **3. Select + confirm (owner-judgment gate, same as Step 7).**
-- `POOL <= TARGET` → select **all** pool items. Report: `TD intake: <POOL> of <POOL> available — debt backlog below the 20% target (healthy)`.
-- `POOL > TARGET` → surface the top `TARGET` oldest candidates to the owner for confirmation; the owner may swap in higher-priority debt. Final selection = `TARGET` items. **On the final wave of a phase, `TARGET` is a floor, not the cap** (see the relaxation note above) — surface the whole pool and let the owner pull in as much debt as phase-exit cleanup warrants.
+
+Render the verdict through `td_intake_gate.py` rather than a hand-written comparison — a TD-saturated wave (`BASE == 0`) must never print as `healthy` (#1374: measured `/wave-scope 10 30` printing `TD intake: 0 of 0 available … (healthy)` over a 174-item real backlog):
+
+```bash
+python3 "$REPO_ROOT/.claude/skills/wave-scope/td_intake_gate.py" --base "$BASE" --pool "$POOL"
+```
+
+Branch on the printed `state`:
+- **`healthy`** (`BASE > 0`, `POOL <= TARGET`) → select **all** pool items. This is the only state that legitimately means "debt backlog below target."
+- **`applies`** (`BASE > 0`, `POOL > TARGET`) → surface the top `TARGET` oldest candidates to the owner for confirmation; the owner may swap in higher-priority debt. Final selection = `TARGET` items. **On the final wave of a phase, `TARGET` is a floor, not the cap** (see the relaxation note above) — surface the whole pool and let the owner pull in as much debt as phase-exit cleanup warrants.
+- **`not_applicable`** (`BASE == 0`, TD-saturated wave) → the 20%-of-feature-scope ratio is undefined; do **not** auto-select and do **not** report healthy. Surface the full `POOL` to the owner (mirroring the last-wave-of-phase relaxation: with no feature/bug base to ratio against, the un-scheduled debt pool itself is the only meaningful signal) and record the state as `not_applicable` in Step 12/13, not as a numeric `td_intake` ratio — a reader of the wave summary must be able to tell "not measured" from "measured and fine" (same requirement as #1254 for the manifest-orphan report).
 
 This is a blocking owner-judgment gate exactly like Step 7 — present, don't auto-apply.
 
@@ -429,7 +438,7 @@ This is a blocking owner-judgment gate exactly like Step 7 — present, don't au
 - add it to the `tier_3_tech_debt` array of `WAVE_SCOPE_STRUCTURED` as an assignment-row dict (§ 13.1), assigning implementer/reviewers from the **owning repo's** roster;
 - add it to project board 2 (`gh project item-add 2 --owner noorinalabs --url <url>`).
 
-Record `td_intake: <selected>/<target>` (and `td_pool: <POOL>`) for the Step 12 summary and Step 13 `wave_{M}_scope`.
+Record `td_intake: <selected>/<target>` (and `td_pool: <POOL>`) for the Step 12 summary and Step 13 `wave_{M}_scope` — or, in the `not_applicable` state, record `td_intake: not_applicable (BASE=0)` plus `td_pool: <POOL>` so the summary shows an un-measured ratio rather than a numeric one that looks clean.
 
 **Interaction with phase criterion #6.** This step is the operational mechanism behind the TD goal. The cumulative-ratio reading stays *informational*, but the gate the team actually works to is "did the wave take its 20% intake," not a brittle ratio threshold — which avoids the small-backlog whipsaw the owner flagged. Cross-ref `phase-4.md` § criterion #6.
 

--- a/.claude/skills/wave-scope/td_intake_gate.py
+++ b/.claude/skills/wave-scope/td_intake_gate.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Classify the /wave-scope Step 8.5 tech-debt-intake gate verdict (#1374).
+
+`/wave-scope` Step 8.5 sizes the mandatory tech-debt intake as
+``TARGET = ceil(0.20 * BASE)``, where ``BASE`` is the count of in-scope
+issues that are NOT `tech-debt` and NOT `meta-issue` (the feature/bug/
+security content the owner just kept for the wave), and ``POOL`` is the
+un-scheduled `tech-debt`-labeled backlog available to top the wave up with.
+
+Before this module existed, Step 3 ("Select + confirm") rendered the
+verdict inline with a two-way branch:
+
+    POOL <= TARGET -> "TD intake: <POOL> of <POOL> available — debt
+                       backlog below the 20% target (healthy)"
+    POOL >  TARGET -> surface the top TARGET candidates
+
+That branch is silently wrong on a TD-saturated wave. When the wave's
+in-scope content is ITSELF all tech-debt, BASE collapses to 0, so
+TARGET is 0 too. If POOL also happens to be 0 at that moment (e.g. every
+candidate the pool query would otherwise surface is already carrying a
+wave label), `POOL <= TARGET` (0 <= 0) is true, and the gate prints
+`TD intake: 0 of 0 available — debt backlog below the 20% target
+(healthy)` — even though the *un-scheduled* debt backlog elsewhere may be
+in the hundreds. "The ratio could not be measured" renders identically to
+"the ratio was measured and is fine". That is the failure shape #1374
+(and its sibling #1254) names: a mechanism reporting success/benign
+inaction while incapable of the outcome it describes.
+
+This module is the single source of truth for the verdict, replacing the
+inline two-way branch with a three-way classification:
+
+  1. ``BASE > 0``, ``POOL <= TARGET``  -> ``healthy``        (genuinely OK)
+  2. ``BASE > 0``, ``POOL >  TARGET``  -> ``applies``        (intake fires)
+  3. ``BASE == 0``                     -> ``not_applicable`` (ratio undefined
+                                           — NEVER rendered as healthy)
+
+State 3 is the one #1374 measured as having no representation: the ratio
+is undefined when there is nothing to measure it against, and printing
+"healthy" for an undefined ratio is indistinguishable from a genuinely
+clean bill of health to a reader who only sees the one-line verdict.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import TypedDict
+
+
+class TdIntakeVerdict(TypedDict):
+    state: str  # "healthy" | "applies" | "not_applicable"
+    base: int
+    target: int
+    pool: int
+    line: str
+
+
+def compute_target(base: int) -> int:
+    """``ceil(0.20 * base)`` — mirrors the SKILL.md Step 1 bash arithmetic."""
+    if base < 0:
+        raise ValueError(f"base must be >= 0, got {base}")
+    return (base * 20 + 99) // 100
+
+
+def td_intake_verdict(base: int, pool: int) -> TdIntakeVerdict:
+    """Classify the Step 8.5 gate's state for a given ``base``/``pool``.
+
+    ``base`` is the post-Step-7 in-scope feature/bug/security count (NOT
+    `tech-debt`, NOT `meta-issue`). ``pool`` is the un-scheduled `tech-debt`
+    candidate pool size. Returns the verdict state plus the exact line
+    `/wave-scope` should print — callers must not reconstruct the string
+    themselves, so there is exactly one place this renders (#1374).
+    """
+    if base < 0 or pool < 0:
+        raise ValueError(f"base and pool must be >= 0, got base={base} pool={pool}")
+    target = compute_target(base)
+    if base == 0:
+        return {
+            "state": "not_applicable",
+            "base": base,
+            "target": target,
+            "pool": pool,
+            "line": (
+                "TD intake: not applicable (TD-saturated wave, BASE=0) — "
+                "the 20%-of-feature-scope ratio is undefined when there is no "
+                f"non-debt content to measure against. {pool} un-scheduled "
+                "tech-debt item(s) are pending in the candidate pool; this is "
+                "NOT a clean bill of health — defer to the phase plan's "
+                "declared TD posture."
+            ),
+        }
+    if pool <= target:
+        return {
+            "state": "healthy",
+            "base": base,
+            "target": target,
+            "pool": pool,
+            "line": (
+                f"TD intake: {pool} of {pool} available — debt backlog below "
+                "the 20% target (healthy)"
+            ),
+        }
+    return {
+        "state": "applies",
+        "base": base,
+        "target": target,
+        "pool": pool,
+        "line": (
+            f"TD intake: surfacing top {target} of {pool} un-scheduled "
+            "tech-debt candidates for owner selection (#1374 § state 2)"
+        ),
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Classify the /wave-scope Step 8.5 tech-debt intake gate verdict."
+    )
+    parser.add_argument("--base", type=int, required=True, help="in-scope non-TD, non-meta count")
+    parser.add_argument("--pool", type=int, required=True, help="un-scheduled tech-debt pool size")
+    return parser
+
+
+def main(argv: list[str]) -> int:
+    args = _build_parser().parse_args(argv[1:])
+    result = td_intake_verdict(args.base, args.pool)
+    print(result["line"])
+    print(
+        f"[state={result['state']} base={result['base']} "
+        f"target={result['target']} pool={result['pool']}]"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.claude/skills/wave-scope/tests/test_td_intake_gate.py
+++ b/.claude/skills/wave-scope/tests/test_td_intake_gate.py
@@ -67,6 +67,30 @@ def test_base_positive_pool_above_target_applies_intake():
     assert result["target"] == 2
 
 
+def test_pool_equals_target_boundary_is_healthy():
+    """Boundary pin (merge-gate fold-in, PR #1419): POOL == TARGET is the
+    inclusive edge of the `<=` comparison at `td_intake_gate.py`'s state-1/
+    state-2 branch. State 1 and state 2's existing tests use pool=1 and
+    pool=5 against target=2, so neither one exercises `pool == target`
+    itself — the exact boundary the branch is written to distinguish.
+    Un-pinned, `if pool <= target` -> `if pool < target` survives the
+    suite: an at-target wave would silently reclassify healthy -> applies.
+    """
+    result = td_intake_verdict(base=10, pool=2)  # target = 2, POOL == TARGET
+    assert result["state"] == "healthy"
+
+
+def test_pool_one_over_target_boundary_applies_intake():
+    """Boundary pin (merge-gate fold-in, PR #1419): POOL == TARGET + 1 is
+    the first value on the `applies` side of the same branch. Un-pinned,
+    `if pool <= target` -> `if pool <= target + 1` survives the suite: an
+    over-target wave would render `healthy` — #1374's exact failure shape
+    one boundary over, inside the fix for that same defect class.
+    """
+    result = td_intake_verdict(base=10, pool=3)  # target = 2, POOL == TARGET + 1
+    assert result["state"] == "applies"
+
+
 def test_compute_target_matches_skill_md_ceil_arithmetic():
     """Mirrors the SKILL.md bash: `(BASE * 20 + 99) / 100` == ceil(0.20*base)."""
     assert compute_target(0) == 0

--- a/.claude/skills/wave-scope/tests/test_td_intake_gate.py
+++ b/.claude/skills/wave-scope/tests/test_td_intake_gate.py
@@ -1,0 +1,86 @@
+"""Tests for the /wave-scope Step 8.5 tech-debt intake gate verdict (#1374).
+
+Pins the failure `/wave-scope 10 30` measured 2026-08-09: a wave whose
+entire in-scope set is `tech-debt`-labeled collapses BASE to 0, and the
+pre-#1374 selection branch (`POOL <= TARGET -> healthy`) printed
+`TD intake: 0 of 0 available — debt backlog below the 20% target
+(healthy)` for that input — an undefined ratio rendering identically to a
+genuinely clean one, over a 174-item real backlog.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from td_intake_gate import compute_target, td_intake_verdict  # noqa: E402
+
+
+def test_all_scope_issues_tech_debt_does_not_report_healthy():
+    """#1374 core acceptance case: N in-scope issues, all `tech-debt`-labeled.
+
+    BASE (non-TD, non-meta in-scope count) is 0 for this input. The
+    pre-fix branch only ever compared POOL to TARGET, so a POOL that also
+    happens to be 0 (every pool candidate already wave-labeled elsewhere)
+    satisfied `POOL <= TARGET` (0 <= 0) and rendered the `healthy` verdict.
+    That is the exact string measured live: "TD intake: 0 of 0 available —
+    debt backlog below the 20% target (healthy)".
+    """
+    result = td_intake_verdict(base=0, pool=0)
+    assert result["state"] != "healthy", (
+        f"BASE=0 must never classify as healthy — an undefined ratio is not "
+        f"a measured clean bill of health. Got state={result['state']!r}."
+    )
+    assert "healthy" not in result["line"].lower(), (
+        f"BASE=0 line must not contain the word 'healthy': {result['line']!r}"
+    )
+    assert result["state"] == "not_applicable"
+    assert "not applicable" in result["line"].lower()
+
+
+def test_base_zero_nonzero_pool_still_not_applicable_not_healthy():
+    """BASE=0 with a real un-scheduled backlog (the live #1374 measurement:
+    174 un-scheduled tech-debt items) must surface the pool size, not hide
+    it behind a healthy-looking 0-of-0.
+    """
+    result = td_intake_verdict(base=0, pool=174)
+    assert result["state"] == "not_applicable"
+    assert "healthy" not in result["line"].lower()
+    assert "174" in result["line"]
+
+
+def test_base_positive_pool_below_target_is_genuinely_healthy():
+    """State 1: BASE > 0, POOL <= TARGET is the one legitimate 'healthy'."""
+    result = td_intake_verdict(base=10, pool=1)  # target = ceil(0.2*10) = 2
+    assert result["state"] == "healthy"
+    assert "healthy" in result["line"].lower()
+    assert result["target"] == 2
+
+
+def test_base_positive_pool_above_target_applies_intake():
+    """State 2: BASE > 0, POOL > TARGET — intake fires, selects TARGET items."""
+    result = td_intake_verdict(base=10, pool=5)  # target = 2
+    assert result["state"] == "applies"
+    assert "healthy" not in result["line"].lower()
+    assert result["target"] == 2
+
+
+def test_compute_target_matches_skill_md_ceil_arithmetic():
+    """Mirrors the SKILL.md bash: `(BASE * 20 + 99) / 100` == ceil(0.20*base)."""
+    assert compute_target(0) == 0
+    assert compute_target(1) == 1
+    assert compute_target(5) == 1
+    assert compute_target(6) == 2
+    assert compute_target(10) == 2
+    assert compute_target(95) == 19
+
+
+def test_negative_inputs_rejected():
+    import pytest
+
+    with pytest.raises(ValueError):
+        td_intake_verdict(base=-1, pool=0)
+    with pytest.raises(ValueError):
+        td_intake_verdict(base=0, pool=-1)


### PR DESCRIPTION
## Summary

`/wave-scope` Step 8.5 sizes the mandatory tech-debt intake as `TARGET = ceil(0.20 * BASE)`, where `BASE` excludes `tech-debt` and `meta-issue` issues. On a phase whose content is *itself* tech-debt, `BASE` collapses to 0, and the old two-way branch (`POOL <= TARGET -> healthy`) rendered `TD intake: 0 of 0 available — debt backlog below the 20% target (healthy)` whenever `POOL` also happened to be 0 — indistinguishable from a genuinely clean bill of health, even over a 174-item real un-scheduled backlog (measured `/wave-scope 10 30`, 2026-08-09). "Did not measure" must never render like "measured and fine" — the same requirement recorded on #1254 for the manifest-orphan report.

## Fix

Extracted the verdict logic into `.claude/skills/wave-scope/td_intake_gate.py` as the single source of truth, replacing the inline two-way branch with a three-way classification:

1. `BASE > 0`, `POOL <= TARGET` → `healthy` (genuinely OK — unchanged behavior)
2. `BASE > 0`, `POOL > TARGET` → `applies` (intake fires — unchanged behavior)
3. `BASE == 0` → `not_applicable` (ratio undefined — **new state**, never renders "healthy")

`SKILL.md` Step 8.5.3 now calls the module instead of hand-writing the comparison, and branches on the three states (the `not_applicable` branch surfaces the full pool to the owner instead of auto-selecting or reporting clean).

## Test-first (failing before fix)

`test_all_scope_issues_tech_debt_does_not_report_healthy` and `test_base_zero_nonzero_pool_still_not_applicable_not_healthy` were run against the pre-fix two-way branch (temporarily restored in the module) before the fix landed:

```
FAILED tests/test_td_intake_gate.py::test_all_scope_issues_tech_debt_does_not_report_healthy
    result = td_intake_verdict(base=0, pool=0)
>   assert result["state"] != "healthy", (...)
E   AssertionError: BASE=0 must never classify as healthy — an undefined ratio is not
    a measured clean bill of health. Got state='healthy'.
E   assert 'healthy' != 'healthy'

FAILED tests/test_td_intake_gate.py::test_base_zero_nonzero_pool_still_not_applicable_not_healthy
    result = td_intake_verdict(base=0, pool=174)
>   assert result["state"] == "not_applicable"
E   AssertionError: assert 'applies' == 'not_applicable'
E     - not_applicable
E     + applies

2 failed, 4 passed in 0.18s
```

After the fix: `6 passed` (full `test_td_intake_gate.py`), and the full `wave-scope` skill suite: `77 passed, 38 subtests passed`.

## Gates run locally (full local⇄CI parity)

- `ruff-format` / `ruff-lint` — pass
- `cspell` — pass
- `mypy .claude/skills/wave-scope` — pass, clean
- `pytest .claude/skills/wave-scope/tests/` — 77 passed
- pre-push suite (mypy, pytest, pytest-skills, memory-budget, headcount-budget, doc-freshness, office-drift, mermaid-render) — all pass

## Not fixed / found but out of scope

- The `not_applicable` state surfaces the raw pool count to the owner rather than prescribing a specific selection quantity — Step 3's guidance intentionally mirrors the existing last-wave-of-phase relaxation rather than inventing a new numeric target, per the issue's "not prescriptive" suggested direction. If the owner wants a firmer absolute floor for the `not_applicable` case (issue's phrase: "fall through to an absolute floor"), that is a follow-on scoping decision, not implemented here.
- Did not verify the live `/wave-scope 10 30` re-run against real GitHub data (GraphQL quota was near-exhausted this session) — verified via the unit tests + manual CLI invocations with the issue's own measured numbers (`--base 0 --pool 174`) instead.

Closes #1374

Peer reviewer: Aino Virtanen
Merge gate: Nadia Khoury

🤖 Generated with [Claude Code](https://claude.com/claude-code)
