### PR TITLE
fix(wave_status): count a non-list tier_* value as unparseable, not a silent skip (#1255)

### DIFF
--- a/.claude/lib/tests/test_wave_status.py
+++ b/.claude/lib/tests/test_wave_status.py
@@ -671,6 +671,45 @@ class CanonicalIssueNumbers(unittest.TestCase):
         self.assertEqual(by_repo, {"noorinalabs-main": {1160}})
         self.assertEqual(unparseable, 3)
 
+    def test_non_list_tier_value_counted_not_silently_skipped(self) -> None:
+        """main#1255: #1201 Edge 1 fixed the ROW-level silent zero (a row
+        within a `tier_*` list that fails to parse). This is the same
+        failure shape one structural level up -- a `tier_*` KEY whose value
+        is not a list at all (a bare dict, or a plain string) used to hit
+        the `not isinstance(value, list)` half of the container guard and
+        `continue` past the whole tier, contributing to neither `by_repo`
+        NOR `unparseable`. If it is the only `tier_*` key, `_canonical_pairs`
+        returns `(set(), 0)`, `_reconciliation_warning_from_claims`'s
+        `if not canonical and not unparseable: return None` guard fires, and
+        a real reconciliation problem prints nothing at all -- the exact
+        silent zero #1201 was filed to close, just one level up.
+
+        A malformed *tier value* must count toward `unparseable` (as one
+        unparseable "row" standing in for the whole malformed tier) exactly
+        like a malformed row does, so the container-level guard in
+        `_reconciliation_warning_from_claims` fires instead of returning
+        `None`."""
+        with TemporaryDirectory() as td:
+            status = Path(td) / "cross-repo-status.json"
+            data = {
+                "wave_29_scope": {
+                    # tier value is a dict, not a list
+                    "tier_1_dict_shaped": {"id": "noorinalabs-main#1160"},
+                    # tier value is a plain string, not a list
+                    "tier_2_string_shaped": "noorinalabs-main#1161",
+                    # a normal, correctly-shaped tier alongside the two
+                    # malformed ones, proving they don't clobber real rows
+                    "tier_3_normal": [{"id": "noorinalabs-main#1200"}],
+                }
+            }
+            status.write_text(json.dumps(data))
+            by_repo, unparseable = wave_status._canonical_issue_numbers_by_repo("29", status)
+        self.assertEqual(by_repo, {"noorinalabs-main": {1200}})
+        # Pre-fix: unparseable == 0 here (both malformed tiers vanished
+        # silently) -- this assertion is what fails against the unmodified
+        # implementation.
+        self.assertEqual(unparseable, 2)
+
 
 class MergedPrsDirectToMain(unittest.TestCase):
     """merged_prs() for a direct-to-main wave, driven by the canonical scope

--- a/.claude/lib/wave_status.py
+++ b/.claude/lib/wave_status.py
@@ -169,7 +169,11 @@ def _canonical_issue_numbers_by_repo(
     reconciliation warning (main#1190) unless its count is carried out
     alongside the parsed rows, so :func:`_reconciliation_warning_from_claims`
     can report against the wave's actual declared row count rather than
-    silently reporting against only the rows that happened to parse.
+    silently reporting against only the rows that happened to parse. main#1255
+    extends this one structural level up: a ``tier_*`` key whose VALUE is not
+    a list at all (a bare dict, or a plain string) is the same silent-zero
+    shape as an unparseable row and is folded into ``unparseable`` the same
+    way, rather than being skipped wholesale by the container-level guard.
     """
     data = _load_status(status_path)
     scope = data.get(f"wave_{wave}_scope")
@@ -179,7 +183,18 @@ def _canonical_issue_numbers_by_repo(
     by_repo: dict[str, set[int]] = {}
     unparseable = 0
     for key, value in scope.items():
-        if not key.startswith("tier_") or not isinstance(value, list):
+        if not key.startswith("tier_"):
+            continue
+        if not isinstance(value, list):
+            # main#1255: a tier_* value that is not a list at all (a bare
+            # dict, or a plain string) is the same failure shape as an
+            # unparseable ROW (main#1201 Edge 1), one structural level up --
+            # `continue`-ing past it silently drops it from both the
+            # numerator and the denominator. Count it as one unparseable
+            # "row" standing in for the whole malformed tier so
+            # `_reconciliation_warning_from_claims` sees it instead of
+            # returning `None` on an empty canonical set.
+            unparseable += 1
             continue
         for row in value:
             if not isinstance(row, dict):


### PR DESCRIPTION
## Summary

Closes #1255.

#1201 Edge 1 fixed the **row-level** silent zero in `_canonical_issue_numbers_by_repo`: a scope row that fails to parse (legacy plain-string row, a dict `id` with no `#`, or a non-numeric tail) now increments `unparseable` instead of vanishing from both the numerator and denominator of the main#1190 reconciliation warning.

This PR closes the same failure shape one structural level up. The container guard —

```python
if not key.startswith("tier_") or not isinstance(value, list):
    continue
```

— skipped a `tier_*` **key** whose value is not a list at all (a bare dict, or a plain string) with zero signal. If such a malformed tier is the only `tier_*` key, `_canonical_pairs` returns `(set(), 0)`, `_reconciliation_warning_from_claims`'s `if not canonical and not unparseable: return None` guard fires, and a real reconciliation problem prints nothing on stderr — the exact silent zero #1201 was filed to close.

## Fix

Split the guard so a non-list `tier_*` value increments `unparseable` (one unparseable "row" standing in for the whole malformed tier) instead of `continue`-ing past it silently. `_reconciliation_warning_from_claims` already folds `unparseable` into its guard and its reported denominator, so no downstream change was needed — the fix is scoped entirely to `_canonical_issue_numbers_by_repo`'s container guard.

## Test — constructed, and confirmed failing pre-fix

Per the issue: **not reachable through today's data** (21 waves / 293 tier rows swept, 0 non-list tier values live), so the failing-before case had to be constructed rather than harvested.

`test_non_list_tier_value_counted_not_silently_skipped` builds a `wave_29_scope` with a dict-shaped tier value, a string-shaped tier value, and a normal well-formed tier alongside them, and asserts `unparseable == 2`.

Run against the **unmodified** pre-fix implementation:

```
FAILED .claude/lib/tests/test_wave_status.py::CanonicalIssueNumbers::test_non_list_tier_value_counted_not_silently_skipped
E       AssertionError: 0 != 2
```

(pre-fix: both malformed tiers vanished silently — `unparseable` stayed at `0`.)

After the fix, full suite: `.claude/lib/tests/ .claude/hooks/tests/` — **4394 passed**.

## Scope

Kept intentionally narrow per the collision warning on #1362 (also touching `wave_status.py`): only `_canonical_issue_numbers_by_repo`'s container guard is touched, plus its docstring `Returns` note and one new test. No other function in the module is restructured.

## Functions touched in `wave_status.py`

- `_canonical_issue_numbers_by_repo` — the guard fix + docstring update. That's the only function changed.

## Gates

- `pre-commit run` (commit stage): ruff-format, ruff-lint, checksums-ascii — all passed.
- `pre-commit run --hook-stage pre-push`: mypy, mypy-skills, pytest, pytest-skills, memory-budget, headcount-budget, doc-freshness, office-drift, mermaid-render — all passed.
- Full local test suite (`.claude/lib/tests/ .claude/hooks/tests/`): 4394 passed.

## Reviewers

- Peer reviewer: **Aino Virtanen**
- Secondary: **Santiago Ferreira**
- Merge gate: **Aino Virtanen**

Do not merge — awaiting review per charter.
