### PR TITLE
fix(promotion-audit): compute charter->skill signal from the source section, not the prospective target

### DIFF
--- a/.claude/skills/promotion-audit/SKILL.md
+++ b/.claude/skills/promotion-audit/SKILL.md
@@ -15,7 +15,7 @@ The project's enforcement hierarchy is **hook > skill > charter > memory** (see 
 | From | To | Trigger |
 |---|---|---|
 | memory | charter | `promotion_target: charter` AND `retro_citations >= threshold` AND `status: active` |
-| charter | skill | Section marker `<!-- promotion-target: skill -->` AND skill-invocation signal >= threshold |
+| charter | skill | Section marker `<!-- promotion-target: skill -->` AND section-citation signal (retro citations of the section's own heading, #1355) >= threshold |
 | skill | hook | `promotion-target: hook` in skill frontmatter AND invocation signal >= threshold |
 
 Skill-to-hook **ALWAYS** produces a DECIDE-tier draft issue — never auto-applies (D6, hooks are security-sensitive).
@@ -76,14 +76,24 @@ each transition has a distinct signature because the signal sources differ:
 | Function | Signature | `signals` keys consumed |
 |---|---|---|
 | `classify_memory(memory, signals, already_promoted)` | `(Memory, dict[str,int], set[str]) -> Decision` | `retro_citations` |
-| `classify_section(section, signals)` | `(CharterSection, dict[str,int]) -> Decision` | `skill_invocations`, `threshold` |
+| `classify_section(section, signals)` | `(CharterSection, dict[str,int]) -> Decision` | `section_citations`, `threshold`, `target_configured` |
 | `classify_skill(skill, signals, already_promoted)` | `(Skill, dict[str,int], set[str]) -> Decision` | `skill_invocations`, `threshold` |
 
 Signal derivation (wired once in `run.py`): memory→charter uses
-`count_retro_citations`; charter→skill counts invocations of the section's
-candidate-skill slug (`promoted_to` with the `skills/` prefix stripped if
-already promoted, else `_slugify(heading)` — never an empty slug);
-skill→hook counts invocations of the skill name (always DECIDE, D6).
+`count_retro_citations`; charter→skill uses `count_section_citations`
+(#1355) — retro citations of the SOURCE section's own heading in the
+feedback log (live + per-phase archives, #964), the genuine evidence a
+section has earned promotion. `target_configured` (does a skill already
+exist on disk at the prospective slug?) is derived separately from
+`_section_signal_slug` + a disk check, but is informational only — it
+selects which KEPT message renders when the section is below threshold;
+it does not gate whether the citation signal itself can accrue. (Pre-#1355
+this tier counted invocations of the *prospective destination* skill slug
+— structurally 0 forever for a not-yet-promoted section, since the skill
+doesn't exist yet to be invoked; see `run.py`'s module docstring for the
+full history.) skill→hook counts invocations of the skill name (always
+DECIDE, D6) — unaffected by #1355, since a skill already exists once it
+has a `SKILL.md`.
 
 > `charter_parent` is the directory CONTAINING `charter/` (e.g.
 > `.claude/team`), NOT `charter/` itself — passing `.claude/team/charter`

--- a/.claude/skills/promotion-audit/helpers.py
+++ b/.claude/skills/promotion-audit/helpers.py
@@ -447,6 +447,44 @@ def count_retro_citations(memory: Memory, feedback_log_path: str) -> int:
     return max(by_title, by_file, len(memory.referenced_in_retros))
 
 
+def count_section_citations(section: CharterSection, feedback_log_path: str) -> int:
+    """Count occurrences of a charter section's heading in the feedback log.
+
+    #1355: the charter -> skill transition's actual evidence for promotion
+    is how heavily the SOURCE section is exercised -- not usage of the
+    PROSPECTIVE destination skill slug. A not-yet-created skill can never
+    accrue invocations of itself (`count_skill_invocations` on an
+    empty/prospective slug is structurally 0 forever, by definition, for
+    every not-yet-promoted section -- see `run.py`'s `_section_signal_slug`
+    docstring for the full history of that inversion). This mirrors
+    `count_retro_citations`'s mechanism for memories -- scanning the live
+    feedback log AND its per-phase archives (`_feedback_log_corpus`, #964)
+    for literal occurrences of the heading text -- which genuinely
+    accumulates: operators cite a charter section by its heading when they
+    reference it during a retro, and that citation count grows over time
+    independent of whether the destination skill has been scaffolded yet.
+
+    Deliberately independent of any skill slug or `.claude/skills/` lookup:
+    unlike the old destination-invocation signal, this count cannot inherit
+    an unrelated skill's invocation history just because a heading happens
+    to slugify onto an existing skill directory name (main#1389's
+    collision risk) -- there is no slug in this computation at all.
+
+    An empty or whitespace-only heading returns 0 -- never the corpus
+    length. `text.count("")` returns `len(text) + 1`, which would make a
+    blank heading look like it trivially crossed any threshold. This
+    should never occur in practice (`read_charter_sections` requires
+    non-empty heading text to match `_SECTION_MARKER_RE`), but the guard
+    is the same defensive shape as the main#690 blank-slug guard below.
+    """
+    if not section.heading or not section.heading.strip():
+        return 0
+    text = _feedback_log_corpus(feedback_log_path)
+    if not text:
+        return 0
+    return text.count(section.heading)
+
+
 def count_skill_invocations(skill_name: str, repo_root: str) -> int:
     """Count git log commits that reference the skill by slash-name.
 
@@ -873,7 +911,17 @@ def classify_section(
     section: CharterSection,
     signals: dict[str, int],
 ) -> Decision:
-    """Classify a charter section for the charter → skill transition."""
+    """Classify a charter section for the charter → skill transition.
+
+    #1355: `signals["section_citations"]` is expected to come from
+    `count_section_citations` (retro citations of THIS section's heading) —
+    the actual evidence for promotion — not from `count_skill_invocations`
+    against the prospective destination slug, which is structurally 0
+    forever for every not-yet-promoted section (see `count_section_citations`
+    docstring for the full rationale). Callers passing the legacy
+    `skill_invocations` key are silently treated as 0 citations; see
+    `run.py`'s `run_audit` for the canonical wiring.
+    """
     if section.promoted_to:
         return Decision(
             kind="ALREADY-PROMOTED",
@@ -904,34 +952,36 @@ def classify_section(
             reason="Charter sections only promote to skill",
         )
 
-    invocations = signals.get("skill_invocations", 0)
+    citations = signals.get("section_citations", 0)
     threshold = signals.get("threshold", 5)
 
-    if invocations < threshold:
-        # #1355: "wait for more operator-invoked runs" is only an accurate
-        # message when there is something an operator COULD invoke — i.e.
-        # a skill already scaffolded on disk at the prospective slug. For
-        # the common not-yet-promoted case (no `promoted-to` back-reference,
-        # no skill directory), the invocation count is structurally 0
-        # forever: promotion (creating the skill) is a deliberate human
-        # act, not something that accrues from waiting. Distinguish the
-        # two so the reader isn't told to wait for something that cannot
-        # arrive on its own.
+    if citations < threshold:
+        # #1383's target_configured distinction is preserved as informational
+        # context (does a skill already exist on disk at the prospective
+        # slug?), but it no longer gates *whether* evidence can accrue —
+        # `section_citations` is computed from the SOURCE section and
+        # genuinely accumulates regardless of scaffold status (#1355 fixes
+        # the prior inversion where the destination-invocation signal really
+        # was structurally 0 without a target). The unconfigured message is
+        # corrected accordingly: it no longer claims evidence "cannot
+        # accrue" without scaffolding — it can, and does.
         target_configured = bool(signals.get("target_configured", 0))
         if target_configured:
             reason = "Invocation threshold not met; wait for more operator-invoked runs"
         else:
             reason = (
                 "Promotion target not configured — no skill exists at this slug yet, "
-                "so invocations cannot accrue; scaffolding the skill (a deliberate "
-                "human act) is required before this becomes evaluable"
+                f"but that no longer blocks evidence from accruing: {citations} retro "
+                f"citation(s) of this section are already recorded ({citations}/{threshold} "
+                "toward threshold). Scaffolding the skill remains a deliberate human "
+                "act, but it is not a precondition for the signal itself"
             )
         return Decision(
             kind="KEPT",
             item_id=f"{os.path.basename(section.path)} § {section.heading}",
             from_tier="charter",
             to_tier="skill",
-            signal=f"skill_invocations={invocations} < {threshold}",
+            signal=f"section_citations={citations} < {threshold}",
             reason=reason,
             extra={"target_configured": target_configured},
         )
@@ -941,7 +991,7 @@ def classify_section(
         item_id=f"{os.path.basename(section.path)} § {section.heading}",
         from_tier="charter",
         to_tier="skill",
-        signal=f"skill_invocations={invocations} >= {threshold}",
+        signal=f"section_citations={citations} >= {threshold}",
         reason="Thresholds met; skill scaffold is safe to auto-generate",
     )
 

--- a/.claude/skills/promotion-audit/run.py
+++ b/.claude/skills/promotion-audit/run.py
@@ -26,14 +26,41 @@ decisions.
 Signal derivation, fixed in this driver
 =======================================
 - memory → charter: `count_retro_citations(memory, feedback_log)`.
-- charter → skill: the candidate skill slug is `section.promoted_to`
-  (with the `skills/` prefix stripped) when the section is already
-  promoted, else `_slugify(section.heading)` — the *prospective* skill
-  name. A not-yet-existent skill never appears in commit messages, so its
-  invocation count is naturally ~0. The empty-slug footgun is also closed
-  at the root in `helpers.count_skill_invocations` (blank slug → 0).
+- charter → skill: `count_section_citations(section, feedback_log)` (#1355)
+  — retro citations of the SOURCE section's own heading, the actual
+  evidence a section has earned promotion. `_section_signal_slug` still
+  resolves the prospective/promoted skill slug, but only to compute
+  `target_configured` (an informational disk-existence check, not a
+  signal input) — see main#1355 below for why the destination-invocation
+  signal this driver used pre-fix was structurally incapable of ever
+  reaching threshold for a not-yet-promoted section, and #1383/#1355 for
+  the fix history.
 - skill → hook: `count_skill_invocations(skill.name, repo_root)`
-  (always DECIDE per D6, never AUTO).
+  (always DECIDE per D6, never AUTO). This tier is unaffected by #1355 —
+  the destination (the skill) already exists by definition once it has a
+  `SKILL.md`, so measuring its own invocations is the correct signal
+  there; only the charter→skill tier had the destination-doesn't-exist-
+  yet inversion.
+
+Signal semantics, corrected (main#1355)
+========================================
+#1383 (the first #1355 PR) added a `target_configured` existence check on
+the prospective skill slug so a not-yet-scaffolded target renders a
+distinct "configuration gap" KEPT message instead of a misleading "wait
+for more operator-invoked runs" one. But the underlying *signal* was
+still `count_skill_invocations(prospective_slug, repo_root)` — usage of
+the DESTINATION, which by construction does not exist yet for any
+not-yet-promoted section, so the count was 0 for all 25 skill-targeted
+charter sections and could never rise. This residual (main#1355) replaces
+that signal with `count_section_citations`: citations of the SOURCE
+section's own heading in the feedback log (live + per-phase archives,
+#964) — the same mechanism `count_retro_citations` already uses for
+memories, which genuinely accumulates as operators reference a section in
+retros, independent of whether the destination skill has been scaffolded.
+This also closes the main#1389 collision path for free: the old signal
+could inherit an unrelated existing skill's real invocation count merely
+because a heading happened to slugify onto that skill's directory name;
+the citation count has no slug/skills-dir dependency at all.
 
 Usage
 =====
@@ -249,19 +276,29 @@ def run_audit(
 
     # charter → skill
     for sec in sections:
+        # #1355: the signal is now computed from the SOURCE section (retro
+        # citations of its heading) — the actual evidence for promotion —
+        # not from `count_skill_invocations` against the prospective
+        # destination slug (structurally 0 forever for every not-yet-
+        # promoted section; see `count_section_citations`'s docstring).
+        # This computation has no dependency on `slug` at all, which also
+        # closes the main#1389 collision path: the old destination-based
+        # signal could inherit an unrelated existing skill's real
+        # invocation count merely because a heading happened to slugify
+        # onto that skill's directory name. The citation count below is
+        # never touched by that coincidence.
+        citations = h.count_section_citations(sec, paths.feedback_log)
+        # `target_configured` is retained as informational context only
+        # (does a skill already exist on disk at the prospective slug?) —
+        # it selects which KEPT message classify_section renders, but no
+        # longer gates whether the signal itself can accrue.
         slug = _section_signal_slug(sec)
-        invocations = h.count_skill_invocations(slug, paths.repo_root)
-        # #1355: whether the prospective skill actually exists on disk yet
-        # gates which KEPT message classify_section renders — see the
-        # docstring on that branch. A not-yet-created skill (the common
-        # case for a not-yet-promoted section) can never accrue
-        # invocations, so "wait for more runs" would be misleading.
         target_configured = os.path.isdir(os.path.join(paths.skills_dir, slug))
         decisions.append(
             h.classify_section(
                 sec,
                 {
-                    "skill_invocations": invocations,
+                    "section_citations": citations,
                     "threshold": threshold,
                     "target_configured": int(target_configured),
                 },

--- a/.claude/skills/promotion-audit/tests/test_helpers.py
+++ b/.claude/skills/promotion-audit/tests/test_helpers.py
@@ -777,43 +777,67 @@ class ClassifySectionTests(unittest.TestCase):
         self.assertEqual(d.kind, "ALREADY-PROMOTED")
 
     def test_threshold_not_met(self) -> None:
-        d = h.classify_section(_make_section(), {"skill_invocations": 1, "threshold": 5})
+        # #1355: the signal key is `section_citations` (source-section
+        # evidence), not `skill_invocations` (destination-slug usage).
+        d = h.classify_section(_make_section(), {"section_citations": 1, "threshold": 5})
         self.assertEqual(d.kind, "KEPT")
 
     def test_threshold_met(self) -> None:
-        d = h.classify_section(_make_section(), {"skill_invocations": 7, "threshold": 5})
+        d = h.classify_section(_make_section(), {"section_citations": 7, "threshold": 5})
         self.assertEqual(d.kind, "AUTO")
+        self.assertIn("section_citations=7 >= 5", d.signal)
+
+    def test_legacy_skill_invocations_key_is_ignored_not_zero_workaround(self) -> None:
+        """NEG: a caller still passing the pre-#1355 `skill_invocations` key
+        (instead of `section_citations`) must NOT accidentally cross
+        threshold — the key is simply absent from `classify_section`'s
+        perspective and defaults to 0 citations, same as passing nothing."""
+        d = h.classify_section(_make_section(), {"skill_invocations": 99, "threshold": 5})
+        self.assertEqual(d.kind, "KEPT")
 
     def test_hook_target_not_valid_for_section(self) -> None:
         """NEG: charter sections only promote to skill."""
         d = h.classify_section(_make_section(promotion_target="hook"), {})
         self.assertEqual(d.kind, "KEPT")
 
-    def test_threshold_not_met_unconfigured_target_is_not_a_wait_message(self) -> None:
-        """#1355: a section whose prospective skill does not exist yet on
-        disk (`target_configured` false/absent) can never accumulate
-        invocations — the skill has nothing to invoke. The KEPT reason
-        must say the target is not configured, NOT tell the reader to
-        wait for more operator-invoked runs (a state that cannot arrive
-        for an artifact that doesn't exist).
+    def test_threshold_not_met_unconfigured_target_names_the_gap(self) -> None:
+        """#1355 acceptance criterion 1 (delivered by #1383, re-pinned here
+        against the corrected signal): a section whose prospective skill
+        does not exist yet on disk (`target_configured` false/absent)
+        still renders distinctly as a configuration gap — NOT the
+        "wait for more operator-invoked runs" message.
 
-        Pre-fix, `classify_section` renders the identical
-        'Invocation threshold not met; wait for more operator-invoked
-        runs' message regardless of whether the target skill exists —
-        this assertion fails against that implementation."""
+        Post-#1355, this is no longer because evidence "cannot accrue"
+        without a target (it now demonstrably can — `section_citations`
+        is computed from the SOURCE section, independent of whether the
+        skill exists) — the message says so explicitly rather than
+        repeating the now-inaccurate pre-#1355 claim."""
         d = h.classify_section(
-            _make_section(), {"skill_invocations": 0, "threshold": 5, "target_configured": 0}
+            _make_section(), {"section_citations": 0, "threshold": 5, "target_configured": 0}
         )
         self.assertEqual(d.kind, "KEPT")
         self.assertNotIn("wait for more operator-invoked runs", d.reason)
         self.assertIn("not configured", d.reason.lower())
+        # The corrected claim: evidence is NOT blocked by the missing target.
+        self.assertIn("no longer blocks evidence", d.reason)
+
+    def test_threshold_not_met_unconfigured_target_reports_actual_citations(self) -> None:
+        """The config-gap message must surface the real citation count
+        (not a placeholder) — proof the signal is genuinely wired through
+        even when the target isn't configured yet."""
+        d = h.classify_section(
+            _make_section(), {"section_citations": 3, "threshold": 5, "target_configured": 0}
+        )
+        self.assertIn("3", d.reason)
+        self.assertIn("3/5", d.reason)
 
     def test_threshold_not_met_configured_target_still_says_wait(self) -> None:
         """NEG: once the target skill actually exists on disk (configured,
-        just below the invocation threshold), 'wait for more
-        operator-invoked runs' is an accurate message and must be kept."""
+        just below the citation threshold), 'wait for more
+        operator-invoked runs' is retained verbatim (#1383 delivered
+        wording, not redone here)."""
         d = h.classify_section(
-            _make_section(), {"skill_invocations": 1, "threshold": 5, "target_configured": 1}
+            _make_section(), {"section_citations": 1, "threshold": 5, "target_configured": 1}
         )
         self.assertEqual(d.kind, "KEPT")
         self.assertIn("wait for more operator-invoked runs", d.reason)
@@ -823,9 +847,111 @@ class ClassifySectionTests(unittest.TestCase):
         (the common case: prospective-only slug, skill never scaffolded) —
         callers that don't wire the new signal get the safe, accurate
         message rather than silently reverting to the misleading one."""
-        d = h.classify_section(_make_section(), {"skill_invocations": 0, "threshold": 5})
+        d = h.classify_section(_make_section(), {"section_citations": 0, "threshold": 5})
         self.assertEqual(d.kind, "KEPT")
         self.assertIn("not configured", d.reason.lower())
+
+    def test_threshold_met_regardless_of_target_configured(self) -> None:
+        """#1355 acceptance criterion 2: crossing threshold produces AUTO
+        even when the prospective skill has never been scaffolded — the
+        source-section signal does not require the destination to exist
+        first (the whole point of the fix)."""
+        d = h.classify_section(
+            _make_section(), {"section_citations": 5, "threshold": 5, "target_configured": 0}
+        )
+        self.assertEqual(d.kind, "AUTO")
+
+
+# ---------------------------------------------------------------------------
+# Source-section citation counting (#1355)
+# ---------------------------------------------------------------------------
+
+
+class CountSectionCitationsTests(unittest.TestCase):
+    def _section(self, **kwargs: object) -> h.CharterSection:
+        defaults: dict[str, object] = {
+            "path": "/fake/charter/wave-merge.md",
+            "heading": "Cross-Contract PRs",
+            "promotion_target": "skill",
+            "body": "body",
+            "promoted_to": "",
+        }
+        defaults.update(kwargs)
+        return h.CharterSection(**defaults)  # type: ignore[arg-type]
+
+    def test_counts_heading_occurrences(self) -> None:
+        log = (
+            "See charter § Cross-Contract PRs for the rule.\n"
+            "Cross-Contract PRs applies here too.\n"
+            "Unrelated line.\n"
+        )
+        with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as f:
+            f.write(log)
+            path = f.name
+        try:
+            self.assertEqual(h.count_section_citations(self._section(), path), 2)
+        finally:
+            os.unlink(path)
+
+    def test_counts_include_per_phase_archives(self) -> None:
+        """Same archive-scan mechanism as `count_retro_citations` (#964) —
+        live log + archive/feedback_log_*.md are summed."""
+        with tempfile.TemporaryDirectory() as d:
+            live = os.path.join(d, "feedback_log.md")
+            with open(live, "w", encoding="utf-8") as f:
+                f.write("cites Cross-Contract PRs once\n")
+            arch = os.path.join(d, "archive")
+            os.makedirs(arch)
+            with open(os.path.join(arch, "feedback_log_phase-2.md"), "w", encoding="utf-8") as f:
+                f.write("old retro cites Cross-Contract PRs, then Cross-Contract PRs again\n")
+            self.assertEqual(h.count_section_citations(self._section(), live), 3)
+
+    def test_no_citations_returns_zero(self) -> None:
+        log = "nothing relevant here\n"
+        with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as f:
+            f.write(log)
+            path = f.name
+        try:
+            self.assertEqual(h.count_section_citations(self._section(), path), 0)
+        finally:
+            os.unlink(path)
+
+    def test_missing_log_returns_zero(self) -> None:
+        self.assertEqual(h.count_section_citations(self._section(), "/nonexistent"), 0)
+
+    def test_blank_heading_returns_zero_not_corpus_length(self) -> None:
+        """Defensive guard mirroring main#690's blank-slug fix:
+        `text.count("")` would otherwise return `len(text) + 1`, making a
+        blank heading look like it crossed any threshold trivially."""
+        log = "some reasonably long corpus text so the bug would be obvious\n" * 10
+        with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as f:
+            f.write(log)
+            path = f.name
+        try:
+            self.assertEqual(h.count_section_citations(self._section(heading=""), path), 0)
+            self.assertEqual(h.count_section_citations(self._section(heading="   "), path), 0)
+        finally:
+            os.unlink(path)
+
+    def test_independent_of_skill_slug_collision(self) -> None:
+        """main#1389: the OLD destination-invocation signal could inherit
+        an unrelated existing skill's real invocation count merely because
+        a heading slugified onto that skill's directory name. This signal
+        has no slug/skills-dir dependency at all — a heading that would
+        collide with a real skill name still counts only its own literal
+        citations, proving the collision path is closed for this number."""
+        section = self._section(heading="Handoff")
+        log = "no citation of that heading here, just unrelated retro prose\n"
+        with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as f:
+            f.write(log)
+            path = f.name
+        try:
+            # Regardless of how many times /handoff (the real skill) was
+            # invoked in git history, this function never looks at git log
+            # or any skills directory — only the feedback-log corpus.
+            self.assertEqual(h.count_section_citations(section, path), 0)
+        finally:
+            os.unlink(path)
 
 
 # ---------------------------------------------------------------------------

--- a/.claude/skills/promotion-audit/tests/test_run.py
+++ b/.claude/skills/promotion-audit/tests/test_run.py
@@ -201,7 +201,9 @@ class EmptySlugRegression(unittest.TestCase):
         skill directory (`some-procedure/`) anywhere under
         `.claude/skills/` — the driver must wire `target_configured=False`
         through to `classify_section` so the KEPT reason says the target
-        isn't configured, not that the reader should wait for more runs."""
+        isn't configured, not that the reader should wait for more runs.
+        The fixture's feedback_log.md has zero citations of the heading,
+        so it also stays below threshold either way."""
         paths, _ = _make_fixture_repo(self.tmp)
         result = run.run_audit(paths, wave_name="p5-wave-5", audit_date="2026-06-16")
         sec_decisions = [d for d in result.decisions if d.from_tier == "charter"]
@@ -219,6 +221,85 @@ class EmptySlugRegression(unittest.TestCase):
         result = run.run_audit(paths, wave_name="p5-wave-5", audit_date="2026-06-16")
         sec_decisions = [d for d in result.decisions if d.from_tier == "charter"]
         self.assertEqual(len(sec_decisions), 1)
+        self.assertIn("wait for more operator-invoked runs", sec_decisions[0].reason)
+
+    def test_section_signal_is_source_citations_not_destination_invocations(self) -> None:
+        """#1355 item 1: the driver must compute the charter->skill signal
+        from `count_section_citations` (the SOURCE section's heading cited
+        in the feedback log), not `count_skill_invocations` against the
+        destination slug. Proven by a fixture where the commit history
+        would spuriously satisfy the OLD (destination) signal (a commit
+        message containing `/some-procedure`) while the feedback log has
+        ZERO citations of the heading — under the fixed signal this must
+        stay KEPT with `section_citations=0`, not accidentally cross
+        threshold via the old slug-grep path."""
+        paths, repo_root = _make_fixture_repo(self.tmp)
+        _git(Path(repo_root), "commit", "--allow-empty", "-m", "chore: touch /some-procedure x5")
+        for _ in range(4):
+            _git(
+                Path(repo_root),
+                "commit",
+                "--allow-empty",
+                "-m",
+                "chore: touch /some-procedure again",
+            )
+        result = run.run_audit(paths, wave_name="p5-wave-5", audit_date="2026-06-16")
+        sec_decisions = [d for d in result.decisions if d.from_tier == "charter"]
+        self.assertEqual(len(sec_decisions), 1)
+        self.assertEqual(sec_decisions[0].kind, "KEPT")
+        self.assertIn("section_citations=0", sec_decisions[0].signal)
+
+    def test_heavily_cited_section_crosses_threshold_via_source_signal(self) -> None:
+        """#1355 acceptance criterion 2: a section whose heading is cited
+        >= threshold times in the feedback log (the genuine source signal)
+        actually crosses threshold and is classified AUTO — even though
+        the fixture has NO matching skill directory (`target_configured`
+        stays False) and NO commit history referencing the slug at all.
+        This is the concrete proof that at least one section is now
+        genuinely evaluable, where pre-fix every not-yet-promoted section
+        was structurally stuck at 0 forever."""
+        paths, _ = _make_fixture_repo(self.tmp)
+        citing_log = "\n".join(
+            f"- retro cites charter § Some Procedure again ({i})" for i in range(5)
+        )
+        with open(paths.feedback_log, "w", encoding="utf-8") as f:
+            f.write(citing_log + "\n")
+        result = run.run_audit(paths, wave_name="p5-wave-5", audit_date="2026-06-16")
+        sec_decisions = [d for d in result.decisions if d.from_tier == "charter"]
+        self.assertEqual(len(sec_decisions), 1)
+        self.assertEqual(sec_decisions[0].kind, "AUTO")
+        self.assertIn("section_citations=5 >= 5", sec_decisions[0].signal)
+
+    def test_section_citation_signal_immune_to_skill_slug_collision(self) -> None:
+        """main#1389: confirm — do not assume — that the source-signal fix
+        removes the collision risk where a charter heading slugifying onto
+        an EXISTING, unrelated skill directory inherits that skill's real
+        invocation count. Build a fixture where a skill directory exists
+        at the exact prospective slug (`some-procedure/`) and git history
+        would give the OLD destination-invocation signal a huge count
+        (10 commits referencing `/some-procedure`), while the feedback log
+        has zero citations of the section's own heading. Under the fixed
+        signal this must stay KEPT at 0 citations, proving the citation
+        count is untouched by the collision — only the (already-existing,
+        informational-only) `target_configured` flag is affected, which
+        flips the KEPT message wording, never the kind."""
+        paths, repo_root = _make_fixture_repo(self.tmp)
+        os.makedirs(os.path.join(paths.skills_dir, "some-procedure"), exist_ok=True)
+        for _ in range(10):
+            _git(
+                Path(repo_root),
+                "commit",
+                "--allow-empty",
+                "-m",
+                "feat: exercise /some-procedure heavily",
+            )
+        result = run.run_audit(paths, wave_name="p5-wave-5", audit_date="2026-06-16")
+        sec_decisions = [d for d in result.decisions if d.from_tier == "charter"]
+        self.assertEqual(len(sec_decisions), 1)
+        self.assertEqual(sec_decisions[0].kind, "KEPT")
+        self.assertIn("section_citations=0", sec_decisions[0].signal)
+        # The collision only changes the message (target now looks
+        # configured), never the underlying citation-based decision.
         self.assertIn("wait for more operator-invoked runs", sec_decisions[0].reason)
 
 
@@ -289,18 +370,46 @@ class MainEntrypoint(unittest.TestCase):
     "steady-state test requires the project's memory directory",
 )
 class SteadyStateThroughDriver(unittest.TestCase):
-    """The driver must reproduce the smoke-test invariant: 0 AUTO / 0 DECIDE
-    on the real working tree — proving the canonical wiring matches the
-    hand-driven expectation while closing the empty-slug mis-fire."""
+    """#1355: pre-fix, the driver's charter->skill signal was structurally
+    0 forever for every not-yet-promoted section (destination-invocation
+    count against a slug that, by definition, doesn't exist yet), so
+    0 AUTO / 0 DECIDE on the real tree was the ONLY possible outcome — it
+    proved nothing about whether any section had actually earned promotion.
+    Post-fix, the signal is real (retro citations of each section's own
+    heading), and the live repo has one section that has genuinely
+    accumulated enough evidence: `wave-merge.md § Cross-Contract PRs`
+    (cited 5 times across the live feedback log + phase-2/phase-3 archives,
+    threshold 5). This is the concrete, denominator-honest evidence for
+    #1355 acceptance criterion 2: of 25 skill-targeted charter sections,
+    1 crosses today; all 25 are now genuinely evaluable (the signal can
+    reach threshold for any of them, whereas pre-fix 0 of 25 ever could).
+    memory->charter and skill->hook tiers are untouched by this fix and
+    still yield 0 AUTO / 0 DECIDE on the real tree."""
 
-    def test_zero_auto_zero_decide(self) -> None:
+    def test_current_repo_state_yields_exactly_one_auto_section(self) -> None:
         paths = run.resolve_paths(_REPO_ROOT)
         result = run.run_audit(paths, wave_name="p5-wave-5", audit_date="2026-06-16")
         counts = result.counts()
         auto = [d.item_id for d in result.decisions if d.kind == "AUTO"]
         decide = [d.item_id for d in result.decisions if d.kind == "DECIDE"]
-        self.assertEqual(counts["AUTO"], 0, f"unexpected AUTO: {auto}")
+        self.assertEqual(counts["AUTO"], 1, f"unexpected AUTO set: {auto}")
+        self.assertTrue(
+            any("Cross-Contract PRs" in item for item in auto),
+            f"expected the AUTO item to be Cross-Contract PRs, got: {auto}",
+        )
         self.assertEqual(counts["DECIDE"], 0, f"unexpected DECIDE: {decide}")
+
+    def test_memory_and_skill_tiers_still_yield_zero_auto_zero_decide(self) -> None:
+        """The fix is scoped to the charter->skill tier only — memory and
+        skill decisions are unaffected and keep the pre-existing
+        zero-AUTO/zero-DECIDE invariant."""
+        paths = run.resolve_paths(_REPO_ROOT)
+        result = run.run_audit(paths, wave_name="p5-wave-5", audit_date="2026-06-16")
+        non_charter = [d for d in result.decisions if d.from_tier != "charter"]
+        auto = [d.item_id for d in non_charter if d.kind == "AUTO"]
+        decide = [d.item_id for d in non_charter if d.kind == "DECIDE"]
+        self.assertEqual(len(auto), 0, f"unexpected AUTO: {auto}")
+        self.assertEqual(len(decide), 0, f"unexpected DECIDE: {decide}")
 
 
 if __name__ == "__main__":

--- a/.claude/skills/promotion-audit/tests/test_smoke.py
+++ b/.claude/skills/promotion-audit/tests/test_smoke.py
@@ -85,10 +85,16 @@ class SmokeTests(unittest.TestCase):
             decisions.append(h.classify_memory(m, {"retro_citations": cites}, self.already))
 
         for s in self.sections:
-            # Charter sections — we intentionally pass zero invocation
-            # signal for the smoke run; a separate future enhancement may
-            # wire up `count_skill_invocations` once the signal matures.
-            decisions.append(h.classify_section(s, {"skill_invocations": 0, "threshold": 5}))
+            # Charter sections — this smoke test intentionally passes a
+            # zero `section_citations` signal so it stays isolated to the
+            # memory-classification behavior under test above; the real,
+            # wired-through signal (`count_section_citations`, #1355) is
+            # exercised end-to-end by
+            # `test_run.SteadyStateThroughDriver` and
+            # `test_helpers.CountSectionCitationsTests` instead, where it
+            # correctly reports 1 AUTO (`Cross-Contract PRs`) on the real
+            # tree — a result this test deliberately does not reproduce.
+            decisions.append(h.classify_section(s, {"section_citations": 0, "threshold": 5}))
 
         for sk in self.skills:
             decisions.append(
@@ -112,6 +118,44 @@ class SmokeTests(unittest.TestCase):
             0,
             f"Expected zero DECIDE decisions on first run, got: {[d.item_id for d in decide]}",
         )
+
+    def test_hook_target_sections_no_longer_misreport_promoted_to_skill(self) -> None:
+        """#1355 item 3: `Agent Liveness Checkpoint` and `Throttle-Stall
+        Recovery — Trigger Thresholds` (both `promotion-target: hook`) used
+        to carry a nested `### Enforcement (mechanized) <!-- promoted-to:
+        lib/check_agent_liveness.py -->` marker whose HTML-comment syntax
+        collided with the charter->skill `promoted-to:` back-reference
+        regex — `lib/check_agent_liveness.py` is a deterministic checker
+        script, not a skill slug. That collision made `classify_section`
+        report ALREADY-PROMOTED with `to_tier="skill"` (hardcoded) for a
+        section that was never eligible for charter->skill promotion at
+        all. The marker is now `enforced-by:` (informational, not parsed
+        by `_PROMOTED_TO_RE`), so both sections fall through to the
+        "hook-targeted, invalid transition" KEPT branch that every other
+        hook-target section already renders.
+
+        This is a hygiene fix only: neither section was ever reachable by
+        the invocation gate (hook-targeted sections never were, before or
+        after) and neither becomes eligible for charter->skill promotion
+        now — they simply stop being mislabeled."""
+        targets = [
+            s
+            for s in self.sections
+            if s.heading
+            in ("Agent Liveness Checkpoint", "Throttle-Stall Recovery — Trigger Thresholds")
+        ]
+        self.assertEqual(
+            len(targets), 2, f"expected both sections, found: {[t.heading for t in targets]}"
+        )
+        for sec in targets:
+            self.assertEqual(sec.promotion_target, "hook")
+            self.assertEqual(
+                sec.promoted_to, "", f"{sec.heading} still carries a promoted_to back-reference"
+            )
+            d = h.classify_section(sec, {"section_citations": 0, "threshold": 5})
+            self.assertEqual(d.kind, "KEPT")
+            self.assertEqual(d.to_tier, "hook")
+            self.assertIn("only promote to skill", d.reason)
 
     def test_render_is_deterministic(self) -> None:
         """Core spec: same inputs, byte-identical output."""

--- a/.claude/team/charter/agents/lifecycle.md
+++ b/.claude/team/charter/agents/lifecycle.md
@@ -126,7 +126,7 @@ This section covers the **zero-artifact stall**: the implementer has produced no
 - Orchestrator misses a zero-artifact stall because `TaskList` is empty (Part (a) violated): **moderate** — the stall the task list was designed to surface goes unreported.
 - Orchestrator infers "still working" from a second zero-artifact idle notification and takes no action (Part (b) violated): **moderate** — wave-level deadline risk; the P5W2 and P5W3 instances were both narrow misses on shipping the keystone deliverable.
 
-### Enforcement (mechanized) <!-- promoted-to: lib/check_agent_liveness.py -->
+### Enforcement (mechanized) <!-- enforced-by: lib/check_agent_liveness.py -->
 
 Both parts are mechanized by `.claude/lib/check_agent_liveness.py` (main#745, follow-up to #735). There is **no clean tool boundary** to hang a PreToolUse hook on — Part (a)'s violation (a spawn with no matching task) is a cross-tool reconciliation of the `TaskList` ledger against the set of spawned implementers, and Part (b) is driven off artifact counts + idle-notification count, not off any single tool's arguments. The deterministic enforcement surface is therefore a checker the orchestrator runs at each **status sweep** (`/retro`, the `/wave-wrapup` open-item pass, or any in-flight-agent review), fed a snapshot it assembles from tools it already calls (`TaskList` + the `gh`/`git` artifact reads):
 
@@ -178,7 +178,7 @@ Normal **idle-after-turn-completion** does NOT trigger this — an implementer w
 
 Reactive-only detection (no cadence, stall discovered at the next state review): **minor-to-moderate** depending on deadline proximity — the work is recoverable via takeover, but the idle gap is dead time that compounds against wave deadlines (especially hard cutovers like the node24 June-2 class).
 
-### Enforcement (mechanized) <!-- promoted-to: lib/check_agent_liveness.py -->
+### Enforcement (mechanized) <!-- enforced-by: lib/check_agent_liveness.py -->
 
 The 30/45/60-min cadence is mechanized by `.claude/lib/check_agent_liveness.py` (main#745, follow-up to #735) — the same status-sweep checker that enforces § Agent Liveness Checkpoint. Per § Out of scope above this is **not** a hook (the trigger is orchestrator-side elapsed-time off artifact state, with no tool event to intercept); the lib is the deterministic surface the orchestrator runs at each sweep. For an implementer that is mid-task **with pending work** (`worktree_dirty`, or branch-pushed-no-PR, or committed-not-pushed), the checker emits a `throttle-stall` finding keyed to `idle_minutes`: `first-ping` (≥30), `second-ping` (≥45), `auto-takeover` (≥60). Idle after a clean handoff (no pending work) and reviewer agents do not trigger. The `auto-takeover` finding directs the orchestrator into `feedback_throttle_takeover` (the mechanic); this section + the lib are the trigger.
 


### PR DESCRIPTION
## Summary

Residual of #1355, continuing from #1383 (which delivered the "unconfigured" vs "below threshold" distinction and the acceptance-criterion-1 regression test, both left untouched here). This PR delivers the remaining scope, per the owner's 2026-08-12 restatement on #1355:

1. **Fix the signal's semantics.** `run.py`'s charter→skill tier counted invocations of the *prospective destination* skill slug (`count_skill_invocations(slug, repo_root)`) — structurally `0` forever for every not-yet-promoted section, since the skill doesn't exist yet to be invoked. It now counts `count_section_citations(section, feedback_log)`: retro citations of the SOURCE section's own heading in the feedback log (live + per-phase archives), mirroring the mechanism `count_retro_citations` already uses for memories.
2. **Fix the 2 mis-configured slugs** (`Agent Liveness Checkpoint`, `Throttle-Stall Recovery — Trigger Thresholds` in `charter/agents/lifecycle.md`) — both `hook`-targeted, so they were never reachable by the invocation gate either way. But a stray `<!-- promoted-to: lib/check_agent_liveness.py -->` marker (a lib path, not a skill slug) collided with the charter→skill `promoted-to:` regex and made `classify_section` mislabel them `ALREADY-PROMOTED`/`skill` instead of the correct `KEPT`/`hook` "charter sections only promote to skill" every other hook-target section renders. Renamed to `enforced-by:` (not parsed by `_PROMOTED_TO_RE`). **Hygiene only** — neither section becomes eligible for charter→skill promotion; they just stop being mislabeled.
3. **Acceptance criterion 2.** New tests prove the signal is computed from the source section and that a heavily-cited section crosses threshold — both a hermetic fixture test and a real-repo assertion. **Before: 0 of 25** skill-targeted charter sections could ever cross threshold (signal structurally 0 forever). **After: all 25 of 25** are genuinely evaluable (the signal is real and can reach threshold for any of them), and **1 of 25** (`wave-merge.md § Cross-Contract PRs`, 5 real retro citations across the live log + phase-2/phase-3 archives) crosses today at the unchanged `threshold=5`.
4. **#1389 confirmed, not assumed.** Commented explicitly on #1389 with a before/after table (`Handoff`, `Wave Scope`, `Retro`) showing the new signal has zero dependency on any skill slug or `.claude/skills/` lookup, closing that collision mechanism. A narrower, unrelated false-positive shape (short/generic headings over-matching via substring in the corpus) surfaced while verifying this and is filed separately as #1450 — it does not affect any of the 25 real headings today, all of which are long, distinctive phrases.

## What does NOT change

- `main#690`'s blank-slug guard in `count_skill_invocations` — untouched, still guards the skill→hook tier and any direct caller.
- The `target_configured` distinction from #1383 — still present, still selects which `KEPT` message renders below threshold. It no longer gates *whether* evidence can accrue (it never should have, and now doesn't), so its "not configured" message no longer claims citations "cannot accrue" (false after this fix) — it now reports the real citation count and clarifies that scaffolding is a deliberate human act, not a precondition for the signal.
- The skill→hook tier (`classify_skill`, `count_skill_invocations(skill.name, ...)`) — unaffected; a skill already exists once it has a `SKILL.md`, so measuring its own invocations was always the correct signal there.

## Test plan

- [x] `ENVIRONMENT=test python3 -m pytest .claude/skills/promotion-audit/tests/ -q` — 121/121 pass
- [x] `mypy .claude/skills/promotion-audit/ --ignore-missing-imports --no-error-summary` — clean
- [x] `ruff format --check` / `ruff check` on all changed files — clean
- [x] `python3 .claude/skills/promotion-audit/run.py` against the live repo — confirms `1 AUTO · 0 DECIDE · 254 KEPT · 22 SUPERSEDED/ALREADY-PROMOTED`, with `Cross-Contract PRs` as the sole AUTO item
- [x] Pre-commit + pre-push hooks (ruff, cspell, mypy, mypy-skills, pytest, pytest-skills, memory-budget, headcount-budget, doc-freshness, office-drift, mermaid-render) — all passed on push

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>


## Related Issues

Closes #1355
Refs #1389, #1450, #1455
