### PR TITLE
fix(#1362): add an RE2-syntax guard for _CHANGES_REQUESTED_RE alongside the jq semantics test

### DIFF
--- a/.claude/lib/tests/test_wave_status.py
+++ b/.claude/lib/tests/test_wave_status.py
@@ -337,6 +337,35 @@ class Counters(unittest.TestCase):
                 )
         self.assertEqual(rc, 0)
 
+    # -- main#1362: production runs `_CHANGES_REQUESTED_RE` through `gh --jq`
+    # (gojq -> Go's `regexp`, i.e. RE2), not the system `jq` binary the
+    # semantics test above shells out to (Oniguruma). RE2 has no lookaround
+    # or backreferences; Oniguruma has both, so a future widening of the
+    # constant with e.g. a lookahead would compile fine under the test above
+    # and hard-error live. `_re2_incompatible_reason` is a cheap syntax scan
+    # (not a full RE2 parse, and not a new gojq/Go-toolchain dependency in
+    # CI/pre-commit) for the specific constructs RE2's parser rejects
+    # outright. These three tests demonstrate it catches the exact failure
+    # shape #1362 documented and stays quiet on the real pattern.
+    def test_re2_guard_rejects_lookahead(self) -> None:
+        # The exact construct from #1362's repro: compiles under jq
+        # (Oniguruma) but `gh --jq` (gojq/RE2) hard-errors with "invalid or
+        # unsupported Perl syntax: `(?='".
+        reason = wave_status._re2_incompatible_reason(r"RequestOrReplied:\s*(?=Changes)Changes")
+        self.assertIsNotNone(reason)
+
+    def test_re2_guard_rejects_lookbehind_and_backreference(self) -> None:
+        self.assertIsNotNone(wave_status._re2_incompatible_reason(r"(?<=Foo)Bar"))
+        self.assertIsNotNone(wave_status._re2_incompatible_reason(r"(?<!Foo)Bar"))
+        self.assertIsNotNone(wave_status._re2_incompatible_reason(r"(Foo)\1"))
+
+    def test_re2_guard_accepts_current_changes_requested_pattern(self) -> None:
+        # Regression guard: if `_CHANGES_REQUESTED_RE` is ever widened to
+        # include one of the forbidden constructs, this fails fast in CI
+        # instead of passing green and hard-erroring in the live gh --jq
+        # call the way an unguarded lookahead would.
+        self.assertIsNone(wave_status._re2_incompatible_reason(wave_status._CHANGES_REQUESTED_RE))
+
 
 class Write(unittest.TestCase):
     def test_write_upserts_three_canonical_keys(self) -> None:

--- a/.claude/lib/wave_status.py
+++ b/.claude/lib/wave_status.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 import argparse
 import json
 import math
+import re
 import subprocess
 import sys
 from collections import Counter
@@ -95,6 +96,54 @@ _DEFAULT_STATUS = wave_state.DEFAULT_STATUS_PATH
 # wave-29 merged-PR set, where it now reproduces the retro's corrected 51
 # (was 49).
 _CHANGES_REQUESTED_RE = "RequestOrReplied:\\\\s*Changes(\\\\s*Requested)?\\\\b"
