### PR TITLE
fix(roster-union-sync): make the manifest-orphan report visible and ordered (#1254)

### DIFF
--- a/.claude/lib/roster_union_sync.py
+++ b/.claude/lib/roster_union_sync.py
@@ -116,6 +116,37 @@ disposition of the 16 (§ above) could reasonably promote them to blocking;
 that is a separate, explicit decision, not a side effect of this check
 existing.
 
+Observability: job summary + stream ordering (#1254)
+======================================================================
+The orphan report above is advisory in EXIT STATUS (previous section), but
+that left it advisory in VISIBILITY too: its only channel was text in the
+log of a job that is ALWAYS green (continue-on-error, forward section
+above), and a fetch failure (any roster.json or card-directory SKIP)
+suppresses the whole orphan check — which, at every surface except the log
+text, was indistinguishable from a clean pass. Two fixes:
+
+1. Every line of the orphan-check verdict is ALSO written, Markdown-
+   structured, to `$GITHUB_STEP_SUMMARY` (a file GitHub Actions provides to
+   every step automatically — no workflow YAML change needed), so it renders
+   on the workflow run's Summary page without opening any job's log, green
+   or not. The verdict is always exactly one of three explicit, disjoint
+   states — `DID NOT RUN`, `CLEAN`, or `ORPHANS FOUND (N)` — so "did not
+   run" can never render like "clean" (the requirement recorded in #1254).
+   `_write_step_summary` is a silent no-op when the env var is unset (local
+   runs, unit tests, non-GHA CI) — never raises, never touches `exit_code`.
+2. Every `print()` call in `main` now passes `flush=True`. Pre-fix, the
+   per-repo `OK`/`SKIPPED` context lines went to stdout (block-buffered
+   under a pipe — CI's actual I/O shape) while the DRIFT/MANIFEST-ORPHAN
+   blocks went to stderr (unbuffered), so stdout's buffered lines were only
+   written at process exit — AFTER every stderr line had already landed.
+   Measured on a live run (#1254): the `MANIFEST ORPHAN` block printed
+   ABOVE the `OK ...` context lines it must be read against. `flush=True`
+   forces each print's underlying `write()` syscall to happen at the point
+   of the call (program order) rather than being deferred by Python's stdio
+   buffering, so the two streams interleave in the order the script
+   actually emits them regardless of which fd a downstream consumer (e.g. a
+   CI log that merges a step's stdout+stderr onto one pipe) merges them onto.
+
 Input Language
 ==============
 CLI:  roster_union_sync.py [--repo-root <dir>] [--repos a,b,c] [--owner <org>]
@@ -138,6 +169,7 @@ from __future__ import annotations
 import argparse
 import base64
 import json
+import os
 import re
 import subprocess
 import sys
@@ -389,6 +421,29 @@ def compute_drift(
     return {name: sorted(repos) for name, repos in sorted(missing.items())}
 
 
+def _write_step_summary(lines: list[str]) -> None:
+    """Append the manifest-orphan report to the GitHub Actions job summary (#1254).
+
+    `GITHUB_STEP_SUMMARY` is a file path GitHub Actions sets for every step
+    automatically (no workflow YAML change needed) — content appended to it
+    renders on the workflow run's Summary page, visible without opening any
+    job's log, green or not. Best-effort / advisory-safe: if the env var is
+    unset (local runs, unit tests, non-GHA CI) or the file can't be opened,
+    this is a silent no-op — it never raises and never touches `exit_code`.
+    Appends (never truncates), matching GHA's own convention of accumulating
+    one summary file across every step in a job.
+    """
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+    try:
+        with open(summary_path, "a", encoding="utf-8") as fh:
+            fh.write("\n".join(lines))
+            fh.write("\n")
+    except OSError:
+        pass
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--repo-root", default=".", help="repo root hosting the parent roster.json")
@@ -408,6 +463,7 @@ def main(argv: list[str] | None = None) -> int:
         print(
             f"ERROR: no parent roster names loaded from {repo_root}/{ROSTER_PATH_IN_REPO}.",
             file=sys.stderr,
+            flush=True,
         )
         return 2
 
@@ -423,10 +479,10 @@ def main(argv: list[str] | None = None) -> int:
         roster = fetch_child_roster(args.owner, repo)
         if roster is None:
             skipped.append(repo)
-            print(f"SKIPPED {repo}: no readable {ROSTER_PATH_IN_REPO} (fail-open).")
+            print(f"SKIPPED {repo}: no readable {ROSTER_PATH_IN_REPO} (fail-open).", flush=True)
         else:
             child_rosters[repo] = roster
-            print(f"OK      {repo}: {len(roster)} persona(s).")
+            print(f"OK      {repo}: {len(roster)} persona(s).", flush=True)
 
     exit_code = 0
 
@@ -439,21 +495,24 @@ def main(argv: list[str] | None = None) -> int:
             "commit-identity gate (verify_commit_identity.py) recognizes them on a "
             "cross-repo main PR (#634):",
             file=sys.stderr,
+            flush=True,
         )
         for name, owners in drift.items():
-            print(f'  - "{name}"  (canonical in: {", ".join(owners)})', file=sys.stderr)
+            print(f'  - "{name}"  (canonical in: {", ".join(owners)})', file=sys.stderr, flush=True)
         exit_code = 1
     else:
         observed = sum(len(r) for r in child_rosters.values())
         if not child_rosters:
             print(
                 f"\nNo child roster could be read ({len(skipped)} skipped); "
-                "nothing to cross-check for drift. Passing (advisory)."
+                "nothing to cross-check for drift. Passing (advisory).",
+                flush=True,
             )
         else:
             print(
                 f"\nParent roster covers all {observed} observed child persona(s) "
-                f"across {len(child_rosters)} repo(s). No drift."
+                f"across {len(child_rosters)} repo(s). No drift.",
+                flush=True,
             )
 
     # Reverse direction (#1181): manifest ⊆ (this repo's cards) ∪ (every
@@ -471,17 +530,36 @@ def main(argv: list[str] | None = None) -> int:
             names = fetch_child_card_names(args.owner, repo)
             if names is None:
                 card_skipped.append(repo)
-                print(f"SKIPPED {repo}: no readable {CARD_PATH_IN_REPO}/*.md (fail-open).")
+                print(
+                    f"SKIPPED {repo}: no readable {CARD_PATH_IN_REPO}/*.md (fail-open).",
+                    flush=True,
+                )
             else:
                 child_cards[repo] = names
-                print(f"OK      {repo}: {len(names)} card(s).")
+                print(f"OK      {repo}: {len(names)} card(s).", flush=True)
+
+    # #1254: the job-summary rendering of the orphan-check verdict below is
+    # ALWAYS exactly one of three disjoint, explicitly-labelled states — a
+    # SKIPPED (did-not-run) verdict must never share text with a CLEAN
+    # (zero-orphans) one, so a summary reader can never mistake "this check
+    # made no claim" for "this check looked and found nothing."
+    summary_lines = ["### Manifest-orphan check (#1181)", ""]
 
     if skipped or card_skipped:
         unreadable = len(skipped) + len(card_skipped)
-        print(
-            f"\nManifest-orphan check (#1181) SKIPPED: {unreadable} repo/directory fetch(es) "
+        skip_msg = (
+            f"Manifest-orphan check (#1181) SKIPPED: {unreadable} repo/directory fetch(es) "
             "unreadable — an orphan report over partial data could wrongly flag a name backed "
             "only by something we failed to fetch."
+        )
+        print(f"\n{skip_msg}", flush=True)
+        summary_lines.extend(
+            [
+                f"**Status: DID NOT RUN** — {unreadable} repo/directory fetch(es) unreadable.",
+                "",
+                "_This is NOT the same as a clean pass — the check did not execute, so it "
+                "made no claim about orphans either way._",
+            ]
         )
     else:
         card_names = local_card_names(repo_root)
@@ -489,13 +567,19 @@ def main(argv: list[str] | None = None) -> int:
             card_names |= names
         orphans = compute_manifest_orphans(parent_map, card_names, child_rosters)
         if orphans["non_persona"]:
-            print(
-                "\nManifest carries non-persona entrie(s) (#1181) — informational only, never "
+            non_persona_header = (
+                "Manifest carries non-persona entrie(s) (#1181) — informational only, never "
                 "a reconciliation target (pruning would break their own use, e.g. the "
                 "annunaki-attack skill's own commit identity):"
             )
+            print(f"\n{non_persona_header}", flush=True)
+            summary_lines.append(
+                f"**Non-persona entries** (informational only): {non_persona_header}"
+            )
             for name in orphans["non_persona"]:
-                print(f'  - "{name}"')
+                print(f'  - "{name}"', flush=True)
+                summary_lines.append(f'- "{name}"')
+            summary_lines.append("")
         if orphans["unreconciled"]:
             # Advisory ONLY (owner correction, PR #1240 review): this must NOT
             # move exit_code. continue-on-error at the WORKFLOW level does not
@@ -517,14 +601,30 @@ def main(argv: list[str] | None = None) -> int:
                 "  (a) onboard the persona — add a real roster card in the repo it belongs to, or\n"
                 "  (b) the persona is retired — remove the row from .claude/team/roster.json.",
                 file=sys.stderr,
+                flush=True,
+            )
+            summary_lines.extend(
+                [
+                    f"**Status: ORPHANS FOUND** ({len(orphans['unreconciled'])} unreconciled) "
+                    "— advisory, does not fail this job.",
+                    "",
+                    "Pick one: (a) onboard the persona with a real roster card, or (b) remove "
+                    "the row from `.claude/team/roster.json` if the persona is retired.",
+                    "",
+                ]
             )
             for name in orphans["unreconciled"]:
-                print(f'  - "{name}"', file=sys.stderr)
+                print(f'  - "{name}"', file=sys.stderr, flush=True)
+                summary_lines.append(f'- "{name}"')
         else:
-            print(
-                "\nManifest-orphan check (#1181): every persona-shaped manifest entry is backed "
+            clean_msg = (
+                "Manifest-orphan check (#1181): every persona-shaped manifest entry is backed "
                 "by a card or a child roster.json. No unreconciled orphans."
             )
+            print(f"\n{clean_msg}", flush=True)
+            summary_lines.append(f"**Status: CLEAN** — {clean_msg}")
+
+    _write_step_summary(summary_lines)
 
     return exit_code
 

--- a/.claude/lib/tests/test_roster_union_sync.py
+++ b/.claude/lib/tests/test_roster_union_sync.py
@@ -32,6 +32,19 @@ Verifies:
      dedicated test pins both halves of that distinction together — advisory
      orphan drift alongside a genuine forward violation still exits 1, driven
      by the forward finding alone.
+  8. Observability (#1254): the report is invisible unless someone opens a
+     green job's log, and its two streams interleaved out of order. Two
+     dedicated test classes cover the fix: `StreamOrderingRegressionTest`
+     drives the script as a REAL subprocess (fake `gh` on PATH, no network)
+     with stdout+stderr merged onto one pipe — the actual CI I/O shape — and
+     asserts the `OK ...` context line prints BEFORE the `MANIFEST ORPHAN`
+     block that must be read against it (an in-process `redirect_stdout`
+     capture, as every other test here uses, does NOT reproduce this bug —
+     `StringIO` has no buffering semantics, so only a real OS pipe shows it).
+     `JobSummaryTests` asserts the report also renders on
+     `$GITHUB_STEP_SUMMARY`, and that a SKIPPED (did-not-run) verdict and a
+     CLEAN (zero-orphans) verdict use disjoint, distinguishable text there —
+     the exact "did not run must never read like clean" requirement.
 """
 
 from __future__ import annotations
@@ -39,6 +52,7 @@ from __future__ import annotations
 import base64
 import io
 import json
+import os
 import subprocess
 import sys
 import unittest
@@ -549,6 +563,208 @@ class RealMeasuredDriftRegressionTests(unittest.TestCase):
             out = stderr.getvalue()
             for name in set(self.REAL_UNBACKED_18) - {"Annunaki", "Steven French"}:
                 self.assertIn(name, out)
+
+
+class StreamOrderingRegressionTest(unittest.TestCase):
+    """#1254: the MANIFEST ORPHAN block (stderr) must not print ABOVE the
+    `OK ...` context line (stdout) it needs to be read against.
+
+    Reproduces the ACTUAL CI I/O shape: the script run as a real subprocess
+    with stdout and stderr merged onto ONE pipe (`stderr=subprocess.STDOUT`,
+    matching how a GitHub Actions log captures a step's combined output).
+    Pre-fix, CPython block-buffers stdout when it is not a tty (true of a
+    pipe) but leaves stderr unbuffered, so the `OK ...` line is only flushed
+    to the pipe at process exit — AFTER every stderr `MANIFEST ORPHAN` line
+    has already landed, reproducing the exact reordering measured in #1254
+    deterministically (not a timing-dependent flake): stdout's total output
+    here is far under the block-buffer threshold, so it is guaranteed to sit
+    unflushed until exit regardless of machine speed. A `redirect_stdout` /
+    `redirect_stderr` in-process capture, as every other test in this file
+    uses, does NOT reproduce this — `StringIO` has no buffering semantics,
+    so the bug is only observable through a real OS pipe.
+
+    No network: a fake `gh` shim script is put first on PATH and answers
+    every `gh api .../contents/...` call the script issues.
+    """
+
+    def setUp(self) -> None:
+        self._tmp = TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.repo_root = Path(self._tmp.name) / "repo"
+        _write_parent_roster(
+            self.repo_root,
+            {
+                "Backed Person": "parametrization+Backed.Person@gmail.com",
+                "Orphan Person": "parametrization+Orphan.Person@gmail.com",
+            },
+        )
+        self._install_fake_gh()
+
+    def _install_fake_gh(self) -> None:
+        """Write a fake `gh` on PATH answering the exact `api` calls main() issues.
+
+        Deterministic: every roster.json / card-directory / card-file fetch
+        the script performs for `noorinalabs-isnad-graph` (via --repos) and
+        `noorinalabs-deploy` (always added for the #1181 card pass) succeeds,
+        so the run reaches the real MANIFEST ORPHAN branch rather than the
+        SKIPPED branch.
+        """
+        bin_dir = Path(self._tmp.name) / "bin"
+        bin_dir.mkdir()
+        roster_b64 = base64.b64encode(json.dumps({"Backed Person": "b@x"}).encode()).decode()
+        graph_card = base64.b64encode(b"# Filler Graph - Role\n").decode()
+        deploy_card = base64.b64encode(b"# Filler Deploy - Role\n").decode()
+        fake_gh = f"""#!/usr/bin/env python3
+import sys
+argv = sys.argv[1:]
+path = argv[1] if len(argv) > 1 else ""
+jq = argv[-1] if argv else ""
+graph = "noorinalabs-isnad-graph"
+deploy = "noorinalabs-deploy"
+if path.endswith(graph + "/contents/.claude/team/roster.json") and jq == ".content":
+    print({roster_b64!r})
+elif path.endswith(graph + "/contents/.claude/team/roster") and jq == ".[].name":
+    print("filler.md")
+elif path.endswith(graph + "/contents/.claude/team/roster/filler.md") and jq == ".content":
+    print({graph_card!r})
+elif path.endswith(deploy + "/contents/.claude/team/roster") and jq == ".[].name":
+    print("filler2.md")
+elif path.endswith(deploy + "/contents/.claude/team/roster/filler2.md") and jq == ".content":
+    print({deploy_card!r})
+else:
+    sys.exit(1)
+"""
+        gh_path = bin_dir / "gh"
+        gh_path.write_text(fake_gh)
+        gh_path.chmod(0o755)
+        self.env = dict(os.environ)
+        self.env["PATH"] = f"{bin_dir}{os.pathsep}{self.env.get('PATH', '')}"
+
+    def _run_script(self) -> str:
+        script = Path(roster_union_sync.__file__)
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(script),
+                "--repo-root",
+                str(self.repo_root),
+                "--repos",
+                "noorinalabs-isnad-graph",
+            ],
+            env=self.env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            timeout=30,
+        )
+        return proc.stdout
+
+    def test_ok_context_line_precedes_manifest_orphan_block(self) -> None:
+        merged = self._run_script()
+        ok_idx = merged.find("OK      noorinalabs-isnad-graph: 1 persona(s).")
+        orphan_idx = merged.find("MANIFEST ORPHAN")
+        self.assertNotEqual(ok_idx, -1, merged)
+        self.assertNotEqual(orphan_idx, -1, merged)
+        self.assertLess(
+            ok_idx,
+            orphan_idx,
+            "the OK context line must print BEFORE the MANIFEST ORPHAN block it "
+            "is read against, not after — pipe buffering must not reorder the "
+            f"two streams (#1254). Full merged output:\n{merged}",
+        )
+
+
+class JobSummaryTests(unittest.TestCase):
+    """#1254: the manifest-orphan report also renders on `$GITHUB_STEP_SUMMARY`,
+    and a SKIPPED (did-not-run) verdict must never read like a CLEAN one there.
+    """
+
+    def _run_with_summary(
+        self,
+        parent: dict[str, str],
+        fetched: dict[str, dict | None],
+        repos: str,
+        card_fetched: dict[str, set[str] | None] | None = None,
+    ) -> str:
+        with TemporaryDirectory() as td:
+            repo = Path(td) / "repo"
+            summary_path = Path(td) / "summary.md"
+            summary_path.write_text("")  # GHA pre-creates this file; simulate that
+            _write_parent_roster(repo, parent)
+            orig_roster = roster_union_sync.fetch_child_roster
+            orig_cards = roster_union_sync.fetch_child_card_names
+            roster_union_sync.fetch_child_roster = lambda owner, r: fetched.get(r)  # type: ignore[assignment]
+            roster_union_sync.fetch_child_card_names = lambda owner, r: (  # type: ignore[assignment]
+                card_fetched or {}
+            ).get(r)
+            try:
+                with patch.dict(os.environ, {"GITHUB_STEP_SUMMARY": str(summary_path)}):
+                    stdout, stderr = io.StringIO(), io.StringIO()
+                    with redirect_stdout(stdout), redirect_stderr(stderr):
+                        main(["--repo-root", str(repo), "--repos", repos])
+            finally:
+                roster_union_sync.fetch_child_roster = orig_roster
+                roster_union_sync.fetch_child_card_names = orig_cards
+            return summary_path.read_text()
+
+    def test_skipped_run_renders_did_not_run_not_clean(self) -> None:
+        summary = self._run_with_summary(
+            {"Persona X": "parametrization+Persona.X@gmail.com"},
+            {"noorinalabs-isnad-graph": {}, "noorinalabs-user-service": None},
+            "noorinalabs-isnad-graph,noorinalabs-user-service",
+        )
+        self.assertIn("DID NOT RUN", summary)
+        self.assertNotIn("CLEAN", summary)
+        self.assertNotIn("ORPHANS FOUND", summary)
+
+    def test_clean_run_renders_clean_not_did_not_run(self) -> None:
+        summary = self._run_with_summary(
+            {"Wanjiku Mwangi": "parametrization+Wanjiku.Mwangi@gmail.com"},
+            {"noorinalabs-isnad-graph": {}},
+            "noorinalabs-isnad-graph",
+            card_fetched={
+                "noorinalabs-isnad-graph": {"Wanjiku Mwangi"},
+                "noorinalabs-deploy": set(),
+            },
+        )
+        self.assertIn("CLEAN", summary)
+        self.assertNotIn("DID NOT RUN", summary)
+        self.assertNotIn("ORPHANS FOUND", summary)
+
+    def test_orphans_found_run_renders_orphans_found_with_name(self) -> None:
+        summary = self._run_with_summary(
+            {"Persona X": "parametrization+Persona.X@gmail.com"},
+            {"noorinalabs-isnad-graph": {}},
+            "noorinalabs-isnad-graph",
+            card_fetched={
+                "noorinalabs-isnad-graph": set(),
+                "noorinalabs-deploy": set(),
+            },
+        )
+        self.assertIn("ORPHANS FOUND", summary)
+        self.assertIn("Persona X", summary)
+        self.assertNotIn("DID NOT RUN", summary)
+        self.assertNotIn("**Status: CLEAN**", summary)
+
+    def test_no_env_var_is_silent_noop(self) -> None:
+        with TemporaryDirectory() as td:
+            repo = Path(td) / "repo"
+            _write_parent_roster(
+                repo, {"Wanjiku Mwangi": "parametrization+Wanjiku.Mwangi@gmail.com"}
+            )
+            orig_roster = roster_union_sync.fetch_child_roster
+            orig_cards = roster_union_sync.fetch_child_card_names
+            roster_union_sync.fetch_child_roster = lambda owner, r: {}  # type: ignore[assignment]
+            roster_union_sync.fetch_child_card_names = lambda owner, r: set()  # type: ignore[assignment]
+            env = dict(os.environ)
+            env.pop("GITHUB_STEP_SUMMARY", None)
+            try:
+                with patch.dict(os.environ, env, clear=True):
+                    rc = main(["--repo-root", str(repo), "--repos", "noorinalabs-isnad-graph"])
+            finally:
+                roster_union_sync.fetch_child_roster = orig_roster
+                roster_union_sync.fetch_child_card_names = orig_cards
+            self.assertEqual(rc, 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #1254

## Problem

The #1181 manifest-orphan check (`.claude/lib/roster_union_sync.py`) is
correctly advisory in exit status (PR #1240 review correction — a non-zero
exit here would have turned the `Roster union sync-drift gate` job FAILING
on every PR in the repo). That correction, however, left the report with no
observable channel:

- The job is `SUCCESS` whether the report found orphans, found none, or did
  not run at all (a fetch-skip is fail-safe-closed but renders identically
  to "clean" everywhere except the log text).
- The only artifact was text in the log of a green job — nobody opens that.
- Compounding it, the `MANIFEST ORPHAN` block went to stderr (unbuffered)
  while the `OK`/`SKIPPED` context lines it needs to be read against went to
  stdout (block-buffered under a pipe — CI's actual I/O shape), so under a
  real pipe the orphan block printed **above** the context it belongs below.

## Fix

1. **Job summary** — the orphan-check verdict is now also appended to
   `$GITHUB_STEP_SUMMARY` (a file GitHub Actions provides to every step
   automatically — no workflow YAML change needed), so it renders on the
   workflow run's Summary page without opening any job's log, green or not.
2. **Explicit disjoint states** — the summary verdict is always exactly one
   of three: `DID NOT RUN`, `CLEAN`, or `ORPHANS FOUND (N)`. "Did not run"
   can never render like "clean".
3. **Stream ordering** — every `print()` in `main()` now passes
   `flush=True`, so the two streams interleave in the order the script
   actually emits them regardless of which fd a downstream consumer (a CI
   log merging a step's stdout+stderr) merges them onto.

Exit-code contract is unchanged: only the forward-direction (#634) violation
can move `exit_code`; the orphan report remains advisory in exit status.

## Failing-before proof

Both new test classes were written first and run against the **unmodified**
`roster_union_sync.py`. Both fail, targeting exactly the defect (not merely
"the report prints the orphan", which passes even pre-fix):

```
$ ENVIRONMENT=test python3 -m pytest .claude/lib/tests/test_roster_union_sync.py -q -k "StreamOrdering or JobSummary"
...
E       AssertionError: 356 not less than 1 : the OK context line must print BEFORE the MANIFEST ORPHAN block it is read against, not after — pipe buffering must not reorder the two streams (#1254). Full merged output:
E
E       MANIFEST ORPHAN (#1181, advisory — does not fail this job): persona-shaped parent-roster entry with NO backing card or child roster.json observed anywhere in the org. Pick one:
E         (a) onboard the persona — add a real roster card in the repo it belongs to, or
E         (b) the persona is retired — remove the row from .claude/team/roster.json.
E         - "Orphan Person"
E       OK      noorinalabs-isnad-graph: 1 persona(s).
E
E       Parent roster covers all 1 observed child persona(s) across 1 repo(s). No drift.
E       OK      noorinalabs-isnad-graph: 1 card(s).
E       OK      noorinalabs-deploy: 1 card(s).

.claude/lib/tests/test_roster_union_sync.py:666: AssertionError
_________ JobSummaryTests.test_clean_run_renders_clean_not_did_not_run _________
...
AssertionError: 'CLEAN' not found in ''
____ JobSummaryTests.test_orphans_found_run_renders_orphans_found_with_name ____
...
AssertionError: 'ORPHANS FOUND' not found in ''
________ JobSummaryTests.test_skipped_run_renders_did_not_run_not_clean ________
...
AssertionError: 'DID NOT RUN' not found in ''
=========================== short test summary info ============================
FAILED .claude/lib/tests/test_roster_union_sync.py::StreamOrderingRegressionTest::test_ok_context_line_precedes_manifest_orphan_block
FAILED .claude/lib/tests/test_roster_union_sync.py::JobSummaryTests::test_clean_run_renders_clean_not_did_not_run
FAILED .claude/lib/tests/test_roster_union_sync.py::JobSummaryTests::test_orphans_found_run_renders_orphans_found_with_name
FAILED .claude/lib/tests/test_roster_union_sync.py::JobSummaryTests::test_skipped_run_renders_did_not_run_not_clean
4 failed, 1 passed, 32 deselected in 0.67s
```

After the fix, the full suite (37 tests) passes.

`StreamOrderingRegressionTest` reproduces the ordering bug deterministically
(not a timing flake) by running the script as a **real subprocess** with a
fake `gh` shim on PATH (no network) and `stderr=subprocess.STDOUT` — the
actual CI I/O shape. An in-process `redirect_stdout`/`redirect_stderr`
capture (as the rest of the test file uses) does **not** reproduce this,
since `StringIO` has no buffering semantics — that's the "the report prints
the orphan" trap the issue calls out.

## Scope note

Per the spawn brief: #1374 needs an overlapping requirement in a different
surface (`/wave-scope` Step 8.5, owned by Wanjiku) — this PR does not touch
any files under that skill.

## Gates

- `pre-commit` (ruff-format, ruff-lint) — passed at commit time.
- `pre-push` (mypy, mypy-skills, pytest, pytest-skills, memory-budget,
  headcount-budget, doc-freshness, office-drift, mermaid-render) — all
  passed before this branch left the machine.
- `python3 .claude/lib/pre_commit_ci_sync.py .` — OK, no drift.

## Reviewers

- Peer reviewer: **Nadia Khoury**
- Secondary reviewer: **Weronika Zielinska** (added because peer reviewer
  and merge gate would otherwise be the same person — the 2-distinct-
  reviewer gate needs a second name)
- Merge gate: **Nadia Khoury**

Not merging — leaving this for review per the spawn brief.
