### PR TITLE
fix(session-start): a fresh worktree is merged but is not a removal candidate (#1341)

### DIFF
--- a/.claude/lib/check_worktree_merged.py
+++ b/.claude/lib/check_worktree_merged.py
@@ -123,6 +123,43 @@ looks only at patch-id (diff content), `git cherry`'s own explicit
 verdicts, or a merge's own combined diff, never at commit graph shape or a
 fixed strategy label as such.
 
+**Removal candidacy is a SECOND, ORTHOGONAL axis (#1341) — merged-ness is
+not the removal decision.** Everything above answers *"is this branch's
+content already on `remote_ref`?"*. Step 0 asks a different question:
+*"is there anything here worth reclaiming?"*. Those came apart on a
+**freshly-created worktree that has not committed yet**: its HEAD *is*
+`origin/main`, so it is trivially an ancestor, the fast path answers
+`merged` — **correctly**, since a branch with no commits of its own has, by
+construction, no unlanded content — and Step 0 removed a clean, live
+worktree out from under an active agent (observed on in-flight #1117 during
+wave-29). The false verdict was never about merged-ness; it was about
+reading merged-ness as a reclaim decision.
+
+So the merged classification above is **unchanged and untraded** — a fresh
+worktree still classifies `merged`/`ancestor`, exactly as the #1213
+guarantee requires. What is added is a separate predicate that gates the
+*removal* decision only:
+
+    a branch whose HEAD is itself a commit on `remote_ref`'s own
+    first-parent (mainline) history has produced **no commits of its own**,
+    so there is nothing to reclaim -> `removal_block = "no-own-commits"`,
+    `safe_to_remove` False, CLI exit 3 (not 0).
+
+Why the first-parent chain rather than the `HEAD == remote_ref` equality
+the issue proposed: equality only catches a worktree branched off the
+*current* tip. Sessions here run long enough that `origin/main` advances
+under an idle worktree, after which HEAD is an ancestor but no longer equal
+— same zero-own-work branch, same live agent, and equality would have
+missed it. Mainline membership covers both, and it does not touch the
+population the sweep exists for (#526): a squash- or rebase-merged branch
+tip is not an ancestor at all (it never reaches this guard), and a
+merge-commit-merged tip is reachable only through the merge's **second**
+parent, so it is an ancestor but *not* on the mainline chain — it stays a
+removal candidate. The one shape this over-flags is a fast-forward-merged
+branch (its tip literally becomes a mainline commit); GitHub's three merge
+buttons never fast-forward, and over-flagging costs a stale directory,
+which is the accepted-cheap direction.
+
 **Safety stance (never relaxed):**
 
   * A branch whose net content since `merge_base` is not fully present on
@@ -157,18 +194,39 @@ fixed strategy label as such.
   * The whole test is 100% local git plumbing — no `gh`/network calls, so it
     works offline and never blocks the mandatory session-start step on
     network/auth availability.
+  * The removal-candidacy probe (#1341) degrades in the same direction:
+    if either of its two git calls fails, the result is
+    ``removal_block = "mainline-check-failed"`` — a probe that could not be
+    run is not evidence that the branch has work of its own, so removal is
+    withheld and the worktree is flagged. Note the *classification* is left
+    intact in that case (still `merged`); only removal candidacy degrades,
+    because the two axes are independent and a failure on one is not
+    evidence about the other.
   * **Step 0 no longer force-removes** (owner decision, PR #1213 round 3): a
     worktree that does not remove cleanly is FLAGGED for a manual decision.
     Since `git worktree remove` never deletes the branch ref either way,
     this means a misclassification by this module can cost, at worst, a
     stale worktree *directory* — never a commit, never a branch, and (with
     the force fallback gone) never even uncommitted content, since a dirty
-    worktree that fails a plain `remove` is simply left alone.
+    worktree that fails a plain `remove` is simply left alone. That bound
+    holds for *committed* work; it never covered the #1341 case, where the
+    worktree being destroyed was clean precisely because its agent had not
+    written anything yet.
 
 CLI: ``python3 check_worktree_merged.py <repo_root> <head> [remote_ref]``
 (default ``remote_ref`` is ``origin/main``). Prints one line
-``<status> (<reason>): <detail>`` and exits 0 iff merged, 1 otherwise — the
-exit code is the only thing a caller needs to decide auto-remove vs FLAG.
+``<status> (<reason>)[ [not-a-removal-candidate: <block>]]: <detail>``.
+Exit codes — the exit code is the only thing a caller needs to decide
+auto-remove vs FLAG:
+
+  * ``0`` — merged **and** a removal candidate: safe to auto-remove.
+  * ``1`` — not merged (``unmerged`` or ``error``).
+  * ``2`` — usage error.
+  * ``3`` — merged, but **not** a removal candidate (#1341: no commits of
+    its own, or the candidacy probe failed). Non-zero, so a caller that
+    only knows the old ``0 == remove`` contract still fails safe; a caller
+    that distinguishes it can label the worktree FRESH rather than the
+    misleading UNMERGED.
 """
 
 from __future__ import annotations
@@ -322,16 +380,38 @@ class MergeClassification:
     truly empty commit (explicitly filtered even though `git cherry` does
     mark it `+`) or a merge commit with no unique content of its own — see
     the module docstring's per-commit-corroboration section.
+
+    ``removal_block`` — the SECOND, orthogonal axis (#1341). Empty means
+    "nothing blocks reclaiming this worktree"; non-empty is a short machine-
+    readable reason why it must not be auto-removed even though its content
+    is fully landed:
+
+      * ``no-own-commits``       — HEAD is a commit on ``remote_ref``'s own
+        first-parent history, so the branch has produced nothing of its own
+        (a fresh, not-yet-committed worktree — very likely live).
+      * ``mainline-check-failed`` — the candidacy probe itself errored;
+        withhold removal rather than assume there is work here.
+
+    It never affects ``status``/``merged``: a fresh worktree is genuinely
+    merged, it is just not a reclaim candidate. Callers deciding
+    auto-remove-vs-FLAG must read :attr:`safe_to_remove`, not
+    :attr:`merged`.
     """
 
     status: str
     reason: str
     detail: str = ""
     unmatched_commits: list[str] = field(default_factory=list)
+    removal_block: str = ""
 
     @property
     def merged(self) -> bool:
         return self.status == "merged"
+
+    @property
+    def safe_to_remove(self) -> bool:
+        """The auto-remove predicate: fully landed AND has work to reclaim."""
+        return self.merged and not self.removal_block
 
 
 def _parse_patch_ids(text: str) -> list[tuple[str, str]]:
@@ -352,6 +432,65 @@ def _degrade(reason: str, detail: str) -> MergeClassification:
     return MergeClassification("unmerged", reason, detail)
 
 
+def _removal_block(root: Path, head: str, remote_ref: str, runner: GitRunner) -> tuple[str, str]:
+    """Removal-candidacy probe (#1341) — the axis orthogonal to merged-ness.
+
+    Returns ``(block_reason, block_detail)``; ``("", "")`` means the branch
+    has commits of its own and is a genuine reclaim candidate.
+
+    Only meaningful once ``head`` is known to be an ancestor of
+    ``remote_ref`` (mainline membership implies ancestry, so calling it off
+    that path would always answer "not blocked" at the cost of two git
+    invocations). The test: is ``head`` itself one of the commits on
+    ``remote_ref``'s **first-parent** chain? If so the branch has never
+    committed anything of its own — nothing to reclaim, and very likely a
+    worktree an agent is about to write into.
+
+    Both git calls degrade toward *withholding removal* (never toward
+    removing): a probe we could not run is not evidence of work.
+    """
+    head_res = runner(["rev-parse", "--verify", f"{head}^{{commit}}"], root)
+    head_sha = head_res.stdout.strip() if head_res.returncode == 0 else ""
+    if not head_sha:
+        return (
+            "mainline-check-failed",
+            f"could not resolve {head} to a commit "
+            f"(exit {head_res.returncode}): {head_res.stderr.strip()} — "
+            f"cannot confirm this worktree has commits of its own, so removal is withheld",
+        )
+
+    # First-parent chain of remote_ref. Membership is an exact SHA-set test:
+    # every line is a full 40-char object name, so no prefix/substring
+    # ambiguity is possible.
+    chain = runner(["rev-list", "--first-parent", remote_ref], root)
+    if chain.returncode != 0:
+        return (
+            "mainline-check-failed",
+            f"git rev-list --first-parent {remote_ref} failed "
+            f"(exit {chain.returncode}): {chain.stderr.strip()} — "
+            f"cannot confirm this worktree has commits of its own, so removal is withheld",
+        )
+    mainline = set(chain.stdout.split())
+    if not mainline:
+        # `git rev-list` over a resolvable ref always lists at least that
+        # ref's own commit, so a successful-but-empty result is an unknown
+        # state — never read it as "head is not on the mainline, remove away"
+        # (the same fail-open guard the patch-id path carries).
+        return (
+            "mainline-check-failed",
+            f"git rev-list --first-parent {remote_ref} succeeded but listed no commits — "
+            f"unexpected state, so removal is withheld",
+        )
+    if head_sha in mainline:
+        return (
+            "no-own-commits",
+            f"{head_sha[:12]} is itself a commit on {remote_ref}'s first-parent history, "
+            f"so this branch has no commits of its own — a fresh/unstarted worktree with "
+            f"nothing to reclaim (very likely in active use), not a removal candidate",
+        )
+    return ("", "")
+
+
 def classify_merged(
     repo_root: str | Path,
     head: str,
@@ -367,7 +506,15 @@ def classify_merged(
     # ---- fast path: plain ancestry (covers the merge-commit majority) ------
     anc = runner(["merge-base", "--is-ancestor", head, remote_ref], root)
     if anc.returncode == 0:
-        return MergeClassification("merged", "ancestor", f"{head} is an ancestor of {remote_ref}")
+        # Merged — but ancestry alone does not mean there is anything here to
+        # reclaim. A worktree that has not committed yet sits ON remote_ref's
+        # mainline, which is trivially an ancestor (#1341). Classification is
+        # untouched; only removal candidacy is gated.
+        block_reason, block_detail = _removal_block(root, head, remote_ref, runner)
+        detail = f"{head} is an ancestor of {remote_ref}"
+        if block_reason:
+            detail = f"{detail}; {block_detail}"
+        return MergeClassification("merged", "ancestor", detail, removal_block=block_reason)
     if anc.returncode != 1:
         # `--is-ancestor` signals a true negative with exit 1; anything else
         # (bad rev, corrupt repo, ...) is a plumbing error, not "not merged".
@@ -576,8 +723,16 @@ def main(argv: Sequence[str] | None = None) -> int:
     remote_ref = args[2] if len(args) > 2 else "origin/main"
 
     result = classify_merged(repo_root, head, remote_ref)
-    print(f"{result.status} ({result.reason}): {result.detail}")
-    return 0 if result.merged else 1
+    prefix = f"{result.status} ({result.reason})"
+    if result.removal_block:
+        prefix = f"{prefix} [not-a-removal-candidate: {result.removal_block}]"
+    print(f"{prefix}: {result.detail}")
+    if result.safe_to_remove:
+        return 0
+    # Merged but not a reclaim candidate gets its own non-zero code (#1341)
+    # so a caller can say FRESH instead of the misleading UNMERGED; a caller
+    # that only knows `0 == remove` still fails safe on it.
+    return 3 if result.merged else 1
 
 
 if __name__ == "__main__":

--- a/.claude/lib/tests/test_check_worktree_merged.py
+++ b/.claude/lib/tests/test_check_worktree_merged.py
@@ -288,6 +288,125 @@ class CheckWorktreeMergedTest(unittest.TestCase):
         self.assertEqual(result.status, "merged")
         self.assertEqual(result.reason, "ancestor")
         self.assertTrue(result.merged)
+        # A genuinely merged feature branch IS a reclaim candidate — the
+        # #1341 guard below must not touch this (#526's whole motivation).
+        self.assertEqual(result.removal_block, "")
+        self.assertTrue(result.safe_to_remove)
+
+    # ---- removal candidacy: the orthogonal freshness axis (#1341) -----------
+
+    def test_fresh_worktree_at_remote_tip_is_not_a_removal_candidate(self) -> None:
+        """THE #1341 CASE. A worktree branched off `remote_ref` that has not
+        committed yet has HEAD == remote_ref, which is trivially an ancestor
+        — the fast path calls it `merged` (correct about ancestry) and Step 0
+        removes a live, clean worktree out from under an active agent.
+
+        Merged-ness itself is NOT contested here: a branch with no commits of
+        its own genuinely has no unlanded content, so `status`/`merged` must
+        stay `merged` (that is the PR #1213 net-content guarantee, preserved
+        verbatim). What the fix adds is a SECOND, orthogonal predicate — is
+        there any work here to reclaim? — which is what the removal decision
+        (the CLI exit code Step 0 reads) consults."""
+        _git(["checkout", "-b", "agent-worktree"], self.repo)
+        fresh_head = _head(self.repo)
+        self.assertEqual(fresh_head, _git_ok(["rev-parse", "main"], self.repo).stdout.strip())
+
+        result = self._classify(fresh_head)
+        # Unchanged classification (the #1213 guarantee is not traded away).
+        self.assertEqual(result.status, "merged")
+        self.assertEqual(result.reason, "ancestor")
+        self.assertTrue(result.merged)
+        # ...but it is NOT a removal candidate.
+        self.assertEqual(result.removal_block, "no-own-commits")
+        self.assertFalse(result.safe_to_remove)
+
+    def test_fresh_worktree_off_older_remote_tip_is_not_a_removal_candidate(self) -> None:
+        """The aged form of the same hole: the worktree was branched off
+        `remote_ref` and `remote_ref` has since moved on, so HEAD is no
+        longer *equal* to the remote tip — only an ancestor of it. A bare
+        `HEAD == remote_ref` guard would miss this; the branch still has zero
+        commits of its own, so there is still nothing to reclaim. Sessions in
+        this org run long enough for main to advance under an idle worktree,
+        so this is the common shape, not the exotic one."""
+        _git(["checkout", "-b", "agent-worktree"], self.repo)
+        fresh_head = _head(self.repo)
+        _git(["checkout", "main"], self.repo)
+        _commit(self.repo, "later.txt", "main moved on\n", "unrelated main commit")
+        self.assertNotEqual(fresh_head, _git_ok(["rev-parse", "main"], self.repo).stdout.strip())
+
+        result = self._classify(fresh_head)
+        self.assertEqual(result.status, "merged")
+        self.assertTrue(result.merged)
+        self.assertEqual(result.removal_block, "no-own-commits")
+        self.assertFalse(result.safe_to_remove)
+
+    def test_squash_merged_branch_stays_a_removal_candidate(self) -> None:
+        """No regression on the population the sweep exists for: a squash-
+        merged branch has commits of its own (it is not on `remote_ref`'s
+        mainline at all), so it remains auto-removable."""
+        feature_tip = self._multi_commit_squash()
+
+        result = self._classify(feature_tip)
+        self.assertEqual(result.status, "merged")
+        self.assertEqual(result.reason, "content-equivalent")
+        self.assertEqual(result.removal_block, "")
+        self.assertTrue(result.safe_to_remove)
+
+    def test_unmerged_branch_is_never_a_removal_candidate(self) -> None:
+        _git(["checkout", "-b", "feature"], self.repo)
+        _commit(self.repo, "a.txt", "A\n", "never merged")
+        feature_tip = _head(self.repo)
+
+        result = self._classify(feature_tip)
+        self.assertEqual(result.status, "unmerged")
+        self.assertFalse(result.safe_to_remove)
+
+    def test_mainline_probe_failure_blocks_removal(self) -> None:
+        """The freshness guard's own `git rev-list --first-parent` failing
+        must degrade toward FLAG, not toward remove — a probe that could not
+        be run is not evidence that the branch has work of its own. The
+        merged *classification* is deliberately left intact; only removal
+        candidacy degrades."""
+        _git(["checkout", "-b", "agent-worktree"], self.repo)
+        fresh_head = _head(self.repo)
+
+        runner = _runner_intercepting("rev-list", occurrence=1, mode="fail")
+        result = classify_merged(
+            self.repo, fresh_head, "main", runner=runner, pipe_runner=_git_pipe_real
+        )
+        self.assertEqual(result.status, "merged")
+        self.assertEqual(result.removal_block, "mainline-check-failed")
+        self.assertFalse(result.safe_to_remove)
+
+    def test_mainline_probe_empty_output_blocks_removal(self) -> None:
+        """`git rev-list` over a resolvable ref always lists at least that
+        ref's own commit, so a successful-but-EMPTY chain is an unknown
+        state. Reading it as "head is not on the mainline" would fail open
+        into a removal — the exact shape of the fail-open guard the patch-id
+        path already carries."""
+        _git(["checkout", "-b", "agent-worktree"], self.repo)
+        fresh_head = _head(self.repo)
+
+        runner = _runner_intercepting("rev-list", occurrence=1, mode="empty")
+        result = classify_merged(
+            self.repo, fresh_head, "main", runner=runner, pipe_runner=_git_pipe_real
+        )
+        self.assertEqual(result.removal_block, "mainline-check-failed")
+        self.assertFalse(result.safe_to_remove)
+
+    def test_head_resolution_failure_blocks_removal(self) -> None:
+        """Same stance for the `git rev-parse --verify` that resolves HEAD to
+        a comparable SHA (Step 0 passes a raw SHA, but the CLI accepts any
+        rev): unresolvable HEAD -> flag, never remove."""
+        _git(["checkout", "-b", "agent-worktree"], self.repo)
+        fresh_head = _head(self.repo)
+
+        runner = _runner_intercepting("rev-parse", occurrence=1, mode="fail")
+        result = classify_merged(
+            self.repo, fresh_head, "main", runner=runner, pipe_runner=_git_pipe_real
+        )
+        self.assertEqual(result.removal_block, "mainline-check-failed")
+        self.assertFalse(result.safe_to_remove)
 
     # ---- test 1: net-content match ------------------------------------------
 
@@ -1036,6 +1155,21 @@ class CheckWorktreeMergedTest(unittest.TestCase):
     def test_cli_usage_error(self) -> None:
         rc = cli_main([str(self.repo)])
         self.assertEqual(rc, 2)
+
+    def test_cli_exit_code_fresh_worktree_is_not_zero(self) -> None:
+        """THE #1341 CASE, at the seam Step 0 actually reads. Step 0's whole
+        remove-vs-FLAG decision is `rc == 0`, so the exit code — not the
+        dataclass — is the load-bearing contract: a fresh, uncommitted
+        worktree must NOT return 0. It returns the dedicated code 3
+        ("merged, but nothing of its own to reclaim") so a caller can label
+        it FRESH rather than the misleading UNMERGED; every caller that only
+        knows the old `0 == remove` rule still fails safe."""
+        _git(["checkout", "-b", "agent-worktree"], self.repo)
+        fresh_head = _head(self.repo)
+
+        rc = cli_main([str(self.repo), fresh_head, "main"])
+        self.assertNotEqual(rc, 0)
+        self.assertEqual(rc, 3)
 
 
 if __name__ == "__main__":

--- a/.claude/lib/tests/test_session_start_step0_fallback.py
+++ b/.claude/lib/tests/test_session_start_step0_fallback.py
@@ -1,0 +1,142 @@
+"""Pin `/session-start` Step 0's *helper-missing* fallback (#1341).
+
+Step 0 has two classification paths, and #1341 was present in BOTH:
+
+  * the tested helper `.claude/lib/check_worktree_merged.py` (covered by
+    `test_check_worktree_merged.py`), and
+  * the inline shell fallback Step 0 uses when that helper is absent from a
+    very old checkout — which was a bare
+    ``git merge-base --is-ancestor "$head" origin/main``. A worktree that has
+    not committed yet has ``HEAD == origin/main``, so that test passes
+    trivially and Step 0 removed a clean, live worktree.
+
+Fixing only the helper would leave the same false-MERGED reachable on the
+degraded path, so the mainline guard is replicated there — and this test
+**extracts that shell block from `SKILL.md` and executes it verbatim**
+(between the ``BEGIN/END legacy-ancestry-fallback`` sentinels) rather than
+restating the logic, which would pin a copy and prove nothing about the file
+Step 0 actually runs.
+
+The block is executed under **zsh**, the org's real agent/interactive shell
+(CLAUDE.md § Shell environment) — bash-only idioms in a Step 0 edit would
+silently misbehave in production, so testing it under `sh`/`bash` would be
+testing a shell nobody runs it in.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import unittest
+from collections.abc import Sequence
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+SKILL_MD = Path(__file__).resolve().parents[3] / ".claude" / "skills" / "session-start" / "SKILL.md"
+_BEGIN = "# BEGIN legacy-ancestry-fallback"
+_END = "# END legacy-ancestry-fallback"
+
+_IDENT = [
+    "-c",
+    "user.name=Test",
+    "-c",
+    "user.email=test@example.com",
+    "-c",
+    "commit.gpgsign=false",
+]
+
+
+def _git(args: Sequence[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *_IDENT, *args], cwd=str(cwd), capture_output=True, text=True, check=True
+    )
+
+
+def _commit(repo: Path, name: str, content: str, msg: str) -> str:
+    (repo / name).write_text(content)
+    _git(["add", name], repo)
+    _git(["commit", "-m", msg], repo)
+    return _git(["rev-parse", "HEAD"], repo).stdout.strip()
+
+
+def _extract_fallback() -> str:
+    """The Step 0 fallback block, straight out of SKILL.md."""
+    text = SKILL_MD.read_text()
+    if text.count(_BEGIN) != 1 or text.count(_END) != 1:
+        raise AssertionError(
+            f"expected exactly one {_BEGIN}/{_END} sentinel pair in {SKILL_MD} — "
+            "Step 0's fallback block moved or was duplicated; this test pins it by sentinel"
+        )
+    # Take everything AFTER the sentinel's own line (a trailing remark on the
+    # sentinel line itself is a comment in SKILL.md but bare words here).
+    body = text.split(_BEGIN, 1)[1].split("\n", 1)[1].split(_END, 1)[0]
+    lines = [line for line in body.splitlines() if line.strip()]
+    if not lines:
+        raise AssertionError("SKILL.md fallback block is empty between its sentinels")
+    return "\n".join(lines)
+
+
+@unittest.skipIf(shutil.which("zsh") is None, "zsh (the org's shell) not available")
+class SessionStartStep0FallbackTest(unittest.TestCase):
+    """The shell fallback must reach the same remove/FLAG decision as the
+    helper: 0 = remove, 3 = FRESH (merged, nothing of its own), 1 = unmerged."""
+
+    def setUp(self) -> None:
+        self._tmp = TemporaryDirectory()
+        self.repo = Path(self._tmp.name) / "repo"
+        self.repo.mkdir()
+        _git(["init", "-b", "main"], self.repo)
+        _commit(self.repo, "README.md", "hello\n", "initial commit")
+        # Step 0 compares against origin/main; stand one up locally so the
+        # block runs against the exact ref name it uses in production.
+        self._sync_origin()
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def _sync_origin(self) -> None:
+        _git(["update-ref", "refs/remotes/origin/main", "main"], self.repo)
+
+    def _mrc(self, head: str) -> int:
+        script = f'repo={self.repo!s}\nhead={head}\n{_extract_fallback()}\nprintf "%s" "$_mrc"\n'
+        res = subprocess.run(["zsh", "-c", script], capture_output=True, text=True, check=False)
+        self.assertEqual(res.returncode, 0, f"fallback block errored under zsh: {res.stderr}")
+        return int(res.stdout.strip())
+
+    def test_fresh_uncommitted_worktree_is_not_removed(self) -> None:
+        """THE #1341 CASE on the degraded path: HEAD == origin/main, so the
+        old bare ancestry test said "remove" (0). It must now say FRESH (3)."""
+        fresh_head = _git(["rev-parse", "HEAD"], self.repo).stdout.strip()
+        self.assertEqual(self._mrc(fresh_head), 3)
+
+    def test_fresh_worktree_off_older_origin_main_is_not_removed(self) -> None:
+        """Still zero commits of its own after origin/main moves on — the
+        case a bare `HEAD == origin/main` equality guard would miss."""
+        fresh_head = _git(["rev-parse", "HEAD"], self.repo).stdout.strip()
+        _commit(self.repo, "later.txt", "main moved on\n", "unrelated main commit")
+        self._sync_origin()
+        self.assertEqual(self._mrc(fresh_head), 3)
+
+    def test_merge_commit_merged_branch_is_still_removed(self) -> None:
+        """No regression on #526's population: a merged feature tip is
+        reachable only through the merge's SECOND parent, so it is an
+        ancestor but not on origin/main's first-parent chain."""
+        _git(["checkout", "-b", "feature"], self.repo)
+        _commit(self.repo, "a.txt", "A\n", "feature commit")
+        feature_tip = _git(["rev-parse", "HEAD"], self.repo).stdout.strip()
+        _git(["checkout", "main"], self.repo)
+        _git(["merge", "--no-ff", "-m", "merge feature", "feature"], self.repo)
+        self._sync_origin()
+
+        self.assertEqual(self._mrc(feature_tip), 0)
+
+    def test_unmerged_branch_is_still_flagged(self) -> None:
+        _git(["checkout", "-b", "feature"], self.repo)
+        _commit(self.repo, "a.txt", "A\n", "never merged")
+        feature_tip = _git(["rev-parse", "HEAD"], self.repo).stdout.strip()
+
+        self.assertEqual(self._mrc(feature_tip), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/memory/feedback_flag_precision_decays_with_age.md
+++ b/.claude/memory/feedback_flag_precision_decays_with_age.md
@@ -29,9 +29,9 @@ force-removes, so a false `UNMERGED`/`DIRTY` costs at most a stale directory,
 while a false `merged` could cost work. What is wrong is *reading its output as a
 verdict*.
 
-**But "correctly biased" is not true in general — there is a known false-MERGED
-hole on a different axis (#1341, added 2026-08-09 within the hour of writing this
-note).** A **freshly-created worktree that has not committed yet** has
+**But "correctly biased" is not true in general — there WAS a false-MERGED hole on
+a different axis (#1341, added 2026-08-09 within the hour of writing this note;
+closed 2026-08-11).** A **freshly-created worktree that has not committed yet** has
 `HEAD == origin/main`, which is trivially an ancestor, so the `merge-base
 --is-ancestor` **fast path** classifies it `merged` and removes it — correct about
 ancestry, wrong about intent — and it fires *before* the richer patch-id
@@ -40,15 +40,29 @@ worktree for in-flight #1117. Non-force removal protects an agent that has alrea
 written files (removal refuses on uncommitted/untracked content → FLAGGED), so the
 exposed case is a **clean** fresh worktree, destroyed under an agent about to use it.
 
+**Fixed (#1341, 2026-08-11):** merged-ness and *removal candidacy* are now two
+orthogonal axes. A HEAD that is itself a commit on `origin/main`'s **first-parent**
+history has no commits of its own, so it still classifies `merged` (that is true —
+it has no unlanded content) but is no longer a reclaim candidate:
+`removal_block="no-own-commits"`, `safe_to_remove` False, CLI **exit 3**, and Step 0
+surfaces it as **FRESH** rather than removing it. First-parent membership, not
+`HEAD == origin/main` equality, because a worktree branched off an *older* main is
+the same zero-work case and equality misses it. Sweep at fix time: 5 of 17 live
+worktrees changed verdict, all of them fresh (3 owned by then-live agents), 12
+unchanged. The lesson below survives the fix — the *reading* rule is what
+generalizes, not the specific hole.
+
 So the two axes behave oppositely, and the safe reading is direction-specific:
 
 | axis | direction of error | cost |
 |---|---|---|
 | **age** (a landed branch) | false `UNMERGED` — over-flags | cheap: a stale directory |
-| **freshness** (an unstarted branch) | false `merged` — under-flags | destroys a clean live worktree |
+| **freshness** (an unstarted branch) | false `merged` — under-flags | destroys a clean live worktree (closed by #1341) |
 
 Treat `merged` as trustworthy only for a branch that has actually committed. Never
-generalize "this classifier errs safe" from the aged case to all cases.
+generalize "this classifier errs safe" from the aged case to all cases — the
+freshness hole was found *by* refusing that generalization, and the next one on
+some third axis will be too.
 
 **The operational rule:** a FLAGGED list is **candidates to verify, ordered by
 suspicion — never a batch to act on.** Verify content, not the flag: compare the

--- a/.claude/skills/session-start/SKILL.md
+++ b/.claude/skills/session-start/SKILL.md
@@ -17,7 +17,7 @@ Execute all 7 steps below. Steps that are independent of each other SHOULD run i
 
 ### Step 0 — Worktree cleanup (parent + child repos)
 
-Worktrees accumulate in the parent AND every child repo (#526 — ~33 stale child worktrees found uncaught on 2026-05-24). The block iterates all 8 repos with a **verify-merged-then-remove guard**: auto-remove only a worktree whose HEAD is fully merged into that repo's `origin/main`; FLAG (never auto-remove) anything locked, unmerged, or that fails to remove cleanly. "Fully merged" is decided by `.claude/lib/check_worktree_merged.py` (#1212, sibling of #1177; guarantee revised by owner decision 2026-08-02, PR #1213 round 3): ancestry is the fast path (the merge-commit majority); the fallback classifies `merged` iff **the branch's cumulative diff since its merge-base is fully present on `origin/main`** — a net-content test, not a per-commit one, searched over `origin/main`'s own history (not a snapshot compare against its current tip, which would decay as unrelated later commits keep touching the same files) — so a squash-merged (single- or multi-commit), rebase-merged, or cherry-picked branch is recognized as landed instead of being flagged `UNMERGED` forever just because its tip is never an ancestor. Verdicts are **order-independent**: the same commit set in a different order always classifies identically, because the primary test depends only on the branch's final tree state, never on the order of the commits that produced it (and the per-commit fallback test is order-independent too, for the separate reason that `git patch-id --stable` is invariant to the line-number shifts a commutative reorder causes) — a per-commit design (tried in an earlier round) could not provide this. A branch's own internal merge commit (round 4, PR #1213) is checked for unique conflict-resolution content (`git diff-tree --cc --no-commit-id`) that `git cherry` structurally cannot see, since `git cherry` never examines merge commits at all — this closes the one path where a merge's resolution could carry unlanded content past both other tests undetected. The disclosed residual is `git patch-id`'s own whitespace-normalization (a change indistinguishable from an already-landed one, character-for-character after whitespace is stripped, is treated as landed — the same reason `--verbatim` is deliberately not used, since it would misclassify the real #1156 fixture as unmerged); see the module docstring for the full guarantee and its two coordinated tests. The check is 100% local git plumbing (no `gh`/network dependency) and degrades to the pre-fix ancestry-only result on any internal git-command failure. **Step 0 never force-removes** (owner decision, round 3): the plain `git worktree remove` call either succeeds or the worktree is FLAGGED — the `--force` fallback that used to destroy uncommitted content on a dirty worktree is gone, so the worst a misclassification can now cost is a stale worktree directory (a commit or branch was never at risk either way, since `worktree remove` never deletes the branch ref).
+Worktrees accumulate in the parent AND every child repo (#526 — ~33 stale child worktrees found uncaught on 2026-05-24). The block iterates all 8 repos with a **verify-merged-then-remove guard**: auto-remove only a worktree whose HEAD is fully merged into that repo's `origin/main`; FLAG (never auto-remove) anything locked, unmerged, or that fails to remove cleanly. "Fully merged" is decided by `.claude/lib/check_worktree_merged.py` (#1212, sibling of #1177; guarantee revised by owner decision 2026-08-02, PR #1213 round 3): ancestry is the fast path (the merge-commit majority); the fallback classifies `merged` iff **the branch's cumulative diff since its merge-base is fully present on `origin/main`** — a net-content test, not a per-commit one, searched over `origin/main`'s own history (not a snapshot compare against its current tip, which would decay as unrelated later commits keep touching the same files) — so a squash-merged (single- or multi-commit), rebase-merged, or cherry-picked branch is recognized as landed instead of being flagged `UNMERGED` forever just because its tip is never an ancestor. Verdicts are **order-independent**: the same commit set in a different order always classifies identically, because the primary test depends only on the branch's final tree state, never on the order of the commits that produced it (and the per-commit fallback test is order-independent too, for the separate reason that `git patch-id --stable` is invariant to the line-number shifts a commutative reorder causes) — a per-commit design (tried in an earlier round) could not provide this. A branch's own internal merge commit (round 4, PR #1213) is checked for unique conflict-resolution content (`git diff-tree --cc --no-commit-id`) that `git cherry` structurally cannot see, since `git cherry` never examines merge commits at all — this closes the one path where a merge's resolution could carry unlanded content past both other tests undetected. The disclosed residual is `git patch-id`'s own whitespace-normalization (a change indistinguishable from an already-landed one, character-for-character after whitespace is stripped, is treated as landed — the same reason `--verbatim` is deliberately not used, since it would misclassify the real #1156 fixture as unmerged); see the module docstring for the full guarantee and its two coordinated tests. The check is 100% local git plumbing (no `gh`/network dependency) and degrades to the pre-fix ancestry-only result on any internal git-command failure. **Step 0 never force-removes** (owner decision, round 3): the plain `git worktree remove` call either succeeds or the worktree is FLAGGED — the `--force` fallback that used to destroy uncommitted content on a dirty worktree is gone, so the worst a misclassification can now cost is a stale worktree directory (a commit or branch was never at risk either way, since `worktree remove` never deletes the branch ref). **Merged is not the removal decision (#1341).** A worktree that has not committed yet has `HEAD == origin/main` — trivially an ancestor, so the fast path answers `merged`, *correctly* (a branch with no commits of its own has no unlanded content) — and Step 0 removed a clean, live worktree out from under an agent working in another session. The helper therefore answers a **second, orthogonal** question: does this branch have any commits of its own to reclaim? A HEAD that is itself a commit on `origin/main`'s **first-parent** history has none, so removal is withheld and the worktree is surfaced as **FRESH**, not the misleading `UNMERGED` (CLI exit **3**; exit 0 now means merged *and* a reclaim candidate, 1 means not merged — so any caller that only knows the old `0 == remove` contract still fails safe). This does not touch the population the sweep exists for: a squash/rebase-merged tip is never an ancestor at all, and a merge-commit-merged tip is reachable only via the merge's *second* parent, so neither is on the first-parent chain. Sweep over this repo's 17 live worktrees: 5 verdicts changed, every one of them a fresh not-yet-committed worktree (3 belonging to agents live at the time), 12 unchanged.
 
 ```bash
 # Anchor REPO_ROOT to the PARENT org repo deterministically (#533). Using a
@@ -121,12 +121,39 @@ for repo in "${REPOS[@]}"; do
             _mrc=$?
           else
             # Helper missing (very old checkout) — degrade to the legacy
-            # ancestry-only test rather than failing closed.
-            git -C "$repo" merge-base --is-ancestor "$head" origin/main 2>/dev/null
-            _mrc=$?
+            # ancestry-only test rather than failing closed. The #1341 guard
+            # is replicated inline here, because ancestry ALONE removes a
+            # freshly-branched worktree that has not committed yet (its HEAD
+            # IS origin/main, hence trivially an ancestor). Mainline
+            # membership is tested with a `case` glob over the first-parent
+            # SHA list rather than a pipe to grep: every line is a full
+            # 40-char object name, so a substring hit implies equality, and
+            # a bare `grep` is hard-blocked in this org (#1008).
+            # The block between the sentinels below is extracted and executed
+            # verbatim by .claude/lib/tests/test_session_start_step0_fallback.py
+            # — keep both sentinels on their own lines, and keep the block
+            # dependent only on $repo and $head.
+            # BEGIN legacy-ancestry-fallback
+            _mrc=1
             _mreason="ancestry-only (helper not found)"
+            if git -C "$repo" merge-base --is-ancestor "$head" origin/main 2>/dev/null; then
+              _mainline="$(git -C "$repo" rev-list --first-parent origin/main 2>/dev/null)"
+              case "$_mainline" in
+                *"$head"*)
+                  _mrc=3
+                  _mreason="ancestry-only (helper not found) — HEAD is on origin/main's first-parent history: no commits of its own, not a removal candidate" ;;
+                *) _mrc=0 ;;
+              esac
+            fi
+            # END legacy-ancestry-fallback
           fi
-          if [ "$_mrc" -eq 0 ]; then
+          if [ "$_mrc" -eq 3 ]; then
+            # Merged, but nothing of its own to reclaim (#1341) — a fresh,
+            # not-yet-committed worktree, very likely one a live agent in
+            # ANOTHER session is about to write into. Removal is withheld and
+            # it is surfaced under its own label, not the misleading UNMERGED.
+            FLAGGED+=("FRESH  $repo :: $wt (HEAD ${head:-?}) [$_mreason]")
+          elif [ "$_mrc" -eq 0 ]; then
             # Never force-remove (owner decision, PR #1213 round 3): a
             # worktree that does not remove cleanly (uncommitted/untracked
             # content in the way) is FLAGGED for a manual decision instead.
@@ -169,7 +196,7 @@ if [ "${#FLAGGED[@]}" -gt 0 ]; then
 fi
 ```
 
-Report merged-worktree removals and surface the FLAGGED list (locked + unmerged) for a manual call — never force-remove a FLAGGED worktree without explicit confirmation. Also report the `check_child_checkouts.py` result (#832): children fast-forwarded vs FLAGGED (dirty/diverged/feature-branch — left untouched; a child many commits behind `origin/main` is the #816 stale-config root cause).
+Report merged-worktree removals and surface the FLAGGED list (locked + unmerged + FRESH) for a manual call — never force-remove a FLAGGED worktree without explicit confirmation. A **FRESH** entry is *not* a cleanup backlog item: it is a worktree with no commits of its own, which usually means a live agent is about to write into it (#1341). Leave it alone unless you know the session that owns it is gone. Also report the `check_child_checkouts.py` result (#832): children fast-forwarded vs FLAGGED (dirty/diverged/feature-branch — left untouched; a child many commits behind `origin/main` is the #816 stale-config root cause).
 
 ### Step 1 — Team orientation
 


### PR DESCRIPTION
Closes #1341.

## The bug, in one sentence

`/session-start` Step 0 read **merged-ness as a removal decision**. A worktree that has not committed yet has `HEAD == origin/main`, which is trivially an ancestor, so the fast path answered `merged` — *correctly*, a branch with no commits of its own has no unlanded content — and Step 0 removed a clean, live worktree out from under an agent working in another session (observed on in-flight #1117 during wave-29).

## Failing before the fix

Live, against the unmodified helper, on this very worktree's pre-branch HEAD (clean, uncommitted, actively in use):

```
$ python3 .claude/lib/check_worktree_merged.py . 40cfe9ff4a328c757b7e06a36a27686af10d4203 origin/main
merged (ancestor): 40cfe9ff4a328c757b7e06a36a27686af10d4203 is an ancestor of origin/main
exit=0            # 0 => Step 0 runs `git worktree remove`
```

And the same for Step 0's helper-missing fallback path:

```
$ git merge-base --is-ancestor 40cfe9ff4a328c757b7e06a36a27686af10d4203 origin/main; echo $?
0                 # 0 => Step 0 runs `git worktree remove`
```

The new test, run against the **pre-fix** implementation:

```
$ ENVIRONMENT=test python3 -m pytest .claude/lib/tests/test_check_worktree_merged.py -q -k cli_exit_code_fresh
____ CheckWorktreeMergedTest.test_cli_exit_code_fresh_worktree_is_not_zero _____

        rc = cli_main([str(self.repo), fresh_head, "main"])
>       self.assertNotEqual(rc, 0)
E       AssertionError: 0 == 0

----------------------------- Captured stdout call -----------------------------
merged (ancestor): 3fecef4cc90b9b5e5483ab8f2efac6068d6f4439 is an ancestor of main
1 failed, 38 deselected in 0.29s
```

After the fix, the same live command:

```
$ python3 .claude/lib/check_worktree_merged.py . 40cfe9ff4a328c757b7e06a36a27686af10d4203 origin/main
merged (ancestor) [not-a-removal-candidate: no-own-commits]: 40cfe9ff4a32... is an ancestor of
origin/main; 40cfe9ff4a32 is itself a commit on origin/main's first-parent history, so this branch
has no commits of its own — a fresh/unstarted worktree with nothing to reclaim (very likely in
active use), not a removal candidate
exit=3
```

## How the PR #1213 guarantee is preserved (not traded)

The guarantee is `merged` **iff** the branch's cumulative diff since its merge-base is fully present on `remote_ref`, order-independently, with the `--cc` merge check and the disclosed patch-id whitespace residual. A fresh worktree **satisfies** that guarantee — it has no unlanded content — so reclassifying it `unmerged` would have *broken* the guarantee to fix the symptom.

Nothing in the classification changed. Not one line of the net-content test, the `git cherry` corroboration, the evil-merge `--cc` check, or their degrade paths was touched; a fresh worktree still classifies `merged`/`ancestor`, and `test_fresh_worktree_at_remote_tip_is_not_a_removal_candidate` asserts exactly that.

What is added is a **second, orthogonal predicate** that gates only the *removal* decision:

- `MergeClassification.removal_block` — `""`, `"no-own-commits"`, or `"mainline-check-failed"`.
- `MergeClassification.safe_to_remove` = `merged and not removal_block` — the new auto-remove predicate. `.merged` keeps its old meaning exactly.
- CLI exit codes: `0` merged **and** a reclaim candidate · `1` not merged · `2` usage · **`3` merged but not a reclaim candidate**. Any caller that only knows the old `0 == remove` rule still fails safe on 3.

The two axes stay independent under failure too: a probe failure blocks removal but leaves the classification intact, because a failure on one axis is not evidence about the other.

## Why first-parent membership, not `HEAD == origin/main`

The issue proposed the equality guard. It only catches a worktree branched off the **current** tip; sessions here run long enough that `origin/main` advances under an idle worktree, after which HEAD is an ancestor but no longer equal — same zero-work branch, same live agent, and equality misses it. `test_fresh_worktree_off_older_remote_tip_is_not_a_removal_candidate` pins that case.

Mainline membership does not touch #526's population: a squash- or rebase-merged tip is not an ancestor at all (never reaches the guard), and a merge-commit-merged tip is reachable only through the merge's **second** parent, so it is an ancestor but not on the first-parent chain — it stays a removal candidate. The one shape this over-flags is a fast-forward merge; GitHub's three merge buttons never fast-forward, and over-flagging costs a stale directory, which is the accepted-cheap direction.

## Both code paths, and they cannot drift

The issue noted the hole existed in the helper **and** in Step 0's inline fallback for a checkout without the helper (a bare `git merge-base --is-ancestor`). Fixing only the helper would leave the same false-MERGED reachable on the degraded path, so the guard is replicated in the shell — using a `case` glob over the first-parent SHA list, not a pipe to `grep` (hard-blocked, #1008; and every line is a full 40-char object name, so a substring hit implies equality).

`.claude/lib/tests/test_session_start_step0_fallback.py` **extracts that block from `SKILL.md` by sentinel and executes it verbatim under zsh** rather than restating the logic, which would pin a copy and prove nothing about the file Step 0 actually runs.

## Live regression sweep

Old vs new verdict over all 17 worktrees in this checkout:

| verdict change | count | which |
|---|---|---|
| `remove` -> `FLAG` (FRESH) | 5 | every one a fresh not-yet-committed worktree — including 3 owned by agents live at the time (#1254, #1272, #1399) and this PR's own |
| unchanged | 12 | 8 squash/content-equivalent merged (still auto-removed), 4 genuinely unmerged (still flagged) |

## Fail-safe review

Every new probe failure withholds removal rather than allowing it: `rev-parse --verify` failing, `rev-list --first-parent` failing, and `rev-list` succeeding but listing **nothing** (an unknown state — reading it as "not on the mainline" would fail open into a removal). Each has its own test.

## Found, not fixed

- **The blast-radius bound in the module docstring was subtly wrong and is now corrected in place.** It claimed a misclassification "can cost, at worst, a stale worktree directory ... never even uncommitted content, since a dirty worktree that fails a plain `remove` is simply left alone." That bound holds for *committed* work but never covered #1341, where the worktree destroyed was clean precisely because its agent had not written anything yet. No code change — the sentence now says so.
- **`git worktree remove` on a clean worktree with a `locked` record.** Step 0 already FLAGs `locked` worktrees before classifying, and every Claude-agent worktree here is locked, which is what kept the observed blast radius at zero in practice. That is a second, independent layer, not a substitute — a worktree created by hand or by a non-agent path carries no lock. Not filed; noted here for the reviewer's model of the defense in depth.
- **The mainline probe is O(first-parent history) per worktree per repo** (one `git rev-list` walk). Measured negligible on this repo; a bounded formulation exists but is materially harder to read, and this runs once per worktree in a step that already does a network `fetch` per repo. Deliberately not optimized.

## Gates

- `ENVIRONMENT=test pytest .claude/lib/tests/ .claude/hooks/tests/` — **4405 passed, 1037 subtests passed**.
- `pre-commit` commit-stage on all touched files — green (ruff-format, ruff-lint, cspell, checksums-ascii, skill-graphql-pagination).
- `pre-commit --hook-stage pre-push --all-files` — exit 0.
- `mypy` on the changed/added modules — clean.
- No `--no-verify`, no force. Commit identity via per-commit `-c` flags.

## Review

- Peer reviewer: **Weronika Zielinska**
- Merge gate: **Aino Virtanen**