+
+
+# main#1362: `_changes_requested_cycles` below evaluates `_CHANGES_REQUESTED_RE`
+# through `gh --jq`, and gh embeds gojq (`itchyny/gojq`), which compiles
+# regexes through Go's `regexp` package — i.e. RE2. RE2 has no lookaround and
+# no backreferences. `test_changes_requested_regex_variants_via_real_jq`
+# (test_wave_status.py, Counters) validates this constant's *semantics*
+# against the system `jq` binary (Oniguruma), which accepts a strictly wider
+# syntax than RE2 — it demonstrated a lookahead compiles under jq but hard-
+# errors under `gh --jq`: "invalid or unsupported Perl syntax: `(?=`". So a
+# future widening of `_CHANGES_REQUESTED_RE` expressed with a lookahead would
+# pass that test green and hard-error live.
+#
+# `_re2_incompatible_reason` closes that gap as a syntax scan — not a full
+# RE2 parse — for the specific constructs RE2's parser rejects outright. This
+# was chosen over installing gojq (or a Go toolchain) in CI/pre-commit: gojq
+# is not otherwise a dependency of this repo, and mirroring it into
+# `.pre-commit-config.yaml` per the org's full local/CI parity rule would add
+# a new external binary everywhere this repo is worked on, for a check this
+# scan gets for free out of the standard library. It does not claim
+# RE2-completeness for constructs outside this known list — see the
+# `Counters` class's `test_re2_guard_*` tests in test_wave_status.py, which
+# exercise both the reject and the accept path against the real constant
+# above.
+_RE2_INCOMPATIBLE_CONSTRUCTS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"\(\?<[=!]"), "lookbehind (?<= or (?<!"),
+    (re.compile(r"\(\?[=!]"), "lookahead (?= or (?!"),
+    (re.compile(r"\(\?P="), "named backreference (?P="),
+    (re.compile(r"\(\?>"), "atomic group (?>"),
+    (re.compile(r"\(\?\("), "conditional (?("),
+    (re.compile(r"\\[1-9]"), "backreference \\N"),
+)
+
+
+def _re2_incompatible_reason(pattern: str) -> str | None:
+    """Return the name of the first known RE2-incompatible construct found in
+    ``pattern``, or ``None`` if the scan finds none of them.
+
+    This is a syntax guard for the failure shape main#1362 documented (a
+    lookahead compiles under jq/Oniguruma but gojq/RE2 — the engine
+    ``gh --jq`` actually uses in production — hard-errors on it). It is
+    intentionally a regex-on-the-regex scan, not an actual RE2 compile, so it
+    adds no new dependency (no gojq, no Go toolchain) to CI or pre-commit.
+    """
+    for construct_re, name in _RE2_INCOMPATIBLE_CONSTRUCTS:
+        if construct_re.search(pattern):
+            return name
+    return None
 
 
 # The shared gh shim and status reader (main#1119). These stay module-level


### PR DESCRIPTION
Closes #1362.

## Problem

`test_changes_requested_regex_variants_via_real_jq` (Counters, `test_wave_status.py`) validates `_CHANGES_REQUESTED_RE` against the system `jq` binary — Oniguruma. Production evaluates the same pattern through `gh --jq`, which embeds **gojq**, compiling regexes through Go's `regexp` package — **RE2**. RE2 has no lookaround or backreferences. A future widening of the pattern with a lookahead would pass the existing test green and hard-error live. No behavioural defect today (gojq vs Oniguruma agree 51/51 on the live wave-29 corpus per the issue) — this is about what tomorrow's test run can and cannot catch.

## Remedy chosen — cheap RE2-syntax guard, not a gojq/Go dependency

The issue offers two remedies: run the assertion through gojq in CI+pre-commit, or keep the jq semantics test and add a syntax guard for RE2-incompatible constructs. I chose the **syntax guard**:

