### PR TITLE
fix(hooks): one verdict-direction classifier, and bare `Changes` is a verdict (#1371)

### DIFF
--- a/.claude/hooks/tests/test_validate_review_comment_format.py
+++ b/.claude/hooks/tests/test_validate_review_comment_format.py
@@ -1045,9 +1045,9 @@ class ConditionalVerdictFieldTests(unittest.TestCase):
 
     def test_spaced_and_bare_changes_spellings_are_accepted(self):
         # Must agree with `_direction_is_changes_requested` (and, through it,
-        # `charter_trailer.verdict_kind(..., include_bare_changes=True)`,
-        # main#1359), which counts all three spellings — including the bare
-        # `Changes` that `_VERDICT_DIRECTIONS` deliberately excludes.
+        # `charter_trailer.is_changes_requested`, main#1359/#1371), which
+        # counts all three spellings — including the bare `Changes` that the
+        # retired `_VERDICT_DIRECTIONS` excluded.
         for direction in ("ChangesRequested", "Changes Requested", "Changes"):
             with self.subTest(direction=direction):
                 result = self._check(

--- a/.claude/hooks/tests/test_validate_review_comment_format_failopen.py
+++ b/.claude/hooks/tests/test_validate_review_comment_format_failopen.py
@@ -604,13 +604,28 @@ class TrailerHelperSingularityTests(unittest.TestCase):
         private `_verdict_kind` / `_normalize_verdict_token` pair this exact
         sweep would have caught (verified against the pre-#1359 tree — the
         sweep found `lib/trust_signals.py:normalize_verdict_token` and
-        `lib/trust_signals.py:verdict_kind`)."""
+        `lib/trust_signals.py:verdict_kind`).
+
+        The three PREDICATES joined in main#1371. The `_?` prefix is what
+        makes them worth listing: the copies that change removed were named
+        `_is_verdict` / `_is_approved` (`validate_pr_review`) and
+        `_is_changes_requested` (`trust_signals`), so a reintroduced `def
+        _is_approved(` or `def _is_changes_requested(` is caught here by the
+        underscore branch. `_is_verdict` is a different WORD, not a prefixed
+        form of `is_verdict_direction`, so this sweep cannot see it — that one
+        is pinned by identity instead
+        (`test_verdict_direction_agreement.PredicateSingularityTests`), which
+        is the stronger guard and the reason a name-based sweep is never the
+        only one."""
         defs = {
             "strip_code_regions",
             "trailer_block_substring",
             "extract_charter_field",
             "verdict_kind",
             "normalize_verdict_token",
+            "is_verdict_direction",
+            "is_changes_requested",
+            "is_approved",
         }
         searched = sorted(_HOOKS_DIR.glob("*.py")) + sorted(_LIB_DIR.glob("*.py"))
         self.assertGreater(len(searched), 20, "file sweep found almost nothing — verify the glob")

--- a/.claude/hooks/tests/test_validate_review_comment_format_parser.py
+++ b/.claude/hooks/tests/test_validate_review_comment_format_parser.py
@@ -215,13 +215,29 @@ class DirectionVerdictHelperTests(unittest.TestCase):
     def test_unknown_not_verdict(self):
         self.assertFalse(hook._direction_is_verdict(self._body("Asdf")))
 
-    def test_bare_changes_not_verdict(self):
-        """`Changes` alone (without `Requested`) is NOT a verdict — must NOT match.
+    def test_bare_changes_is_a_verdict(self):
+        """`Changes` alone IS a verdict direction as of main#1371 — INVERTED.
 
-        Defensive guard: tolerating the bare prefix would over-narrow and
-        leave legitimate non-verdict comments mis-classified as verdicts.
+        This assertion read `assertFalse` from #378 until main#1371, pinning
+        the retired `_VERDICT_DIRECTIONS` exclusion of the bare spelling on
+        the stated grounds that "tolerating the bare prefix would over-narrow
+        and leave legitimate non-verdict comments mis-classified as verdicts".
+
+        That reasoning does not survive contact with the consumer. This hook
+        does not adjudicate whether a verdict word is well-formed — its own
+        module docstring hands that to `validate_pr_review` and fails OPEN on
+        anything it does not recognize — and `validate_pr_review._is_verdict`
+        has counted bare `Changes` as a verdict since #147. So the exclusion
+        made the gate's grammar narrower than the consumer's (main#1150) and
+        the swap heuristic simply never ran on a bare-`Changes` verdict, while
+        `_direction_is_changes_requested` (main#1363) called the same comment
+        blocking. One comment, two answers, in one file.
+
+        Flipping it can only ADD blocks, never remove them: the swap check now
+        applies to a direction it previously skipped. See
+        `test_verdict_direction_agreement.py` for the cross-consumer matrix.
         """
-        self.assertFalse(hook._direction_is_verdict(self._body("Changes")))
+        self.assertTrue(hook._direction_is_verdict(self._body("Changes")))
 
     def test_empty_value_not_verdict(self):
         self.assertFalse(hook._direction_is_verdict("Requestor: A\nRequestOrReplied: "))

--- a/.claude/hooks/tests/test_verdict_direction_agreement.py
+++ b/.claude/hooks/tests/test_verdict_direction_agreement.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+"""Every consumer of the `RequestOrReplied:` direction must agree (main#1371).
+
+Verdict-direction classification was implemented FOUR times after main#1359
+extracted the vocabulary:
+
+  * `validate_review_comment_format._VERDICT_DIRECTIONS` + `._direction_is_verdict`
+        first-1-and-first-2-token join against a frozenset; EXCLUDED bare `Changes`.
+  * `validate_review_comment_format._direction_is_changes_requested`
+        first-token alnum normalisation; INCLUDED bare `Changes` (main#1363,
+        deliberately, so the gate would share the grammar of the counter it
+        guards).
+  * `validate_pr_review._is_verdict` + `._VERDICT_REQUIRING_TECH_DEBT`
+        whole-value lowercase + `rstrip("*")` + exact-set membership.
+  * `validate_pr_review._is_approved`
+        whole-value lowercase + `rstrip("*")` + `== "approved"`.
+
+Four algorithms, three answers for bare `Changes`, and — the axis nobody had
+written down — two different *extractions*: the two hook-local predicates read
+the FIRST raw `re.search(r"RequestOrReplied:\\s*(.+)")` hit over the whole
+un-stripped body, while the counter reads `charter_trailer
+.extract_charter_field`'s code-stripped, trailer-scoped, last-match-wins value.
+Agreeing on the vocabulary but not on WHICH TEXT is classified is half an
+agreement; #934 fixed exactly this for the `Requestor` field in this same hook
+and left `RequestOrReplied` on the raw first match.
+
+THIS FILE IS THE PRE-FIX FAILURE. Against the parent of the main#1371 commit,
+`AgreementMatrixTests` and `SwapGateReadsTheValueTheCounterReadsTests` fail;
+`PredicateSingularityTests` fails at import (the shared predicates do not
+exist yet). Run:
+
+    python3 -m pytest .claude/hooks/tests/test_verdict_direction_agreement.py
+"""
+
+from __future__ import annotations
+
+import unittest
+from typing import ClassVar
+from unittest import mock
+
+import _test_helpers
+
+# `_test_helpers`' import side effect puts the hooks dir and the lib dir on
+# `sys.path`, so it MUST be imported before the four modules below. It is here
+# on the strength of alphabetical ordering alone — a leading underscore sorts
+# first, so ruff's isort keeps it there — plus this statement, which breaks the
+# import block so the sort cannot move anything across it. See `_test_helpers`
+# § docstring for the failure mode (an autofix silently relocating a bootstrap
+# import after the import that needs it).
+_LIB_DIR = _test_helpers.LIB_DIR
+
+import charter_trailer as ct  # noqa: E402
+import trust_signals as ts  # noqa: E402
+import validate_pr_review as counting  # noqa: E402
+import validate_review_comment_format as fmt  # noqa: E402
+
+
+def _body(direction: str) -> str:
+    """A minimal charter comment carrying `direction` in a real trailer block."""
+    return (
+        "Looks correct.\n\n"
+        "---\n"
+        "Requestor: Nadia Khoury\n"
+        "Requestee: Aino Virtanen\n"
+        f"RequestOrReplied: {direction}\n"
+        "TechDebt: none\n"
+    )
+
+
+# The full spelling matrix. Every row is a `RequestOrReplied:` value that has
+# been typed, or is one keystroke away from a value that has been typed, in
+# this org's PR threads. `kind` is the answer `charter_trailer.verdict_kind`
+# gives — the ONE classifier every consumer must now route through.
+#
+# The rows marked `# div` are where the four pre-main#1371 implementations
+# disagreed with each other. They are not decoration: each one is a comment
+# that the format gate blesses as a verdict and the counting gate scores as
+# zero reviews, or vice versa.
+SPELLINGS: tuple[tuple[str, str], ...] = (
+    ("Approved", "approved"),
+    ("approved", "approved"),
+    ("APPROVED", "approved"),
+    ("**Approved**", "approved"),
+    ("Approved (post-merge)", "approved"),
+    ("Approved!", "approved"),  # div: exact-set members rejected the `!`
+    ("Approved with nits", "approved"),  # div: trailing words, no parens
+    ("Approved - see below", "approved"),  # div
+    ("ChangesRequested", "changesrequested"),
+    ("changesrequested", "changesrequested"),
+    ("**ChangesRequested**", "changesrequested"),
+    ("ChangesRequested.", "changesrequested"),  # div: trailing period
+    ("Changes Requested", "changesrequested"),
+    ("Changes REQUESTED", "changesrequested"),
+    ("Changes  Requested", "changesrequested"),  # div: double space
+    ("**Changes** Requested", "changesrequested"),  # div: inner bolding
+    ("Changes", "changesrequested"),  # div: THE crux row
+    ("changes", "changesrequested"),  # div
+    ("Changes needed", "changesrequested"),  # div
+    ("Request", "request"),
+    ("Reply", "reply"),
+    ("Replied", "reply"),
+    ("Pending", ""),
+    ("Maybe", ""),
+    ("Not Approved", ""),
+)
+
+_VERDICT_KINDS = frozenset({"approved", "changesrequested"})
+
+
+class AgreementMatrixTests(unittest.TestCase):
+    """One classifier, so every consumer gives the same answer on every row.
+
+    A future divergence is a FAILURE here rather than a discovery in a merge
+    thread six weeks later (main#1371 acceptance criterion 3).
+    """
+
+    def test_format_gate_verdict_scope_matches_the_counter(self) -> None:
+        """`_direction_is_verdict` gates the Requestor/Requestee swap check;
+        `_is_verdict` decides what the merge gate treats as a verdict. A gate
+        narrower than the consumer it guards is the #1150 defect class — and
+        pre-fix these two disagreed on 9 of the 25 rows below.
+        """
+        for value, kind in SPELLINGS:
+            with self.subTest(value=value):
+                self.assertEqual(
+                    fmt._direction_is_verdict(_body(value)),
+                    counting._is_verdict(value),
+                    f"format gate and counting gate disagree on {value!r}",
+                )
+                self.assertEqual(
+                    counting._is_verdict(value),
+                    kind in _VERDICT_KINDS,
+                    f"counting gate disagrees with the shared classifier on {value!r}",
+                )
+
+    def test_changes_requested_predicate_matches_trust_signals(self) -> None:
+        """The blocking question, asked by the conditional-field gate
+        (main#1363) and by `trust_signals`' retraction/attribution gating."""
+        for value, kind in SPELLINGS:
+            with self.subTest(value=value):
+                self.assertEqual(
+                    fmt._direction_is_changes_requested(_body(value)),
+                    ts._is_changes_requested(value),
+                    f"format gate and trust_signals disagree on {value!r}",
+                )
+                self.assertEqual(
+                    ts._is_changes_requested(value),
+                    kind == "changesrequested",
+                    f"trust_signals disagrees with the shared classifier on {value!r}",
+                )
+
+    def test_approved_predicate_matches_the_shared_classifier(self) -> None:
+        """`_is_approved` is the 2-reviewer threshold's whole input."""
+        for value, kind in SPELLINGS:
+            with self.subTest(value=value):
+                self.assertEqual(
+                    counting._is_approved(value),
+                    kind == "approved",
+                    f"approver set disagrees with the shared classifier on {value!r}",
+                )
+
+    def test_bare_changes_is_the_same_answer_everywhere(self) -> None:
+        """The crux row, called out on its own so a regression names itself.
+
+        Pre-fix: `_is_verdict("Changes")` True, `_direction_is_changes_requested`
+        True, `_direction_is_verdict` False. A bare-`Changes` verdict was
+        simultaneously a blocking ChangesRequested (so `Retracted:` was allowed
+        on it) and not-a-verdict (so the swap check never ran on it).
+        """
+        for value in ("Changes", "changes", "**Changes**"):
+            with self.subTest(value=value):
+                self.assertTrue(counting._is_verdict(value))
+                self.assertTrue(ts._is_changes_requested(value))
+                self.assertTrue(fmt._direction_is_changes_requested(_body(value)))
+                self.assertTrue(
+                    fmt._direction_is_verdict(_body(value)),
+                    "bare `Changes` is a ChangesRequested verdict to the counter, so the "
+                    "swap gate must apply to it too",
+                )
+                self.assertFalse(counting._is_approved(value))
+
+
+class SwapGateReadsTheValueTheCounterReadsTests(unittest.TestCase):
+    """The extraction axis: same vocabulary, different text, opposite answers.
+
+    `_direction_is_verdict` read the FIRST raw `RequestOrReplied:` hit anywhere
+    in the body. A reviewer who quotes or narrates an earlier direction above
+    their trailer therefore had the swap heuristic decided by their prose.
+    #934 fixed precisely this for `Requestor:` in this hook ("the swap
+    heuristic must read the Requestor the COUNTING hook reads — never the
+    first `re.search` hit over the whole body") and left `RequestOrReplied:`
+    on the raw first match.
+    """
+
+    BRANCH: ClassVar[str] = "L.Ferreira/1371-x"
+
+    @staticmethod
+    def _cmd(body: str) -> str:
+        return "gh pr comment 42 --repo noorinalabs/noorinalabs-main --body '" + body + "'"
+
+    def _check(self, body: str):
+        with mock.patch.object(fmt, "get_branch_name", return_value=self.BRANCH):
+            return fmt.check(_test_helpers.bash_input(self._cmd(body)))
+
+    # -- fail-OPEN: prose above the trailer suppressed the swap check -------- #
+
+    _PROSE_REPLY_ABOVE_APPROVED_TRAILER = (
+        "Earlier in this thread I posted RequestOrReplied: Reply and never "
+        "followed up. Doing so now.\n\n"
+        "---\n"
+        "Requestor: Lucas Ferreira\n"
+        "Requestee: Santiago Ferreira\n"
+        "RequestOrReplied: Approved\n"
+        "TechDebt: none\n"
+    )
+
+    def test_prose_direction_no_longer_suppresses_the_swap_block(self) -> None:
+        """Requestor IS the branch author — a genuine swap — and pre-fix it was
+        ALLOWED, because the first `RequestOrReplied:` hit was the prose
+        `Reply` and the verdict-scope gate returned early.
+
+        The counter reads the trailer's `Approved`, counts the comment as a
+        verdict, and self-review-excludes the swapped Requestor — so the real
+        reviewer's approval lands under the author's name and evaporates. That
+        is the #932 uncountable-verdict shape, reached through the one gate
+        that exists to catch it.
+        """
+        result = self._check(self._PROSE_REPLY_ABOVE_APPROVED_TRAILER)
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result.get("decision"), "block")
+        self.assertIn("swapped", result.get("reason", ""))
+
+    # -- fail-CLOSED: prose above a genuinely out-of-scope trailer ----------- #
+
+    _PROSE_APPROVED_ABOVE_REPLY_TRAILER = (
+        "You asked whether I would post RequestOrReplied: Approved here — not "
+        "yet, this is only a reply.\n\n"
+        "---\n"
+        "Requestor: Lucas Ferreira\n"
+        "Requestee: Santiago Ferreira\n"
+        "RequestOrReplied: Reply\n"
+        "TechDebt: none\n"
+    )
+
+    def test_prose_verdict_no_longer_drags_a_reply_into_scope(self) -> None:
+        """The mirror image: a Reply trailer whose prose mentions `Approved`.
+
+        Request/Reply invert the Direction table's role bindings (#378), so the
+        swap heuristic is unsound there — Requestor IS the PR author by
+        definition. Pre-fix the prose hit dragged this into verdict scope and
+        the hook BLOCKED a correctly-formed reply.
+        """
+        self.assertIsNone(self._check(self._PROSE_APPROVED_ABOVE_REPLY_TRAILER))
+
+    def test_fenced_example_no_longer_decides_the_direction(self) -> None:
+        """A reviewer documenting the charter template inside a fence.
+
+        `extract_charter_field` strips code regions (main#1359/#1361); the raw
+        `re.search` did not, so the fenced example's direction won.
+        """
+        body = (
+            "The template is:\n\n"
+            "```\n"
+            "Requestor: <reviewer>\n"
+            "RequestOrReplied: Reply\n"
+            "```\n\n"
+            "---\n"
+            "Requestor: Lucas Ferreira\n"
+            "Requestee: Santiago Ferreira\n"
+            "RequestOrReplied: Approved\n"
+            "TechDebt: none\n"
+        )
+        result = self._check(body)
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result.get("decision"), "block")
+
+
+class ConditionalFieldGateFollowsTrustSignalsTests(unittest.TestCase):
+    """The `Retracted:` / `OrchestratorCaused:` gate vs. the consumer it guards.
+
+    main#1363 reconciled this gate's VOCABULARY with `trust_signals`. It did
+    not reconcile the EXTRACTION, and the gate read the first raw
+    `RequestOrReplied:` hit anywhere in the body while `trust_signals` reads a
+    line-anchored (`^…$`) first match — so a reviewer merely MENTIONING a
+    direction mid-sentence flipped the gate and not the consumer.
+    """
+
+    @staticmethod
+    def _cmd(body: str) -> str:
+        return "gh pr comment 42 --repo noorinalabs/noorinalabs-main --body '" + body + "'"
+
+    def _check(self, body: str):
+        with mock.patch.object(fmt, "get_branch_name", return_value="A.Virtanen/1371-x"):
+            return fmt.check(_test_helpers.bash_input(self._cmd(body)))
+
+    _PROSE_MENTION_ABOVE_A_RETRACTING_TRAILER = (
+        "You asked whether I would post RequestOrReplied: Approved here — not "
+        "yet; my must-fix was wrong and I am withdrawing it.\n\n"
+        "---\n"
+        "Requestor: Nadia Khoury\n"
+        "Requestee: Aino Virtanen\n"
+        "RequestOrReplied: ChangesRequested\n"
+        "TechDebt: none\n"
+        "Retracted: my finding was wrong.\n"
+    )
+
+    def test_prose_mention_no_longer_false_blocks_a_retraction(self) -> None:
+        """Pre-fix this BLOCKED, saying `Retracted:` is "only meaningful on a
+        ChangesRequested verdict" about a comment whose verdict IS
+        ChangesRequested — and whose retraction `trust_signals` honours.
+
+        `parse_verdicts` is unaffected by the prose (its regex is line-anchored,
+        so a mid-sentence mention is not a field) and returns
+        `false_positive=True`. The gate now agrees.
+        """
+        self.assertTrue(
+            ts.parse_verdicts([self._PROSE_MENTION_ABOVE_A_RETRACTING_TRAILER])[0].false_positive,
+            "instrument check: trust_signals must honour this retraction, or the "
+            "assertion below proves nothing",
+        )
+        self.assertIsNone(self._check(self._PROSE_MENTION_ABOVE_A_RETRACTING_TRAILER))
+
+    _LINE_ANCHORED_MENTION_ABOVE_A_RETRACTING_TRAILER = (
+        "RequestOrReplied: Approved\n\nwas my earlier call; I am withdrawing "
+        "the must-fix I raised after it.\n\n"
+        "---\n"
+        "Requestor: Nadia Khoury\n"
+        "Requestee: Aino Virtanen\n"
+        "RequestOrReplied: ChangesRequested\n"
+        "TechDebt: none\n"
+        "Retracted: my finding was wrong.\n"
+    )
+
+    def test_line_anchored_mention_is_the_known_residual_divergence(self) -> None:
+        """The shape where the gate and its consumer still disagree — PINNED
+        so it is a documented residual, not a latent surprise (main#1371).
+
+        `trust_signals._FIELD_RE["verdict"]` is line-anchored over the RAW
+        body and first-match, so it reads the stray line and silently drops
+        the retraction. The gate reads the trailer and stays quiet. Nothing
+        merges wrongly — the author simply is not warned that their
+        `Retracted:` will be ignored.
+
+        The repair is `trust_signals` routing through
+        `charter_trailer.extract_charter_field` (#932/#934's declared single
+        source of truth for field extraction), which is the same axis main#1372
+        owns for the presence pair. When that lands, THIS TEST MUST FLIP: the
+        `assertFalse` becomes `assertTrue` and the gate's silence becomes
+        correct rather than merely harmless.
+        """
+        body = self._LINE_ANCHORED_MENTION_ABOVE_A_RETRACTING_TRAILER
+        self.assertFalse(
+            ts.parse_verdicts([body])[0].false_positive,
+            "trust_signals now honours this retraction — the divergence is gone, "
+            "so flip this test rather than deleting it",
+        )
+        self.assertIsNone(self._check(body))
+
+
+class PredicateSingularityTests(unittest.TestCase):
+    """No local pattern set, no local algorithm — the predicates ARE the shared ones."""
+
+    def test_counting_hook_predicates_are_the_shared_objects(self) -> None:
+        self.assertIs(counting._is_verdict, ct.is_verdict_direction)
+        self.assertIs(counting._is_approved, ct.is_approved)
+
+    def test_format_hook_has_no_private_direction_table(self) -> None:
+        self.assertFalse(
+            hasattr(fmt, "_VERDICT_DIRECTIONS"),
+            "the frozenset was the fourth copy — it must not come back",
+        )
+
+    def test_counting_hook_has_no_private_verdict_table(self) -> None:
+        self.assertFalse(
+            hasattr(counting, "_VERDICT_REQUIRING_TECH_DEBT"),
+            "the exact-match set was the third copy — it must not come back",
+        )
+
+    def test_trust_signals_uses_the_named_predicate(self) -> None:
+        self.assertIs(ts._is_changes_requested, ct.is_changes_requested)
+
+    def test_include_bare_changes_is_only_load_bearing_for_changesrequested(self) -> None:
+        """`is_approved` takes no `include_bare_changes` knob, and provably
+        needs none: bare `Changes` can never classify as approved either way.
+
+        This is why the consolidation has TWO questions and not three.
+        """
+        for value, _kind in SPELLINGS:
+            with self.subTest(value=value):
+                self.assertEqual(
+                    ct.verdict_kind(value, include_bare_changes=True) == "approved",
+                    ct.verdict_kind(value, include_bare_changes=False) == "approved",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/hooks/validate_pr_review.py
+++ b/.claude/hooks/validate_pr_review.py
@@ -271,7 +271,9 @@ from charter_trailer import (
     branch_author_first_initial,
     extract_branch_author_lastname,
     extract_charter_field,
+    is_approved,
     is_branch_author,
+    is_verdict_direction,
     is_wave_branch,
     name_first_initial,
     name_lastname,
@@ -1399,47 +1401,48 @@ class CommentReviewResult:
         self.undetermined: str = ""  # non-empty ⇒ scan incomplete, caller must fail closed
 
 
-# Only these RequestOrReplied values represent actual review verdicts that
-# REQUIRE the TechDebt attestation line. Request / Reply comments are
-# process metadata (review requests, author replies) and do NOT require it.
-# Issue #147: the prior implementation flagged any Requestee+RequestOrReplied
-# comment, which over-enforced TechDebt on Request/Replied traffic.
+# The verdict-direction questions have ONE implementation, in
+# `charter_trailer` (main#1359 extracted the vocabulary, main#1371 the
+# predicates). These module-level ALIASES keep the historical private names —
+# and their existing test surface, plus the read-back recipe the charter
+# prescribes (`agents/orchestration-model.md`, memory
+# `feedback_pr_review_verdict_format` §7, both of which import `_is_approved`
+# by name) — while making a second, drifting copy impossible. Do NOT
+# reimplement them here.
 #
-# Includes both the canonical `ChangesRequested` (one word, charter-line-14)
-# and the spaced/short variants observed in practice.
-_VERDICT_REQUIRING_TECH_DEBT = {
-    "approved",
-    "changes requested",
-    "changesrequested",
-    "changes",
-}
-
-
-def _is_verdict(value: str) -> bool:
-    """Return True if a RequestOrReplied value is an actual review verdict.
-
-    Comparison is case-insensitive and whitespace-trimmed. Accepts the
-    canonical `ChangesRequested` (per charter line 14), the spaced
-    `Changes Requested` form, and the shorter `Changes` variant noted in
-    charter discussion as seen in practice. Does NOT accept Request (a
-    review request) or Reply / Replied (an author's reply).
-    """
-    normalized = value.strip().lower()
-    # Strip trailing markdown markers and stray punctuation
-    normalized = normalized.rstrip("*").strip()
-    return normalized in _VERDICT_REQUIRING_TECH_DEBT
-
-
-def _is_approved(value: str) -> bool:
-    """Return True if a RequestOrReplied value is specifically Approved.
-
-    The 2-reviewer rule (charter line 36) counts distinct Requestor values
-    across `Approved` comments only — NOT ChangesRequested. A
-    ChangesRequested comment is a verdict (TechDebt required) but does not
-    contribute to the 2-reviewer threshold.
-    """
-    normalized = value.strip().lower().rstrip("*").strip()
-    return normalized == "approved"
+# What they replace:
+#   `_VERDICT_REQUIRING_TECH_DEBT` — a frozenset of four literal spellings,
+#       matched by lowercasing and `rstrip("*")`ing the WHOLE value, then
+#       testing exact membership. Issue #147 introduced it so TechDebt was
+#       demanded on verdicts (Approved / ChangesRequested) and not on
+#       Request/Reply process traffic; that scope is unchanged.
+#   `_is_verdict` / `_is_approved` — the two readers of it.
+#
+# THIS WIDENS WHAT THE MERGE GATE COUNTS, in both directions, because
+# `charter_trailer.verdict_kind` classifies the first token after stripping
+# non-alphanumerics rather than exact-matching the whole value. Reachable
+# end-to-end (these values survive `extract_charter_field`'s own bold and
+# trailing-parenthetical stripping and arrive here intact):
+#
+#   `Approved!`, `Approved with nits`, `Approved - see below`
+#       were NOT verdicts and NOT approvals; now both. **This enlarges the
+#       2-reviewer approver set** — the one loosening in main#1371, called
+#       out here rather than left to be discovered. The alternative is the
+#       main#932 shape: `validate_review_comment_format` has always matched
+#       these on the first token, so the reviewer is told their verdict is
+#       well-formed while this hook counts it as zero reviews.
+#   `Changes  Requested` (double space), `**Changes** Requested`,
+#   `Changes needed`, `ChangesRequested.`
+#       were NOT verdicts; now blocking verdicts requiring TechDebt. Strictly
+#       stricter, and the same narrow-capture defect main#1347/#1357 fixed in
+#       the sibling counters.
+#
+# A hedge that is not an approval is unaffected: `Not Approved` does not lead
+# with the token and classifies as nothing at all, before and after. See
+# `charter_trailer` § "The questions, as named predicates" for the bare-
+# `Changes` ruling and `test_verdict_direction_agreement.py` for the matrix.
+_is_verdict = is_verdict_direction
+_is_approved = is_approved
 
 
 # The charter trailer convention has ONE definition, shared with

--- a/.claude/hooks/validate_review_comment_format.py
+++ b/.claude/hooks/validate_review_comment_format.py
@@ -250,6 +250,8 @@ from charter_trailer import (
     extract_branch_author_lastname,
     extract_charter_field,
     is_branch_author,
+    is_changes_requested,
+    is_verdict_direction,
     name_lastname,
     strip_code_regions,
 )
@@ -733,23 +735,20 @@ def get_branch_name(pr_number: str, repo: str | None = None) -> str | None:
 # asserts this module's binding IS `charter_trailer`'s.
 
 
-# Verdict direction values from charter `pull-requests.md` § Comment-Based
-# Reviews Direction table. These are the rows where the swap heuristic is
-# sound (Requestee = PR-author).
+# The verdict-direction vocabulary lives in `charter_trailer` (main#1359,
+# main#1371) — do NOT reintroduce a local table here.
 #
-# Tolerated form variants: validate_pr_review counts the literal
-# "Changes Requested" (with space) per `feedback_pr_review_verdict_format`,
-# while some templates and older fixtures use the camelCase "ChangesRequested".
-# Both are accepted here. Comparison is case-insensitive on the canonical token
-# match. The bare "Changes" prefix is NOT a verdict on its own — we require
-# the full token (with or without internal space) to avoid false-narrowing.
-_VERDICT_DIRECTIONS = frozenset(
-    {
-        "approved",
-        "changesrequested",
-        "changes requested",
-    }
-)
+# What used to sit at this line was `_VERDICT_DIRECTIONS`, a frozenset matched
+# by joining the first one-or-two tokens of the value, which deliberately
+# EXCLUDED bare `Changes` on the grounds that it "is NOT a verdict on its own".
+# main#1371 retracted that: this hook validates FORM and explicitly fails open
+# on unrecognized directions ("Validating the verdict word itself is covered by
+# a sibling hook", § Scope above), and the sibling counts bare `Changes` as a
+# verdict — so the exclusion was a gate scoped more narrowly than the consumer
+# it guards (main#1150), not a second question. It let a swapped bare-`Changes`
+# verdict past the swap gate while `validate_pr_review` counted it. See
+# `charter_trailer` § "The questions, as named predicates" for the evidence and
+# the full behaviour-change table.
 
 
 # main#1364 / main#1366: two OPTIONAL trailer fields that `trust_signals.py`
@@ -792,13 +791,52 @@ _VERDICT_DIRECTIONS = frozenset(
 #      `._ORCHESTRATOR_CAUSED_RE`, because `charter_trailer.extract_charter_field`
 #      narrows to the trailer block and this predicate deliberately does not
 #      (main#1359 extracted the STRIPPER and the verdict-KIND vocabulary, not
-#      this presence-detection pair — tracked separately, main#1371/#1372).
+#      this presence-detection pair — tracked separately, main#1372).
+#
+# NOTE (main#1371): the scope split above is now asymmetric WITHIN this gate.
+# `_direction_is_changes_requested` reads the trailer-scoped, code-stripped,
+# last-match value (`charter_trailer.extract_charter_field`) while
+# `_conditional_fields_present` still scans the WHOLE code-stripped body. The
+# presence half is right by construction — `trust_signals._RETRACTION_RE` /
+# `._ORCHESTRATOR_CAUSED_RE` are whole-body, so scoping it to the trailer
+# would re-open MF1.
+#
+# THE DIRECTION HALF IS A CHOICE BETWEEN TWO CONSUMERS THAT DISAGREE WITH EACH
+# OTHER, and it is worth stating plainly rather than implying agreement it
+# does not have. This comment's verdict direction is read by:
+#
+#   validate_pr_review   via `charter_trailer.extract_charter_field` —
+#                        code-stripped, trailer-scoped, LAST match.
+#   trust_signals        via its own private `_FIELD_RE["verdict"]` —
+#                        raw body, line-anchored (`^…$`, MULTILINE), FIRST
+#                        match. NOT the shared extractor.
+#
+# On a well-formed comment (fields only in the trailer) the two agree and so
+# does this gate. They diverge on a comment that carries a `RequestOrReplied:`
+# line ABOVE its trailer, and no single reading can match both:
+#
+#   prose mid-sentence ("…post RequestOrReplied: Approved here — not yet")
+#       trust_signals: not line-anchored, so it reads the TRAILER. The old raw
+#       `re.search` here read the prose and BLOCKED a legitimate retraction
+#       comment its consumer would have honoured. main#1371 fixes that.
+#   a line-anchored `RequestOrReplied: Approved` above the trailer
+#       trust_signals reads the PROSE line and silently drops the retraction;
+#       this gate now reads the trailer and stays quiet, so the author is not
+#       warned. Advisory shortfall, not a merge-gate fail-open — the strictly
+#       better trade against an unblockable false positive.
+#
+# The real repair is `trust_signals._FIELD_RE` routing through
+# `charter_trailer.extract_charter_field`, the declared single source of truth
+# for charter field extraction (#932/#934). That is the SAME axis-3 scope
+# question main#1372 owns for the presence pair, is out of scope here, and is
+# reported on main#1371 rather than fixed in passing. Do not "tidy" these two
+# halves onto one scope before it lands.
 #
 # The field-presence definitions below still mirror the counter's regexes
 # (axis 1 + axis 3 remain open) and are pinned against it by
 # `ConditionalFieldGrammarAgreementTests`, which drives both implementations
 # over one corpus so a future divergence reds rather than silently
-# false-blocks. Full consolidation of this remaining pair is main#1371/#1372.
+# false-blocks. Full consolidation of this remaining pair is main#1372.
 _CONDITIONAL_VERDICT_FIELDS = ("Retracted", "OrchestratorCaused")
 
 # Mirrors trust_signals._RETRACTION_RE / ._ORCHESTRATOR_CAUSED_RE.
@@ -848,75 +886,77 @@ def _conditional_fields_present(body: str) -> list[str]:
     ]
 
 
+def _direction_value(body: str) -> str | None:
+    """The `RequestOrReplied:` value THE COUNTING HOOK reads, not the first hit.
+
+    Both direction predicates below classify this. They used to classify a raw
+    ``re.search(r"RequestOrReplied:\\s*(.+)", body)`` — the FIRST occurrence
+    anywhere in the un-stripped body — while `validate_pr_review` reads
+    `extract_charter_field`'s code-stripped, trailer-scoped, last-match-wins
+    value. Sharing the vocabulary but not the TEXT is half an agreement, and
+    the half that was missing broke this hook in both directions (main#1371):
+
+      fail-OPEN    a reviewer narrating an earlier direction above their
+                   trailer — "Earlier I posted RequestOrReplied: Reply" —
+                   made `_direction_is_verdict` False, so `check()` returned
+                   at the verdict-scope gate and the swap heuristic never ran
+                   on the genuine `Approved` trailer below it. The counter
+                   read that trailer, counted the verdict, and self-review-
+                   excluded the swapped Requestor: the real reviewer's
+                   approval recorded under the author's name and evaporating,
+                   which is the main#932 uncountable-verdict shape reached
+                   through the one gate built to catch it.
+
+      fail-CLOSED  the mirror image — prose mentioning `Approved` above a
+                   genuine `Reply` trailer dragged a correctly-formed reply
+                   into verdict scope, where Requestor IS the PR author by
+                   the Direction table's own binding (#378), and BLOCKED it.
+                   No observable-body workaround: the prose is the comment.
+
+    Also inherits code-region stripping for free, so a fenced example of the
+    charter template no longer decides the direction (main#1359/#1361).
+
+    This is #934's `Requestor:` fix — "the swap heuristic must read the
+    Requestor the COUNTING hook reads … never the first `re.search` hit over
+    the whole body" — finally applied to the sibling field it left behind.
+    `check()` reaches these predicates only after gate 2 has established that
+    this field parses, so the value is non-None there.
+    """
+    return extract_charter_field(CHARTER_FIELD, body)
+
+
 def _direction_is_changes_requested(body: str) -> bool:
     """True if the `RequestOrReplied:` value is specifically ChangesRequested.
 
     Narrower than :func:`_direction_is_verdict`, which also accepts Approved.
-    Accepts the bare ``Changes`` spelling that `_VERDICT_DIRECTIONS`
-    deliberately excludes, because `trust_signals.parse_verdicts` (via
-    `charter_trailer.verdict_kind(..., include_bare_changes=True)`, main#1359)
-    DOES count it as ChangesRequested — this predicate must agree with the
-    consumer whose behaviour it is protecting, not with the sibling
-    verdict-set.
+    One line over `charter_trailer.is_changes_requested`, the shared predicate
+    `trust_signals` also asks (main#1371) — this gate protects that consumer's
+    behaviour, so it must not merely resemble it.
 
-    That makes **two** verdict-direction classifiers left in this file
-    (`_VERDICT_DIRECTIONS` here and this function), disagreeing on bare
-    ``Changes`` *by design* — `trust_signals`'s own former third copy was
-    deleted in main#1359, which also added `charter_trailer.verdict_kind(...,
-    include_bare_changes=...)` as the shared classifier these two migrate
-    onto. Consolidating them is tracked as **main#1371**; it is not a change
-    to make incidentally, because the divergence is intentional per-consumer
-    and collapsing it wrongly would silently re-scope two hooks.
+    The VOCABULARY is now identical to its consumer's. The EXTRACTION is not,
+    on one shape: `trust_signals` reads its own line-anchored first match over
+    the raw body rather than the shared `extract_charter_field`. See the
+    § main#1371 note above `_CONDITIONAL_VERDICT_FIELDS` for which shape, which
+    way each errs, and why this reading is still the better of the two.
     """
-    match = re.search(r"RequestOrReplied:\s*(.+)", body)
-    if not match:
-        return False
-    raw = match.group(1).strip().strip("*").strip().lower()
-    if not raw:
-        return False
-    parts = raw.split()
-    if not parts:
-        return False
-    return re.sub(r"[^a-z0-9]", "", parts[0]) in {"changesrequested", "changes"}
+    return is_changes_requested(_direction_value(body))
 
 
 def _direction_is_verdict(body: str) -> bool:
     """True if the comment body's `RequestOrReplied:` value is a verdict direction.
 
-    Matches the value on the same line as the `RequestOrReplied:` label. The
-    value is stripped of trailing markdown bolding / whitespace and lowercased
-    before comparison against `_VERDICT_DIRECTIONS`. If no value is captured
-    (label present but value empty), returns False (fail-out-of-scope —
-    consistent with the path-2 stance of narrowing rather than blocking on
-    ambiguous shapes).
+    Scope gate for the Requestor/Requestee swap heuristic (#378): Approved and
+    ChangesRequested bind `Requestor = reviewer`, while Request/Reply invert
+    the binding and unrecognized values are out of scope entirely. Absent or
+    empty field ⇒ False (fail-out-of-scope, unchanged).
+
+    One line over `charter_trailer.is_verdict_direction`, the shared predicate
+    `validate_pr_review._is_verdict` also is (main#1371), so this gate cannot
+    scope itself more narrowly than the counter it guards. That is why bare
+    ``Changes`` — which the retired local `_VERDICT_DIRECTIONS` excluded — is
+    now in scope here.
     """
-    match = re.search(r"RequestOrReplied:\s*(.+)", body)
-    if not match:
-        return False
-    raw = match.group(1).strip()
-    raw = raw.strip("*").strip()
-    if not raw:
-        return False
-    # Take the leading verdict word(s). The value may be followed by additional
-    # text on the same line in some custom shapes; we only look at what comes
-    # before a newline (already handled by `.+` group consuming up to EOL).
-    # Lowercase for case-insensitive match against the canonical set.
-    canonical = raw.lower()
-    # Direct match against the canonical set covers both "approved",
-    # "changesrequested", and "changes requested" forms.
-    if canonical in _VERDICT_DIRECTIONS:
-        return True
-    # Tolerate trailing-token noise: e.g. "Approved (post-merge)" should still
-    # be treated as Approved. Split on whitespace and join the first 1-2 tokens
-    # to attempt the camelCase / two-word verdict match.
-    parts = canonical.split()
-    if not parts:
-        return False
-    if parts[0] in _VERDICT_DIRECTIONS:
-        return True
-    if len(parts) >= 2 and " ".join(parts[:2]) in _VERDICT_DIRECTIONS:
-        return True
-    return False
+    return is_verdict_direction(_direction_value(body))
 
 
 def _unreadable_cause(command: str) -> str:
@@ -1100,7 +1140,11 @@ def check(input_data: dict) -> dict | None:
     # of the misplacements worth catching.
     misplaced = _conditional_fields_present(body)
     if misplaced and not _direction_is_changes_requested(body):
-        direction = extract_charter_field(CHARTER_FIELD, body) or "(unreadable)"
+        # Same extraction the predicate just used (main#1371). Before that,
+        # the predicate read the first raw `RequestOrReplied:` hit while this
+        # line read the trailer-scoped value, so a block message could NAME a
+        # direction that was not the one it blocked on.
+        direction = _direction_value(body) or "(unreadable)"
         result = {
             "decision": "block",
             "reason": (

--- a/.claude/lib/charter_trailer.py
+++ b/.claude/lib/charter_trailer.py
@@ -53,11 +53,15 @@ from __future__ import annotations
 import re
 
 __all__ = [
+    "VERDICT_DIRECTION_KINDS",
     "VERDICT_KIND",
     "branch_author_first_initial",
     "extract_branch_author_lastname",
     "extract_charter_field",
+    "is_approved",
     "is_branch_author",
+    "is_changes_requested",
+    "is_verdict_direction",
     "is_wave_branch",
     "name_first_initial",
     "name_lastname",
@@ -333,15 +337,20 @@ def extract_charter_field(field_name: str, body: str) -> str | None:
 #     three raw implementations.
 #
 # `verdict_kind` below is the one classifier. The bare-`Changes` disagreement
-# is real and deliberate (a well-formed-verdict question vs. a
-# does-this-comment-block question, per main#1371) — it is kept as the
-# `include_bare_changes` ARGUMENT, not as a fourth silently-forked table, so
-# a caller states which of the two questions it is asking. `trust_signals`
-# migrates onto this in the same change that defines it (its three private
-# copies deleted); `validate_pr_review` and `validate_review_comment_format`
-# migrate their four remaining copies onto it under main#1371 — that
-# consolidation is sequenced to land AFTER this module gains the shared
-# definition, so it lands ONTO one owner rather than creating a fourth.
+# is carried as the `include_bare_changes` ARGUMENT, not as a fourth
+# silently-forked table, so a caller states which question it is asking.
+# `trust_signals` migrated onto this in the same change that defined it (its
+# three private copies deleted); `validate_pr_review` and
+# `validate_review_comment_format` migrated their four remaining copies under
+# main#1371, landing ONTO one owner rather than creating a fourth.
+#
+# main#1371 ALSO RULED ON THE DISAGREEMENT ITSELF, and the ruling is not the
+# one this comment originally anticipated: the bare-`Changes` exclusion was
+# NOT a second legitimate question, it was a gate narrower than its consumer,
+# and every production caller now passes `include_bare_changes=True`. The
+# evidence, the retracted premise and the full behaviour-change table live in
+# the § "The questions, as named predicates" block below — read it before
+# reintroducing an excluding caller.
 VERDICT_KIND: dict[str, str] = {
     "approved": "approved",
     "changesrequested": "changesrequested",
@@ -412,6 +421,155 @@ def verdict_kind(value: str | None, *, include_bare_changes: bool = True) -> str
             return "changesrequested"
         return "changesrequested" if include_bare_changes else ""
     return VERDICT_KIND.get(token, "")
+
+
+# ---------------------------------------------------------------------------
+# The questions, as named predicates over the one classifier (main#1371)
+# ---------------------------------------------------------------------------
+#
+# main#1359 (above) made `verdict_kind` the one classifier and migrated
+# `trust_signals`. main#1371 migrates the two hooks' four remaining copies:
+#
+#   validate_review_comment_format._VERDICT_DIRECTIONS + ._direction_is_verdict
+#   validate_review_comment_format._direction_is_changes_requested
+#   validate_pr_review._VERDICT_REQUIRING_TECH_DEBT + ._is_verdict
+#   validate_pr_review._is_approved
+#
+# Each answered a QUESTION, and the questions are what get names here — a
+# caller asks `is_verdict_direction(...)`, not `verdict_kind(...) in {...}`,
+# so the set membership has one definition too. Three questions, because
+# three are asked in production:
+#
+#   is_verdict_direction  Does the charter Direction table bind
+#                         Requestor=reviewer / Requestee=PR-author here?
+#                         (the swap heuristic's scope, and the counter's
+#                         "this comment is a verdict, TechDebt required")
+#   is_changes_requested  Is this comment BLOCKING? (the conditional-field
+#                         gate, main#1363; trust_signals' retraction and
+#                         orchestrator-attribution gating)
+#   is_approved           Does this count toward the 2-reviewer threshold?
+#
+# THE BARE `Changes` RESOLUTION — READ THIS BEFORE CHANGING A DEFAULT
+# ===================================================================
+#
+# main#1371 was filed on the premise that the exclusion of bare `Changes` in
+# `validate_review_comment_format._VERDICT_DIRECTIONS` "is not a bug — it
+# serves a different question (which spellings constitute a well-formed
+# declared verdict) from the one the counter asks (which comments count as
+# blocking)". THAT PREMISE IS RETRACTED, on evidence, and the consolidation
+# adopts INCLUDE-bare-`Changes` at every production call site.
+#
+# Why: nothing in `validate_review_comment_format` asks a well-formedness
+# question. Its own module docstring disclaims it — "Unrecognized
+# `RequestOrReplied` values (typos, future verdict types the hook doesn't
+# know about) fail OPEN … Validating the verdict word itself is covered by a
+# sibling hook (`validate_pr_review`)". And the sibling does not reject bare
+# `Changes`; it counts it (`_VERDICT_REQUIRING_TECH_DEBT` included it). So
+# the exclusion was a gate whose grammar was NARROWER THAN THE CONSUMER IT
+# GUARDS — the main#1150 defect class the issue itself cites — with no
+# backstop anywhere, and it was live:
+#
+#     RequestOrReplied: Changes, with Requestor = the PR author
+#       `_direction_is_changes_requested`  True  (main#1363 fixed this half)
+#       `_direction_is_verdict`            False → check() returned early,
+#                                                 the SWAP CHECK NEVER RAN
+#       `validate_pr_review._is_verdict`   True  → counted as a verdict,
+#                                                 Requestor self-excluded,
+#                                                 the real reviewer's verdict
+#                                                 recorded under the author's
+#                                                 name and evaporating.
+#
+# One comment, simultaneously a blocking ChangesRequested (so `Retracted:`
+# was accepted on it) and not-a-verdict (so the swap gate skipped it).
+#
+# The fix direction is also the SAFE one: including bare `Changes` can only
+# make the format gate examine MORE comments, never fewer. Excluding it is
+# the allowing direction. A gate does not get to pick the allowing direction
+# to preserve a distinction no consumer asked for.
+#
+# `include_bare_changes` SURVIVES anyway, on both direction predicates, and
+# `verdict_kind` keeps it. main#1359 documented it at length, the excluding
+# question stays expressible and tested, and deleting a parameter is a
+# separate decision from migrating call sites. But be aware, and do not read
+# the parameter as evidence of a live disagreement: AFTER main#1371 NO
+# PRODUCTION CALLER PASSES `include_bare_changes=False`. If a future reader
+# is looking for the second answer's consumer, there isn't one — that is
+# reported on main#1371, not hidden here.
+#
+# `is_approved` deliberately takes NO `include_bare_changes` knob, and needs
+# none: bare `Changes` cannot classify as `approved` under either setting.
+# The parameter is load-bearing only on the changesrequested branch, which is
+# why there are two direction questions and not three
+# (`test_include_bare_changes_is_only_load_bearing_for_changesrequested`).
+#
+# WHAT ELSE CHANGED, BECAUSE ONE ALGORITHM REPLACED FOUR
+# ======================================================
+#
+# The four copies did not merely disagree on bare `Changes`; they used three
+# different normalisations. `verdict_kind` classifies the FIRST token
+# (or first two, for `Changes Requested`) after stripping non-alphanumerics,
+# so migrating widens every exact-set consumer. Reachable end-to-end (i.e.
+# surviving `extract_charter_field`'s own bold/parenthetical stripping):
+#
+#   value                    _is_verdict  _is_approved   after
+#   `Approved!`                  False       False       verdict + approval
+#   `Approved with nits`         False       False       verdict + approval
+#   `Approved - see below`       False       False       verdict + approval
+#   `Changes  Requested` (2 sp)  False       False       verdict, blocking
+#   `**Changes** Requested`      False       False       verdict, blocking
+#   `Changes needed`             False       False       verdict, blocking
+#   `ChangesRequested.`          False       False       verdict, blocking
+#
+# The `_is_approved` rows WIDEN THE 2-REVIEWER APPROVER SET — the only
+# loosening in this change, and it is stated here rather than discovered.
+# It is the direction the org has ruled for repeatedly (main#1347, #1357,
+# #1359 each widened a narrow verdict capture) and the alternative is worse:
+# `RequestOrReplied: Approved with nits` is a verdict to the format gate
+# (which has always matched on the first token) and zero reviews to the
+# counter — the main#932 uncountable-verdict shape, with the reviewer
+# believing they approved. A first token of `Approved` is an approval; a
+# hedge that is not one (`Not Approved`) does not start with the token and
+# classifies as nothing at all, before and after.
+VERDICT_DIRECTION_KINDS = frozenset({"approved", "changesrequested"})
+
+
+def is_verdict_direction(value: str | None, *, include_bare_changes: bool = True) -> bool:
+    """True when `value` is an Approved / ChangesRequested direction.
+
+    These are the rows of the charter `pull-requests.md` § Comment-Based
+    Reviews Direction table where the binding is `Requestor = reviewer,
+    Requestee = PR-author`. `Request` / `Reply` invert that binding and are
+    NOT verdict directions; an unrecognized value is not one either.
+
+    See the block comment above for why `include_bare_changes` defaults to
+    True here — a gate scoping itself with a narrower grammar than the
+    counter it guards is the main#1150 defect, and it was live on bare
+    `Changes`.
+    """
+    return verdict_kind(value, include_bare_changes=include_bare_changes) in VERDICT_DIRECTION_KINDS
+
+
+def is_changes_requested(value: str | None, *, include_bare_changes: bool = True) -> bool:
+    """True when `value` is specifically a ChangesRequested direction.
+
+    Narrower than :func:`is_verdict_direction`, which also accepts Approved.
+    This is the "is this comment BLOCKING?" question: whether a must-fix was
+    raised, hence whether `Retracted:` / `OrchestratorCaused:` mean anything
+    on it (main#1363/#1364/#1366) and whether the reviewer currently blocks.
+    """
+    return verdict_kind(value, include_bare_changes=include_bare_changes) == "changesrequested"
+
+
+def is_approved(value: str | None) -> bool:
+    """True when `value` is specifically an Approved direction.
+
+    This is the whole input to the charter's 2-reviewer threshold — a
+    reviewer counts only when their LATEST current verdict is Approved
+    (main#940). No `include_bare_changes` parameter, because bare `Changes`
+    can never classify as `approved`; adding one would suggest a distinction
+    that does not exist here.
+    """
+    return verdict_kind(value) == "approved"
 
 
 # ---------------------------------------------------------------------------

--- a/.claude/lib/tests/test_charter_trailer.py
+++ b/.claude/lib/tests/test_charter_trailer.py
@@ -532,30 +532,46 @@ class VerdictKindTests(unittest.TestCase):
         is no divergence on `"Approved (post-merge)"` specifically. The
         genuinely reachable divergences — `"Approved!"`,
         `"Approved with nits"`, `"Approved - see below"`,
-        `"Changes  Requested"` (double space), `"Changes needed"` — are all
-        `False` under `validate_pr_review._is_verdict`/`._is_approved` today
-        and would become `True` under this function; see
-        `main#1371` for the full table and the `_is_approved` /
-        2-reviewer-approver-set consequence.
+        `"Changes  Requested"` (double space), `"Changes needed"` — were all
+        `False` under `validate_pr_review._is_verdict`/`._is_approved` at the
+        time this was written, and BECAME `True` when main#1371 migrated those
+        two names onto this function. That migration has landed; the full
+        table, and the fact that the `_is_approved` rows enlarge the
+        2-reviewer approver set, are recorded in `charter_trailer` §
+        "The questions, as named predicates" and pinned by
+        `.claude/hooks/tests/test_verdict_direction_agreement.py`.
         """
         self.assertEqual(verdict_kind("Approved (post-merge)"), "approved")
 
     def test_bold_markers_do_not_defeat_the_match(self) -> None:
         self.assertEqual(verdict_kind("**ChangesRequested**"), "changesrequested")
 
-    # -- The deliberate divergence (main#1371): bare "Changes" -- #
+    # -- The bare "Changes" divergence, RULED ON by main#1371 -- #
 
     def test_bare_changes_included_by_default(self) -> None:
-        """Default matches `trust_signals`'s pre-migration behaviour and
-        `validate_pr_review._VERDICT_REQUIRING_TECH_DEBT` (both include it)."""
+        """The default is what every production caller now passes.
+
+        It matched `trust_signals`' pre-#1359 behaviour and the retired
+        `validate_pr_review._VERDICT_REQUIRING_TECH_DEBT`; as of main#1371 it
+        also matches both `validate_review_comment_format` predicates, whose
+        `_VERDICT_DIRECTIONS` used to be the lone excluder."""
         self.assertEqual(verdict_kind("Changes"), "changesrequested")
 
     def test_bare_changes_included_when_requested_explicitly(self) -> None:
         self.assertEqual(verdict_kind("Changes", include_bare_changes=True), "changesrequested")
 
     def test_bare_changes_excluded_when_requested(self) -> None:
-        """Matches `validate_review_comment_format._VERDICT_DIRECTIONS`, which
-        deliberately excludes the bare form ("not a verdict on its own")."""
+        """The excluding answer stays REACHABLE and pinned, with no production
+        caller (main#1371).
+
+        `validate_review_comment_format._VERDICT_DIRECTIONS` was the only one,
+        and it was retired: this hook fails open on unrecognized directions by
+        design and does not adjudicate well-formedness, so excluding a
+        spelling the counter accepts made it a gate narrower than its consumer
+        (main#1150) rather than a second legitimate question. Keeping the
+        parameter tested means reinstating that answer stays a one-argument
+        change if a caller ever genuinely needs it — but DO NOT read this test
+        as evidence that one currently does."""
         self.assertEqual(verdict_kind("Changes", include_bare_changes=False), "")
 
     def test_exclusion_does_not_affect_the_full_spelling(self) -> None:

--- a/.claude/lib/trust_signals.py
+++ b/.claude/lib/trust_signals.py
@@ -420,10 +420,12 @@ def parse_verdicts(comment_bodies: list[str]) -> list[Verdict]:
         # — pinned by `UnterminatedFenceDirectionChangeTests` in
         # `test_trust_signals.py` so it is not rediscovered as a surprise.
         scanned = charter_trailer.strip_code_regions(body)
-        is_changes_requested = (
-            charter_trailer.verdict_kind(verdict_str, include_bare_changes=True)
-            == "changesrequested"
-        )
+        # main#1371: the named shared predicate, not a hand-written comparison
+        # against the classifier's return value. The comparison was correct,
+        # but it was the same expression written out at two sites in this file
+        # and at four more in the two hooks — which is how the vocabulary came
+        # to have four implementations in the first place.
+        is_changes_requested = charter_trailer.is_changes_requested(verdict_str)
         is_false_positive = is_changes_requested and bool(_RETRACTION_RE.search(scanned))
         # `OrchestratorCaused:` is gated identically and for the same reason
         # (main#1366): there is no rework round to reattribute unless THIS
@@ -443,18 +445,21 @@ def parse_verdicts(comment_bodies: list[str]) -> list[Verdict]:
     return out
 
 
-def _is_changes_requested(verdict: str | None) -> bool:
-    """True if *verdict* (a captured ``RequestOrReplied`` value) is ChangesRequested.
-
-    #1347: routes through :func:`charter_trailer.verdict_kind` so the three
-    spelling variants (``ChangesRequested`` / ``Changes Requested`` /
-    ``Changes``) all classify identically — the previous
-    ``verdict.lower() == "changesrequested"`` exact-match silently dropped
-    the spaced form because the capturing regex used to stop at the first
-    space. ``include_bare_changes=True`` preserves this module's original
-    (pre-main#1359) behaviour of counting bare ``Changes`` (main#1359).
-    """
-    return charter_trailer.verdict_kind(verdict, include_bare_changes=True) == "changesrequested"
+# The "is this comment BLOCKING?" question, asked once org-wide
+# (`charter_trailer.is_changes_requested`, main#1371) and merely re-exported
+# under this module's historical private name for its existing callers and
+# test surface.
+#
+# #1347: routing through the shared classifier is what makes the three
+# spelling variants (``ChangesRequested`` / ``Changes Requested`` /
+# ``Changes``) classify identically — the pre-#1347 ``verdict.lower() ==
+# "changesrequested"`` exact match silently dropped the spaced form because
+# the capturing regex used to stop at the first space. main#1359 moved the
+# classifier to `charter_trailer`; main#1371 replaced the hand-written
+# ``verdict_kind(...) == "changesrequested"`` comparison with the named
+# predicate, which defaults to ``include_bare_changes=True`` and so preserves
+# this module's original behaviour of counting bare ``Changes``.
+_is_changes_requested = charter_trailer.is_changes_requested
 
 
 def _pr_comment_bodies(repo: str, number: int) -> list[str]:

--- a/.claude/lib/wave_status.py
+++ b/.claude/lib/wave_status.py
@@ -74,16 +74,23 @@ _DEFAULT_STATUS = wave_state.DEFAULT_STATUS_PATH
 # (now ``charter_trailer.verdict_kind``, main#1359 — that private copy is
 # deleted), just reimplemented here as a jq regex instead of a Python one.
 # ``Changes(\s*Requested)?\b`` accepts all three spellings — the union of
-# what the org's own PR templates and hooks actually produce, NOT a claim
-# that every existing consumer already agrees on all three:
-# ``validate_pr_review.py``'s ``_VERDICT_REQUIRING_TECH_DEBT`` (~line 1410)
-# and ``charter_trailer.verdict_kind(..., include_bare_changes=True)`` (the
-# argument ``trust_signals.py`` now passes at its one call site) both accept
-# the bare short form, but ``validate_review_comment_format.py``'s
-# ``_VERDICT_DIRECTIONS`` (~line 664) deliberately excludes it (see main#1359
-# — the sibling consumers disagreeing with each other is itself evidence for
-# a single shared vocabulary owner, not a reason to assume copies stay in
-# sync). This counter counts every ChangesRequested verdict regardless of
+# what the org's own PR templates and hooks actually produce. As of main#1371
+# that union is also what every Python consumer answers: the four private
+# copies (``validate_pr_review._VERDICT_REQUIRING_TECH_DEBT``,
+# ``validate_review_comment_format._VERDICT_DIRECTIONS`` and their readers)
+# are gone, replaced by ``charter_trailer.is_verdict_direction`` /
+# ``.is_changes_requested`` / ``.is_approved`` over the one
+# ``charter_trailer.verdict_kind`` classifier, and the bare short form is now
+# INCLUDED everywhere (``_VERDICT_DIRECTIONS`` had excluded it — the sibling
+# consumers disagreeing with each other was itself the evidence for a single
+# shared vocabulary owner, not a reason to assume copies stay in sync).
+#
+# THIS JQ REGEX IS THE LAST NON-PYTHON SPELLING OF THE SAME QUESTION and is
+# NOT consolidated: it runs inside a ``jq`` filter, so it cannot call the
+# shared predicate. It is a genuine fifth expression of the vocabulary, kept
+# deliberately and pinned by ``test_changes_requested_regex_variants_via_real_jq``
+# — a Python rewrite of this counter is the only way to remove it (not filed;
+# reported on main#1371). This counter counts every ChangesRequested verdict regardless of
 # form, so it takes the wider set. The optional group matches "Requested"
 # immediately after "Changes" (no space — the unspaced form) or after a
 # space (the spaced form), and is skippable entirely for the bare short


### PR DESCRIPTION
Closes #1371.

## What this does

Verdict-direction classification had **four** implementations after #1359 extracted the vocabulary. All four now route through `charter_trailer`, where the *questions* get names over the one `verdict_kind` classifier:

| retired | replaced by |
|---|---|
| `validate_review_comment_format._VERDICT_DIRECTIONS` + `._direction_is_verdict` | `charter_trailer.is_verdict_direction` |
| `validate_review_comment_format._direction_is_changes_requested` | `charter_trailer.is_changes_requested` |
| `validate_pr_review._VERDICT_REQUIRING_TECH_DEBT` + `._is_verdict` | `charter_trailer.is_verdict_direction` (alias `_is_verdict`) |
| `validate_pr_review._is_approved` | `charter_trailer.is_approved` (alias `_is_approved`) |
| `trust_signals._is_changes_requested` + the inline comparison in `parse_verdicts` | `charter_trailer.is_changes_requested` |

Dependency direction is unchanged: `.claude/lib/charter_trailer.py` is the home, nothing in `.claude/lib/` imports from `.claude/hooks/`.

## The bare `Changes` disagreement — ruled, not preserved

**Adopted: INCLUDE bare `Changes` at every production call site.** The issue's own Constraint paragraph says the `_VERDICT_DIRECTIONS` exclusion "is not a bug — it serves a different question (which spellings constitute a well-formed declared verdict)". **I am retracting that premise, on evidence.**

`validate_review_comment_format` does not ask a well-formedness question. Its own module docstring disclaims it:

> Unrecognized `RequestOrReplied` values (typos, future verdict types the hook doesn't know about) fail OPEN … Validating the verdict word itself is covered by a sibling hook (`validate_pr_review`).

And the sibling does not reject bare `Changes` — it has counted it since #147. So the exclusion was a gate whose grammar was **narrower than the consumer it guards** (the #1150 class the issue itself cites), with no backstop. It was live:

```
Direction value `Changes`, with Requestor = the PR author (a genuine swap)
  _direction_is_changes_requested   True   <- #1363 fixed this half
  _direction_is_verdict             False  -> check() returned early,
                                             THE SWAP CHECK NEVER RAN
  validate_pr_review._is_verdict    True   -> counted as a verdict, the
                                             swapped Requestor self-excluded,
                                             the real reviewer's verdict
                                             recorded under the author's name
                                             and evaporating (#932 shape)
```

One comment, simultaneously a blocking ChangesRequested (so `Retracted:` was accepted on it) and not-a-verdict (so the swap gate skipped it).

Collapsing toward **exclude** is what would have re-introduced the #1363 false block — the Constraint's real warning. Collapsing toward **include** cannot: it only makes the format gate examine *more* comments, never fewer. A gate does not get to pick the allowing direction to preserve a distinction no consumer asked for.

`include_bare_changes` survives on `verdict_kind` and both direction predicates, and stays tested — but **after this PR no production caller passes `False`.** That is stated in the code, not hidden. `is_approved` deliberately has no such knob (bare `Changes` can never be `approved` either way; pinned by a test).

## Second axis, not in the issue: the two predicates read the wrong text

`_direction_is_verdict` / `_direction_is_changes_requested` classified the **first raw `re.search` hit over the un-stripped body**, while `validate_pr_review` reads `extract_charter_field`'s code-stripped, trailer-scoped, last-match value. Sharing the vocabulary but not the *text* is half an agreement, and the missing half broke the hook in both directions:

* **fail-OPEN** — "Earlier I posted `RequestOrReplied: Reply`…" above a genuine `Approved` trailer suppressed the verdict-scope gate, so the swap heuristic never ran on the trailer the counter *did* read.
* **fail-CLOSED** — prose mentioning `Approved` above a genuine `Reply` trailer dragged a correctly-formed reply into verdict scope and **blocked** it. Requestor IS the PR author on a Reply by the Direction table's own binding (#378), so there was no observable-body workaround.
* A **fenced example** of the charter template decided the direction, because the raw search did not strip code regions.

This is #934's `Requestor:` fix ("must read the Requestor the COUNTING hook reads — never the first `re.search` hit over the whole body") finally applied to the sibling field it left behind. **No fence/stripping semantics were changed** — `strip_code_regions` and `trailer_block_substring` are untouched, so #1413/#1415/#1416 and the #1417 renderer-fidelity ruling are unaffected; the predicates simply now go through the existing `extract_charter_field`.

## COUNTING CHANGE — read this

`verdict_kind` classifies the first token after stripping non-alphanumerics, so migrating the exact-match consumers widens them. Reachable end-to-end (these survive `extract_charter_field`'s own bold/parenthetical stripping):

| value | `_is_verdict` before | `_is_approved` before | after |
|---|---|---|---|
| `Approved!` | False | False | verdict **+ approval** |
| `Approved with nits` | False | False | verdict **+ approval** |
| `Approved - see below` | False | False | verdict **+ approval** |
| `Changes  Requested` (2 spaces) | False | False | blocking verdict |
| `**Changes** Requested` | False | False | blocking verdict |
| `Changes needed` | False | False | blocking verdict |
| `ChangesRequested.` | False | False | blocking verdict |

The `_is_approved` rows **enlarge the 2-reviewer approver set**. That is the one loosening in this PR and I am not burying it. The argument for it: `validate_review_comment_format` has always matched these on the first token, so today the reviewer is told their verdict is well-formed while the merge gate counts it as **zero reviews** — the #932 uncountable-verdict shape, and the same narrow-capture defect #1347/#1357/#1359 each fixed in a sibling counter. `Not Approved` does not lead with the token and classifies as nothing at all, before and after.

If the reviewer prefers to keep `_is_approved` on exact-match, say so — but note that costs the one-classifier property, which is the whole issue.

## Failing-before

`test_verdict_direction_agreement.py` against `40cfe9f` (the branch point) with the pre-fix source restored:

```
29 failed, 5 passed, 83 subtests passed in 0.48s
```

```
SUBFAILED(value='Changes')      ::AgreementMatrixTests::test_bare_changes_is_the_same_answer_everywhere
SUBFAILED(value='changes')      ::AgreementMatrixTests::test_bare_changes_is_the_same_answer_everywhere
SUBFAILED(value='**Changes**')  ::AgreementMatrixTests::test_bare_changes_is_the_same_answer_everywhere
SUBFAILED(value='Approved!')            ::test_format_gate_verdict_scope_matches_the_counter
SUBFAILED(value='Approved with nits')   ::test_format_gate_verdict_scope_matches_the_counter
SUBFAILED(value='Changes  Requested')   ::test_format_gate_verdict_scope_matches_the_counter
SUBFAILED(value='**Changes** Requested')::test_format_gate_verdict_scope_matches_the_counter
SUBFAILED(value='ChangesRequested.')    ::test_format_gate_verdict_scope_matches_the_counter
   (… 12 more matrix subtests)
FAILED ::SwapGateReadsTheValueTheCounterReadsTests::test_prose_direction_no_longer_suppresses_the_swap_block
FAILED ::SwapGateReadsTheValueTheCounterReadsTests::test_prose_verdict_no_longer_drags_a_reply_into_scope
FAILED ::SwapGateReadsTheValueTheCounterReadsTests::test_fenced_example_no_longer_decides_the_direction
FAILED ::ConditionalFieldGateFollowsTrustSignalsTests::test_prose_mention_no_longer_false_blocks_a_retraction
FAILED ::ConditionalFieldGateFollowsTrustSignalsTests::test_line_anchored_mention_is_the_known_residual_divergence
FAILED ::PredicateSingularityTests::test_counting_hook_predicates_are_the_shared_objects
FAILED ::PredicateSingularityTests::test_counting_hook_has_no_private_verdict_table
FAILED ::PredicateSingularityTests::test_format_hook_has_no_private_direction_table
FAILED ::PredicateSingularityTests::test_trust_signals_uses_the_named_predicate
```

One pre-existing test was **deliberately inverted**: `test_validate_review_comment_format_parser.DirectionVerdictHelperTests.test_bare_changes_not_verdict` → `test_bare_changes_is_a_verdict`. It pinned the exclusion; the docstring records why the original reasoning does not survive contact with the consumer. It is the only assertion in 4405 that this change flips.

## Found but NOT fixed

1. **`trust_signals._FIELD_RE["verdict"]` is a private field-extraction copy.** It is line-anchored (`^…$`, MULTILINE) over the RAW body and first-match, while `charter_trailer.extract_charter_field` — the declared single source of truth for field extraction (#932/#934) — is code-stripped, trailer-scoped and last-match. Verified divergent both ways. The conditional-field gate now agrees with it on the common shape and diverges on one (a *line-anchored* `RequestOrReplied:` above the trailer, where `trust_signals` reads the stray line and silently drops the retraction while the gate stays quiet — an unshown warning, not a merge-gate fail-open). Pinned by `test_line_anchored_mention_is_the_known_residual_divergence` with a "flip me when it lands" note. Same axis-3 scope question #1372 owns.
2. **An empty direction value silently absorbs the NEXT trailer line.** `extract_charter_field`'s `\s*` matches newlines, so a `RequestOrReplied:` line with an empty value followed by `TechDebt: none` extracts `"TechDebt: none"`. Identical before and after (the retired raw regex had the same `\s*`), so this PR changes nothing — but it means gate 2 passes a comment whose direction is unreadable. Belongs with #1415's field-extraction findings.
3. **`wave_status._CHANGES_REQUESTED_RE` is a fifth expression of the vocabulary**, as a jq regex. It cannot call the shared predicate from inside a jq filter; removing it needs the counter rewritten in Python. Comment updated to say so.

## Is #1372 now moot?

**No — and I would not descope it.** #1372's corpus test (`ConditionalFieldGrammarAgreementTests`) certifies the `Retracted:` / `OrchestratorCaused:` **presence-detection** pair (`_CONDITIONAL_FIELD_RE` mirroring `trust_signals._RETRACTION_RE` / `._ORCHESTRATOR_CAUSED_RE`), which is a different pair of symbols from anything this PR touches. #1371 consolidated the *direction* vocabulary; the presence regexes and their whole-body-vs-trailer scope split are untouched and still mirrored by hand.

Two things did change for #1372, both making it *more* worth doing:

* the `tracked separately, main#1371/#1372` markers now read `main#1372` alone, so its scope is unambiguous;
* finding 1 above (`trust_signals._FIELD_RE`) is the same axis-3 extraction question #1372 owns, and is arguably the more valuable half of it. Consider folding it in.

## Symbols touched

* `.claude/lib/charter_trailer.py` — **added** `VERDICT_DIRECTION_KINDS`, `is_verdict_direction`, `is_changes_requested`, `is_approved`; `__all__`; doc block. `verdict_kind` / `VERDICT_KIND` / `normalize_verdict_token` / `strip_code_regions` / `trailer_block_substring` / `extract_charter_field` **unchanged**.
* `.claude/hooks/validate_review_comment_format.py` — **removed** `_VERDICT_DIRECTIONS`; **added** `_direction_value`; rewrote `_direction_is_verdict` / `_direction_is_changes_requested` as one-liners.
* `.claude/hooks/validate_pr_review.py` — **removed** `_VERDICT_REQUIRING_TECH_DEBT`; `_is_verdict` / `_is_approved` are now aliases (names kept — `agents/orchestration-model.md` and `feedback_pr_review_verdict_format` §7 import `_is_approved` by name for the verdict read-back).
* `.claude/lib/trust_signals.py` — `_is_changes_requested` is now an alias; `parse_verdicts`' inline comparison uses the named predicate. **`apply_distribution_discipline` / `composite()` untouched** (PRs #1420 / #1370).
* `.claude/lib/wave_status.py` — comment only.
* Tests: new `test_verdict_direction_agreement.py`; singularity sweep extended; one assertion inverted; three stale docstrings corrected.

## Gates

`pre-commit run --all-files` green at both stages (ruff-format, ruff-lint, actionlint, cspell, fixture-realism, checksums-ascii, mypy, mypy-skills, pytest, pytest-skills, memory-budget, headcount-budget, doc-freshness, office-drift, mermaid-render). `python3 .claude/lib/pre_commit_ci_sync.py .` → `OK: pre-commit config mirrors all CI-enforced checks.` Full suite **4407 passed, 1140 subtests passed**. No `--no-verify`.

## Reviewers

* Peer reviewer: **Santiago Ferreira**
* Secondary reviewer: **Weronika Zielinska**
* Merge gate: **Nadia Khoury**

Author is Aino Virtanen — no self-review; all three named above are distinct from the author and from each other.

Not added to project 2: ProjectsV2 is GraphQL-only and the GraphQL quota is exhausted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