- gojq (and a Go toolchain to build/run it) is not otherwise a dependency of this repo. Installing it would need to be mirrored into `.pre-commit-config.yaml` per the org's full local/CI parity rule (`ci-gates.md` § Full Local⇄CI Tooling Parity), adding a new external binary requirement everywhere this repo is worked on.
- The actual risk surface is narrow and well-known (lookaround, backreferences, atomic groups, conditionals — the constructs RE2's parser rejects outright), so a Python `re`-on-the-pattern scan catches the demonstrated failure shape for free, using only the standard library.
- **No new CI or pre-commit dependency was added.** `_re2_incompatible_reason` (`.claude/lib/wave_status.py`) is pure-stdlib `re`.

Added `_re2_incompatible_reason(pattern) -> str | None` plus three tests in the `Counters` class (`test_wave_status.py`):
- `test_re2_guard_rejects_lookahead` — the exact construct from the issue's repro.
- `test_re2_guard_rejects_lookbehind_and_backreference`
- `test_re2_guard_accepts_current_changes_requested_pattern` — regression guard against the real `_CHANGES_REQUESTED_RE` constant.

I cross-checked the guard's judgments against the real RE2 engine (Go's `regexp` package, available on this box) rather than trusting the syntax scan blind:
```
$ go run re2check.go 'RequestOrReplied:\\s*Changes(\\s*Requested)?\\b'
OK
$ go run re2check.go 'RequestOrReplied:\s*(?=Changes)Changes'
REJECT: error parsing regexp: invalid or unsupported Perl syntax: `(?=`
$ go run re2check.go '(?<=Foo)Bar'
REJECT: error parsing regexp: invalid named capture: `(?<=Foo)Bar`
$ go run re2check.go '(Foo)\1'
REJECT: error parsing regexp: invalid escape sequence: `\1`
```
Matches exactly: current production pattern compiles clean under real RE2; the demonstrated lookahead and the added lookbehind/backreference cases all reject with the same error class `gh --jq` produces live.

## Failing-before-fix (acceptance bar)

Ran the three new tests against the pre-fix tree (function doesn't exist yet):
```
$ ENVIRONMENT=test python3 -m pytest .claude/lib/tests/test_wave_status.py -k "re2_guard" -q
...
E       AttributeError: module 'wave_status' has no attribute '_re2_incompatible_reason'
FAILED .claude/lib/tests/test_wave_status.py::Counters::test_re2_guard_accepts_current_changes_requested_pattern
FAILED .claude/lib/tests/test_wave_status.py::Counters::test_re2_guard_rejects_lookahead
FAILED .claude/lib/tests/test_wave_status.py::Counters::test_re2_guard_rejects_lookbehind_and_backreference
3 failed, 45 deselected in 0.39s
```
After the fix, full `test_wave_status.py` suite: `48 passed, 7 subtests passed`.

## Acceptance checklist (from #1362)

- [x] The regex is validated against the engine production actually uses, or a guard rejects syntax RE2 cannot compile — the syntax guard, cross-checked against real RE2 above.
- [x] The test comment no longer claims Oniguruma is the production engine — already correct as of `f1b3ef0` (a prior #1356-review fix); verified unchanged/accurate, not re-touched here.
- [x] The `feedback_log.md` sentence is already corrected (same prior commit `f1b3ef0`) — verified, not re-touched here.
- [x] `@unittest.skipUnless(shutil.which("jq"), ...)` reviewed: the semantics test's skip is inherent (it needs the real Oniguruma binary), so it stays skippable. The new `_re2_incompatible_reason` guard tests are **unconditional** — no subprocess, no `jq` dependency — so the demonstrated failure shape (a lookahead widening) is still caught even in an environment where `jq` is absent and the semantics test silently skips.

## Not fixed / found but out of scope

- Did not touch `_canonical_issue_numbers_by_repo` or the `CanonicalIssueNumbers` test class — those are owned by the in-flight #1421 (Weronika Zielinska), confirmed non-overlapping with this diff.
- Did not restructure or reformat unrelated regions of either file.

## CI dependency

None added. No `.pre-commit-config.yaml` change needed — the guard is pure Python `re` (stdlib), already covered by the existing `pytest`/`ruff` mirrors.

## Gates run locally (fresh worktree, hooks installed this session)

- `pre-commit run` (commit stage: ruff-format, ruff-lint, checksums-ascii) — pass.
- `mypy .claude/hooks/ .claude/lib/ --ignore-missing-imports --no-error-summary` — clean.
- `ENVIRONMENT=test python3 -m pytest .claude/hooks/tests/ .claude/lib/tests/ -q` — 4396 passed, 1037 subtests passed.
- `python3 .claude/lib/pre_commit_ci_sync.py .` — OK, no drift.
- `git push` (pre-push stage: mypy, mypy-skills, pytest, pytest-skills, memory-budget, headcount-budget, doc-freshness, office-drift, mermaid-render) — all pass.

## Reviewers

- Peer reviewer: **Weronika Zielinska**
- Merge gate: **Nino Kavtaradze**

Co-Authored-By: Lucas Ferreira <parametrization+Lucas.Ferreira@gmail.com>
